### PR TITLE
chore(agents): right-size model tiers — 8 opus→sonnet, 1 sonnet→haiku

### DIFF
--- a/.claude/agents/agent-maker.md
+++ b/.claude/agents/agent-maker.md
@@ -2,7 +2,7 @@
 name: agent-maker
 description: Creates new AI agent files in .claude/agents/ following AI Agents Convention. Changes are then synced to .opencode/agent/ via npm run sync:claude-to-opencode. Ensures proper structure, skills integration, and documentation.
 tools: Read, Write, Glob, Grep, Bash
-model:
+model: sonnet
 color: blue
 skills:
   - docs-applying-content-quality
@@ -15,15 +15,14 @@ skills:
 
 - **Role**: Maker (blue)
 - **Created**: 2025-12-01
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
+**Model Selection Justification**: This agent uses `model: sonnet` because agent authoring is template-driven scaffolding governed by the `agent-developing-agents` skill:
 
-- Advanced reasoning to create well-structured AI agent files
-- Sophisticated frontmatter and prompt generation
-- Deep understanding of AI Agents Convention and Skills integration
-- Complex decision-making for tool selection and model choice
-- Multi-step agent creation workflow
+- YAML frontmatter and prompt structure are pinned down by the AI Agents Convention; the agent fills a template rather than inventing one
+- Tool-list, model-selection, and skills decisions follow explicit rules documented in the skill — sonnet-tier reasoning handles this comfortably
+- Structured content generation with a clear quality rubric matches the sonnet profile in the model-selection matrix
+- Opus remains appropriate for the novel decisions the agent author makes _before_ invoking this agent; the agent itself just materializes those decisions into a file
 
 Create new AI agent files following AI Agents Convention.
 

--- a/.claude/agents/apps-oseplatform-web-content-maker.md
+++ b/.claude/agents/apps-oseplatform-web-content-maker.md
@@ -2,7 +2,7 @@
 name: apps-oseplatform-web-content-maker
 description: Creates content for oseplatform-web Next.js 16 content platform. English-only with date-based organization.
 tools: Read, Write, Edit, Glob, Grep
-model:
+model: sonnet
 color: blue
 skills:
   - docs-applying-content-quality
@@ -15,15 +15,14 @@ skills:
 
 - **Role**: Maker (blue)
 - **Created**: 2025-12-20
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
+**Model Selection Justification**: This agent uses `model: sonnet` because oseplatform-web is a flat, English-only content platform with a simpler authoring profile than the bilingual AyoKoding makers:
 
-- Advanced reasoning to create engaging landing page content
-- Sophisticated content generation for Next.js 16 with tRPC
-- Deep understanding of landing page best practices
-- Complex decision-making for content structure and organization
-- Multi-step content creation workflow
+- English-only content removes the bilingual nuance that justifies opus for `apps-ayokoding-web-*-maker` agents
+- The `apps-oseplatform-web-developing-content` skill pins down landing page structure, date-prefixed filenames, frontmatter fields, and flat organization
+- Parity with peer agents: `apps-oseplatform-web-content-checker` and `apps-oseplatform-web-content-fixer` are both sonnet, and the three-agent trio should share a tier
+- Sonnet handles structured content generation with a quality rubric, matching the task profile
 
 Create landing page content for oseplatform-web (Next.js 16 with tRPC, English-only).
 

--- a/.claude/agents/docs-file-manager.md
+++ b/.claude/agents/docs-file-manager.md
@@ -2,7 +2,7 @@
 name: docs-file-manager
 description: Expert at managing files and directories in docs/ directory. Use for renaming, moving, or deleting files/directories while maintaining kebab-case conventions, fixing links, and preserving git history.
 tools: Read, Edit, Glob, Grep, Bash
-model: sonnet
+model: haiku
 color: yellow
 skills:
   - repo-practicing-trunk-based-development
@@ -17,17 +17,19 @@ skills:
 
 - **Role**: Fixer (yellow)
 - **Created**: 2025-11-30
-- **Last Updated**: 2026-04-04
-- **Size Tier**: Tier 2 (standard agent with complex decision logic — cascading directory operations, multi-step link tracking, deletion safety analysis)
+- **Last Updated**: 2026-04-12
+- **Size Tier**: Tier 2 (standard agent — deterministic file operations with scripted link updates)
 
-**Model Selection Justification**: This agent uses `model: sonnet` because it requires advanced reasoning to:
+**Model Selection Justification**: This agent uses `model: haiku` to align with the canonical haiku example documented in the `agent-developing-agents` skill (SKILL.md §"Haiku Examples" → docs-file-manager). The work profile fits haiku's strengths:
 
-- Calculate cascading impacts when renaming directories (affects all files inside and all links pointing to them)
-- Validate kebab-case filename compliance per the file naming convention
-- Track and update all internal link references across the entire documentation tree
-- Validate relative path calculations for links at different nesting depths
-- Orchestrate complex multi-step operations (rename, move, delete, update links, update indices)
-- Assess deletion safety (ensure no broken links, verify files are truly unused)
+- Deterministic file operations (move, rename, delete) with clear pass/fail outcomes
+- Path manipulation and kebab-case compliance are pattern-matching against a regex rule
+- Internal link updates are mechanical find-and-replace driven by the `docs-validating-links` skill, not judgment calls
+- Git history preservation is handled via scripted commands (`git mv`), not reasoning
+- No novel decision-making — cascading rename impacts are enumerated procedurally, not inferred
+- Deletion safety is verified by link-graph traversal, a deterministic check rather than a judgment call
+
+Before this change the agent was sonnet, which contradicted the skill documentation that cited it as the canonical haiku example. The agent and the skill are now consistent.
 
 You are an expert at safely managing files and directories in the `docs/` folder while maintaining all conventions, fixing internal links, and preserving git history.
 

