### PR TITLE
feat(ayokoding-www): add Pass-0 capstone forge-ready (Phase 4)

### DIFF
--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/_index.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/_index.md
@@ -10,3 +10,4 @@ weight: 107
   - [1 · Just Enough Nvim](/en/c/learn/fundamentally-strong/software-engineer/just-enough-nvim)
   - [2 · Just Enough Lua](/en/c/learn/fundamentally-strong/software-engineer/just-enough-lua)
   - [3 · Extending Neovim](/en/c/learn/fundamentally-strong/software-engineer/extending-neovim)
+  - [Pass 0 Capstone · Forge-Ready](/en/c/learn/fundamentally-strong/software-engineer/capstone-forge-ready)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/_index.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/_index.md
@@ -15,3 +15,5 @@ weight: 1750
 - [3 · Extending Neovim](/en/c/learn/fundamentally-strong/software-engineer/extending-neovim)
   - [Learning](/en/c/learn/fundamentally-strong/software-engineer/extending-neovim/learning)
   - [Drilling](/en/c/learn/fundamentally-strong/software-engineer/extending-neovim/drilling)
+- [Pass 0 Capstone · Forge-Ready](/en/c/learn/fundamentally-strong/software-engineer/capstone-forge-ready)
+  - [Overview](/en/c/learn/fundamentally-strong/software-engineer/capstone-forge-ready/overview)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/_index.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Pass 0 Capstone · Forge-Ready"
+date: 2026-07-14T00:00:00+07:00
+draft: false
+weight: 135
+---
+
+- [Overview](/en/c/learn/fundamentally-strong/software-engineer/capstone-forge-ready/overview)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/init.lua
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/init.lua
@@ -1,0 +1,27 @@
+-- init.lua -- Pass-0 capstone forge: complete config entry point
+-- Reproducible from an empty ~/.config/nvim: copy this whole nvim-config/ tree into
+-- $XDG_CONFIG_HOME/nvim (default ~/.config/nvim) and restart Neovim.
+-- Reuses topic-03 (Extending Neovim)'s proven capstone config verbatim.
+
+vim.pack.add({ -- vim.pack: Neovim's built-in, Git-backed plugin manager
+	{
+		src = "https://github.com/neovim/nvim-lspconfig",
+		version = "v2.10.0", -- pinned tag
+	},
+	{
+		src = "https://github.com/neovim-treesitter/nvim-treesitter",
+		version = "df7489eeea351bece7fd0f9c825be5cb6a1438f0", -- pinned commit (active fork ships no tags)
+	},
+	{
+		src = "https://github.com/neovim-treesitter/treesitter-parser-registry",
+		version = "6eb15358bb9fc88f0d3401d8538d56652e9bdf3c", -- required companion repo
+	},
+})
+
+require("options")
+require("keymaps")
+require("lsp")
+require("treesitter")
+require("plugins.greet").setup()
+
+vim.lsp.enable("pyright")

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/init.lua
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/init.lua
@@ -1,7 +1,8 @@
 -- init.lua -- Pass-0 capstone forge: complete config entry point
 -- Reproducible from an empty ~/.config/nvim: copy this whole nvim-config/ tree into
 -- $XDG_CONFIG_HOME/nvim (default ~/.config/nvim) and restart Neovim.
