### PR TITLE
docs(ayokoding-web): bump example counts to 93 in patterns parent overviews

### DIFF
--- a/apps/ayokoding-web/content/en/learn/software-engineering/software-architecture/overview.md
+++ b/apps/ayokoding-web/content/en/learn/software-engineering/software-architecture/overview.md
@@ -19,7 +19,7 @@ Both disciplines complement each other. An e-commerce monolith primarily needs s
 
 This section explores proven architectural methodologies used in modern software engineering:
 
-- **By Example** (umbrella): 85 heavily annotated examples across all patterns, available in OOP (Java, Kotlin, C#, TypeScript) and FP (F#, Clojure, TypeScript, Haskell) variants
+- **By Example** (umbrella): 93 heavily annotated examples — 85 canonical + 5 FP-native extras (#86–90: ROP, Free Monads / Tagless Final, Reader, Kleisli, State) + 3 OOP-native extras (#91–93: Active Record, GRASP, Singleton-with-FP-counterexample). Available in OOP (Java, Kotlin, C#, TypeScript) and FP (F#, Clojure, TypeScript, Haskell) variants with explicit paradigm-fit framing (Norvig/Seemann/Wlaschin/Hickey/Evans/Fowler citations)
 - **C4 Model**: Hierarchical approach to visualizing software architecture at multiple levels of abstraction (Context, Containers, Components, Code)
 - **Domain-Driven Design (DDD)**: Strategic and tactical patterns for modeling complex business domains and organizing code around business concepts
 - **Hexagonal Architecture**: Ports-and-adapters approach that isolates the domain core from external concerns (databases, frameworks, UIs)

--- a/apps/ayokoding-web/content/en/learn/software-engineering/software-architecture/patterns-and-principles/_index.md
+++ b/apps/ayokoding-web/content/en/learn/software-engineering/software-architecture/patterns-and-principles/_index.md
@@ -5,7 +5,7 @@ date: 2026-03-20T00:00:00+07:00
 draft: false
 type: docs
 layout: list
-description: "Learn software architecture through 85 heavily annotated examples covering patterns, principles, styles, trade-offs, and real-world architectural decisions (95% coverage), in paradigm-specific variants"
+description: "Learn software architecture through 93 heavily annotated examples (85 canonical + 5 FP-native extras + 3 OOP-native extras) covering patterns, principles, styles, trade-offs, and real-world architectural decisions (95% coverage), in paradigm-specific variants with explicit paradigm-fit framing"
 ---
 
 - [Overview](/en/learn/software-engineering/software-architecture/patterns-and-principles/overview)

--- a/apps/ayokoding-web/content/en/learn/software-engineering/software-architecture/patterns-and-principles/in-fp-by-example/_index.md
+++ b/apps/ayokoding-web/content/en/learn/software-engineering/software-architecture/patterns-and-principles/in-fp-by-example/_index.md
@@ -5,7 +5,7 @@ date: 2026-05-17T00:00:00+07:00
 draft: false
 type: docs
 layout: list
-description: "FP variant — learn software architecture through 85 heavily annotated examples in F# (canonical), Clojure, TypeScript, and Haskell, covering patterns, principles, styles, trade-offs, and real-world architectural decisions (95% coverage)"
+description: "FP variant — learn software architecture through 93 heavily annotated examples (85 canonical + 5 FP-native extras + 3 OOP-native stubs for parity) in F# (canonical), Clojure, TypeScript, and Haskell, covering patterns, principles, styles, trade-offs, and real-world architectural decisions (95% coverage)"
 tags: ["software-architecture", "tutorial", "by-example", "fp", "fsharp", "clojure", "typescript", "haskell"]
 ---
 

--- a/apps/ayokoding-web/content/en/learn/software-engineering/software-architecture/patterns-and-principles/in-oop-by-example/_index.md
+++ b/apps/ayokoding-web/content/en/learn/software-engineering/software-architecture/patterns-and-principles/in-oop-by-example/_index.md
@@ -5,7 +5,7 @@ date: 2026-05-17T00:00:00+07:00
 draft: false
 type: docs
 layout: list
-description: "OOP variant — learn software architecture through 85 heavily annotated examples covering patterns, principles, styles, trade-offs, and real-world architectural decisions (95% coverage), with code in Java, Kotlin, and C#"
+description: "OOP variant — learn software architecture through 93 heavily annotated examples (85 canonical + 5 FP-native stubs for parity + 3 OOP-native extras) covering patterns, principles, styles, trade-offs, and real-world architectural decisions (95% coverage), with code in Java, Kotlin, C#, and TypeScript"
 tags: ["software-architecture", "tutorial", "by-example", "oop"]
 ---
 

--- a/apps/ayokoding-web/content/en/learn/software-engineering/software-architecture/patterns-and-principles/overview.md
+++ b/apps/ayokoding-web/content/en/learn/software-engineering/software-architecture/patterns-and-principles/overview.md
@@ -3,29 +3,42 @@ title: "Overview"
 date: 2026-05-18T00:00:00+07:00
 draft: false
 weight: 10000000
-description: "Software architecture patterns and principles — SOLID, GRASP, GoF patterns, architectural styles, trade-offs, and real-world decisions taught through 85 annotated examples across two paradigm tracks (OOP and FP)"
+description: "Software architecture patterns and principles — SOLID, GRASP, GoF patterns, architectural styles, trade-offs, and real-world decisions taught through 93 annotated examples (85 canonical + 5 FP-native extras + 3 OOP-native extras) across two paradigm tracks (OOP and FP) with explicit paradigm-fit framing"
 tags:
   ["software-architecture", "patterns", "principles", "solid", "design-patterns", "tutorial", "clojure", "typescript"]
 ---
 
-**You can read every chapter of the Gang of Four and still not know when to reach for a Strategy versus a sealed hierarchy, when SOLID becomes over-engineering, or how an Observer differs from a Domain Event in a production codebase.** This section answers those questions through 85 heavily annotated examples — the same 85 conceptual examples implemented twice, once in OOP and once in FP, so you can see exactly how each pattern and principle changes shape across paradigms.
+**You can read every chapter of the Gang of Four and still not know when to reach for a Strategy versus a sealed hierarchy, when SOLID becomes over-engineering, or how an Observer differs from a Domain Event in a production codebase.** This section answers those questions through 93 heavily annotated examples — the canonical 85 implemented twice (once in OOP and once in FP), plus 5 FP-native extras (#86–90) and 3 OOP-native extras (#91–93) that exist primarily in one paradigm. Every example is paired across both tracks with explicit paradigm-fit framing, so you see exactly how each pattern and principle changes shape across paradigms.
 
 ## What's in this section
 
-Two parallel paradigm tracks, each covering the same 85-example progression:
+Two parallel paradigm tracks, each covering the same 93-example progression:
 
 - [Patterns and Principles in OOP](/en/learn/software-engineering/software-architecture/patterns-and-principles/in-oop-by-example) — Java, Kotlin, C#, and TypeScript examples emphasising classes, interfaces, sealed hierarchies, and pattern-matching
-- [Patterns and Principles in FP](/en/learn/software-engineering/software-architecture/patterns-and-principles/in-fp-by-example) — F#, Clojure, and TypeScript examples emphasising records, discriminated unions, function composition, and pipeline-shaped data flow
+- [Patterns and Principles in FP](/en/learn/software-engineering/software-architecture/patterns-and-principles/in-fp-by-example) — F#, Clojure, TypeScript, and Haskell examples emphasising records, discriminated unions, function composition, and pipeline-shaped data flow
 
-Each FP example carries the same number and conceptual title as its OOP counterpart, enabling direct cross-paradigm comparison.
+Each example carries the same number and conceptual title across both tracks, enabling direct cross-paradigm comparison. For paradigm-foreign patterns, the "non-native" track shows a stub pointing to the native form rather than a contrived reproduction.
+
+## Paradigm-fit framing
+
+Many examples carry a **Paradigm Note** banner citing authoritative sources (Norvig 1996, Seemann, Wlaschin, Hickey, Evans, Fowler) explaining whether the pattern is FP-native, OOP-native, or paradigm-neutral. The classification uses four buckets:
+
+- **NEUTRAL** — paradigm-agnostic concept (microservices, hexagonal architecture, distributed tracing). Both tracks teach legitimately.
+- **OOP-NATIVE** — pattern emerged from OOP. Norvig classified 16 of 23 GoF patterns as absorbed by FP language features (first-class functions, ADTs, modules). The FP track shows the native FP idiom rather than reproducing the OOP shape.
+- **OOP-NATIVE-BUT-TRANSFERABLE** — OOP roots, but the concept transfers cleanly (SOLID, DDD aggregates, Repository). The paradigm note explains the FP encoding.
+- **FP-NATIVE** — pattern emerged from or expresses most naturally in FP (Railway-Oriented Programming, Free Monads, Reader/State monads, Event Sourcing fold, FRP, Kleisli composition).
+
+Banners link to the sibling tutorial so you can compare a pattern's expression in both paradigms side-by-side.
 
 ## What you will learn
 
-The 85 examples are split into three progressive levels:
+The 93 examples are split into three canonical progressive levels plus two paradigm-native addenda:
 
 - **Beginner (Examples 1–28)**: Foundational principles — SOLID, DRY, KISS, YAGNI, coupling and cohesion, layered architecture, repository pattern, service layer, DTOs, dependency injection.
 - **Intermediate (Examples 29–57)**: Composite patterns — Hexagonal Architecture, Clean Architecture, Onion Architecture, GoF behavioural and creational patterns (Strategy, Factory, Builder, Observer, Adapter, Decorator, Command), domain events, event-driven architecture.
 - **Advanced (Examples 58–85)**: Distributed systems — CQRS, event sourcing, saga pattern, circuit breaker, bulkhead, microservices boundaries, distributed transactions, eventual consistency, and the production trade-offs that go with each.
+- **FP-Native Extras (Examples 86–90)**: Railway-Oriented Programming, Free Monads / Tagless Final, Reader Monad DI, Kleisli composition, State Monad. Full treatment lives in the FP track; the OOP track carries stubs.
+- **OOP-Native Extras (Examples 91–93)**: Active Record, GRASP responsibility assignment, Singleton with FP counterexample. Full treatment lives in the OOP track; the FP track carries stubs.
 
 ## Structure of each example
 
@@ -50,5 +63,5 @@ A Strategy pattern in Java is an interface plus implementations plus a construct
 ## What this section is not
 
 - **Not a language tutorial.** You should already be comfortable writing classes in Java/Kotlin/C#/TypeScript (for the OOP track) or functions and records in F#/Clojure/TypeScript (for the FP track).
-- **Not a complete reference of every pattern in existence.** It covers the 85 examples that matter most in modern enterprise codebases. Specialised patterns (parser combinators, free monads, GoF Flyweight) are mentioned only when they illustrate a broader principle.
+- **Not a complete reference of every pattern in existence.** It covers the 93 examples that matter most in modern enterprise codebases (85 canonical + 8 paradigm-native extras). Specialised patterns (parser combinators, GoF Flyweight, Memento) are mentioned only when they illustrate a broader principle.
 - **Not framework-specific.** Examples lean on standard libraries and minimal framework usage so the architectural intent stays visible. Framework-specific wiring (Spring beans, ASP.NET DI containers, Giraffe pipelines) shows up only in the [Cases](/en/learn/software-engineering/software-architecture/cases) section.


### PR DESCRIPTION
## Summary

- Updates parent overviews and _index files for software-architecture and patterns-and-principles to reflect the new 93-example structure (85 canonical + 5 FP-native extras #86-90 + 3 OOP-native extras #91-93)
- Adds paradigm-fit framing section to patterns-and-principles/overview.md documenting NEUTRAL/OOP-NATIVE/OOP-TRANSFERABLE/FP-NATIVE classification with Norvig/Seemann/Wlaschin/Hickey/Evans/Fowler citations
- Follow-up to fc095e84d (the per-file overviews and example bodies)

## Files
- apps/ayokoding-web/content/en/learn/software-engineering/software-architecture/overview.md
- apps/ayokoding-web/content/en/learn/software-engineering/software-architecture/patterns-and-principles/_index.md
- apps/ayokoding-web/content/en/learn/software-engineering/software-architecture/patterns-and-principles/overview.md
- apps/ayokoding-web/content/en/learn/software-engineering/software-architecture/patterns-and-principles/in-fp-by-example/_index.md
- apps/ayokoding-web/content/en/learn/software-engineering/software-architecture/patterns-and-principles/in-oop-by-example/_index.md

## Test plan
- [x] markdownlint passes (`npm run lint:md` 0 errors)
- [ ] Vercel preview deploy renders new copy on patterns-and-principles overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)