--- a/.claude/agents/docs-maker.md
+++ b/.claude/agents/docs-maker.md
@@ -2,7 +2,7 @@
 name: docs-maker
 description: Expert documentation writer specializing in GitHub-compatible markdown and Diátaxis framework. Use when creating, editing, or organizing project documentation.
 tools: Read, Write, Edit, Glob, Grep
-model:
+model: sonnet
 color: blue
 skills:
   - docs-creating-accessible-diagrams
@@ -16,15 +16,14 @@ skills:
 
 - **Role**: Maker (blue)
 - **Created**: 2025-11-29
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires advanced reasoning to create well-structured documentation. The agent requires:
+**Model Selection Justification**: This agent uses `model: sonnet` because Diátaxis-aligned documentation writing is structured content generation with a clear quality rubric:
 
-- Advanced reasoning to create well-structured documentation
-- Sophisticated content generation following Diu00e1taxis framework
-- Deep understanding of documentation quality standards
-- Complex decision-making for content organization and structure
-- Multi-step documentation creation workflow
+- The `docs-applying-diataxis-framework` and `docs-applying-content-quality` skills define structure (tutorial vs how-to vs reference vs explanation), heading hierarchy, accessibility rules, and GitHub-compatible markdown conventions
+- Parity with peer agents: `docs-checker` and `docs-fixer` are both sonnet, and the three-agent trio should share a tier
+- Sonnet's strength at structured long-form writing matches the task profile; the decisions are rule-following within a well-defined framework rather than novel invention
+- Pedagogically demanding tutorial authoring remains with opus via `docs-tutorial-maker` where narrative flow and learning progression justify the extra capability
 
 You are an expert technical documentation writer specializing in creating high-quality, GitHub-compatible markdown documentation. Your expertise includes:
 

--- a/.claude/agents/plan-executor.md
+++ b/.claude/agents/plan-executor.md
@@ -2,7 +2,7 @@
 name: plan-executor
 description: Executes project plans systematically by following delivery checklists, implementing steps sequentially, validating work, and updating progress. Stops at final validation for plan-execution-checker handoff.
 tools: Read, Write, Edit, Glob, Grep, Bash
-model:
+model: sonnet
 color: purple
 skills:
   - docs-applying-content-quality
@@ -16,15 +16,15 @@ skills:
 
 - **Role**: Implementor (purple)
 - **Created**: 2025-12-28
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
+**Model Selection Justification**: This agent uses `model: sonnet` because plan execution is checklist-following with per-step validation rather than novel creative planning:
 
-- Advanced reasoning to execute project plans systematically
-- Sophisticated decision-making for implementation steps
-- Deep understanding of delivery checklists and validation
-- Complex workflow orchestration for sequential execution
-- Multi-step plan execution with progress tracking
+- Sequential execution of a pre-authored delivery checklist (the creative work is already in the plan)
+- Per-step validation against acceptance criteria with clear pass/fail outcomes
+- Multi-step orchestration of well-defined operations — the model-selection matrix in `agent-developing-agents` identifies this as sonnet territory
+- Parity with peer agents: `plan-checker` and `plan-execution-checker` are both sonnet, so the executor should not be a stronger tier than the checker that judges its work
+- Creative planning decisions stay with opus-tier `plan-maker`; `plan-executor` only executes what that agent produced
 
 You are an expert at systematically executing project plans by following delivery checklists, implementing each step, validating work, and tracking progress.
 

--- a/.claude/agents/readme-maker.md
+++ b/.claude/agents/readme-maker.md
@@ -2,7 +2,7 @@
 name: readme-maker
 description: Creates and updates README.md content while maintaining engagement, accessibility, and quality standards. Rewrites jargony sections, adds context to acronyms, breaks up dense paragraphs, and ensures navigation-focused structure. Use when adding or updating README content.
 tools: Read, Write, Edit, Glob, Grep
-model:
+model: sonnet
 color: blue
 skills:
   - docs-applying-content-quality
@@ -15,15 +15,14 @@ skills:
 
 - **Role**: Maker (blue)
 - **Created**: 2025-12-15
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
+**Model Selection Justification**: This agent uses `model: sonnet` because README authoring is structured content generation against a tight, well-defined rubric:
 
-- Advanced reasoning to create engaging, accessible README content
-- Sophisticated content generation for problem-solution hooks
-- Deep understanding of plain language and scannable structure
-- Complex decision-making for benefits-focused messaging
-- Multi-dimensional quality content creation
+- The `readme-writing-readme-files` skill pins down the structure (problem-solution hook, plain language, paragraph limits, scannable hierarchy), so most decisions are rule-following rather than open-ended creation
+- Parity with peer agents: `readme-checker` and `readme-fixer` are both sonnet, and the three-agent trio should operate at a consistent tier
+- Sonnet's strength at structured writing matches the task profile described in the `agent-developing-agents` decision framework
+- Creative tradeoffs (benefits-focused messaging, tone) are well within sonnet's capability; opus was overkill for the decisions actually being made
 
 You are a README content creator specializing in writing engaging, accessible, and welcoming README content while maintaining technical accuracy.
 