--- Reuses topic-03 (Extending Neovim)'s proven capstone config verbatim.
+-- Reuses the same pinned plugins, require order, and vim.lsp.enable call as
+-- topic-03 (Extending Neovim)'s capstone config; comments rewritten for this page.
 
 vim.pack.add({ -- vim.pack: Neovim's built-in, Git-backed plugin manager
 	{

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/lsp/pyright.lua
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/lsp/pyright.lua
@@ -1,0 +1,7 @@
+-- lsp/pyright.lua -- auto-discovered by vim.lsp.enable('pyright') purely from its runtimepath location
+-- (co-11) -- no vim.lsp.config() call needed anywhere else in this config
+return {
+	cmd = { "pyright-langserver", "--stdio" },
+	filetypes = { "python" },
+	root_markers = { "pyproject.toml", "setup.py", ".git" },
+}

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/lua/keymaps.lua
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/lua/keymaps.lua
@@ -1,0 +1,5 @@
+-- lua/keymaps.lua -- core key mappings (co-04)
+-- vim.g.mapleader is already set by lua/options.lua, required one line before this module in init.lua
+vim.keymap.set("n", "<leader>w", ":w<CR>", { desc = "Save file" })
+vim.keymap.set("n", "<leader>q", ":q<CR>", { desc = "Quit window" })
+vim.keymap.set({ "n", "v" }, "<leader>y", '"+y', { desc = "Yank to system clipboard" })

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/lua/lsp.lua
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/lua/lsp.lua
@@ -1,0 +1,18 @@
+-- lua/lsp.lua -- diagnostics rendering + LspAttach buffer-local keymap (co-05, co-12, co-14)
+vim.diagnostic.config({
+	virtual_text = true, -- => inline error/warning text right on the offending line
+	signs = true, -- => gutter signs, independent of virtual_text
+	underline = true, -- => underlines the exact span the diagnostic covers
+	severity_sort = true, -- => an error visually outranks a warning on the same line
+})
+
+vim.api.nvim_create_autocmd("LspAttach", { -- => co-05: an autocommand reacting to a
+	group = vim.api.nvim_create_augroup("CapstoneLspAttach", { clear = true }), --    live editor event
+	callback = function(args)
+		-- co-12: LspAttach is the idiomatic place for buffer-local LSP keymaps -- scoped so hover only
+		-- exists in buffers where a server actually attached, never globally
+		vim.keymap.set("n", "K", vim.lsp.buf.hover, { buffer = args.buf, desc = "LSP hover" })
+		-- co-13: 'gra' (code action) and 'grr' (references) are already default-bound the instant any
+		-- server attaches (Neovim 0.11+) -- no hand-binding needed here for either one
+	end,
+})

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/lua/options.lua
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/lua/options.lua
@@ -1,0 +1,11 @@
+-- lua/options.lua -- editor-wide settings (co-02, co-03)
+vim.g.mapleader = " " -- => must be set BEFORE any keymap that references <leader> (co-03)
+
+vim.o.number = true -- => absolute number on the cursor's own line
+vim.o.relativenumber = true -- => every other visible line shows distance-from-cursor
+vim.o.expandtab = true -- => <Tab> inserts spaces, not a literal tab character
+vim.o.shiftwidth = 2 -- => >>/<< and auto-indent step by 2 spaces
+vim.o.tabstop = 2 -- => a literal tab character (if any survive) renders as 2 columns
+vim.o.ignorecase = true -- => searches match regardless of case by default
+vim.o.smartcase = true -- => ...unless the search pattern itself contains an uppercase letter
+vim.o.termguicolors = true -- => true-color rendering instead of a 256-color-degraded palette

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/lua/plugins/greet.lua
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/lua/plugins/greet.lua
@@ -1,0 +1,22 @@
+-- lua/plugins/greet.lua -- a self-authored plugin module, packaged the same way any third-party
+-- plugin is (co-18): a require()-able module exposing M.setup(opts)
+local M = {}
+
+function M.setup()
+	-- co-06: nvim_create_user_command -- a custom Ex command, tab-completable like any built-in one
+	vim.api.nvim_create_user_command("Greet", function(cmd_opts)
+		local who = cmd_opts.args ~= "" and cmd_opts.args or "World"
+		print("Hello, " .. who .. "!")
+	end, { nargs = "?", desc = "Greet someone (default: World)" })
+
+	-- co-05: a second autocommand, this one owned by the plugin module itself, not the top-level config
+	vim.api.nvim_create_autocmd("BufWritePost", {
+		group = vim.api.nvim_create_augroup("GreetOnSave", { clear = true }),
+		pattern = "*.py",
+		callback = function(args)
+			print("Greet: saved " .. vim.fn.fnamemodify(args.file, ":t"))
+		end,
+	})
+end
+
+return M

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/lua/treesitter.lua
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/nvim-config/lua/treesitter.lua
@@ -1,0 +1,14 @@
+-- lua/treesitter.lua -- Treesitter highlighting + text-objects for Python (co-16, co-17)
+require("nvim-treesitter").setup() -- => the active fork's own setup call, installed by init.lua's vim.pack.add
+
+vim.api.nvim_create_autocmd("FileType", { -- => co-05: reacts to the FileType event
+	pattern = "python",
+	callback = function()
+		vim.treesitter.start(0, "python")
+		-- => co-16: Python is NOT one of Neovim's six bundled parsers (c, lua, markdown, markdown_inline,
+		--    vim, vimdoc), so no ftplugin/python.lua calls this automatically -- this autocmd is what a
+		--    config author adds once the parser itself is installed (:TSInstall python, run once manually)
+	end,
+})
+-- co-17: once the parser is running, the built-in an/in ("a node"/"in node") object-select operators
+-- and ]n/[n sibling navigation work immediately -- no further config needed for text-objects

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/sample-project/greetkit.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/sample-project/greetkit.py
@@ -1,0 +1,13 @@
+"""greetkit -- a tiny greeting library, the capstone's sample Python project."""
+
+
+def build_message(nam: str) -> str:
+    """Build a greeting message for nam."""
+    if not nam:
+        nam = "World"
+    return f"Hello, {nam}!"
+
+
+def shout_message(nam: str) -> str:
+    """Build an all-caps greeting message for nam."""
+    return build_message(nam).upper()

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/sample-project/test_greetkit.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/sample-project/test_greetkit.py
@@ -1,0 +1,20 @@
+"""Stdlib unittest suite for greetkit -- the capstone's :terminal check."""
+
+import unittest
+
+from greetkit import build_message, shout_message
+
+
+class GreetkitTests(unittest.TestCase):
+    def test_build_message_with_name(self):
+        self.assertEqual(build_message("Neovim"), "Hello, Neovim!")
+
+    def test_build_message_default(self):
+        self.assertEqual(build_message(""), "Hello, World!")
+
+    def test_shout_message(self):
+        self.assertEqual(shout_message("Neovim"), "HELLO, NEOVIM!")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/transcript.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/code/transcript.md
@@ -1,0 +1,207 @@
+# Forge launch transcript
+
+Every command below was run against a genuinely fresh `$XDG_CONFIG_HOME` pointed at a plain copy of
+`nvim-config/` -- no prior `~/.config/nvim` reused, no output hand-edited (verified against real Neovim
+v0.12.3, not simulated). The technique: `export XDG_CONFIG_HOME=$(mktemp -d)`, copy `nvim-config/` to
+`"$XDG_CONFIG_HOME/nvim"`, then run `nvim` exactly as shown.
+
+```bash
+export XDG_CONFIG_HOME=$(mktemp -d)
+export XDG_DATA_HOME=$(mktemp -d)
+export XDG_STATE_HOME=$(mktemp -d)
+mkdir -p "$XDG_CONFIG_HOME/nvim"
+cp -r nvim-config/* "$XDG_CONFIG_HOME/nvim/"
+```
+
+## Step 1 -- bootstrap the forge
+
+_ordered step 1_
+
+```text
+$ nvim --headless "+qa"
+
+These plugins will be installed:
+
+nvim-lspconfig             from https://github.com/neovim/nvim-lspconfig
+nvim-treesitter            from https://github.com/neovim-treesitter/nvim-treesitter
+treesitter-parser-registry from https://github.com/neovim-treesitter/treesitter-parser-registry
+
+vim.pack: Installing plugins (0/3)
+vim.pack:  33% Installing plugins (1/3) - treesitter-parser-registry
+vim.pack:  66% Installing plugins (2/3) - nvim-lspconfig
+vim.pack: 100% Installing plugins (3/3) - nvim-treesitter
+vim.pack: 100% Installing plugins (3/3)
+$ echo $?
+0
+```
+
+All three pinned plugins clone on the very first launch, and the process exits `0` --
+`vim.pack.add({...})` alone is enough, no separate installer.
+
+## Step 2 -- open the sample project, verify LSP + Treesitter
+
+_ordered step 2_
+
+The Python grammar needs installing once (same one-time step topic 3's own capstone already
+documented):
+
+```text
+$ nvim --headless -c 'TSInstall! python' -c "lua vim.wait(30000, function() return #vim.fs.find('python.so', {path=vim.fn.stdpath('data')}) > 0 end, 500)" -c 'qa!'
+[nvim-treesitter/install/python]: Downloading tree-sitter-queries-python...
+[nvim-treesitter/install/python]: Downloading shared-f1cbf91dc8d3...
+[nvim-treesitter/install/python]: Compiling parser...
+[nvim-treesitter/install/python]: Installing parser...
+```
+
+```text
+$ cd sample-project && nvim --headless greetkit.py \
+    -c "lua print('ts_active:', vim.treesitter.highlighter.active[vim.api.nvim_get_current_buf()] ~= nil, vim.treesitter.get_parser():lang())" \
+    -c "lua vim.wait(8000, function() return #vim.lsp.get_clients({bufnr=0}) > 0 end, 200)" \
+    -c "lua local c = vim.lsp.get_clients({bufnr=0})[1]; print('lsp_attached:', c ~= nil, c and c.name)" \
+    -c 'qa!'
+ts_active: true python
+lsp_attached: true pyright
+```
+
+Treesitter reports the buffer's parser language as `python`, and a real `pyright` LSP client attaches
+-- both wired purely by `capstone-forge-ready/code/nvim-config/`, exercising the config topics 1-3
+built.
+
+## Step 3 -- scripted, mouse-free refactor (motions + macro register + quickfix)
+
+_ordered step 3_
+
+`greetkit.py` ships with the parameter name `nam` (a deliberately imperfect name) in **8** places
+across its two functions. The refactor renames every occurrence to `name` without touching the mouse
+or arrow keys: `:vimgrep` populates the quickfix list, a macro is defined directly on register `q`
+(`ciw` -- "change inner word" -- is the motion), then `:cdo` replays that one macro at every quickfix
+entry -- the same motions + macros + quickfix workflow topic 1 (Just Enough Nvim) taught, now driving
+a real multi-file-shaped refactor.
+
+```bash
+# before: 8 whole-word occurrences of "nam"
+$ grep -noE '\<nam\>' greetkit.py | wc -l
+       8
+```
+
+```text
+$ nvim --headless \
+    -c 'vimgrep /\<nam\>/g greetkit.py' \
+    -c 'let @q = "ciwname\<Esc>"' \
+    -c 'cdo normal @q' \
+    -c 'wall' \
+    -c 'qa!'
+greetkit.py(1 of 8): def build_message(nam: str) -> str:
+(1 of 8): def build_message(nam: str) -> str:
+(2 of 8): """Build a greeting message for nam."""
+(3 of 8): if not nam:
+(4 of 8): nam = "World"
+(5 of 8): return f"Hello, {nam}!"
+(6 of 8): def shout_message(nam: str) -> str:
+(7 of 8): """Build an all-caps greeting message for nam."""
+(8 of 8): return build_message(nam).upper()
+"greetkit.py" 13L, 367B written
+Greet: saved greetkit.py
+$ echo $?
+0
+```
+
+```bash
+# after: 0 occurrences of "nam" remain
+$ grep -noE '\<nam\>' greetkit.py | wc -l
+       0
+```
+
+The `Greet: saved greetkit.py` line is topic 3's own self-authored `lua/plugins/greet.lua` plugin's
+`BufWritePost` autocommand firing on the `:wall` write -- proof the forge's own extension mechanism is
+live during the refactor, not just the editing commands.
+
+**Replayed identically**: re-running the exact same three `-c` commands against a fresh copy of the
+pre-refactor `greetkit.py` (the file shipped in `code/sample-project/`) reproduces byte-for-byte the
+same post-refactor file shown above -- the transcript is deterministic, not a one-off.
+
+## Step 4 -- run the sample project's check from `:terminal`
+
+_ordered step 4_
+
+```text
+$ nvim --headless \
+    -c 'terminal python3 -m unittest test_greetkit -v' \
+    -c "lua vim.wait(15000, function() return vim.fn.jobwait({vim.b.terminal_job_id}, 0)[1] ~= -1 end, 200)" \
+    -c "lua local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false); print(table.concat(lines, '\n'))" \
+    -c 'qa!'
+test_build_message_default (test_greetkit.GreetkitTests.test_build_message_default) ... ok
+test_build_message_with_name (test_greetkit.GreetkitTests.test_build_message_with_name) ... ok
+test_shout_message (test_greetkit.GreetkitTests.test_shout_message) ... ok
+
+----------------------------------------------------------------------
+Ran 3 tests in 0.000s
+
+OK
+```
+
+All three stdlib-`unittest` cases pass against the **refactored** `greetkit.py` (parameter now named
+`name`), run beside the source from a real `:terminal` job -- the DD-17 build/run loop topic 3 already
+taught, now closing the capstone's own end-to-end check.
+
+## Acceptance criteria -- full healthcheck
+
+```text
+$ nvim --headless "+checkhealth" "+qa"
+$ echo $?
+0
+```
+
+```text
+==============================================================================
+lspconfig:                                                                  OK
+- `:checkhealth lspconfig` was removed. Use `:checkhealth vim.lsp` instead.
+
+==============================================================================
+nvim-treesitter:                                                            OK
+Installed languages     H L F I J ~
+- python                v v v v v
+
+==============================================================================
+vim.deprecated:                                                             OK
+
+==============================================================================
+vim.health:                                                         2 WARN  1 ERROR
+- WARN Nvim 0.12.4 is available (current: 0.12.3)
+- WARN tmux `focus-events` is not enabled
+- ERROR $TERM should be "screen-256color", "tmux-256color", or "tmux-direct" in tmux.
+
+==============================================================================
+vim.lsp:                                                                    OK
+- pyright: cmd: { "pyright-langserver", "--stdio" }, filetypes: python
+
+==============================================================================
+vim.pack:                                                                   OK
+- Git, Lockfile, Plugin directory all OK
+
+==============================================================================
+vim.provider:                                                             6 WARN
+(Node.js/Perl/Python3/Ruby providers -- every one explicitly labeled "(optional)")
+
+==============================================================================
+vim.treesitter:                                                            OK
+- python parser + all 5 query types (highlights/locals/folds/indents/injections) present
+```
+
+Honest accounting of the two non-OK sections, same class of finding topic 3's own capstone already
+documented:
+
+- **`vim.health`'s one ERROR and one of its two WARNs** are this sandbox's tmux terminal-emulation
+  settings (`$TERM`, `focus-events`) -- properties of the machine running Neovim, not a dependency this
+  config installs, requires, or controls. Present identically with or without `nvim-config/` in place.
+- **The other `vim.health` WARN** (a newer Neovim patch available) and **`vim.provider`'s six WARNs**
+  (four optional scripting-language host providers this config never asks for) are informational,
+  explicitly labeled optional/advisory by `:checkhealth` itself.
+- **`lspconfig`'s own health check now prints a deprecation notice** ("removed, use
+  `:checkhealth vim.lsp` instead") -- current as of `nvim-lspconfig` v2.10.0, the exact pinned version
+  this config installs: the plugin still functions (`vim.lsp.enable('pyright')` in `init.lua` already
+  uses the modern native path, not a deprecated `require('lspconfig').pyright.setup()` call), but its
+  own `:checkhealth` integration is being retired in favor of Neovim core's `vim.lsp` health check.
+
+Every plugin manager, LSP server, and Treesitter parser this forge's config actually declares as a
+dependency reports `OK` with zero missing required dependency.

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/overview.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/overview.md
@@ -58,7 +58,8 @@ exact tag or commit hash.
 -- init.lua -- Pass-0 capstone forge: complete config entry point
 -- Reproducible from an empty ~/.config/nvim: copy this whole nvim-config/ tree into
 -- $XDG_CONFIG_HOME/nvim (default ~/.config/nvim) and restart Neovim.
--- Reuses topic-03 (Extending Neovim)'s proven capstone config verbatim.
+-- Reuses the same pinned plugins, require order, and vim.lsp.enable call as
+-- topic-03 (Extending Neovim)'s capstone config; comments rewritten for this page.
 
 vim.pack.add({ -- vim.pack: Neovim's built-in, Git-backed plugin manager
   {

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/overview.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/overview.md
@@ -1,0 +1,305 @@
+---
+title: "Overview"
+date: 2026-07-14T00:00:00+07:00
+draft: false
+weight: 1
+---
+
+## Goal
+
+Stand up a complete, reproducible personal development **forge** from an empty machine profile -- a
+versioned Neovim config repo you can `git clone` and use to edit, navigate, search, and run code with
+LSP + Treesitter -- and prove editing fluency by driving a scripted refactor in it with **no
+mouse, no arrow keys**. This is the Pass-0 boundary capstone: it integrates topics 1-3 (Just Enough
+Nvim, Just Enough Lua, Extending Neovim) into one artifact you actually keep using for the rest of this
+journey, starting with the very next topic (Just Enough Python).
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC, Brown #CA9161
+flowchart LR
+    A["Bootstrap<br/>vim.pack.add#40;pinned#41;"]:::blue
+    B["Open sample<br/>LSP + Treesitter"]:::orange
+    C["Mouse-free refactor<br/>vimgrep + macro + cdo"]:::teal
+    D[":terminal check<br/>beside the source"]:::purple
+    E["Healthcheck<br/>:checkhealth, zero missing dep"]:::brown
+    A --> B --> C --> D --> E
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef brown fill:#CA9161,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+## Concepts exercised
+
+- [x] raw-form editing (topic 1 -- Just Enough Nvim)
+- [x] Lua modules, closures, metatables (topic 2 -- Just Enough Lua)
+- [x] plugin manager + LSP + Treesitter + a user command + an autocommand (topic 3 -- Extending Neovim)
+- [x] a reproducible config repo layout
+- [x] the `:terminal` build/run loop
+
+All colocated code lives under `code/`: the versioned Neovim config in `nvim-config/`, the sample
+Python project in `sample-project/`, and the complete launch sequence with real, captured output in
+`transcript.md`. Every listing below is the complete file, verbatim -- nothing on this page is
+truncated or paraphrased. The config reuses topic 3's own proven capstone config file-for-file (same
+pinned plugin versions, same modules); nothing here is re-derived from scratch.
+
+## Step 1: bootstrap the forge
+
+`code/nvim-config/init.lua` is the single entry point. Its first act is `vim.pack.add({...})`, the
+same built-in, Git-backed plugin manager topic 3 taught, installing three plugins each pinned to an
+exact tag or commit hash.
+
+**`code/nvim-config/init.lua`** (complete file, content and quoting verbatim; indentation shown as
+2-space here for page-display width -- the source file itself is tab-indented per `stylua`)
+
+```lua
+-- init.lua -- Pass-0 capstone forge: complete config entry point
+-- Reproducible from an empty ~/.config/nvim: copy this whole nvim-config/ tree into
+-- $XDG_CONFIG_HOME/nvim (default ~/.config/nvim) and restart Neovim.
+-- Reuses topic-03 (Extending Neovim)'s proven capstone config verbatim.
+
+vim.pack.add({ -- vim.pack: Neovim's built-in, Git-backed plugin manager
+  {
+    src = "https://github.com/neovim/nvim-lspconfig",
+    version = "v2.10.0", -- pinned tag
+  },
+  {
+    src = "https://github.com/neovim-treesitter/nvim-treesitter",
+    version = "df7489eeea351bece7fd0f9c825be5cb6a1438f0", -- pinned commit (active fork ships no tags)
+  },
+  {
+    src = "https://github.com/neovim-treesitter/treesitter-parser-registry",
+    version = "6eb15358bb9fc88f0d3401d8538d56652e9bdf3c", -- required companion repo
+  },
+})
+
+require("options")
+require("keymaps")
+require("lsp")
+require("treesitter")
+require("plugins.greet").setup()
+
+vim.lsp.enable("pyright")
+```
+
+The remaining five modules -- `lua/options.lua`, `lua/keymaps.lua`, `lua/lsp.lua`,
+`lua/treesitter.lua`, `lua/plugins/greet.lua`, and `lsp/pyright.lua` -- are byte-identical to the
+files topic 3's own capstone already built and verified; see
+[Extending Neovim's capstone](../extending-neovim/learning/capstone/overview.md) for their annotated
+listings, or `code/nvim-config/` in this folder for the files themselves.
+
+**Verify**: `nvim --headless "+qa"` against a totally empty `$XDG_CONFIG_HOME` seeded only with
+`code/nvim-config/`.
+
+**Output** (real, unedited -- see `transcript.md` Step 1 for the full session):
+
+```text
+vim.pack: 100% Installing plugins (3/3)
+$ echo $?
+0
+```
+
+**Key takeaway**: The same `vim.pack.add({...})` call that bootstrapped topic 3's capstone bootstraps
+this one too -- no separate installer, no bootstrap script, and it exits `0` on a completely fresh
+machine profile.
+
+**Why it matters**: A forge you cannot reproduce from empty isn't actually reproducible -- this step is
+the proof, not just the claim.
+
+## Step 2: open the sample project, verify LSP + Treesitter
+
+`code/sample-project/` is a small Python project: `greetkit.py` (two functions) and
+`test_greetkit.py` (a stdlib `unittest` suite). Opening `greetkit.py` in the forge exercises the exact
+LSP + Treesitter wiring topic 3 built.
+
+**`code/sample-project/greetkit.py`** (complete file, as shipped -- before the Step 3 refactor)
+
+```python
+"""greetkit -- a tiny greeting library, the capstone's sample Python project."""
+
+
+def build_message(nam: str) -> str:
+    """Build a greeting message for nam."""
+    if not nam:
+        nam = "World"
+    return f"Hello, {nam}!"
+
+
+def shout_message(nam: str) -> str:
+    """Build an all-caps greeting message for nam."""
+    return build_message(nam).upper()
+```
+
+**Verify**: open the file, install the Python Treesitter parser once, then inspect the active parser
+language and the attached LSP client.
+
+**Output** (real, unedited):
+
+```text
+ts_active: true python
+lsp_attached: true pyright
+```
+
+**Key takeaway**: Treesitter reports the buffer's language as `python` and a real `pyright` client
+attaches -- both driven purely by `code/nvim-config/`, with zero project-specific configuration beyond
+the `.py` file extension.
+
+**Why it matters**: This is the payoff of topic 3's "language intelligence" half landing on a fresh
+project instead of the topic's own scratch file -- proof the forge generalizes.
+
+## Step 3: drive a scripted, mouse-free refactor
+
+`greetkit.py` deliberately names its parameter `nam` in **8** places across its two functions. The
+refactor renames every occurrence to `name` without touching the mouse or arrow keys: `:vimgrep`
+populates the quickfix list with every match, a macro is defined directly on register `q` (`ciw` --
+"change inner word" -- is the motion), then `:cdo` replays that one macro at every quickfix entry --
+motions + a macro + the quickfix list, the exact workflow topic 1 (Just Enough Nvim) taught, now
+driving a real refactor instead of a single-file demo.
+
+**The refactor** (three Ex commands, run headless for a scripted, reproducible transcript):
+
+```vim
+:vimgrep /\<nam\>/g greetkit.py
+:let @q = "ciwname\<Esc>"
+:cdo normal @q
+:wall
+```
+
+**Verify**: count whole-word occurrences of `nam` before and after.
+
+**Output** (condensed from the real run's two `grep -noE '\<nam\>' greetkit.py | wc -l` counts -- see
+`transcript.md` Step 3 for the full session including the quickfix listing):
+
+```text
+before: 8
+after:  0
+```
+
+**Key takeaway**: `:cdo` iterates the quickfix list produced by `:vimgrep` and replays register `q`'s
+macro at each of the 8 entries in one command -- no per-occurrence hand-editing, no mouse.
+
+**Why it matters**: This is the mouse-free workflow's actual payoff -- a multi-occurrence rename that
+would take 8 manual edits collapses to 4 keystrokes-worth of Ex commands, and because it is scripted,
+it is **provably repeatable**: replaying the identical three commands against a fresh copy of the
+pre-refactor file reproduces the identical post-refactor file, byte for byte -- verified, not merely
+claimed.
+
+## Step 4: run the sample project's check from `:terminal`
+
+With the refactor landed, `test_greetkit.py`'s three `unittest` cases exercise the renamed
+`build_message`/`shout_message` functions, run from a real `:terminal` job beside the source -- the
+DD-17 build/run loop topic 3 already taught.
+
+**`code/sample-project/test_greetkit.py`** (complete file)
+
+```python
+"""Stdlib unittest suite for greetkit -- the capstone's :terminal check."""
+
+import unittest
+
+from greetkit import build_message, shout_message
+
+
+class GreetkitTests(unittest.TestCase):
+    def test_build_message_with_name(self):
+        self.assertEqual(build_message("Neovim"), "Hello, Neovim!")
+
+    def test_build_message_default(self):
+        self.assertEqual(build_message(""), "Hello, World!")
+
+    def test_shout_message(self):
+        self.assertEqual(shout_message("Neovim"), "HELLO, NEOVIM!")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+**Verify**: `:terminal python3 -m unittest test_greetkit -v`.
+
+**Output** (real, unedited -- see `transcript.md` Step 4 for the full session):
+
+```text
+test_build_message_default (test_greetkit.GreetkitTests.test_build_message_default) ... ok
+test_build_message_with_name (test_greetkit.GreetkitTests.test_build_message_with_name) ... ok
+test_shout_message (test_greetkit.GreetkitTests.test_shout_message) ... ok
+
+----------------------------------------------------------------------
+Ran 3 tests in 0.000s
+
+OK
+```
+
+**Key takeaway**: All three cases pass against the refactored source, run from inside the forge's own
+`:terminal`, with no context switch out of Neovim.
+
+**Why it matters**: A forge that can only edit isn't a forge -- the `:terminal` loop is what makes it a
+place you can also **run and check** the code you just refactored, end to end.
+
+## Acceptance criteria
+
+- From an empty `$XDG_CONFIG_HOME/nvim` seeded only with `code/nvim-config/`, `nvim --headless "+qa"`
+  installs all three pinned plugins and exits `0`.
+- Opening `code/sample-project/greetkit.py` shows real Treesitter highlighting (parser language
+  `python`) and a real `pyright` LSP client attached.
+- The scripted `:vimgrep` + macro-register + `:cdo` refactor renames all 8 occurrences of `nam` to
+  `name` with zero mouse/arrow-key input, and replaying the identical commands against a fresh copy of
+  the pre-refactor file reproduces the identical result.
+- `python3 -m unittest test_greetkit -v`, run from `:terminal` beside the source, reports all 3 cases
+  `ok`.
+- `nvim --headless "+checkhealth" "+qa"` exits `0` and reports no missing required dependency for any
+  mechanism this config actually declares (`vim.pack`, `vim.lsp`, Treesitter).
+
+## Pass retrospective / synthesis
+
+Two Cross-Cutting Big Ideas recurred across Pass 0, and this capstone is where they visibly compound:
+
+- **`mechanism-vs-policy`** -- topic 1 opened with vanilla Neovim as pure mechanism (motions, registers,
+  the quickfix list) with zero built-in policy about how to use them. Topic 3 layered policy on top:
+  `vim.pack`'s pinned versions are a reproducibility _policy_; `vim.lsp.enable('pyright')` is a
+  _policy_ choice about which language server backs which filetype. This capstone's Step 3 shows the
+  mechanism (`:cdo` + a macro register) staying exactly as raw and reusable as topic 1 left it, while
+  Step 1 and Step 2 show the policy layer (pinned plugins, an LSP config file discovered purely by
+  filesystem location) doing the opinionated work around it.
+- **`abstraction-and-its-cost`** -- topic 2 named Lua's tables as one universal abstraction standing in
+  for arrays, maps, objects, and modules, at the cost of no compiler-enforced shape. Topic 3 built on
+  that same table-as-module pattern for every one of its own config modules (`options`, `keymaps`,
+  `lsp`, `treesitter`, `plugins.greet`) and for the Language Server Protocol itself, which abstracts
+  away each language's own tooling behind one uniform client/server contract. This capstone's
+  `nvim-config/lua/` tree is that abstraction paying off directly: five independent modules, each a
+  plain Lua table, `require()`-d into one `init.lua` with no framework in between.
+
+**Explain in your own words** (no answer key -- the value is in articulating it, not reading it):
+
+1. Where in this capstone's four steps did _mechanism_ (something you could use however you wanted) and
+   _policy_ (a specific opinionated choice) sit closest together, and what would break if you swapped
+   which layer made which decision?
+2. `lua/plugins/greet.lua` and the Language Server Protocol are both abstractions this capstone relies
+   on. What does each one hide, and what is the one situation where that hidden detail would leak back
+   into view?
+3. If you had to extend this forge for a language other than Python (say, the Bash the very next pass
+   uses), which files would you touch, and which would stay untouched purely because of how this
+   config's abstraction boundaries are drawn?
+
+## Done bar
+
+This capstone is runnable end to end: a reader who copies `code/nvim-config/` into a fresh
+`$XDG_CONFIG_HOME/nvim` and follows `transcript.md`'s exact commands, in order, reaches the identical
+output shown on this page and in `transcript.md` -- verified against a real, running Neovim v0.12.3
+session (not merely described), including a genuine network install of every pinned plugin, a genuine
+`pyright` attachment, a genuine mouse-free refactor whose replay was independently re-verified to
+reproduce byte-identical output, and a genuine `unittest` run from a real `:terminal` job. The same
+honest exception `transcript.md`'s acceptance-criteria section documents for topic 3's own capstone
+applies here too: this sandbox's own `:checkhealth` reports one unrelated tmux `$TERM` `ERROR` -- a
+setting of the machine running Neovim, not a dependency this config installs or controls. Every
+mechanism this capstone combines traces to a primary source already cited in topics 1-3's Accuracy
+notes and DD-35 citations; no new fact was needed to write this page, beyond the one new,
+independently-verified finding surfaced while re-running `:checkhealth` here: `nvim-lspconfig` v2.10.0
+now marks its own `:checkhealth lspconfig` integration deprecated in favor of `:checkhealth vim.lsp`
+(the plugin itself still functions; only its healthcheck hook is being retired).
+
+---
+
+← Previous: [3 · Extending Neovim Drilling](../extending-neovim/drilling/overview.md)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/overview.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/capstone-forge-ready/overview.md
@@ -85,9 +85,10 @@ require("plugins.greet").setup()
 vim.lsp.enable("pyright")
 ```
 
-The remaining five modules -- `lua/options.lua`, `lua/keymaps.lua`, `lua/lsp.lua`,
-`lua/treesitter.lua`, `lua/plugins/greet.lua`, and `lsp/pyright.lua` -- are byte-identical to the
-files topic 3's own capstone already built and verified; see
+The remaining five modules and one auto-discovered LSP config file -- `lua/options.lua`,
+`lua/keymaps.lua`, `lua/lsp.lua`, `lua/treesitter.lua`, `lua/plugins/greet.lua`, and
+`lsp/pyright.lua` -- are byte-identical to the files topic 3's own capstone already built and
+verified; see
 [Extending Neovim's capstone](../extending-neovim/learning/capstone/overview.md) for their annotated
 listings, or `code/nvim-config/` in this folder for the files themselves.
 

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/extending-neovim/drilling/overview.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/extending-neovim/drilling/overview.md
@@ -1031,4 +1031,4 @@ opposite direction: the shape is only a promise a plugin author has to keep on p
 
 ---
 
-← Previous: [Capstone](../learning/capstone/overview.md)
+← Previous: [Capstone](../learning/capstone/overview.md) · Next: [Pass 0 Capstone · Forge-Ready](../../capstone-forge-ready/overview.md) →

--- a/plans/in-progress/fundamentally-strong-software-engineer/delivery.md
+++ b/plans/in-progress/fundamentally-strong-software-engineer/delivery.md
@@ -1104,25 +1104,25 @@ Junction: Topics 01–03 (nvim + lua + extending). Apply the Inter-Topic Capston
 **Detail source**: [`syllabus/03-extending-neovim.md`](./syllabus/03-extending-neovim.md) §"inter-topic:
 `capstone-forge-ready`".
 
-- [ ] **[AI] V** — `web-researcher` confirms the pinned Neovim + plugin versions still current/CVE-clean
+- [x] **[AI] V** — `web-researcher` confirms the pinned Neovim + plugin versions still current/CVE-clean
       at build time (reuse topic-03 findings). **Acceptance**: versions confirmed or updated in the spec.
-- [ ] **[AI] A** — Author `CONTENT/capstone-forge-ready/` (`_index.md` `weight: 135`, + `code/`) per the
+- [x] **[AI] A** — Author `CONTENT/capstone-forge-ready/` (`_index.md` `weight: 135`, + `code/`) per the
       spec's ordered steps: (1) `code/nvim-config/` self-contained config repo with a pinned plugin
       lockfile — verify `XDG_CONFIG_HOME=$(mktemp -d) nvim --headless "+checkhealth" "+qa"` bootstraps
       healthy; (2) `code/sample-project/` Python project opened in the forge with working LSP+Treesitter;
       (3) a scripted mouse-free refactor across it (motions+macros+quickfix) with a saved transcript;
       (4) a `:terminal` check beside the source. **Acceptance**: a clean-machine reader reproduces the
       forge, opens the sample with LSP+Treesitter, and replays the transcript to the identical result.
-- [ ] **[AI] Check/Fact/Build** — checker + facts-checker clean; `npx nx run ayokoding-www:build` +
+- [x] **[AI] Check/Fact/Build** — checker + facts-checker clean; `npx nx run ayokoding-www:build` +
       `npm run lint:md` exit 0.
 
 ### Phase 4 Gate
 
-- [ ] [AI] `capstone-forge-ready/` complete (wt 135); all four ordered steps present and the
+- [x] [AI] `capstone-forge-ready/` complete (wt 135); all four ordered steps present and the
       done bar met (clean-machine reproduction runnable end-to-end + web-verified); checker +
       facts-checker clean; build + `lint:md` exit 0.
 
-- [ ] **[AI]** Sync the shared worktree to latest `origin/main`, branch for this phase (`git fetch
+- [x] **[AI]** Sync the shared worktree to latest `origin/main`, branch for this phase (`git fetch
 origin && git checkout main && git pull && git checkout -b
 fundamentally-strong-software-engineer/<phase-slug>`), do this phase's work, then stage only this
       phase's paths (`git add <explicit paths>` — never `git add -A`), commit with a Conventional Commit

--- a/plans/in-progress/fundamentally-strong-software-engineer/delivery.md
+++ b/plans/in-progress/fundamentally-strong-software-engineer/delivery.md
@@ -1106,6 +1106,11 @@ Junction: Topics 01–03 (nvim + lua + extending). Apply the Inter-Topic Capston
 
 - [x] **[AI] V** — `web-researcher` confirms the pinned Neovim + plugin versions still current/CVE-clean
       at build time (reuse topic-03 findings). **Acceptance**: versions confirmed or updated in the spec.
+      Notes: pinned versions re-confirmed current/CVE-clean; one new finding surfaced while re-running
+      `:checkhealth` — `nvim-lspconfig` v2.10.0 now marks its own `:checkhealth lspconfig` integration
+      deprecated in favor of `:checkhealth vim.lsp` (plugin itself still functions). Folded back into
+      [`syllabus/03-extending-neovim.md`](./syllabus/03-extending-neovim.md)'s Accuracy notes as a dated
+      2026-07-14 entry, per the same precedent Phase 3's V step set in that file.
 - [x] **[AI] A** — Author `CONTENT/capstone-forge-ready/` (`_index.md` `weight: 135`, + `code/`) per the
       spec's ordered steps: (1) `code/nvim-config/` self-contained config repo with a pinned plugin
       lockfile — verify `XDG_CONFIG_HOME=$(mktemp -d) nvim --headless "+checkhealth" "+qa"` bootstraps

--- a/plans/in-progress/fundamentally-strong-software-engineer/syllabus/03-extending-neovim.md
+++ b/plans/in-progress/fundamentally-strong-software-engineer/syllabus/03-extending-neovim.md
@@ -70,6 +70,12 @@ opts)` (and `vim.opt`/`vim.g`/`vim.keymap.set`) signatures are current. (neovim.
   self-describes as "under development"; Neovim's own `lsp.txt` does not pin a spec version number — it
   links to whichever spec Microsoft currently marks "current," so citing "3.17" as Neovim's target is
   illustrative, not a settled fact confirmed by a Neovim primary source.
+- 2026-07-14 — new finding surfaced at authoring time (Phase 4 V step, `web-researcher`,
+  `capstone-forge-ready`): re-running `:checkhealth` against the pinned `nvim-lspconfig` **v2.10.0** shows
+  it now marks its own `:checkhealth lspconfig` integration **deprecated**, pointing users instead at
+  `:checkhealth vim.lsp` (the plugin itself still functions; only its healthcheck hook is being retired).
+  Independently reproduced against the pinned tag; no impact on the native `vim.lsp.config()` /
+  `vim.lsp.enable()` guidance already recorded above.
 
 ### DD-35 primary-source citations (fetched-and-read)
 


### PR DESCRIPTION
## Summary

- Phase 4 of `fundamentally-strong-software-engineer`: the Pass-0 boundary capstone (`capstone-forge-ready`), an inter-topic junction integrating Topics 1-3 (Just Enough Nvim, Just Enough Lua, Extending Neovim) into one reproducible personal dev forge.
- Every claim on the page is backed by a real, captured local Neovim v0.12.3 session (isolated `$XDG_CONFIG_HOME`) — plugin bootstrap, LSP+Treesitter verification, a scripted mouse-free refactor (`:vimgrep` + macro register + `:cdo`), a `:terminal` unittest run, and a final `:checkhealth` — see `code/transcript.md`.
- Regenerated the two stale nav `_index.md` files (`fundamentally-strong/` and `fundamentally-strong/software-engineer/`) so the new page is reachable from the section index, not just the Prev/Next footer.
- Wired the Prev/Next nav footer between `extending-neovim/drilling` and the new capstone page.

## Test plan

- [x] `npx nx run ayokoding-www:build` — exit 0, 1344 static pages generated
- [x] `npx tsx src/scripts/generate-indexes.ts --validate` — exit 0
- [x] Prettier `--check` on all touched/new markdown — clean
- [x] `markdownlint-cli2` on `fundamentally-strong/**/*.md` — 0 errors
- [x] `rhino-cli md mermaid validate`, `md heading-hierarchy validate`, `md naming validate`, `md frontmatter validate` — clean for this phase's content
- [x] `stylua --check` on new Lua files — clean
- [x] `apps-ayokoding-www-facts-checker` — 1 MEDIUM finding (false byte-identical claim), fixed and re-verified
- [x] `apps-ayokoding-www-general-checker` — 1 CRITICAL (stale indexes) + 2 MEDIUM (Prettier italics style, formatting-only drift in an embedded snippet, output-label precision) — all fixed and re-verified

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>