### PR TITLE
fix(ayokoding-www): rewrite relative content links to real site routes

### DIFF
--- a/apps/ayokoding-www/src/features/content/core/content-link-rewrite.ts
+++ b/apps/ayokoding-www/src/features/content/core/content-link-rewrite.ts
@@ -18,10 +18,12 @@ const ABSOLUTE_HREF = /^(https?:|mailto:|tel:|\/|#)/i;
  * Resolve one markdown-authored `href` against the current page's content slug.
  *
  * Returns `href` unchanged when it is already absolute (external URL, `mailto:`/`tel:`,
- * a site-root path, or an in-page anchor) or when `context` is not provided (no slug to
- * resolve against). Otherwise resolves the relative path against `context.slug`'s
- * directory, strips the `.md`/`_index` suffix the same way the content reader derives
- * slugs from file paths, and maps the result through {@link contentUrl}.
+ * a site-root path, or an in-page anchor), when `context` is not provided (no slug to
+ * resolve against), or when the relative target does not end in `.md` (not a content
+ * link per the repo's Linking convention — e.g. an image or PDF asset). Otherwise
+ * resolves the relative path against `context.slug`'s directory, strips the
+ * `.md`/`_index` suffix the same way the content reader derives slugs from file paths,
+ * and maps the result through {@link contentUrl}.
  */
 export function resolveContentHref(href: string, context?: { locale: Locale; slug: string }): string {
   if (!context || ABSOLUTE_HREF.test(href)) {
@@ -29,6 +31,11 @@ export function resolveContentHref(href: string, context?: { locale: Locale; slu
   }
 
   const [pathPart, hash] = splitHash(href);
+
+  if (!pathPart.endsWith(".md")) {
+    return href;
+  }
+
   const currentDir = path.posix.dirname(`/${context.slug}`);
   const resolved = path.posix.normalize(path.posix.join(currentDir, pathPart));
 

--- a/apps/ayokoding-www/src/features/content/core/content-link-rewrite.ts
+++ b/apps/ayokoding-www/src/features/content/core/content-link-rewrite.ts
@@ -21,11 +21,21 @@ const ABSOLUTE_HREF = /^(https?:|mailto:|tel:|\/|#)/i;
  * a site-root path, or an in-page anchor), when `context` is not provided (no slug to
  * resolve against), or when the relative target does not end in `.md` (not a content
  * link per the repo's Linking convention — e.g. an image or PDF asset). Otherwise
- * resolves the relative path against `context.slug`'s directory, strips the
- * `.md`/`_index` suffix the same way the content reader derives slugs from file paths,
- * and maps the result through {@link contentUrl}.
+ * resolves the relative path against the current page's containing directory, strips
+ * the `.md`/`_index` suffix the same way the content reader derives slugs from file
+ * paths, and maps the result through {@link contentUrl}.
+ *
+ * The current page's containing directory is `context.slug` itself when the current
+ * page is a section index (`context.isSection`, e.g. slug `learn/x` -> file
+ * `learn/x/_index.md`, containing dir `learn/x/`) and `dirname(context.slug)` when it
+ * is a leaf content file (e.g. slug `learn/x/overview` -> file `learn/x/overview.md`,
+ * containing dir `learn/x/`). Getting this wrong resolves sibling/parent-relative links
+ * one directory level off for section-index source pages.
  */
-export function resolveContentHref(href: string, context?: { locale: Locale; slug: string }): string {
+export function resolveContentHref(
+  href: string,
+  context?: { locale: Locale; slug: string; isSection?: boolean },
+): string {
   if (!context || ABSOLUTE_HREF.test(href)) {
     return href;
   }
@@ -36,7 +46,7 @@ export function resolveContentHref(href: string, context?: { locale: Locale; slu
     return href;
   }
 
-  const currentDir = path.posix.dirname(`/${context.slug}`);
+  const currentDir = context.isSection ? `/${context.slug}` : path.posix.dirname(`/${context.slug}`);
   const resolved = path.posix.normalize(path.posix.join(currentDir, pathPart));
 
   let slug = resolved.replace(/^\/+/, "").replace(/\.md$/, "");

--- a/apps/ayokoding-www/src/features/content/core/content-link-rewrite.ts
+++ b/apps/ayokoding-www/src/features/content/core/content-link-rewrite.ts
@@ -1,0 +1,46 @@
+import path from "node:path";
+import type { Locale } from "@/features/i18n/core/config";
+import { contentUrl } from "./content-url";
+
+/**
+ * Content-tree-relative links authored in markdown bodies (e.g. `../../overview.md`,
+ * `./beginner.md`, `../_index.md`) mirror the on-disk file tree per the repo's Linking
+ * convention (relative paths with a literal `.md` extension). The rendered site uses a
+ * different, clean-URL namespace (`/{locale}/c/{slug}`, no `.md`), so these links must be
+ * resolved against the *current page's slug* and remapped through {@link contentUrl} before
+ * they reach the browser — otherwise they ship as literal `href="../../overview.md"` and
+ * 404 on click.
+ */
+
+const ABSOLUTE_HREF = /^(https?:|mailto:|tel:|\/|#)/i;
+
+/**
+ * Resolve one markdown-authored `href` against the current page's content slug.
+ *
+ * Returns `href` unchanged when it is already absolute (external URL, `mailto:`/`tel:`,
+ * a site-root path, or an in-page anchor) or when `context` is not provided (no slug to
+ * resolve against). Otherwise resolves the relative path against `context.slug`'s
+ * directory, strips the `.md`/`_index` suffix the same way the content reader derives
+ * slugs from file paths, and maps the result through {@link contentUrl}.
+ */
+export function resolveContentHref(href: string, context?: { locale: Locale; slug: string }): string {
+  if (!context || ABSOLUTE_HREF.test(href)) {
+    return href;
+  }
+
+  const [pathPart, hash] = splitHash(href);
+  const currentDir = path.posix.dirname(`/${context.slug}`);
+  const resolved = path.posix.normalize(path.posix.join(currentDir, pathPart));
+
+  let slug = resolved.replace(/^\/+/, "").replace(/\.md$/, "");
+  slug = slug.replace(/(^|\/)_index$/, "");
+
+  const url = contentUrl(context.locale, slug);
+  return hash ? `${url}${hash}` : url;
+}
+
+function splitHash(href: string): [string, string] {
+  const hashIndex = href.indexOf("#");
+  if (hashIndex === -1) return [href, ""];
+  return [href.slice(0, hashIndex), href.slice(hashIndex)];
+}

--- a/apps/ayokoding-www/src/features/content/core/parser.ts
+++ b/apps/ayokoding-www/src/features/content/core/parser.ts
@@ -9,15 +9,22 @@ import rehypeKatex from "rehype-katex";
 import rehypeSlug from "rehype-slug";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeStringify from "rehype-stringify";
+import type { Locale } from "@/features/i18n/core/config";
 import type { Heading } from "./types";
 import { transformShortcodes } from "./shortcodes";
+import { resolveContentHref } from "./content-link-rewrite";
 
 interface ParseResult {
   html: string;
   headings: Heading[];
 }
 
-export async function parseMarkdown(content: string): Promise<ParseResult> {
+export interface ParseContext {
+  locale: Locale;
+  slug: string;
+}
+
+export async function parseMarkdown(content: string, context?: ParseContext): Promise<ParseResult> {
   const headings: Heading[] = [];
 
   // Pre-process shortcodes before markdown parsing
@@ -43,6 +50,7 @@ export async function parseMarkdown(content: string): Promise<ParseResult> {
       // Extract headings (H2-H4) for table of contents
       extractHeadings(tree, headings);
     })
+    .use(() => (tree) => rewriteContentLinks(tree, context))
     .use(rehypeStringify, { allowDangerousHtml: true })
     .process(processed);
 
@@ -72,6 +80,22 @@ function extractHeadings(tree: HastNode, headings: Heading[]): void {
     }
     if (node.children) {
       extractHeadings(node, headings);
+    }
+  }
+}
+
+function rewriteContentLinks(tree: HastNode, context?: ParseContext): void {
+  if (!tree.children) return;
+
+  for (const node of tree.children) {
+    if (node.type === "element" && node.tagName === "a" && node.properties) {
+      const href = node.properties.href;
+      if (typeof href === "string") {
+        node.properties.href = resolveContentHref(href, context);
+      }
+    }
+    if (node.children) {
+      rewriteContentLinks(node, context);
     }
   }
 }

--- a/apps/ayokoding-www/src/features/content/core/parser.ts
+++ b/apps/ayokoding-www/src/features/content/core/parser.ts
@@ -22,6 +22,12 @@ interface ParseResult {
 export interface ParseContext {
   locale: Locale;
   slug: string;
+  /**
+   * True when the page being parsed is a section index (`_index.md`), whose containing
+   * directory is `slug` itself rather than `dirname(slug)`. Required by
+   * {@link resolveContentHref} to resolve in-body relative links correctly from section pages.
+   */
+  isSection?: boolean;
 }
 
 export async function parseMarkdown(content: string, context?: ParseContext): Promise<ParseResult> {

--- a/apps/ayokoding-www/src/features/content/shell/service.ts
+++ b/apps/ayokoding-www/src/features/content/shell/service.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import FlexSearch from "flexsearch";
+import type { Locale } from "@/features/i18n/core/config";
 import type { ContentRepository } from "../core/repository";
 import type { ContentIndex, ContentMeta, TreeNode, PageLink, SearchResult, Heading } from "../core/types";
 import { parseMarkdown } from "../core/parser";
@@ -50,7 +51,7 @@ export class ContentService {
     if (!meta) return null;
 
     const { content } = await this.repository.readFileContent(meta.filePath);
-    const { html, headings } = await parseMarkdown(content);
+    const { html, headings } = await parseMarkdown(content, { locale: locale as Locale, slug });
     const prevNext = index.prevNext.get(`${locale}:${slug}`);
 
     return {

--- a/apps/ayokoding-www/src/features/content/shell/service.ts
+++ b/apps/ayokoding-www/src/features/content/shell/service.ts
@@ -51,7 +51,11 @@ export class ContentService {
     if (!meta) return null;
 
     const { content } = await this.repository.readFileContent(meta.filePath);
-    const { html, headings } = await parseMarkdown(content, { locale: locale as Locale, slug });
+    const { html, headings } = await parseMarkdown(content, {
+      locale: locale as Locale,
+      slug,
+      isSection: meta.isSection,
+    });
     const prevNext = index.prevNext.get(`${locale}:${slug}`);
 
     return {

--- a/apps/ayokoding-www/test/unit/be-steps/parser.unit.test.ts
+++ b/apps/ayokoding-www/test/unit/be-steps/parser.unit.test.ts
@@ -70,4 +70,56 @@ describe("parseMarkdown", () => {
     expect(html).toContain('data-callout="info"');
     expect(html).toContain("Important note");
   });
+
+  describe("in-body relative content links", () => {
+    const currentSlug = "learn/fundamentally-strong/software-engineer/just-enough-nvim/learning/overview";
+
+    it("rewrites a relative link that climbs directories to the linked page's real site route", async () => {
+      const md = "[Overview (section)](../../overview.md)";
+      const { html } = await parseMarkdown(md, { locale: "en", slug: currentSlug });
+
+      expect(html).toContain('href="/en/c/learn/fundamentally-strong/software-engineer/overview"');
+      expect(html).not.toContain(".md");
+    });
+
+    it("rewrites a same-directory relative link to the linked page's real site route", async () => {
+      const md = "[Beginner Examples](./beginner.md)";
+      const { html } = await parseMarkdown(md, { locale: "en", slug: currentSlug });
+
+      expect(html).toContain(
+        'href="/en/c/learn/fundamentally-strong/software-engineer/just-enough-nvim/learning/beginner"',
+      );
+      expect(html).not.toContain(".md");
+    });
+
+    it("resolves a relative link to a section's _index.md to the section's own route", async () => {
+      const md = "[Section](../_index.md)";
+      const { html } = await parseMarkdown(md, { locale: "en", slug: currentSlug });
+
+      expect(html).toContain('href="/en/c/learn/fundamentally-strong/software-engineer/just-enough-nvim"');
+    });
+
+    it("leaves already-absolute /en/ links untouched", async () => {
+      const md = "[Home](/en/c/learn/fundamentally-strong)";
+      const { html } = await parseMarkdown(md, { locale: "en", slug: currentSlug });
+
+      expect(html).toContain('href="/en/c/learn/fundamentally-strong"');
+    });
+
+    it("leaves external, mailto, and in-page anchor links untouched", async () => {
+      const md = "[External](https://example.com/x.md) [Mail](mailto:a@example.com) [Anchor](#section)";
+      const { html } = await parseMarkdown(md, { locale: "en", slug: currentSlug });
+
+      expect(html).toContain('href="https://example.com/x.md"');
+      expect(html).toContain('href="mailto:a@example.com"');
+      expect(html).toContain('href="#section"');
+    });
+
+    it("passes relative links through unresolved when no slug context is provided", async () => {
+      const md = "[Beginner Examples](./beginner.md)";
+      const { html } = await parseMarkdown(md);
+
+      expect(html).toContain('href="./beginner.md"');
+    });
+  });
 });

--- a/apps/ayokoding-www/test/unit/be-steps/parser.unit.test.ts
+++ b/apps/ayokoding-www/test/unit/be-steps/parser.unit.test.ts
@@ -131,4 +131,33 @@ describe("parseMarkdown", () => {
       expect(html).not.toContain("/en/c/");
     });
   });
+
+  describe("in-body relative content links authored from a section index page", () => {
+    // isSection: true means this slug's file is `.../just-enough-nvim/_index.md`, so the
+    // section's own containing directory is the slug itself, not dirname(slug).
+    const sectionSlug = "learn/fundamentally-strong/software-engineer/just-enough-nvim";
+
+    it("resolves a same-directory sibling link relative to the section's own directory, not its parent", async () => {
+      const md = "[Sibling Topic](./sibling.md)";
+      const { html } = await parseMarkdown(md, { locale: "en", slug: sectionSlug, isSection: true });
+
+      expect(html).toContain('href="/en/c/learn/fundamentally-strong/software-engineer/just-enough-nvim/sibling"');
+      expect(html).not.toContain(".md");
+    });
+
+    it("resolves a directory-climbing link relative to the section's own directory, not one level above it", async () => {
+      const md = "[Parent Topic](../overview.md)";
+      const { html } = await parseMarkdown(md, { locale: "en", slug: sectionSlug, isSection: true });
+
+      expect(html).toContain('href="/en/c/learn/fundamentally-strong/software-engineer/overview"');
+      expect(html).not.toContain(".md");
+    });
+
+    it("resolves the identical sibling link differently when the same slug is a leaf page instead of a section index", async () => {
+      const md = "[Sibling Topic](./sibling.md)";
+      const { html } = await parseMarkdown(md, { locale: "en", slug: sectionSlug, isSection: false });
+
+      expect(html).toContain('href="/en/c/learn/fundamentally-strong/software-engineer/sibling"');
+    });
+  });
 });

--- a/apps/ayokoding-www/test/unit/be-steps/parser.unit.test.ts
+++ b/apps/ayokoding-www/test/unit/be-steps/parser.unit.test.ts
@@ -121,5 +121,14 @@ describe("parseMarkdown", () => {
 
       expect(html).toContain('href="./beginner.md"');
     });
+
+    it("leaves a relative link to a non-.md asset untouched instead of routing it as content", async () => {
+      const md = "[Slides](./slides.pdf) [Diagram](../assets/diagram.svg)";
+      const { html } = await parseMarkdown(md, { locale: "en", slug: currentSlug });
+
+      expect(html).toContain('href="./slides.pdf"');
+      expect(html).toContain('href="../assets/diagram.svg"');
+      expect(html).not.toContain("/en/c/");
+    });
   });
 });

--- a/apps/ayokoding-www/test/unit/be-steps/service.unit.test.ts
+++ b/apps/ayokoding-www/test/unit/be-steps/service.unit.test.ts
@@ -71,6 +71,16 @@ const baseItems: ContentMeta[] = [
     tags: [],
     filePath: "/en/learn/linked.md",
   },
+  {
+    title: "Guides",
+    slug: "learn/guides",
+    locale: "en",
+    weight: 40,
+    draft: false,
+    isSection: true,
+    tags: [],
+    filePath: "/en/learn/guides/_index.md",
+  },
 ];
 
 const baseFiles = new Map<string, { content: string; frontmatter: Record<string, unknown> }>();
@@ -88,6 +98,10 @@ baseFiles.set("/en/learn/topic/deep.md", { content: "## Deep\n\nDeep dive conten
 baseFiles.set("/en/learn/linked.md", {
   content: "## Linked\n\nSee [Advanced](./advanced.md) for more.",
   frontmatter: { title: "Linked" },
+});
+baseFiles.set("/en/learn/guides/_index.md", {
+  content: "# Guides\n\nSee [Tips](./tips.md) for details.",
+  frontmatter: { title: "Guides" },
 });
 
 describe("ContentService", () => {
@@ -168,6 +182,17 @@ describe("ContentService", () => {
     const result = await service.getBySlug("en", "learn/linked");
     expect(result).not.toBeNull();
     expect(result?.html).toContain('href="/en/c/learn/advanced"');
+    expect(result?.html).not.toContain(".md");
+  });
+
+  it("getBySlug on a section index (_index.md) rewrites an in-body relative link against the section's own directory", async () => {
+    const service = createService(baseItems, baseFiles);
+    const result = await service.getBySlug("en", "learn/guides");
+    expect(result).not.toBeNull();
+    expect(result?.isSection).toBe(true);
+    // If meta.isSection were dropped on its way into parseMarkdown, this would incorrectly
+    // resolve against dirname("learn/guides") == "learn" and produce "/en/c/learn/tips".
+    expect(result?.html).toContain('href="/en/c/learn/guides/tips"');
     expect(result?.html).not.toContain(".md");
   });
 

--- a/apps/ayokoding-www/test/unit/be-steps/service.unit.test.ts
+++ b/apps/ayokoding-www/test/unit/be-steps/service.unit.test.ts
@@ -61,6 +61,16 @@ const baseItems: ContentMeta[] = [
     tags: [],
     filePath: "/en/learn/topic/deep.md",
   },
+  {
+    title: "Linked",
+    slug: "learn/linked",
+    locale: "en",
+    weight: 30,
+    draft: false,
+    isSection: false,
+    tags: [],
+    filePath: "/en/learn/linked.md",
+  },
 ];
 
 const baseFiles = new Map<string, { content: string; frontmatter: Record<string, unknown> }>();
@@ -75,6 +85,10 @@ baseFiles.set("/en/learn/advanced.md", {
   frontmatter: { title: "Advanced" },
 });
 baseFiles.set("/en/learn/topic/deep.md", { content: "## Deep\n\nDeep dive content.", frontmatter: { title: "Deep" } });
+baseFiles.set("/en/learn/linked.md", {
+  content: "## Linked\n\nSee [Advanced](./advanced.md) for more.",
+  frontmatter: { title: "Linked" },
+});
 
 describe("ContentService", () => {
   it("getBySlug returns null for non-existent slug", async () => {
@@ -147,6 +161,14 @@ describe("ContentService", () => {
 
     const advanced = await service.getBySlug("en", "learn/advanced");
     expect(advanced?.prev?.slug).toBe("learn/intro");
+  });
+
+  it("getBySlug rewrites an in-body relative markdown link to its real site route", async () => {
+    const service = createService(baseItems, baseFiles);
+    const result = await service.getBySlug("en", "learn/linked");
+    expect(result).not.toBeNull();
+    expect(result?.html).toContain('href="/en/c/learn/advanced"');
+    expect(result?.html).not.toContain(".md");
   });
 
   it("readFileContent error in search is silently skipped", async () => {

--- a/apps/ayokoding-www/test/unit/fe-steps/navigation.steps.tsx
+++ b/apps/ayokoding-www/test/unit/fe-steps/navigation.steps.tsx
@@ -198,4 +198,33 @@ describeFeature(feature, ({ Scenario, Background }) => {
       expect(html).not.toContain('href="./');
     });
   });
+
+  Scenario(
+    "In-body relative markdown links authored from a section index page resolve to real site routes",
+    ({ Given, When, Then, And }) => {
+      const markdown = "[Sibling Topic](./sibling.md)";
+      let html = "";
+
+      Given("a section index page's markdown body contains a relative link to a sibling content file", () => {
+        expect(markdown).toContain("](./sibling.md)");
+      });
+
+      When("the page is rendered to HTML", async () => {
+        // This slug's file is `.../just-enough-nvim/_index.md` (isSection: true), so the
+        // page's own containing directory is the slug itself, not dirname(slug).
+        const currentSlug = "learn/fundamentally-strong/software-engineer/just-enough-nvim";
+        const result = await parseMarkdown(markdown, { locale: "en", slug: currentSlug, isSection: true });
+        html = result.html;
+      });
+
+      Then("the rendered link's href should be resolved relative to the section's own directory", () => {
+        expect(html).toContain('href="/en/c/learn/fundamentally-strong/software-engineer/just-enough-nvim/sibling"');
+      });
+
+      // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/navigation.feature:In-body relative markdown links authored from a section index page resolve to real site routes
+      And('the href should not contain a literal ".md" extension', () => {
+        expect(html).not.toContain(".md");
+      });
+    },
+  );
 });

--- a/apps/ayokoding-www/test/unit/fe-steps/navigation.steps.tsx
+++ b/apps/ayokoding-www/test/unit/fe-steps/navigation.steps.tsx
@@ -6,6 +6,7 @@ import "./helpers/test-setup";
 import { Breadcrumb } from "@/features/navigation/shell/breadcrumb";
 import { TableOfContents } from "@/features/navigation/shell/toc";
 import { PrevNext } from "@/features/navigation/shell/prev-next";
+import { parseMarkdown } from "@/features/content/core/parser";
 
 const feature = await loadFeature(
   path.resolve(
@@ -166,6 +167,35 @@ describeFeature(feature, ({ Scenario, Background }) => {
     // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/navigation.feature:Active page is highlighted in the sidebar
     And("no other sidebar item should be highlighted as active", () => {
       expect(true).toBe(true);
+    });
+  });
+
+  Scenario("In-body relative markdown links resolve to real site routes", ({ Given, When, Then, And }) => {
+    const markdown = "[Overview (section)](../../overview.md)";
+    let html = "";
+
+    Given("a content page's markdown body contains a relative link to another content file", () => {
+      expect(markdown).toContain("](../../overview.md)");
+    });
+
+    When("the page is rendered to HTML", async () => {
+      const currentSlug = "learn/fundamentally-strong/software-engineer/just-enough-nvim/learning/overview";
+      const result = await parseMarkdown(markdown, { locale: "en", slug: currentSlug });
+      html = result.html;
+    });
+
+    Then("the rendered link's href should be the linked page's real site URL", () => {
+      expect(html).toContain('href="/en/c/learn/fundamentally-strong/software-engineer/overview"');
+    });
+
+    And('the href should not contain a literal ".md" extension', () => {
+      expect(html).not.toContain(".md");
+    });
+
+    // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/navigation.feature:In-body relative markdown links resolve to real site routes
+    And("the href should not be a raw filesystem-relative path", () => {
+      expect(html).not.toContain('href="../');
+      expect(html).not.toContain('href="./');
     });
   });
 });

--- a/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/navigation.feature
+++ b/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/navigation.feature
@@ -52,3 +52,10 @@ Feature: Site Navigation
     Then the rendered link's href should be the linked page's real site URL
     And the href should not contain a literal ".md" extension
     And the href should not be a raw filesystem-relative path
+
+  @unit
+  Scenario: In-body relative markdown links authored from a section index page resolve to real site routes
+    Given a section index page's markdown body contains a relative link to a sibling content file
+    When the page is rendered to HTML
+    Then the rendered link's href should be resolved relative to the section's own directory
+    And the href should not contain a literal ".md" extension

--- a/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/navigation.feature
+++ b/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/navigation.feature
@@ -44,3 +44,11 @@ Feature: Site Navigation
     When a visitor is on a specific content page
     Then the corresponding item in the sidebar should be visually highlighted as active
     And no other sidebar item should be highlighted as active
+
+  @unit
+  Scenario: In-body relative markdown links resolve to real site routes
+    Given a content page's markdown body contains a relative link to another content file
+    When the page is rendered to HTML
+    Then the rendered link's href should be the linked page's real site URL
+    And the href should not contain a literal ".md" extension
+    And the href should not be a raw filesystem-relative path


### PR DESCRIPTION
## Summary

Prod nav Prev/Next links 404 site-wide. Root cause: markdown pipeline never rewrote relative `.md` content links (e.g. `../../overview.md`) into real site routes — shipped raw to browser, clean-URL routing 404s on click.

Fix: rehype-plugin-style link rewrite in `parseMarkdown` reusing existing `contentUrl`/slug-derivation logic (`content-link-rewrite.ts`). Platform-level, so it retroactively repairs every already-deployed topic, not just the reported page.

- `resolveContentHref()` (new) — resolves relative href against current slug, strips `.md`/`_index`, routes through `contentUrl()`
- `parseMarkdown()` — takes optional `{ locale, slug }` context, rewrites all `<a>` hrefs post-render
- `ContentService.getBySlug()` — passes locale/slug context through

## Test plan

- [x] TDD: Gherkin scenario + regression test added first (red), then fix (green)
- [x] Full unit suite (2530 tests) green
- [x] typecheck, lint, Gherkin behavior-coverage all green
- [x] Production build + real locally-booted prod server curl-verified against the exact broken URL — now resolves correctly
- [x] CI

Bug report: https://www.ayokoding.com/en/c/learn/fundamentally-strong/software-engineer/just-enough-nvim/learning/overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)