@@ -80,25 +79,9 @@ Clarify what needs to be written or updated:
 
 ```bash
 # Read current README
-
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
-
-- Advanced reasoning to create engaging, accessible README content
-- Sophisticated content generation for problem-solution hooks
-- Deep understanding of plain language and scannable structure
-- Complex decision-making for benefits-focused messaging
-- Multi-dimensional quality content creation
 Read README.md
 
 # Read related docs for context
-
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
-
-- Advanced reasoning to create engaging, accessible README content
-- Sophisticated content generation for problem-solution hooks
-- Deep understanding of plain language and scannable structure
-- Complex decision-making for benefits-focused messaging
-- Multi-dimensional quality content creation
 Read AGENTS.md
 Grep "relevant keywords" in docs/
 ```
@@ -138,25 +121,9 @@ Before finalizing, check (see `readme-writing-readme-files` Skill for complete c
 
 ```bash
 # For new content
-
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
-
-- Advanced reasoning to create engaging, accessible README content
-- Sophisticated content generation for problem-solution hooks
-- Deep understanding of plain language and scannable structure
-- Complex decision-making for benefits-focused messaging
-- Multi-dimensional quality content creation
 Edit README.md
 
 # Or for complete rewrite
-
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
-
-- Advanced reasoning to create engaging, accessible README content
-- Sophisticated content generation for problem-solution hooks
-- Deep understanding of plain language and scannable structure
-- Complex decision-making for benefits-focused messaging
-- Multi-dimensional quality content creation
 Write README.md
 ```
 

--- a/.claude/agents/repo-workflow-maker.md
+++ b/.claude/agents/repo-workflow-maker.md
@@ -2,7 +2,7 @@
 name: repo-workflow-maker
 description: Creates workflow documentation in governance/workflows/ following workflow pattern convention.
 tools: Read, Write, Edit, Glob, Grep
-model:
+model: sonnet
 color: blue
 skills:
   - docs-applying-content-quality
@@ -17,15 +17,14 @@ skills:
 
 - **Role**: Maker (blue)
 - **Created**: 2025-12-28
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
+**Model Selection Justification**: This agent uses `model: sonnet` because workflow authoring is template filling against the `repo-defining-workflows` convention:
 
-- Advanced reasoning to create standardized workflow documentation
-- Sophisticated workflow generation following pattern conventions
-- Deep understanding of agent orchestration and execution modes
-- Complex decision-making for workflow structure and parameters
-- Multi-step workflow creation workflow
+- YAML frontmatter fields (name, description, tags, status, agents, parameters), execution phase structure, and success criteria are pinned down by the workflow pattern convention
+- Parity with peer agents: `repo-workflow-checker` and `repo-workflow-fixer` are both sonnet, and the three-agent trio should share a tier
+- Decisions about phase structure and agent coordination fit sonnet's structured-reasoning profile — opus was paying for capability the task doesn't use
+- Novel orchestration decisions (which agents, which execution mode) happen at plan-authoring time upstream; this agent just materializes them
 
 Create workflow documentation following workflow pattern convention.
 

--- a/.claude/agents/specs-maker.md
+++ b/.claude/agents/specs-maker.md
@@ -2,7 +2,7 @@
 name: specs-maker
 description: Creates new spec areas, missing README files, and scaffolds Gherkin feature structure at explicitly specified paths under specs/. Use when adding a new app or library to the specs directory.
 tools: Read, Write, Edit, Glob, Grep, Bash
-model:
+model: sonnet
 color: blue
 skills:
   - docs-applying-content-quality
@@ -15,9 +15,14 @@ skills:
 
 - **Role**: Maker (blue)
 - **Created**: 2026-03-13
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) for generating well-structured Gherkin specifications and README documentation that follows repository conventions and maintains consistency with existing spec areas.
+**Model Selection Justification**: This agent uses `model: sonnet` because spec scaffolding at explicitly specified paths is structural work, not open-ended creation:
+
+- The agent only creates content at paths the caller names — it never decides _what_ spec areas should exist
+- Gherkin feature structure, README format, and directory layout are defined by the `plan-writing-gherkin-criteria` skill and repository conventions
+- Parity with peer agents: `specs-checker` and `specs-fixer` are both sonnet, and the three-agent trio should share a tier
+- Template-driven scaffolding with a clear quality rubric matches the sonnet profile in the model-selection matrix
 
 ## Core Responsibility
 

--- a/.claude/agents/swe-e2e-test-developer.md
+++ b/.claude/agents/swe-e2e-test-developer.md
@@ -2,7 +2,7 @@
 name: swe-e2e-test-developer
 description: Develops end-to-end tests using Playwright following OSE Platform testing patterns and standards. Use when implementing E2E tests for OSE Platform applications.
 tools: Read, Write, Edit, Glob, Grep, Bash
-model:
+model: sonnet
 color: purple
 skills:
   - swe-developing-e2e-test-with-playwright
@@ -16,15 +16,14 @@ skills:
 
 - **Role**: Implementor (purple)
 - **Created**: 2026-02-08
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
+**Model Selection Justification**: This agent uses `model: sonnet` because Playwright E2E test authoring is pattern-driven with a dedicated skill and lower cost-of-regression than production application code:
 
-- Advanced reasoning for complex test scenario design and coverage analysis
-- Sophisticated understanding of Playwright-specific idioms and patterns
-- Deep knowledge of E2E testing best practices and anti-patterns
-- Complex problem-solving for test isolation, data management, and flaky test debugging
-- Multi-step test workflow orchestration (setup → execute → assert → cleanup)
+- The `swe-developing-e2e-test-with-playwright` skill documents locators, fixtures, waits, trace viewer, and anti-patterns; most decisions are rule-following within that skill
+- Test code is validated at runtime by CI — regressions surface fast and are cheap to fix, unlike bugs introduced into production application code by a language developer
+- Sonnet handles structured test authoring (Given-When-Then scenarios, page objects, fixture composition) comfortably; the creative work is designing what to test, which is an upstream decision
+- The 12 language developer agents (swe-typescript, swe-golang, etc.) stay on opus because production code has higher stakes and unforgiving idioms — E2E tests do not share that risk profile
 
 ## Core Expertise
 

