### PR TITLE
ci: auto-format affected files on PRs via lint-staged (commit to PR branch)

### DIFF
--- a/.github/workflows/commons-quality-gate.yml
+++ b/.github/workflows/commons-quality-gate.yml
@@ -60,12 +60,33 @@ jobs:
           fi
 
   format:
-    name: Format check (Prettier)
+    name: Auto-format affected (lint-staged)
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
       - uses: ./.github/actions/setup-node
-      - run: npx prettier --check .
+      - name: Format affected files with the project formatters (lint-staged)
+        run: |
+          git fetch --no-tags origin "$GITHUB_BASE_REF"
+          CHANGED=$(git diff --name-only --diff-filter=ACMR "origin/$GITHUB_BASE_REF...HEAD")
+          if [ -n "$CHANGED" ]; then
+            printf '%s' "$CHANGED" | tr '\n' '\0' | xargs -0 -r git add --
+            npx lint-staged --no-stash
+          fi
+      - name: Commit formatting to the PR branch
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -am "style: auto-format affected files (lint-staged)"
+            git push origin "HEAD:$GITHUB_HEAD_REF"
+          fi
 
   shellcheck:
     name: Shell lint (ShellCheck)
@@ -189,7 +210,7 @@ jobs:
 
   quality-gate:
     name: Quality gate
-    needs: [detect, format, shellcheck, hadolint, actionlint, typescript, dotnet, rust, markdown, naming, specs-gate]
+    needs: [detect, shellcheck, hadolint, actionlint, typescript, dotnet, rust, markdown, naming, specs-gate]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What
Replaces the whole-repo `npx prettier --check .` job with an **auto-format** job that, on `pull_request`, runs the project's **lint-staged** formatters (prettier/gofmt/fantomas/rustfmt/ruff/format scripts) on the **affected files** (`git diff origin/<base>...HEAD`) and **commits the result to the PR head branch** (not main). No longer a blocking gate (removed from the aggregate `quality-gate` `needs`).

## Why
The whole-repo check flaked on the self-hosted runner (setup-node returning an HTML error page) and tripped on concurrent / gitignored-generated files it did not own. Local pre-commit already runs lint-staged on staged files; this CI job is the safety net that **fixes instead of failing**.

## Notes
- Runs only on `pull_request` (no PR branch to commit to on push-to-main).
- Job-scoped `permissions: contents: write`; pushes as `github-actions[bot]` to `$GITHUB_HEAD_REF` (GITHUB_TOKEN pushes don't re-trigger workflows — no loop).
- Uses `lint-staged --no-stash` so each file type is formatted by the project's configured tool; prettier types work with setup-node alone, polyglot types use the runner toolchain.
- Identical change across ose-public / ose-primer / ose-infra.