--- a/.opencode/agent/agent-maker.md
+++ b/.opencode/agent/agent-maker.md
@@ -18,15 +18,14 @@ skills:
 
 - **Role**: Maker (blue)
 - **Created**: 2025-12-01
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
+**Model Selection Justification**: This agent uses `model: sonnet` because agent authoring is template-driven scaffolding governed by the `agent-developing-agents` skill:
 
-- Advanced reasoning to create well-structured AI agent files
-- Sophisticated frontmatter and prompt generation
-- Deep understanding of AI Agents Convention and Skills integration
-- Complex decision-making for tool selection and model choice
-- Multi-step agent creation workflow
+- YAML frontmatter and prompt structure are pinned down by the AI Agents Convention; the agent fills a template rather than inventing one
+- Tool-list, model-selection, and skills decisions follow explicit rules documented in the skill — sonnet-tier reasoning handles this comfortably
+- Structured content generation with a clear quality rubric matches the sonnet profile in the model-selection matrix
+- Opus remains appropriate for the novel decisions the agent author makes _before_ invoking this agent; the agent itself just materializes those decisions into a file
 
 Create new AI agent files following AI Agents Convention.
 

--- a/.opencode/agent/apps-oseplatform-web-content-maker.md
+++ b/.opencode/agent/apps-oseplatform-web-content-maker.md
@@ -18,15 +18,14 @@ skills:
 
 - **Role**: Maker (blue)
 - **Created**: 2025-12-20
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
+**Model Selection Justification**: This agent uses `model: sonnet` because oseplatform-web is a flat, English-only content platform with a simpler authoring profile than the bilingual AyoKoding makers:
 
-- Advanced reasoning to create engaging landing page content
-- Sophisticated content generation for Next.js 16 with tRPC
-- Deep understanding of landing page best practices
-- Complex decision-making for content structure and organization
-- Multi-step content creation workflow
+- English-only content removes the bilingual nuance that justifies opus for `apps-ayokoding-web-*-maker` agents
+- The `apps-oseplatform-web-developing-content` skill pins down landing page structure, date-prefixed filenames, frontmatter fields, and flat organization
+- Parity with peer agents: `apps-oseplatform-web-content-checker` and `apps-oseplatform-web-content-fixer` are both sonnet, and the three-agent trio should share a tier
+- Sonnet handles structured content generation with a quality rubric, matching the task profile
 
 Create landing page content for oseplatform-web (Next.js 16 with tRPC, English-only).
 

--- a/.opencode/agent/docs-file-manager.md
+++ b/.opencode/agent/docs-file-manager.md
@@ -1,6 +1,6 @@
 ---
 description: Expert at managing files and directories in docs/ directory. Use for renaming, moving, or deleting files/directories while maintaining kebab-case conventions, fixing links, and preserving git history.
-model: zai-coding-plan/glm-5.1
+model: zai-coding-plan/glm-5-turbo
 tools:
   bash: true
   edit: true
@@ -20,17 +20,19 @@ skills:
 
 - **Role**: Fixer (yellow)
 - **Created**: 2025-11-30
-- **Last Updated**: 2026-04-04
-- **Size Tier**: Tier 2 (standard agent with complex decision logic — cascading directory operations, multi-step link tracking, deletion safety analysis)
+- **Last Updated**: 2026-04-12
+- **Size Tier**: Tier 2 (standard agent — deterministic file operations with scripted link updates)
 
-**Model Selection Justification**: This agent uses `model: sonnet` because it requires advanced reasoning to:
+**Model Selection Justification**: This agent uses `model: haiku` to align with the canonical haiku example documented in the `agent-developing-agents` skill (SKILL.md §"Haiku Examples" → docs-file-manager). The work profile fits haiku's strengths:
 
-- Calculate cascading impacts when renaming directories (affects all files inside and all links pointing to them)
-- Validate kebab-case filename compliance per the file naming convention
-- Track and update all internal link references across the entire documentation tree
-- Validate relative path calculations for links at different nesting depths
-- Orchestrate complex multi-step operations (rename, move, delete, update links, update indices)
-- Assess deletion safety (ensure no broken links, verify files are truly unused)
+- Deterministic file operations (move, rename, delete) with clear pass/fail outcomes
+- Path manipulation and kebab-case compliance are pattern-matching against a regex rule
+- Internal link updates are mechanical find-and-replace driven by the `docs-validating-links` skill, not judgment calls
+- Git history preservation is handled via scripted commands (`git mv`), not reasoning
+- No novel decision-making — cascading rename impacts are enumerated procedurally, not inferred
+- Deletion safety is verified by link-graph traversal, a deterministic check rather than a judgment call
+
+Before this change the agent was sonnet, which contradicted the skill documentation that cited it as the canonical haiku example. The agent and the skill are now consistent.
 
 You are an expert at safely managing files and directories in the `docs/` folder while maintaining all conventions, fixing internal links, and preserving git history.
 

--- a/.opencode/agent/docs-maker.md
+++ b/.opencode/agent/docs-maker.md
@@ -19,15 +19,14 @@ skills:
 
 - **Role**: Maker (blue)
 - **Created**: 2025-11-29
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires advanced reasoning to create well-structured documentation. The agent requires:
+**Model Selection Justification**: This agent uses `model: sonnet` because Diátaxis-aligned documentation writing is structured content generation with a clear quality rubric:
 
-- Advanced reasoning to create well-structured documentation
-- Sophisticated content generation following Diu00e1taxis framework
-- Deep understanding of documentation quality standards
-- Complex decision-making for content organization and structure
-- Multi-step documentation creation workflow
+- The `docs-applying-diataxis-framework` and `docs-applying-content-quality` skills define structure (tutorial vs how-to vs reference vs explanation), heading hierarchy, accessibility rules, and GitHub-compatible markdown conventions
+- Parity with peer agents: `docs-checker` and `docs-fixer` are both sonnet, and the three-agent trio should share a tier
+- Sonnet's strength at structured long-form writing matches the task profile; the decisions are rule-following within a well-defined framework rather than novel invention
+- Pedagogically demanding tutorial authoring remains with opus via `docs-tutorial-maker` where narrative flow and learning progression justify the extra capability
 
 You are an expert technical documentation writer specializing in creating high-quality, GitHub-compatible markdown documentation. Your expertise includes:
 

--- a/.opencode/agent/plan-executor.md
+++ b/.opencode/agent/plan-executor.md
@@ -20,15 +20,15 @@ skills:
 
 - **Role**: Implementor (purple)
 - **Created**: 2025-12-28
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
+**Model Selection Justification**: This agent uses `model: sonnet` because plan execution is checklist-following with per-step validation rather than novel creative planning:
 
-- Advanced reasoning to execute project plans systematically
-- Sophisticated decision-making for implementation steps
-- Deep understanding of delivery checklists and validation
-- Complex workflow orchestration for sequential execution
-- Multi-step plan execution with progress tracking
+- Sequential execution of a pre-authored delivery checklist (the creative work is already in the plan)
+- Per-step validation against acceptance criteria with clear pass/fail outcomes
+- Multi-step orchestration of well-defined operations — the model-selection matrix in `agent-developing-agents` identifies this as sonnet territory
+- Parity with peer agents: `plan-checker` and `plan-execution-checker` are both sonnet, so the executor should not be a stronger tier than the checker that judges its work
+- Creative planning decisions stay with opus-tier `plan-maker`; `plan-executor` only executes what that agent produced
 
 You are an expert at systematically executing project plans by following delivery checklists, implementing each step, validating work, and tracking progress.
 

--- a/.opencode/agent/readme-maker.md
+++ b/.opencode/agent/readme-maker.md
@@ -18,15 +18,14 @@ skills:
 
 - **Role**: Maker (blue)
 - **Created**: 2025-12-15
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
+**Model Selection Justification**: This agent uses `model: sonnet` because README authoring is structured content generation against a tight, well-defined rubric:
 
-- Advanced reasoning to create engaging, accessible README content
-- Sophisticated content generation for problem-solution hooks
-- Deep understanding of plain language and scannable structure
-- Complex decision-making for benefits-focused messaging
-- Multi-dimensional quality content creation
+- The `readme-writing-readme-files` skill pins down the structure (problem-solution hook, plain language, paragraph limits, scannable hierarchy), so most decisions are rule-following rather than open-ended creation
+- Parity with peer agents: `readme-checker` and `readme-fixer` are both sonnet, and the three-agent trio should operate at a consistent tier
+- Sonnet's strength at structured writing matches the task profile described in the `agent-developing-agents` decision framework
+- Creative tradeoffs (benefits-focused messaging, tone) are well within sonnet's capability; opus was overkill for the decisions actually being made
 
 You are a README content creator specializing in writing engaging, accessible, and welcoming README content while maintaining technical accuracy.
 
@@ -83,25 +82,9 @@ Clarify what needs to be written or updated:
 
 ```bash
 # Read current README
-
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
-
-- Advanced reasoning to create engaging, accessible README content
-- Sophisticated content generation for problem-solution hooks
-- Deep understanding of plain language and scannable structure
-- Complex decision-making for benefits-focused messaging
-- Multi-dimensional quality content creation
 Read README.md
 
 # Read related docs for context
-
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
-
-- Advanced reasoning to create engaging, accessible README content
-- Sophisticated content generation for problem-solution hooks
-- Deep understanding of plain language and scannable structure
-- Complex decision-making for benefits-focused messaging
-- Multi-dimensional quality content creation
 Read AGENTS.md
 Grep "relevant keywords" in docs/
 ```
@@ -141,25 +124,9 @@ Before finalizing, check (see `readme-writing-readme-files` Skill for complete c
 
 ```bash
 # For new content
-
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
-
-- Advanced reasoning to create engaging, accessible README content
-- Sophisticated content generation for problem-solution hooks
-- Deep understanding of plain language and scannable structure
-- Complex decision-making for benefits-focused messaging
-- Multi-dimensional quality content creation
 Edit README.md
 
 # Or for complete rewrite
-
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
-
-- Advanced reasoning to create engaging, accessible README content
-- Sophisticated content generation for problem-solution hooks
-- Deep understanding of plain language and scannable structure
-- Complex decision-making for benefits-focused messaging
-- Multi-dimensional quality content creation
 Write README.md
 ```
 

--- a/.opencode/agent/repo-workflow-maker.md
+++ b/.opencode/agent/repo-workflow-maker.md
@@ -20,15 +20,14 @@ skills:
 
 - **Role**: Maker (blue)
 - **Created**: 2025-12-28
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
+**Model Selection Justification**: This agent uses `model: sonnet` because workflow authoring is template filling against the `repo-defining-workflows` convention:
 
-- Advanced reasoning to create standardized workflow documentation
-- Sophisticated workflow generation following pattern conventions
-- Deep understanding of agent orchestration and execution modes
-- Complex decision-making for workflow structure and parameters
-- Multi-step workflow creation workflow
+- YAML frontmatter fields (name, description, tags, status, agents, parameters), execution phase structure, and success criteria are pinned down by the workflow pattern convention
+- Parity with peer agents: `repo-workflow-checker` and `repo-workflow-fixer` are both sonnet, and the three-agent trio should share a tier
+- Decisions about phase structure and agent coordination fit sonnet's structured-reasoning profile — opus was paying for capability the task doesn't use
+- Novel orchestration decisions (which agents, which execution mode) happen at plan-authoring time upstream; this agent just materializes them
 
 Create workflow documentation following workflow pattern convention.
 

--- a/.opencode/agent/specs-maker.md
+++ b/.opencode/agent/specs-maker.md
@@ -19,9 +19,14 @@ skills:
 
 - **Role**: Maker (blue)
 - **Created**: 2026-03-13
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) for generating well-structured Gherkin specifications and README documentation that follows repository conventions and maintains consistency with existing spec areas.
+**Model Selection Justification**: This agent uses `model: sonnet` because spec scaffolding at explicitly specified paths is structural work, not open-ended creation:
+
+- The agent only creates content at paths the caller names — it never decides _what_ spec areas should exist
+- Gherkin feature structure, README format, and directory layout are defined by the `plan-writing-gherkin-criteria` skill and repository conventions
+- Parity with peer agents: `specs-checker` and `specs-fixer` are both sonnet, and the three-agent trio should share a tier
+- Template-driven scaffolding with a clear quality rubric matches the sonnet profile in the model-selection matrix
 
 ## Core Responsibility
 

--- a/.opencode/agent/swe-e2e-test-developer.md
+++ b/.opencode/agent/swe-e2e-test-developer.md
@@ -20,15 +20,14 @@ skills:
 
 - **Role**: Implementor (purple)
 - **Created**: 2026-02-08
-- **Last Updated**: 2026-04-04
+- **Last Updated**: 2026-04-12
 
-**Model Selection Justification**: This agent uses inherited `model: opus` (omit model field) because it requires:
+**Model Selection Justification**: This agent uses `model: sonnet` because Playwright E2E test authoring is pattern-driven with a dedicated skill and lower cost-of-regression than production application code:
 
-- Advanced reasoning for complex test scenario design and coverage analysis
-- Sophisticated understanding of Playwright-specific idioms and patterns
-- Deep knowledge of E2E testing best practices and anti-patterns
-- Complex problem-solving for test isolation, data management, and flaky test debugging
-- Multi-step test workflow orchestration (setup → execute → assert → cleanup)
+- The `swe-developing-e2e-test-with-playwright` skill documents locators, fixtures, waits, trace viewer, and anti-patterns; most decisions are rule-following within that skill
+- Test code is validated at runtime by CI — regressions surface fast and are cheap to fix, unlike bugs introduced into production application code by a language developer
+- Sonnet handles structured test authoring (Given-When-Then scenarios, page objects, fixture composition) comfortably; the creative work is designing what to test, which is an upstream decision
+- The 12 language developer agents (swe-typescript, swe-golang, etc.) stay on opus because production code has higher stakes and unforgiving idioms — E2E tests do not share that risk profile
 
 ## Core Expertise
 

--- a/governance/development/agents/ai-agents.md
+++ b/governance/development/agents/ai-agents.md
@@ -670,9 +670,9 @@ For complete model selection standards, see the [Model Selection Convention](./m
 
 **Three tiers**:
 
-- **Opus** (default): Omit the `model` field. For creative reasoning, code generation, architectural decisions, and nuanced content creation (makers, developers).
-- **Sonnet** (`model: sonnet`): For rule-based validation, applying validated fixes, template-driven output, and structured pattern-following tasks (checkers, fixers).
-- **Haiku** (`model: haiku`): For purely mechanical tasks with no reasoning required -- URL validation, deployment scripts, simple command execution (deployers, link checkers).
+- **Opus** (default): Omit the `model` field. For creative reasoning, code generation, architectural decisions, and nuanced content creation (creative makers, language developers).
+- **Sonnet** (`model: sonnet`): For rule-based validation, applying validated fixes, template-driven output, structured pattern-following tasks, and plan execution (checkers, fixers, structured makers, plan-executor, swe-e2e-test-developer).
+- **Haiku** (`model: haiku`): For purely mechanical tasks with no reasoning required -- URL validation, deployment scripts, deterministic file operations, simple command execution (deployers, link checkers, docs-file-manager).
 
 ### Model Selection Decision Tree
 
@@ -906,7 +906,7 @@ All agent colors are from the verified accessible palette:
 name: docs-maker
 description: Expert documentation writer specializing in GitHub-compatible markdown and Diátaxis framework. Use when creating, editing, or organizing project documentation.
 tools: Read, Write, Edit, Glob, Grep
-model:
+model: sonnet
 color: blue
 ---
 ```
@@ -954,7 +954,7 @@ Colored square emojis follow the [Emoji Usage Convention](../../conventions/form
 name: docs-maker
 description: Expert documentation writer specializing in GitHub-compatible markdown and Diátaxis framework. Use when creating, editing, or organizing project documentation.
 tools: Read, Write, Edit, Glob, Grep
-model:
+model: sonnet
 color: blue
 ---
 ```

--- a/governance/development/agents/model-selection.md
+++ b/governance/development/agents/model-selection.md
@@ -73,13 +73,12 @@ Model selection directly affects agent quality, latency, and resource efficiency
 
 - **SWE developers** (all language-specific agents) -- generate and refactor production code across diverse language ecosystems, requiring deep understanding of idioms, patterns, and trade-offs
 - **plan-maker** -- creates project plans requiring scope analysis, dependency mapping, and strategic sequencing
-- **plan-executor** -- executes complex plans with conditional logic, error recovery, and adaptive decision-making
-- **Content makers** (docs-maker, docs-tutorial-maker, apps-\*-maker, swe-ui-maker) -- produce original content requiring domain knowledge, pedagogical judgment, and audience awareness
-- **agent-maker** -- designs new agents requiring understanding of the governance architecture, tool permissions, and agent ecosystem
+- **docs-tutorial-maker** -- produces tutorial content requiring pedagogical reasoning, narrative flow, and learning progression design
+- **apps-ayokoding-web-by-example-maker** -- creates 75-85 heavily annotated code examples requiring pedagogical progression and bilingual content
+- **apps-ayokoding-web-in-the-field-maker** -- produces production implementation guides requiring framework integration and quality bar judgment
+- **apps-ayokoding-web-general-maker** -- creates bilingual educational content requiring audience awareness and language nuance
+- **swe-ui-maker** -- creates UI components requiring CVA variants, Radix composition, accessibility, tests, and stories in one pass
 - **repo-governance-maker** -- creates governance documents requiring architectural reasoning about layer relationships and traceability
-- **repo-workflow-maker** -- designs multi-step workflows requiring understanding of agent capabilities and orchestration patterns
-- **readme-maker** -- produces project documentation requiring codebase comprehension and audience-appropriate framing
-- **specs-maker** -- creates technical specifications requiring domain modeling and API design judgment
 
 **Frontmatter**: Omit the `model` field (inherits the default, which is opus-tier).
 
@@ -111,8 +110,11 @@ Note: `model` field is omitted — inherits opus tier (creative reasoning, code 
 **Agent examples**:
 
 - **All checkers** -- validate content against conventions using defined rulesets and produce structured audit reports (docs-checker, docs-tutorial-checker, docs-software-engineering-separation-checker, readme-checker, specs-checker, repo-governance-checker, repo-workflow-checker, plan-checker, plan-execution-checker, swe-code-checker, swe-ui-checker, ci-checker, apps-\*-checker)
-- **All fixers** -- apply corrections from checker audit reports following documented fix procedures (docs-fixer, docs-tutorial-fixer, docs-software-engineering-separation-fixer, docs-file-manager, readme-fixer, specs-fixer, repo-governance-fixer, repo-workflow-fixer, plan-fixer, swe-ui-fixer, ci-fixer, apps-\*-fixer)
+- **Most fixers** -- apply corrections from checker audit reports following documented fix procedures (docs-fixer, docs-tutorial-fixer, docs-software-engineering-separation-fixer, readme-fixer, specs-fixer, repo-governance-fixer, repo-workflow-fixer, plan-fixer, swe-ui-fixer, ci-fixer, apps-\*-fixer)
 - **social-linkedin-post-maker** -- generates social media posts following a defined template and tone guidelines
+- **Structured makers** -- makers with tight, well-defined skills that pin down most decisions, making them rule-following rather than open-ended creation (docs-maker, readme-maker, agent-maker, specs-maker, repo-workflow-maker, apps-oseplatform-web-content-maker)
+- **plan-executor** -- executes pre-authored delivery checklists step-by-step with per-step validation; the creative planning decisions were already made by opus-tier plan-maker
+- **swe-e2e-test-developer** -- writes Playwright E2E tests following a dedicated skill with defined patterns (locators, fixtures, waits); lower stakes than production code written by language developer agents
 
 **Frontmatter**: Specify `model: sonnet` explicitly.
 
@@ -144,6 +146,7 @@ color: green
 
 - **Deployers** (apps-ayokoding-web-deployer, apps-oseplatform-web-deployer, apps-organiclever-fe-deployer) -- execute git branch operations and deployment commands following a fixed procedure
 - **Link checkers** (docs-link-general-checker, apps-ayokoding-web-link-checker) -- validate URLs by checking HTTP status codes and managing cache files
+- **docs-file-manager** -- performs deterministic file operations (move, rename, delete) with `git mv`, kebab-case pattern matching, and mechanical link updates; no judgment calls required
 
 **Frontmatter**: Specify `model: haiku` explicitly.
 
@@ -222,14 +225,14 @@ For a deployer agent:
 
 ## Tier Comparison Summary
 
-| Dimension              | Opus (inherit)              | Sonnet                      | Haiku                       |
-| ---------------------- | --------------------------- | --------------------------- | --------------------------- |
-| **Reasoning depth**    | Deep, multi-step            | Moderate, rule-based        | Minimal, mechanical         |
-| **Creativity**         | High (novel solutions)      | Low (follows templates)     | None (fixed procedures)     |
-| **Task ambiguity**     | Handles open-ended problems | Handles structured problems | Requires deterministic flow |
-| **Output originality** | Creates new content/code    | Transforms per rules        | Executes predefined steps   |
-| **Error recovery**     | Adapts to unexpected states | Follows fallback rules      | Fails or retries            |
-| **Typical agents**     | Makers, developers          | Checkers, fixers            | Deployers, link checkers    |
+| Dimension              | Opus (inherit)              | Sonnet                              | Haiku                                  |
+| ---------------------- | --------------------------- | ----------------------------------- | -------------------------------------- |
+| **Reasoning depth**    | Deep, multi-step            | Moderate, rule-based                | Minimal, mechanical                    |
+| **Creativity**         | High (novel solutions)      | Low (follows templates)             | None (fixed procedures)                |
+| **Task ambiguity**     | Handles open-ended problems | Handles structured problems         | Requires deterministic flow            |
+| **Output originality** | Creates new content/code    | Transforms per rules                | Executes predefined steps              |
+| **Error recovery**     | Adapts to unexpected states | Follows fallback rules              | Fails or retries                       |
+| **Typical agents**     | Creative makers, developers | Checkers, fixers, structured makers | Deployers, link checkers, file manager |
 
 ## Common Mistakes
 
@@ -259,6 +262,22 @@ Link checker agents (docs-link-general-checker, apps-ayokoding-web-link-checker)
 ### Social Media Maker as Sonnet
 
 The social-linkedin-post-maker uses sonnet despite being a "maker" agent. This is because LinkedIn post generation follows a rigid template and tone guide, making it a structured pattern-following task rather than creative content creation.
+
+### Structured Makers as Sonnet
+
+Several maker agents use sonnet because their output is structured by tight skills with well-defined rubrics (docs-maker, readme-maker, agent-maker, specs-maker, repo-workflow-maker, apps-oseplatform-web-content-maker). Each has a sonnet checker and sonnet fixer in its maker-checker-fixer trio, and the skill pins down most decisions. Contrast with opus-tier makers (plan-maker, docs-tutorial-maker, swe-ui-maker, apps-ayokoding-web-\*-maker) where the creative work is open-ended, pedagogically demanding, or multi-concern.
+
+### Plan Executor as Sonnet
+
+The plan-executor uses sonnet despite being a "purple" implementor. It follows pre-authored delivery checklists step-by-step — the creative planning was already done by opus-tier plan-maker. Both plan-checker and plan-execution-checker are sonnet; the executor should not be a stronger tier than the checker that judges its work.
+
+### E2E Test Developer as Sonnet
+
+The swe-e2e-test-developer uses sonnet despite the other 12 language developer agents being opus. Playwright E2E tests are pattern-driven (locators, fixtures, waits) with a dedicated skill, and test code regressions surface fast in CI. Production application code written by the language developers has higher stakes and unforgiving idioms, justifying their continued opus tier.
+
+### File Manager as Haiku
+
+The docs-file-manager uses haiku despite being categorized as a fixer (yellow). This is because its operations are deterministic file manipulation (`git mv`, `git rm`, find-and-replace link updates) with no judgment calls. The `agent-developing-agents` skill cites it as the canonical haiku example.
 
 ## Tools and Automation
 
@@ -294,4 +313,4 @@ The following agents enforce or assist with model selection:
 
 ---
 
-**Last Updated**: 2026-04-03
+**Last Updated**: 2026-04-12


### PR DESCRIPTION
## Summary

- Move 8 agents from opus (inherit) to **sonnet** where their work is structured, skill-driven, or template-following rather than open-ended creative reasoning
- Fix `docs-file-manager` from sonnet to **haiku** — resolves contradiction with `agent-developing-agents` skill which already cited it as the canonical haiku example
- Fix pre-existing corruption in `readme-maker.md` (stale opus justification blocks duplicated inside bash code fences)
- Update governance docs: `model-selection.md` (agent catalogs, special considerations), `ai-agents.md` (tier summaries, example frontmatter)
- Sync all changes to `.opencode/agent/` via `rhino-cli`

### Agents moved opus → sonnet (8)

| Agent | Rationale |
|---|---|
| `plan-executor` | Follows pre-authored delivery checklists; checker that judges it is also sonnet |
| `readme-maker` | Structured writing against `readme-writing-readme-files` skill rubric |
| `agent-maker` | Template-driven frontmatter + prompt assembly per AI Agents Convention |
| `specs-maker` | Gherkin scaffolding at caller-specified paths |
| `repo-workflow-maker` | Fills workflow pattern convention template |
| `docs-maker` | Diátaxis-aligned structured docs with quality skill |
| `apps-oseplatform-web-content-maker` | Flat English-only content; simpler than bilingual AyoKoding makers |
| `swe-e2e-test-developer` | Pattern-driven Playwright tests with dedicated skill; lower stakes than language developers |

### Agent moved sonnet → haiku (1)

| Agent | Rationale |
|---|---|
| `docs-file-manager` | Deterministic file ops (`git mv`, link find-and-replace); aligns with `agent-developing-agents` skill haiku example |

### What stays opus (not changed)

- `plan-maker`, `repo-governance-maker` — novel cross-cutting decisions
- `docs-tutorial-maker`, `apps-ayokoding-web-*-maker`, `swe-ui-maker` — pedagogical/multi-concern creative work
- All 12 `swe-*-developer` language agents — production code with high stakes

### Known pre-existing issue (out of scope)

- `ai-agents.md` line ~318 shows `apps-ayokoding-web-general-maker` with `model: sonnet` but the actual agent file uses opus (inherit). This predates this PR and should be addressed separately.

## Test plan

- [x] All 9 `.claude/agents/*.md` files have correct `model:` frontmatter
- [x] All 9 `.opencode/agent/*.md` mirrors synced with correct OpenCode model IDs
- [x] `governance/development/agents/model-selection.md` updated with correct agent catalogs
- [x] `governance/development/agents/ai-agents.md` updated with consistent tier summaries and example blocks
- [x] No residual "inherited `model: opus`" text in any of the 9 changed agent files
- [x] Pre-commit hooks pass (prettier, config validation)
- [x] Pre-push hooks pass (nx affected, markdownlint — 0 errors)
- [ ] Spot-check agent generation quality on a follow-up task (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)