### PR TITLE
feat(ayokoding-www): add SQL Essentials By Example topic (Phase 11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ __pycache__/
 *.pyo
 *.egg-info/
 .ruff_cache/
+.pytest_cache/
 .venv/
 .coverage
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -56,3 +56,11 @@ apps/*/coverage/
 
 # Raw design reference files (prototype source, not production code)
 plans/**/raw/
+
+# ayokoding-www tutorial example-code .sql files: these are sqlite3 CLI REPL
+# scripts (they legitimately embed dot-commands like `.headers`/`.mode`/`.tables`,
+# which are not valid SQL and which prettier-plugin-sql cannot parse), not
+# portable database-migration SQL. Real migration .sql files (e.g.
+# apps/organiclever-be/db/migrations/, apps/ose-be/db/migrations/) are
+# intentionally NOT covered by this exclusion and remain prettier-formatted.
+apps/ayokoding-www/content/**/code/**/*.sql

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/_index.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/_index.md
@@ -13,3 +13,4 @@ weight: 107
   - [Pass 0 Capstone · Forge-Ready](/en/c/learn/fundamentally-strong/software-engineer/capstone-forge-ready)
   - [4 · Just Enough Python](/en/c/learn/fundamentally-strong/software-engineer/just-enough-python)
   - [5 · Just Enough Bash](/en/c/learn/fundamentally-strong/software-engineer/just-enough-bash)
+  - [10 · SQL Essentials](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/_index.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/_index.md
@@ -23,3 +23,6 @@ weight: 1750
 - [5 · Just Enough Bash](/en/c/learn/fundamentally-strong/software-engineer/just-enough-bash)
   - [Learning](/en/c/learn/fundamentally-strong/software-engineer/just-enough-bash/learning)
   - [Drilling](/en/c/learn/fundamentally-strong/software-engineer/just-enough-bash/drilling)
+- [10 · SQL Essentials](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials)
+  - [Learning](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning)
+  - [Drilling](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/drilling)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/_index.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/_index.md
@@ -1,0 +1,15 @@
+---
+title: "10 · SQL Essentials"
+date: 2026-07-14T00:00:00+07:00
+draft: false
+weight: 200
+---
+
+- [Learning](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning)
+  - [Overview](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/overview)
+  - [Beginner Examples](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner)
+  - [Intermediate Examples](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate)
+  - [Advanced Examples](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced)
+  - [Capstone](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone)
+- [Drilling](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/drilling)
+  - [Overview](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/overview)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/_index.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Drilling"
+date: 2026-07-14T00:00:00+07:00
+draft: false
+weight: 210
+---
+
+- [Overview](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/overview)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-01-forgotten-where-update/after/kata.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-01-forgotten-where-update/after/kata.sql
@@ -1,0 +1,15 @@
+-- Kata 1 (after): the WHERE clause narrows the UPDATE to the one intended row.
+DROP TABLE IF EXISTS book;
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+INSERT INTO book(title, price) VALUES
+    ('Refactoring', 45.00),
+    ('Domain-Driven Design', 55.00),
+    ('Clean Code', 35.00);
+
+.headers on
+.mode column
+
+-- THE FIX: WHERE id = 2 scopes the write to exactly the row the promo applies to.
+UPDATE book SET price = 0 WHERE id = 2;
+
+SELECT id, title, price FROM book ORDER BY id;

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-01-forgotten-where-update/before/kata.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-01-forgotten-where-update/before/kata.sql
@@ -1,0 +1,15 @@
+-- Kata 1 (before): UPDATE with no WHERE zeroes every row, not just the intended one.
+DROP TABLE IF EXISTS book;
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+INSERT INTO book(title, price) VALUES
+    ('Refactoring', 45.00),
+    ('Domain-Driven Design', 55.00),
+    ('Clean Code', 35.00);
+
+.headers on
+.mode column
+
+-- intent: put ONE book (id 2) on a free promo -- the WHERE clause is missing.
+UPDATE book SET price = 0;
+
+SELECT id, title, price FROM book ORDER BY id;

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-02-null-equality-bug/after/kata.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-02-null-equality-bug/after/kata.sql
@@ -1,0 +1,13 @@
+-- Kata 2 (after): IS NULL is the correct test for "unknown", not =.
+DROP TABLE IF EXISTS book;
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, published_year INTEGER);
+INSERT INTO book(title, published_year) VALUES
+    ('The Mythical Man-Month', 1975),
+    ('Unknown Draft', NULL),
+    ('Peopleware', 1987);
+
+.headers on
+.mode column
+
+-- THE FIX: IS NULL, not = NULL, matches rows whose value is unknown.
+SELECT id, title FROM book WHERE published_year IS NULL;

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-02-null-equality-bug/before/kata.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-02-null-equality-bug/before/kata.sql
@@ -1,0 +1,13 @@
+-- Kata 2 (before): WHERE column = NULL never matches under three-valued logic.
+DROP TABLE IF EXISTS book;
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, published_year INTEGER);
+INSERT INTO book(title, published_year) VALUES
+    ('The Mythical Man-Month', 1975),
+    ('Unknown Draft', NULL),
+    ('Peopleware', 1987);
+
+.headers on
+.mode column
+
+-- intent: find every book whose published_year was never recorded.
+SELECT id, title FROM book WHERE published_year = NULL;

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-03-inner-join-drops-rows/after/kata.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-03-inner-join-drops-rows/after/kata.sql
@@ -1,0 +1,20 @@
+-- Kata 3 (after): LEFT JOIN keeps every author, filling unmatched book columns with NULL.
+DROP TABLE IF EXISTS book;
+DROP TABLE IF EXISTS author;
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER REFERENCES author(id));
+INSERT INTO author(name) VALUES
+    ('Ada Lovelace'),
+    ('Grace Hopper'),
+    ('Margaret Hamilton');
+INSERT INTO book(title, author_id) VALUES ('Notes on the Analytical Engine', 1);
+
+.headers on
+.mode column
+.nullvalue NULL
+
+-- THE FIX: LEFT JOIN keeps every left-side (author) row, even with zero matches.
+SELECT author.name, book.title
+FROM author
+LEFT JOIN book ON book.author_id = author.id
+ORDER BY author.name;

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-03-inner-join-drops-rows/before/kata.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-03-inner-join-drops-rows/before/kata.sql
@@ -1,0 +1,20 @@
+-- Kata 3 (before): an inner join silently drops authors with zero books.
+DROP TABLE IF EXISTS book;
+DROP TABLE IF EXISTS author;
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER REFERENCES author(id));
+INSERT INTO author(name) VALUES
+    ('Ada Lovelace'),
+    ('Grace Hopper'),
+    ('Margaret Hamilton');
+-- Grace Hopper (id 2) and Margaret Hamilton (id 3) have zero books each so far.
+INSERT INTO book(title, author_id) VALUES ('Notes on the Analytical Engine', 1);
+
+.headers on
+.mode column
+
+-- intent: list every author in the catalog, alongside any books they've published.
+SELECT author.name, book.title
+FROM author
+JOIN book ON book.author_id = author.id
+ORDER BY author.name;

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-04-unparameterized-query/after/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-04-unparameterized-query/after/kata.py
@@ -1,0 +1,25 @@
+# pyright: strict
+"""Kata 4 (after): a parameterized query neutralizes the same injection attempt."""
+
+import sqlite3
+
+
+def find_author_by_name(conn: sqlite3.Connection, name: str) -> list[tuple[int, str]]:
+    cur = conn.cursor()
+    # THE FIX: ? is a placeholder, not a splice point -- the driver binds `name`
+    # as a single opaque value, so it can never change the shape of the query.
+    cur.execute("SELECT id, name FROM author WHERE name = ?", (name,))
+    return cur.fetchall()
+
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")
+conn.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+conn.executemany(
+    "INSERT INTO author(name) VALUES (?)",
+    [("Ada Lovelace",), ("Grace Hopper",)],
+)
+conn.commit()
+
+malicious_input: str = "nobody' OR '1'='1"
+print(find_author_by_name(conn, malicious_input))
+conn.close()

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-04-unparameterized-query/before/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-04-unparameterized-query/before/kata.py
@@ -1,0 +1,28 @@
+# pyright: strict
+"""Kata 4 (before): a WHERE clause built via string interpolation -- injectable."""
+
+import sqlite3
+
+
+def find_author_by_name(conn: sqlite3.Connection, name: str) -> list[tuple[int, str]]:
+    cur = conn.cursor()
+    # THE BUG: f-string interpolation lets the caller's input become SQL syntax,
+    # not just a value -- the query text itself changes shape based on input.
+    query = f"SELECT id, name FROM author WHERE name = '{name}'"
+    cur.execute(query)
+    return cur.fetchall()
+
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")
+conn.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+conn.executemany(
+    "INSERT INTO author(name) VALUES (?)",
+    [("Ada Lovelace",), ("Grace Hopper",)],
+)
+conn.commit()
+
+# a crafted search value: no author is actually named this, but the OR clause
+# it injects makes the WHERE condition true for every row in the table.
+malicious_input: str = "nobody' OR '1'='1"
+print(find_author_by_name(conn, malicious_input))
+conn.close()

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-05-foreign-key-not-enforced/after/kata.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-05-foreign-key-not-enforced/after/kata.sql
@@ -1,0 +1,17 @@
+-- Kata 5 (after): PRAGMA foreign_keys=ON rejects the same orphan insert.
+DROP TABLE IF EXISTS book;
+DROP TABLE IF EXISTS author;
+-- THE FIX: turn on enforcement for this connection BEFORE any writes happen.
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER REFERENCES author(id));
+INSERT INTO author(name) VALUES ('Ada Lovelace');
+
+.headers on
+.mode column
+
+-- author_id 99 still does not exist -- this insert is now rejected.
+INSERT INTO book(title, author_id) VALUES ('Ghost Reference', 99);
+
+SELECT id, title, author_id FROM book;

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-05-foreign-key-not-enforced/before/kata.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-05-foreign-key-not-enforced/before/kata.sql
@@ -1,0 +1,15 @@
+-- Kata 5 (before): PRAGMA foreign_keys is OFF by default -- an orphan insert succeeds silently.
+DROP TABLE IF EXISTS book;
+DROP TABLE IF EXISTS author;
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER REFERENCES author(id));
+INSERT INTO author(name) VALUES ('Ada Lovelace');
+
+.headers on
+.mode column
+
+-- BUG: author_id 99 does not exist in author -- no PRAGMA foreign_keys=ON was ever set,
+-- so SQLite does not enforce the REFERENCES clause for this connection.
+INSERT INTO book(title, author_id) VALUES ('Ghost Reference', 99);
+
+SELECT id, title, author_id FROM book;

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-06-missing-commit/after/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-06-missing-commit/after/kata.py
@@ -1,0 +1,25 @@
+# pyright: strict
+"""Kata 6 (after): an explicit commit() before close() makes the write durable."""
+
+import os
+import sqlite3
+
+DB_PATH: str = "kata.db"
+
+if os.path.exists(DB_PATH):
+    os.remove(DB_PATH)
+
+conn1: sqlite3.Connection = sqlite3.connect(DB_PATH)
+conn1.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+conn1.commit()
+
+conn1.execute("INSERT INTO author(name) VALUES ('Ada Lovelace')")
+# THE FIX: commit() BEFORE close() -- the write is durable before the connection ends.
+conn1.commit()
+conn1.close()
+
+conn2: sqlite3.Connection = sqlite3.connect(DB_PATH)
+rows: list[tuple[int, str]] = conn2.execute("SELECT id, name FROM author").fetchall()
+print(rows)
+conn2.close()
+os.remove(DB_PATH)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-06-missing-commit/before/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-06-missing-commit/before/kata.py
@@ -1,0 +1,25 @@
+# pyright: strict
+"""Kata 6 (before): insert-then-close with no commit() -- the write never reaches disk."""
+
+import os
+import sqlite3
+
+DB_PATH: str = "kata.db"
+
+if os.path.exists(DB_PATH):
+    os.remove(DB_PATH)
+
+conn1: sqlite3.Connection = sqlite3.connect(DB_PATH)
+conn1.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+conn1.commit()  # the schema itself IS committed, so the table persists
+
+conn1.execute("INSERT INTO author(name) VALUES ('Ada Lovelace')")
+# THE BUG: no conn1.commit() here -- close() below discards the open transaction.
+conn1.close()
+
+# a completely fresh connection to the SAME file -- proves what actually landed on disk.
+conn2: sqlite3.Connection = sqlite3.connect(DB_PATH)
+rows: list[tuple[int, str]] = conn2.execute("SELECT id, name FROM author").fetchall()
+print(rows)
+conn2.close()
+os.remove(DB_PATH)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-07-n-plus-1-loop/after/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-07-n-plus-1-loop/after/kata.py
@@ -1,0 +1,48 @@
+# pyright: strict
+"""Kata 7 (after): one LEFT JOIN replaces the per-author loop -- a single round trip."""
+
+import sqlite3
+
+
+def books_by_author(conn: sqlite3.Connection) -> dict[str, list[str]]:
+    query_count: int = 0
+    result: dict[str, list[str]] = {}
+    cur = conn.cursor()
+    # THE FIX: one LEFT JOIN fetches every author-book pair (or lone author) at once.
+    cur.execute(
+        "SELECT author.name, book.title FROM author "
+        "LEFT JOIN book ON book.author_id = author.id "
+        "ORDER BY author.name"
+    )
+    rows: list[tuple[str, str | None]] = cur.fetchall()
+    query_count += 1
+    for name, title in rows:
+        result.setdefault(name, [])
+        if title is not None:
+            result[name].append(title)
+    print(f"queries issued: {query_count}")
+    return result
+
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")
+conn.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+conn.execute(
+    "CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER)"
+)
+conn.executemany(
+    "INSERT INTO author(name) VALUES (?)",
+    [("Ada Lovelace",), ("Grace Hopper",), ("Alan Turing",)],
+)
+conn.executemany(
+    "INSERT INTO book(title, author_id) VALUES (?, ?)",
+    [
+        ("Notes", 1),
+        ("COBOL Manual", 2),
+        ("Compiler Notes", 2),
+        ("On Computable Numbers", 3),
+    ],
+)
+conn.commit()
+
+print(books_by_author(conn))
+conn.close()

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-07-n-plus-1-loop/before/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-07-n-plus-1-loop/before/kata.py
@@ -1,0 +1,45 @@
+# pyright: strict
+"""Kata 7 (before): one SELECT per author inside a loop -- N+1 round trips."""
+
+import sqlite3
+
+
+def books_by_author(conn: sqlite3.Connection) -> dict[str, list[str]]:
+    query_count: int = 0
+    result: dict[str, list[str]] = {}
+    cur = conn.cursor()
+    cur.execute("SELECT id, name FROM author")
+    authors: list[tuple[int, str]] = cur.fetchall()
+    query_count += 1
+    for author_id, name in authors:
+        # THE BUG: one fresh SELECT for EVERY author, instead of one query total.
+        cur.execute("SELECT title FROM book WHERE author_id = ?", (author_id,))
+        titles: list[str] = [row[0] for row in cur.fetchall()]
+        query_count += 1
+        result[name] = titles
+    print(f"queries issued: {query_count}")
+    return result
+
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")
+conn.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+conn.execute(
+    "CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER)"
+)
+conn.executemany(
+    "INSERT INTO author(name) VALUES (?)",
+    [("Ada Lovelace",), ("Grace Hopper",), ("Alan Turing",)],
+)
+conn.executemany(
+    "INSERT INTO book(title, author_id) VALUES (?, ?)",
+    [
+        ("Notes", 1),
+        ("COBOL Manual", 2),
+        ("Compiler Notes", 2),
+        ("On Computable Numbers", 3),
+    ],
+)
+conn.commit()
+
+print(books_by_author(conn))
+conn.close()

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-08-non-grouped-column/after/kata.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-08-non-grouped-column/after/kata.sql
@@ -1,0 +1,17 @@
+-- Kata 8 (after): group_concat aggregates every title per group explicitly.
+DROP TABLE IF EXISTS book;
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL, price REAL NOT NULL);
+INSERT INTO book(title, author_id, price) VALUES
+    ('Notes on the Analytical Engine', 1, 12.00),
+    ('Sketch of the Analytical Engine', 1, 18.00),
+    ('COBOL Manual', 2, 9.50);
+
+.headers on
+.mode column
+.width 10 70 12 12
+
+-- THE FIX: group_concat(title, sep) is a real aggregate -- it names EVERY title
+-- in the group explicitly, instead of silently picking one.
+SELECT author_id, group_concat(title, '; ') AS titles, count(*) AS book_count, sum(price) AS total_price
+FROM book
+GROUP BY author_id;

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-08-non-grouped-column/before/kata.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/code/kata-08-non-grouped-column/before/kata.sql
@@ -1,0 +1,17 @@
+-- Kata 8 (before): title is neither aggregated nor in GROUP BY -- SQLite leniently
+-- picks ONE arbitrary row's title per group instead of raising an error.
+DROP TABLE IF EXISTS book;
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL, price REAL NOT NULL);
+INSERT INTO book(title, author_id, price) VALUES
+    ('Notes on the Analytical Engine', 1, 12.00),
+    ('Sketch of the Analytical Engine', 1, 18.00),
+    ('COBOL Manual', 2, 9.50);
+
+.headers on
+.mode column
+
+-- BUG: title is a non-aggregated, non-grouping column -- which title does author_id
+-- 1's group report back, when it has TWO distinct titles?
+SELECT author_id, title, count(*) AS book_count, sum(price) AS total_price
+FROM book
+GROUP BY author_id;

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/overview.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/drilling/overview.md
@@ -1,0 +1,1505 @@
+---
+title: "Overview"
+date: 2026-07-14T00:00:00+07:00
+draft: false
+weight: 1
+---
+
+This page is the spaced-repetition companion to the SQL Essentials primer: five fixed drills that
+force active recall instead of passive re-reading. Work through them in order -- short-answer recall
+first, then scenario judgment, then hands-on repetition against a real SQLite database, then a
+checklist to confirm real automaticity, and finally why/why-not prompts that test whether you can
+explain the reasoning -- including this topic's cross-cutting big idea, `mechanism-vs-policy` -- not
+just execute the syntax. Every answer is hidden in a `<details>` block; try each item yourself before
+opening it.
+
+## Recall Q&A
+
+Twenty-four short-answer questions, one per concept (`co-01` through `co-24`). Answer from memory,
+then check.
+
+**Q1 (co-01 -- relational-model).** What does it mean for data to be "modeled relationally," and how
+does that differ from an in-memory structure connected by pointers?
+
+<details>
+<summary>Answer</summary>
+
+Data lives in tables (relations) of rows and typed columns, and every fact is stored exactly once,
+related to other facts by matching key _values_ rather than by memory addresses. An in-memory
+structure connects records by pointers that only make sense while the process is alive; a relational
+table's foreign-key values stay meaningful on disk, across processes, and across however many years
+the data outlives the program that first wrote it.
+
+</details>
+
+**Q2 (co-02 -- primary-keys).** What does declaring a column `INTEGER PRIMARY KEY` do in SQLite, and
+how does it relate to `rowid`?
+
+<details>
+<summary>Answer</summary>
+
+It designates that column as the row's unique identifier, and in SQLite specifically, a
+single-column `INTEGER PRIMARY KEY` becomes an alias for the table's internal `rowid` -- inserting
+`NULL` (or omitting the column) makes SQLite auto-assign the next integer value for you, so you never
+hand-manage ids.
+
+</details>
+
+**Q3 (co-03 -- foreign-keys).** What does a foreign key constraint do, and why do you have to
+explicitly opt into it in SQLite?
+
+<details>
+<summary>Answer</summary>
+
+A foreign key constrains a column to only hold values that already exist as a primary key in another
+table (or be NULL), and, when enforced, drives `ON DELETE` actions like `CASCADE` or `RESTRICT`.
+SQLite disables foreign key enforcement by default for backward compatibility with older schemas --
+you must run `PRAGMA foreign_keys = ON` on every connection where you want orphan rows rejected.
+
+</details>
+
+**Q4 (co-04 -- constraints).** Name the four column-level constraints this topic covers and the
+invariant each one enforces.
+
+<details>
+<summary>Answer</summary>
+
+`NOT NULL` forbids a missing value; `UNIQUE` forbids a duplicate value across the whole column;
+`CHECK` forbids any value that fails a boolean expression you supply (e.g. `CHECK(price >= 0)`); and
+`DEFAULT` supplies a value automatically when an `INSERT` omits that column.
+
+</details>
+
+**Q5 (co-05 -- normalization).** What problem does normalization (1NF -> 2NF -> 3NF) solve, and what
+do you give up to get it?
+
+<details>
+<summary>Answer</summary>
+
+It keeps every fact stored in exactly one place by splitting repeating groups and transitive
+dependencies into their own tables, which prevents update anomalies -- e.g. a fact changing in one
+row but not the other rows that duplicated it. The cost is more joins: recombining normalized data at
+query time is more verbose than reading one wide, denormalized table.
+
+</details>
+
+**Q6 (co-06 -- column-types).** What is "type affinity" in SQLite, and how does it differ from the
+rigid typing most other relational databases enforce?
+
+<details>
+<summary>Answer</summary>
+
+SQLite assigns each column a _preferred_ storage class (INTEGER/TEXT/REAL/BLOB/NUMERIC) based on its
+declared type, but it does not rigidly reject a value of a different class the way, say, a strictly
+typed engine would -- the declared type _guides_ storage, it does not _enforce_ it. `typeof(column)`
+reveals what storage class a given value actually landed as.
+
+</details>
+
+**Q7 (co-07 -- ddl-create-table).** What does `CREATE TABLE` do, and what command proves exactly what
+definition SQLite stored?
+
+<details>
+<summary>Answer</summary>
+
+`CREATE TABLE` declares a new relation: its name, its column list, and every constraint on it.
+`.schema <table>` (a CLI dot-command) echoes back the literal `CREATE TABLE` text SQLite stored in
+its internal `sqlite_master` table, comments included -- proof of what the engine actually has, not
+what you remember writing.
+
+</details>
+
+**Q8 (co-08 -- select-projection-filtering).** In relational-algebra terms, what operation does a
+`SELECT` column list perform, and what operation does `WHERE` perform?
+
+<details>
+<summary>Answer</summary>
+
+The `SELECT` column list performs _projection_ -- choosing which columns come back, never changing
+the row count. `WHERE` performs _selection_ -- choosing which rows come back, using comparisons,
+`AND`/`OR`, `LIKE`, `IN`, `CASE`, or a subquery, never changing which columns are visible.
+
+</details>
+
+**Q9 (co-09 -- ordering-and-limiting).** What do `ORDER BY` and `LIMIT`/`OFFSET` each control, and how
+do you combine them to fetch "page 2" of ten-row pages?
+
+<details>
+<summary>Answer</summary>
+
+`ORDER BY` controls the _sequence_ rows come back in; `LIMIT` caps how many rows come back; `OFFSET`
+skips a number of rows before that cap starts counting. `ORDER BY <col> LIMIT 10 OFFSET 10` sorts
+first, then skips the first 10 (page 1) and returns the next 10 (page 2) -- ordering must come first
+or "page 2" is meaningless.
+
+</details>
+
+**Q10 (co-10 -- insert).** What does a basic `INSERT` statement do, and what clause turns it into an
+upsert?
+
+<details>
+<summary>Answer</summary>
+
+`INSERT INTO table(columns) VALUES(...)` adds one or (with comma-separated tuples) many new rows.
+Appending `ON CONFLICT(col) DO UPDATE SET ...` turns the same statement into an upsert -- insert if
+the conflicting key is new, update in place if it already exists, instead of raising a constraint
+error.
+
+</details>
+
+**Q11 (co-11 -- update).** What happens to an `UPDATE` statement if its `WHERE` clause is omitted
+entirely?
+
+<details>
+<summary>Answer</summary>
+
+The `SET` clause applies to _every single row_ in the table, not just the one you had in mind --
+there is no implicit "current row" the way a cursor-based language might assume. This is the single
+most dangerous omission in this whole topic (Kata 1).
+
+</details>
+
+**Q12 (co-12 -- delete).** What is `DELETE`'s equivalent of `UPDATE`'s missing-`WHERE` trap?
+
+<details>
+<summary>Answer</summary>
+
+`DELETE FROM table` with no `WHERE` clause removes _every row_ in the table, not one -- the exact
+same missing-filter danger as an unscoped `UPDATE`, just irreversible instead of merely wrong.
+
+</details>
+
+**Q13 (co-13 -- inner-join).** What rows does an inner join (`JOIN ... ON ...`) return, and what
+happens to rows on either side that have no match?
+
+<details>
+<summary>Answer</summary>
+
+An inner join returns only the rows where the join condition finds a match on _both_ sides -- a row
+from either table with zero matches on the other side is silently dropped from the result entirely,
+never appearing with NULLs or otherwise (Kata 3).
+
+</details>
+
+**Q14 (co-14 -- outer-join).** How does a `LEFT JOIN`'s result differ from an inner join's, and what
+fills in for an unmatched right-side row?
+
+<details>
+<summary>Answer</summary>
+
+A `LEFT JOIN` guarantees every row from the left table appears at least once in the result, even when
+it has zero matches on the right -- unmatched right-side columns are filled with NULL instead of the
+row being dropped. That NULL-filling is also what makes `LEFT JOIN ... WHERE right.id IS NULL` an
+anti-join: it isolates exactly the left rows with no match at all.
+
+</details>
+
+**Q15 (co-15 -- aggregation).** What does `GROUP BY` do to a result set, and name at least four
+aggregate functions you can apply within each group?
+
+<details>
+<summary>Answer</summary>
+
+`GROUP BY <col>` collapses every row sharing the same value of `<col>` into a single summary row per
+distinct value. Any of `COUNT`, `SUM`, `AVG`, `MIN`, `MAX`, or `GROUP_CONCAT` can then summarize the
+rows inside each group.
+
+</details>
+
+**Q16 (co-16 -- having-filter).** How does `HAVING` differ from `WHERE` in terms of _when_ its filter
+applies relative to aggregation?
+
+<details>
+<summary>Answer</summary>
+
+`WHERE` filters individual rows _before_ `GROUP BY` collapses them into groups -- it has no access to
+aggregate values like `count(*)`. `HAVING` filters the already-formed _groups_, after aggregation has
+run, so it can test conditions like `HAVING count(*) > 1` that only make sense once rows are already
+summarized.
+
+</details>
+
+**Q17 (co-17 -- null-semantics).** Why does `WHERE column = NULL` never match any row, no matter what
+is actually stored?
+
+<details>
+<summary>Answer</summary>
+
+NULL means "unknown," and under SQL's three-valued logic, comparing anything to an unknown value --
+including `NULL = NULL` -- yields NULL (neither true nor false), which `WHERE` treats as a non-match.
+The only correct test for "is this value unknown" is `IS NULL` (or `IS NOT NULL` for the opposite);
+`COALESCE(col, fallback)` substitutes a default when you want a NULL to read as a concrete value
+instead.
+
+</details>
+
+**Q18 (co-18 -- transactions).** What guarantee does a transaction make about a group of writes, and
+what construct lets you undo only _part_ of one without ending it?
+
+<details>
+<summary>Answer</summary>
+
+A transaction (`BEGIN` ... `COMMIT`/`ROLLBACK`) makes every write inside it atomic as a group --
+either all of them apply, or none do; there is no partially applied state a reader can ever observe.
+`SAVEPOINT` creates a named point inside a still-open transaction that `ROLLBACK TO` can undo back
+to, without ending the outer transaction or discarding writes made before the savepoint.
+
+</details>
+
+**Q19 (co-19 -- python-sqlite3-connection).** Name the four core lifecycle steps of a Python
+`sqlite3` script, from opening a database to finalizing it.
+
+<details>
+<summary>Answer</summary>
+
+`sqlite3.connect(path)` opens (or creates) the database file and returns a `Connection`; `.cursor()`
+gets a cursor to run SQL through; `.execute(sql, params)` runs a statement; `.commit()` makes any
+pending writes durable and `.close()` releases the connection -- skipping `.commit()` before
+`.close()` silently discards uncommitted writes (Kata 6).
+
+</details>
+
+**Q20 (co-20 -- parameterized-queries).** Why does passing a value as a `?` placeholder rather than
+splicing it into the SQL string neutralize SQL injection?
+
+<details>
+<summary>Answer</summary>
+
+A `?` (or `:name`) placeholder tells the driver "this is a single opaque _value_, never SQL syntax"
+-- the driver sends the query text and the value separately to the engine, so nothing the value
+contains (quotes, `OR`, `;`, anything) can change the shape of the statement being executed. String
+interpolation, by contrast, makes the value part of the SQL text itself before the engine ever sees
+it, so a crafted value can add real clauses (Kata 4).
+
+</details>
+
+**Q21 (co-21 -- cursor-and-results).** What is the difference between `fetchone()` and `fetchall()`,
+and what does setting `conn.row_factory = sqlite3.Row` change?
+
+<details>
+<summary>Answer</summary>
+
+`fetchone()` returns the next single row (or `None` once exhausted), letting you stream through a
+large result without holding it all in memory; `fetchall()` returns every remaining row as a list in
+one call. Setting `row_factory = sqlite3.Row` changes how a _row_ itself is accessed -- from a plain
+positional tuple (`row[0]`) to name-based access (`row["name"]`) as well, without giving up
+tuple-style indexing.
+
+</details>
+
+**Q22 (co-22 -- schema-migration).** What makes an `ALTER TABLE ADD COLUMN` migration "safe" for
+existing rows, and what does `PRAGMA user_version` track?
+
+<details>
+<summary>Answer</summary>
+
+Adding a column with a `DEFAULT` value means every existing row instantly gets that default for the
+new column -- no existing row becomes invalid or needs a separate backfill just to satisfy a
+`NOT NULL` constraint on the new column. `PRAGMA user_version` is a single integer stored in the
+database file itself that a migration script can read and bump, so a deploy script can tell "has this
+migration already been applied to this exact file" and skip re-running it.
+
+</details>
+
+**Q23 (co-23 -- n-plus-1-avoidance).** What is the "N+1 query" problem, and name two different fixes
+for it.
+
+<details>
+<summary>Answer</summary>
+
+It is issuing one query to fetch N parent rows, then one _additional_ query per parent inside a loop
+to fetch each parent's children -- N+1 total round trips for what should be a small, fixed number.
+The two standard fixes are replacing the loop with a single `JOIN` query, or batching the child fetch
+into one `WHERE id IN (?, ?, ...)` query (Kata 7).
+
+</details>
+
+**Q24 (co-24 -- cli-usage).** Name at least four `sqlite3` CLI dot-commands and what each one does.
+
+<details>
+<summary>Answer</summary>
+
+Any four of: `.tables` (lists table names), `.schema` (echoes stored `CREATE TABLE` text), `.mode`
+(sets output format, e.g. `column` or `csv`), `.output` (redirects query results to a file),
+`.headers on` (prints a column-name header row), or `< file.sql` (feeding an entire script to the CLI
+non-interactively) -- there is no GUI anywhere in this topic, every operation goes through the CLI
+plus `PRAGMA` checks.
+
+</details>
+
+## Applied problems
+
+Twelve scenarios. Each describes a task without naming the construct -- decide which SQL or Python
+feature solves it, then check.
+
+**AP1.** A monthly report needs per-author revenue totals, but only for authors whose combined
+revenue exceeds $20 -- and out-of-print books must never count toward that total at all, not even to
+be excluded later from the display.
+
+<details>
+<summary>Answer</summary>
+
+Use both: `WHERE in_stock = 1 ... GROUP BY author_id HAVING sum(price) > 20`. `WHERE` excludes the
+out-of-print rows _before_ aggregation ever runs, so they never contribute to the sum in the first
+place; `HAVING` then filters the resulting per-author sums afterward. Using `HAVING` alone to exclude
+out-of-print rows would still let their revenue count toward each sum first, since `HAVING` only
+filters already-aggregated groups, not the raw rows that fed them.
+
+</details>
+
+**AP2.** A catalog report needs to list every author in the system alongside any books they have
+published -- but a handful of newly signed authors with zero books published so far still need to
+appear on the report by name, not silently disappear.
+
+<details>
+<summary>Answer</summary>
+
+A `LEFT JOIN` from `author` to `book`, not an inner join. An inner join drops the zero-book side
+entirely; `LEFT JOIN` keeps every row from the left table (`author`) regardless of whether it has any
+matches (Kata 3).
+
+</details>
+
+**AP3.** A report needs to find every book whose `published_year` was never recorded, and a first
+attempt using a plain equality test against SQL's NULL keyword returns zero rows, even though such
+books clearly exist in the table.
+
+<details>
+<summary>Answer</summary>
+
+`WHERE published_year IS NULL`, not `= NULL`. Under three-valued logic, `= NULL` never evaluates to
+true no matter what is stored -- `IS NULL` is the dedicated operator for testing "unknown" (Kata 2).
+
+</details>
+
+**AP4.** A search-by-title feature takes free-text input straight from a web form and needs to safely
+embed it into a `WHERE title LIKE ...` clause, without giving an attacker a way to inject arbitrary
+SQL through that input box.
+
+<details>
+<summary>Answer</summary>
+
+A parameterized query using a `?` or `:name` placeholder, never f-string/`.format`/`%`
+interpolation. The driver binds the value as an opaque parameter, never as SQL text, so nothing the
+input contains can change the query's shape (Kata 4).
+
+</details>
+
+**AP5.** A report page loads a list of 50 authors, then, for each one separately, issues a second
+query to fetch just that author's books -- the page feels sluggish, and a query log shows 51 total
+round trips for what should be a single page of data.
+
+<details>
+<summary>Answer</summary>
+
+This is the N+1 query problem. Replace the per-author loop with one `JOIN` query, or one batched
+`WHERE author_id IN (?, ?, ...)` query -- either collapses 51 round trips into 1 (Kata 7).
+
+</details>
+
+**AP6.** A nightly sync job needs to insert a row keyed by an external id if it is new, but update it
+in place -- not raise a `UNIQUE`-constraint error -- if a row with that same id already exists.
+
+<details>
+<summary>Answer</summary>
+
+`INSERT ... ON CONFLICT(id) DO UPDATE SET ...` -- an upsert. The same statement inserts on a new key
+and updates on a colliding one, with no separate "does this row already exist?" query needed first.
+
+</details>
+
+**AP7.** A larger transaction handles three unrelated sub-tasks in sequence; if the second one fails
+partway through, the first sub-task's writes need to stay intact, and only the second sub-task's work
+should be undone -- restarting the whole transaction from scratch is not acceptable.
+
+<details>
+<summary>Answer</summary>
+
+`SAVEPOINT` before the risky sub-task, then `ROLLBACK TO` that savepoint on failure. The outer
+transaction stays open the whole time; only the work done since the savepoint is undone, and the
+first sub-task's already-applied writes are untouched.
+
+</details>
+
+**AP8.** A migration script inserts a `book` row that references an `author_id` an earlier step in
+the same script accidentally deleted, and the insert succeeds without complaint even though the
+schema declares a `REFERENCES` clause on that column.
+
+<details>
+<summary>Answer</summary>
+
+`PRAGMA foreign_keys = ON` was never set for that connection. SQLite disables foreign key enforcement
+by default, so a `REFERENCES` clause is purely documentation until you explicitly turn enforcement on
+(Kata 5).
+
+</details>
+
+**AP9.** A `book` table stores every contributing author's name as a single comma-separated string in
+one `authors` text column, and a new report needs to count how many books each individual author has
+written -- the comma-separated column makes that count awkward and error-prone to write.
+
+<details>
+<summary>Answer</summary>
+
+Split the repeating group into its own table (a child or junction table holding one author per row)
+-- 1NF normalization. A single column packing multiple values together is exactly the repeating-group
+shape 1NF exists to eliminate.
+
+</details>
+
+**AP10.** A report function currently reads query results by numeric tuple index (`row[0]`,
+`row[2]`), and every time a column gets added or reordered in the `SELECT` list, the indices silently
+shift and the report starts reading the wrong column with no error raised.
+
+<details>
+<summary>Answer</summary>
+
+Set `conn.row_factory = sqlite3.Row` and access columns by name (`row["title"]`) instead of position.
+Name-based access is immune to a `SELECT` list being reordered or extended later.
+
+</details>
+
+**AP11.** A seed script inserts 500 rows one at a time inside a Python `for` loop, each with its own
+`cur.execute(...)` call and its own round trip to the engine, and it is noticeably slower than it
+needs to be for what is really one bulk load.
+
+<details>
+<summary>Answer</summary>
+
+`cur.executemany("INSERT ... VALUES (?)", rows)` instead of looping over `cur.execute(...)` per row
+-- one Python-level call driving the same 500 inserts, with far less per-row call overhead.
+
+</details>
+
+**AP12.** A deploy script needs to apply an additive schema migration exactly once, even if the
+deploy is retried after a partial failure and the same script runs again against the same database
+file -- running the identical `ALTER TABLE ADD COLUMN` a second time would error.
+
+<details>
+<summary>Answer</summary>
+
+`PRAGMA user_version` tracks a single integer inside the database file itself. Read it before
+migrating, bump it after, and skip the migration entirely if the stored version already reflects it
+-- the migration becomes idempotent across retries.
+
+</details>
+
+## Code katas
+
+Eight hands-on repetition drills against a real SQLite database. Each is a before/after `.sql` or
+typed `.py` file colocated under `drilling/code/`. Every "before" script is real and runnable and
+misapplies the concept being drilled -- run it yourself, diagnose the bug from the observed output,
+fix it from memory, then compare your fix against the "after" script and the model solution before
+checking your work against the actually-executed output shown.
+
+### Kata 1 -- forgotten WHERE on UPDATE
+
+**Task.** `UPDATE book SET price = 0` is meant to put exactly one book (id 2) on a free promo. The
+version below is broken: without a `WHERE` clause, `UPDATE` has no way to know which row you meant,
+so it rewrites every row's price to zero.
+
+**Before** (`drilling/code/kata-01-forgotten-where-update/before/kata.sql`)
+
+```sql
+-- Kata 1 (before): UPDATE with no WHERE zeroes every row, not just the intended one.
+DROP TABLE IF EXISTS book;
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+INSERT INTO book(title, price) VALUES
+    ('Refactoring', 45.00),
+    ('Domain-Driven Design', 55.00),
+    ('Clean Code', 35.00);
+
+.headers on
+.mode column
+
+-- intent: put ONE book (id 2) on a free promo -- the WHERE clause is missing.
+UPDATE book SET price = 0;
+
+SELECT id, title, price FROM book ORDER BY id;
+```
+
+**Observed (buggy) output** (captured by actually running `sqlite3 app.db < kata.sql` -- all three
+prices went to zero, not just book 2's):
+
+```text
+id  title                 price
+--  --------------------  -----
+1   Refactoring           0.0
+2   Domain-Driven Design  0.0
+3   Clean Code            0.0
+```
+
+**After** (`drilling/code/kata-01-forgotten-where-update/after/kata.sql`)
+
+```sql
+-- Kata 1 (after): the WHERE clause narrows the UPDATE to the one intended row.
+DROP TABLE IF EXISTS book;
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+INSERT INTO book(title, price) VALUES
+    ('Refactoring', 45.00),
+    ('Domain-Driven Design', 55.00),
+    ('Clean Code', 35.00);
+
+.headers on
+.mode column
+
+-- THE FIX: WHERE id = 2 scopes the write to exactly the row the promo applies to.
+UPDATE book SET price = 0 WHERE id = 2;
+
+SELECT id, title, price FROM book ORDER BY id;
+```
+
+<details>
+<summary>Model solution</summary>
+
+```sql
+-- THE FIX: WHERE id = 2 (co-11) scopes the write to exactly the row the promo
+-- applies to -- UPDATE without WHERE has no concept of "the row I meant."
+UPDATE book
+SET
+  price = 0
+WHERE
+  id = 2;
+
+SELECT
+  id,
+  title,
+  price
+FROM
+  book
+ORDER BY
+  id;
+
+-- => only row 2's price changed
+```
+
+**Root cause**: `UPDATE table SET ...` applies its `SET` clause to _every row currently in the
+table_ unless a `WHERE` clause narrows it -- there is no implicit "current row" the way a
+cursor-based or spreadsheet-style tool might assume. Omitting `WHERE` is not a smaller version of the
+bug; it is the single most common way to silently destroy production data with one keystroke's
+difference from the safe version.
+
+**Run**: `sqlite3 app.db < kata.sql`
+
+**Output**:
+
+```text
+id  title                 price
+--  --------------------  -----
+1   Refactoring           45.0
+2   Domain-Driven Design  0.0
+3   Clean Code            35.0
+```
+
+</details>
+
+### Kata 2 -- NULL equality bug
+
+**Task.** A report needs every book whose `published_year` was never recorded. The version below
+tests `published_year = NULL`, which never matches anything, no matter how many books really do have
+an unrecorded year.
+
+**Before** (`drilling/code/kata-02-null-equality-bug/before/kata.sql`)
+
+```sql
+-- Kata 2 (before): WHERE column = NULL never matches under three-valued logic.
+DROP TABLE IF EXISTS book;
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, published_year INTEGER);
+INSERT INTO book(title, published_year) VALUES
+    ('The Mythical Man-Month', 1975),
+    ('Unknown Draft', NULL),
+    ('Peopleware', 1987);
+
+.headers on
+.mode column
+
+-- intent: find every book whose published_year was never recorded.
+SELECT id, title FROM book WHERE published_year = NULL;
+```
+
+**Observed (buggy) output** (captured by actually running `sqlite3 app.db < kata.sql` -- zero rows,
+even though "Unknown Draft" has a NULL `published_year`; `.headers on`/`.mode column` print nothing
+at all for an empty result set):
+
+```text
+
+```
+
+**After** (`drilling/code/kata-02-null-equality-bug/after/kata.sql`)
+
+```sql
+-- Kata 2 (after): IS NULL is the correct test for "unknown", not =.
+DROP TABLE IF EXISTS book;
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, published_year INTEGER);
+INSERT INTO book(title, published_year) VALUES
+    ('The Mythical Man-Month', 1975),
+    ('Unknown Draft', NULL),
+    ('Peopleware', 1987);
+
+.headers on
+.mode column
+
+-- THE FIX: IS NULL, not = NULL, matches rows whose value is unknown.
+SELECT id, title FROM book WHERE published_year IS NULL;
+```
+
+<details>
+<summary>Model solution</summary>
+
+```sql
+-- THE FIX: IS NULL (co-17), not = NULL, is the correct test for "value unknown".
+SELECT
+  id,
+  title
+FROM
+  book
+WHERE
+  published_year IS NULL;
+
+-- => matches the one row whose published_year was never recorded
+```
+
+**Root cause**: NULL means "unknown" under SQL's three-valued logic -- comparing anything to NULL,
+including with `=`, yields NULL, and `WHERE` discards any row whose condition is not literally true.
+`IS NULL` is a distinct operator built specifically to test for "unknown," which is why it is the
+only correct way to find NULL values.
+
+**Run**: `sqlite3 app.db < kata.sql`
+
+**Output**:
+
+```text
+id  title
+--  -------------
+2   Unknown Draft
+```
+
+</details>
+
+### Kata 3 -- inner join drops rows
+
+**Task.** A report is meant to list every author in the catalog alongside any books they have
+published. The version below uses an inner join, which silently drops authors who have zero books --
+exactly the two authors the report was supposed to surface as "needs books."
+
+**Before** (`drilling/code/kata-03-inner-join-drops-rows/before/kata.sql`)
+
+```sql
+-- Kata 3 (before): an inner join silently drops authors with zero books.
+DROP TABLE IF EXISTS book;
+DROP TABLE IF EXISTS author;
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER REFERENCES author(id));
+INSERT INTO author(name) VALUES
+    ('Ada Lovelace'),
+    ('Grace Hopper'),
+    ('Margaret Hamilton');
+-- Grace Hopper (id 2) and Margaret Hamilton (id 3) have zero books each so far.
+INSERT INTO book(title, author_id) VALUES ('Notes on the Analytical Engine', 1);
+
+.headers on
+.mode column
+
+-- intent: list every author in the catalog, alongside any books they've published.
+SELECT author.name, book.title
+FROM author
+JOIN book ON book.author_id = author.id
+ORDER BY author.name;
+```
+
+**Observed (buggy) output** (captured by actually running `sqlite3 app.db < kata.sql` -- only Ada
+Lovelace appears; Grace Hopper and Margaret Hamilton vanish entirely instead of showing up with no
+books):
+
+```text
+name          title
+------------  ------------------------------
+Ada Lovelace  Notes on the Analytical Engine
+```
+
+**After** (`drilling/code/kata-03-inner-join-drops-rows/after/kata.sql`)
+
+```sql
+-- Kata 3 (after): LEFT JOIN keeps every author, filling unmatched book columns with NULL.
+DROP TABLE IF EXISTS book;
+DROP TABLE IF EXISTS author;
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER REFERENCES author(id));
+INSERT INTO author(name) VALUES
+    ('Ada Lovelace'),
+    ('Grace Hopper'),
+    ('Margaret Hamilton');
+INSERT INTO book(title, author_id) VALUES ('Notes on the Analytical Engine', 1);
+
+.headers on
+.mode column
+.nullvalue NULL
+
+-- THE FIX: LEFT JOIN keeps every left-side (author) row, even with zero matches.
+SELECT author.name, book.title
+FROM author
+LEFT JOIN book ON book.author_id = author.id
+ORDER BY author.name;
+```
+
+<details>
+<summary>Model solution</summary>
+
+```sql
+-- THE FIX: LEFT JOIN (co-14) keeps every author row, even ones with zero matching
+-- books -- unmatched book columns come back as NULL instead of the row vanishing.
+SELECT
+  author.name,
+  book.title
+FROM
+  author
+  LEFT JOIN book ON book.author_id = author.id
+ORDER BY
+  author.name;
+
+-- => all three authors appear; Grace Hopper and Margaret Hamilton show a NULL title
+```
+
+**Root cause**: An inner join (`JOIN`) only returns rows where both sides find a match -- an author
+with zero books contributes zero rows to an inner join's result and simply disappears from the
+output, with no error or warning. `LEFT JOIN` guarantees every row from the left table (`author`)
+appears at least once, substituting NULL for any unmatched right-side (`book`) column.
+
+**Run**: `sqlite3 app.db < kata.sql`
+
+**Output**:
+
+```text
+name               title
+-----------------  ------------------------------
+Ada Lovelace       Notes on the Analytical Engine
+Grace Hopper       NULL
+Margaret Hamilton  NULL
+```
+
+</details>
+
+### Kata 4 -- unparameterized query
+
+**Task.** `find_author_by_name` should safely look up an author by a caller-supplied name. The
+version below builds the `WHERE` clause with an f-string, so a crafted search value can inject its
+own SQL and match every row in the table instead of none.
+
+**Before** (`drilling/code/kata-04-unparameterized-query/before/kata.py`)
+
+```python
+# pyright: strict
+"""Kata 4 (before): a WHERE clause built via string interpolation -- injectable."""
+
+import sqlite3
+
+
+def find_author_by_name(conn: sqlite3.Connection, name: str) -> list[tuple[int, str]]:
+    cur = conn.cursor()
+    # THE BUG: f-string interpolation lets the caller's input become SQL syntax,
+    # not just a value -- the query text itself changes shape based on input.
+    query = f"SELECT id, name FROM author WHERE name = '{name}'"
+    cur.execute(query)
+    return cur.fetchall()
+
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")
+conn.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+conn.executemany(
+    "INSERT INTO author(name) VALUES (?)",
+    [("Ada Lovelace",), ("Grace Hopper",)],
+)
+conn.commit()
+
+# a crafted search value: no author is actually named this, but the OR clause
+# it injects makes the WHERE condition true for every row in the table.
+malicious_input: str = "nobody' OR '1'='1"
+print(find_author_by_name(conn, malicious_input))
+conn.close()
+```
+
+**Observed (buggy) output** (captured by actually running `python3 kata.py` -- both authors come
+back, even though no author is named `"nobody' OR '1'='1"`):
+
+```text
+[(1, 'Ada Lovelace'), (2, 'Grace Hopper')]
+```
+
+**After** (`drilling/code/kata-04-unparameterized-query/after/kata.py`)
+
+```python
+# pyright: strict
+"""Kata 4 (after): a parameterized query neutralizes the same injection attempt."""
+
+import sqlite3
+
+
+def find_author_by_name(conn: sqlite3.Connection, name: str) -> list[tuple[int, str]]:
+    cur = conn.cursor()
+    # THE FIX: ? is a placeholder, not a splice point -- the driver binds `name`
+    # as a single opaque value, so it can never change the shape of the query.
+    cur.execute("SELECT id, name FROM author WHERE name = ?", (name,))
+    return cur.fetchall()
+
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")
+conn.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+conn.executemany(
+    "INSERT INTO author(name) VALUES (?)",
+    [("Ada Lovelace",), ("Grace Hopper",)],
+)
+conn.commit()
+
+malicious_input: str = "nobody' OR '1'='1"
+print(find_author_by_name(conn, malicious_input))
+conn.close()
+```
+
+<details>
+<summary>Model solution</summary>
+
+```python
+def find_author_by_name(conn: sqlite3.Connection, name: str) -> list[tuple[int, str]]:
+    cur = conn.cursor()
+    # THE FIX: ? is a placeholder (co-20), not a splice point -- the driver binds
+    # `name` as one opaque value, so it can never change the shape of the query.
+    cur.execute("SELECT id, name FROM author WHERE name = ?", (name,))
+    return cur.fetchall()
+
+
+malicious_input: str = "nobody' OR '1'='1"
+print(find_author_by_name(conn, malicious_input))  # => Output: [] (correctly zero matches)
+```
+
+**Root cause**: Building `f"... WHERE name = '{name}'"` makes the caller's input part of the SQL
+_text itself_ -- a value crafted with an embedded `' OR '1'='1` does not just fail to match, it adds
+a real `OR` clause that makes the whole condition true for every row. A `?` placeholder sends the
+value to the engine as a bound parameter, entirely separate from the query text, so no character
+sequence inside it can ever be interpreted as SQL syntax.
+
+**Run**: `python3 kata.py`
+
+**Output**:
+
+```text
+[]
+```
+
+</details>
+
+### Kata 5 -- foreign key not enforced
+
+**Task.** `book.author_id` declares `REFERENCES author(id)`. The version below inserts a book row
+whose `author_id` does not exist in `author` at all, and the insert succeeds without complaint,
+because no connection in this script ever turned foreign key enforcement on.
+
+**Before** (`drilling/code/kata-05-foreign-key-not-enforced/before/kata.sql`)
+
+```sql
+-- Kata 5 (before): PRAGMA foreign_keys is OFF by default -- an orphan insert succeeds silently.
+DROP TABLE IF EXISTS book;
+DROP TABLE IF EXISTS author;
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER REFERENCES author(id));
+INSERT INTO author(name) VALUES ('Ada Lovelace');
+
+.headers on
+.mode column
+
+-- BUG: author_id 99 does not exist in author -- no PRAGMA foreign_keys=ON was ever set,
+-- so SQLite does not enforce the REFERENCES clause for this connection.
+INSERT INTO book(title, author_id) VALUES ('Ghost Reference', 99);
+
+SELECT id, title, author_id FROM book;
+```
+
+**Observed (buggy) output** (captured by actually running `sqlite3 app.db < kata.sql` -- the orphan
+row inserts and shows up in the `SELECT`, with no error anywhere):
+
+```text
+id  title            author_id
+--  ---------------  ---------
+1   Ghost Reference  99
+```
+
+**After** (`drilling/code/kata-05-foreign-key-not-enforced/after/kata.sql`)
+
+```sql
+-- Kata 5 (after): PRAGMA foreign_keys=ON rejects the same orphan insert.
+DROP TABLE IF EXISTS book;
+DROP TABLE IF EXISTS author;
+-- THE FIX: turn on enforcement for this connection BEFORE any writes happen.
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER REFERENCES author(id));
+INSERT INTO author(name) VALUES ('Ada Lovelace');
+
+.headers on
+.mode column
+
+-- author_id 99 still does not exist -- this insert is now rejected.
+INSERT INTO book(title, author_id) VALUES ('Ghost Reference', 99);
+
+SELECT id, title, author_id FROM book;
+```
+
+<details>
+<summary>Model solution</summary>
+
+```sql
+-- THE FIX: turn on enforcement (co-03) for this connection BEFORE any writes happen.
+PRAGMA foreign_keys = ON;
+
+-- author_id 99 still does not exist -- this insert is now rejected outright.
+INSERT INTO
+  book (title, author_id)
+VALUES
+  ('Ghost Reference', 99);
+
+-- => the statement fails; zero rows are inserted (SQLite statements fail atomically)
+```
+
+**Root cause**: SQLite disables foreign key enforcement by default for backward compatibility with
+database files created before FK support existed -- a `REFERENCES` clause in `CREATE TABLE` is purely
+documentation until `PRAGMA foreign_keys = ON` is set on that specific connection. With it set, the
+same orphan insert that silently succeeded before now fails outright, and because SQLite statements
+fail atomically, the failed `INSERT` touches zero rows -- there is no partial write to clean up.
+
+**Run**: `sqlite3 app.db < kata.sql`
+
+**Output**:
+
+```text
+Runtime error near line 15: FOREIGN KEY constraint failed (19)
+```
+
+The script halts at the failed statement -- `sqlite3`'s non-interactive default stops on the first
+error -- so the trailing `SELECT` never runs. That is exactly the point: the orphan row was never
+created to select.
+
+</details>
+
+### Kata 6 -- missing commit
+
+**Task.** A script inserts an author row through one connection, closes it, then opens a _fresh_
+connection to the same database file to confirm the write landed. The version below never calls
+`.commit()` before `.close()`, so the fresh connection sees an empty table.
+
+**Before** (`drilling/code/kata-06-missing-commit/before/kata.py`)
+
+```python
+# pyright: strict
+"""Kata 6 (before): insert-then-close with no commit() -- the write never reaches disk."""
+
+import os
+import sqlite3
+
+DB_PATH: str = "kata.db"
+
+if os.path.exists(DB_PATH):
+    os.remove(DB_PATH)
+
+conn1: sqlite3.Connection = sqlite3.connect(DB_PATH)
+conn1.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+conn1.commit()  # the schema itself IS committed, so the table persists
+
+conn1.execute("INSERT INTO author(name) VALUES ('Ada Lovelace')")
+# THE BUG: no conn1.commit() here -- close() below discards the open transaction.
+conn1.close()
+
+# a completely fresh connection to the SAME file -- proves what actually landed on disk.
+conn2: sqlite3.Connection = sqlite3.connect(DB_PATH)
+rows: list[tuple[int, str]] = conn2.execute("SELECT id, name FROM author").fetchall()
+print(rows)
+conn2.close()
+os.remove(DB_PATH)
+```
+
+**Observed (buggy) output** (captured by actually running `python3 kata.py` -- the author row is
+gone, even though the `INSERT` itself never raised an error):
+
+```text
+[]
+```
+
+**After** (`drilling/code/kata-06-missing-commit/after/kata.py`)
+
+```python
+# pyright: strict
+"""Kata 6 (after): an explicit commit() before close() makes the write durable."""
+
+import os
+import sqlite3
+
+DB_PATH: str = "kata.db"
+
+if os.path.exists(DB_PATH):
+    os.remove(DB_PATH)
+
+conn1: sqlite3.Connection = sqlite3.connect(DB_PATH)
+conn1.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+conn1.commit()
+
+conn1.execute("INSERT INTO author(name) VALUES ('Ada Lovelace')")
+# THE FIX: commit() BEFORE close() -- the write is durable before the connection ends.
+conn1.commit()
+conn1.close()
+
+conn2: sqlite3.Connection = sqlite3.connect(DB_PATH)
+rows: list[tuple[int, str]] = conn2.execute("SELECT id, name FROM author").fetchall()
+print(rows)
+conn2.close()
+os.remove(DB_PATH)
+```
+
+<details>
+<summary>Model solution</summary>
+
+```python
+conn1.execute("INSERT INTO author(name) VALUES ('Ada Lovelace')")
+# THE FIX: commit() (co-18/co-19) BEFORE close() -- the write is durable before
+# the connection that made it ever goes away.
+conn1.commit()
+conn1.close()
+
+conn2: sqlite3.Connection = sqlite3.connect(DB_PATH)
+rows: list[tuple[int, str]] = conn2.execute("SELECT id, name FROM author").fetchall()
+print(rows)  # => Output: [(1, 'Ada Lovelace')] -- the row survived the connection swap
+```
+
+**Root cause**: `sqlite3`'s default `isolation_level` opens an implicit transaction before the first
+data-modifying statement, and that transaction stays open -- uncommitted -- until `.commit()` is
+called explicitly. `.close()` does not commit a pending transaction on your behalf; it simply ends
+the connection, and the uncommitted `INSERT` never reached durable storage, so a fresh connection to
+the same file sees a table that is still empty.
+
+**Run**: `python3 kata.py`
+
+**Output**:
+
+```text
+[(1, 'Ada Lovelace')]
+```
+
+</details>
+
+### Kata 7 -- N+1 query loop
+
+**Task.** `books_by_author` should return every author's list of book titles. The version below
+fetches the author list with one query, then issues a _second_ query per author inside a loop --
+N+1 total round trips for N authors, when a single join would do.
+
+**Before** (`drilling/code/kata-07-n-plus-1-loop/before/kata.py`)
+
+```python
+# pyright: strict
+"""Kata 7 (before): one SELECT per author inside a loop -- N+1 round trips."""
+
+import sqlite3
+
+
+def books_by_author(conn: sqlite3.Connection) -> dict[str, list[str]]:
+    query_count: int = 0
+    result: dict[str, list[str]] = {}
+    cur = conn.cursor()
+    cur.execute("SELECT id, name FROM author")
+    authors: list[tuple[int, str]] = cur.fetchall()
+    query_count += 1
+    for author_id, name in authors:
+        # THE BUG: one fresh SELECT for EVERY author, instead of one query total.
+        cur.execute("SELECT title FROM book WHERE author_id = ?", (author_id,))
+        titles: list[str] = [row[0] for row in cur.fetchall()]
+        query_count += 1
+        result[name] = titles
+    print(f"queries issued: {query_count}")
+    return result
+
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")
+conn.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+conn.execute(
+    "CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER)"
+)
+conn.executemany(
+    "INSERT INTO author(name) VALUES (?)",
+    [("Ada Lovelace",), ("Grace Hopper",), ("Alan Turing",)],
+)
+conn.executemany(
+    "INSERT INTO book(title, author_id) VALUES (?, ?)",
+    [
+        ("Notes", 1),
+        ("COBOL Manual", 2),
+        ("Compiler Notes", 2),
+        ("On Computable Numbers", 3),
+    ],
+)
+conn.commit()
+
+print(books_by_author(conn))
+conn.close()
+```
+
+**Observed (buggy) output** (captured by actually running `python3 kata.py` -- correct data, but 4
+queries for 3 authors, one query more than the round trip count should ever grow to as authors are
+added):
+
+```text
+queries issued: 4
+{'Ada Lovelace': ['Notes'], 'Grace Hopper': ['COBOL Manual', 'Compiler Notes'], 'Alan Turing': ['On Computable Numbers']}
+```
+
+**After** (`drilling/code/kata-07-n-plus-1-loop/after/kata.py`)
+
+```python
+# pyright: strict
+"""Kata 7 (after): one LEFT JOIN replaces the per-author loop -- a single round trip."""
+
+import sqlite3
+
+
+def books_by_author(conn: sqlite3.Connection) -> dict[str, list[str]]:
+    query_count: int = 0
+    result: dict[str, list[str]] = {}
+    cur = conn.cursor()
+    # THE FIX: one LEFT JOIN fetches every author-book pair (or lone author) at once.
+    cur.execute(
+        "SELECT author.name, book.title FROM author "
+        "LEFT JOIN book ON book.author_id = author.id "
+        "ORDER BY author.name"
+    )
+    rows: list[tuple[str, str | None]] = cur.fetchall()
+    query_count += 1
+    for name, title in rows:
+        result.setdefault(name, [])
+        if title is not None:
+            result[name].append(title)
+    print(f"queries issued: {query_count}")
+    return result
+
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")
+conn.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+conn.execute(
+    "CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER)"
+)
+conn.executemany(
+    "INSERT INTO author(name) VALUES (?)",
+    [("Ada Lovelace",), ("Grace Hopper",), ("Alan Turing",)],
+)
+conn.executemany(
+    "INSERT INTO book(title, author_id) VALUES (?, ?)",
+    [
+        ("Notes", 1),
+        ("COBOL Manual", 2),
+        ("Compiler Notes", 2),
+        ("On Computable Numbers", 3),
+    ],
+)
+conn.commit()
+
+print(books_by_author(conn))
+conn.close()
+```
+
+<details>
+<summary>Model solution</summary>
+
+```python
+def books_by_author(conn: sqlite3.Connection) -> dict[str, list[str]]:
+    query_count: int = 0
+    result: dict[str, list[str]] = {}
+    cur = conn.cursor()
+    # THE FIX: one LEFT JOIN (co-13/co-14/co-23) fetches every author-book pair
+    # (or lone author) in a single round trip, instead of one query per author.
+    cur.execute(
+        "SELECT author.name, book.title FROM author "
+        "LEFT JOIN book ON book.author_id = author.id "
+        "ORDER BY author.name"
+    )
+    rows: list[tuple[str, str | None]] = cur.fetchall()
+    query_count += 1  # => exactly ONE query, regardless of how many authors exist
+    for name, title in rows:
+        result.setdefault(name, [])
+        if title is not None:
+            result[name].append(title)
+    print(f"queries issued: {query_count}")  # => Output line 1: queries issued: 1
+    return result
+```
+
+**Root cause**: The buggy version issues one `SELECT` to list authors, then a _second_ `SELECT` per
+author inside the loop -- N+1 total round trips for N authors, each one paying its own overhead even
+against a local file. Replacing the loop with one `LEFT JOIN` (kept instead of an inner join
+specifically so authors with zero books still appear) fetches every author-book pair the query needs
+in exactly one round trip, regardless of how many authors exist.
+
+**Run**: `python3 kata.py`
+
+**Output**:
+
+```text
+queries issued: 1
+{'Ada Lovelace': ['Notes'], 'Alan Turing': ['On Computable Numbers'], 'Grace Hopper': ['COBOL Manual', 'Compiler Notes']}
+```
+
+</details>
+
+### Kata 8 -- non-grouped column
+
+**Task.** A per-author report groups `book` rows by `author_id` and also selects `book.title`
+directly, even though `title` is neither aggregated nor part of `GROUP BY`. SQLite permits this
+leniently and silently picks one arbitrary title per group instead of raising an error, which
+surprises anyone expecting the stricter behavior of other engines.
+
+**Before** (`drilling/code/kata-08-non-grouped-column/before/kata.sql`)
+
+```sql
+-- Kata 8 (before): title is neither aggregated nor in GROUP BY -- SQLite leniently
+-- picks ONE arbitrary row's title per group instead of raising an error.
+DROP TABLE IF EXISTS book;
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL, price REAL NOT NULL);
+INSERT INTO book(title, author_id, price) VALUES
+    ('Notes on the Analytical Engine', 1, 12.00),
+    ('Sketch of the Analytical Engine', 1, 18.00),
+    ('COBOL Manual', 2, 9.50);
+
+.headers on
+.mode column
+
+-- BUG: title is a non-aggregated, non-grouping column -- which title does author_id
+-- 1's group report back, when it has TWO distinct titles?
+SELECT author_id, title, count(*) AS book_count, sum(price) AS total_price
+FROM book
+GROUP BY author_id;
+```
+
+**Observed (buggy) output** (captured by actually running `sqlite3 app.db < kata.sql` -- author_id
+1's group shows only one of its two real titles, with no error or warning that a column was dropped
+arbitrarily):
+
+```text
+author_id  title                           book_count  total_price
+---------  ------------------------------  ----------  -----------
+1          Notes on the Analytical Engine  2           30.0
+2          COBOL Manual                    1           9.5
+```
+
+**After** (`drilling/code/kata-08-non-grouped-column/after/kata.sql`)
+
+```sql
+-- Kata 8 (after): group_concat aggregates every title per group explicitly.
+DROP TABLE IF EXISTS book;
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL, price REAL NOT NULL);
+INSERT INTO book(title, author_id, price) VALUES
+    ('Notes on the Analytical Engine', 1, 12.00),
+    ('Sketch of the Analytical Engine', 1, 18.00),
+    ('COBOL Manual', 2, 9.50);
+
+.headers on
+.mode column
+.width 10 70 12 12
+
+-- THE FIX: group_concat(title, sep) is a real aggregate -- it names EVERY title
+-- in the group explicitly, instead of silently picking one.
+SELECT author_id, group_concat(title, '; ') AS titles, count(*) AS book_count, sum(price) AS total_price
+FROM book
+GROUP BY author_id;
+```
+
+<details>
+<summary>Model solution</summary>
+
+```sql
+-- THE FIX: group_concat(title, sep) (co-15) is a genuine aggregate -- it names
+-- EVERY title in the group explicitly, instead of SQLite silently picking one.
+SELECT
+  author_id,
+  group_concat (title, '; ') AS titles,
+  count(*) AS book_count,
+  sum(price) AS total_price
+FROM
+  book
+GROUP BY
+  author_id;
+
+-- => author_id 1's group now correctly shows BOTH of its titles, not just one
+```
+
+**Root cause**: SQLite's `GROUP BY` is lenient about non-aggregated, non-grouping columns in the
+`SELECT` list -- rather than raising an error the way a stricter engine's default mode would, it
+silently picks one arbitrary row's value for that column per group. `title` is neither wrapped in an
+aggregate function nor listed in `GROUP BY`, so `author_id` 1's group (with two distinct titles)
+reports back only one of them, and which one is an implementation detail, not a guarantee. Wrapping
+`title` in a real aggregate (`group_concat`) makes every title in the group explicit instead of
+leaving one silently dropped.
+
+**Run**: `sqlite3 app.db < kata.sql`
+
+**Output**:
+
+```text
+author_id   titles                                                                  book_count    total_price
+----------  ----------------------------------------------------------------------  ------------  ------------
+1           Notes on the Analytical Engine; Sketch of the Analytical Engine         2             30.0
+2           COBOL Manual                                                            1             9.5
+```
+
+</details>
+
+## Self-check checklist
+
+Confirm each item without checking the manual first. If you hesitate, that concept needs another
+pass.
+
+- [ ] I can explain what it means for data to be "modeled relationally" instead of connected by
+      in-memory pointers. (co-01)
+- [ ] I can write a `CREATE TABLE` with an `INTEGER PRIMARY KEY` and explain how it aliases SQLite's
+      rowid. (co-02)
+- [ ] I can explain why `PRAGMA foreign_keys=ON` is required before SQLite enforces a `REFERENCES`
+      clause. (co-03)
+- [ ] I can name all four column-level constraints and the invariant each one enforces. (co-04)
+- [ ] I can split a repeating-group column into a child table and explain which normal form the split
+      satisfies. (co-05)
+- [ ] I can explain SQLite's type affinity and predict what `typeof()` reports for a mismatched
+      value. (co-06)
+- [ ] I can write a `CREATE TABLE` statement and confirm what SQLite stored with `.schema`. (co-07)
+- [ ] I can write a `SELECT` with a `WHERE` clause combining `AND`/`OR`/`LIKE`/`IN` and explain
+      projection versus selection. (co-08)
+- [ ] I can write `ORDER BY ... LIMIT ... OFFSET ...` to fetch a specific page of results. (co-09)
+- [ ] I can write a multi-row `INSERT` and an `ON CONFLICT` upsert. (co-10)
+- [ ] I can predict what happens to an `UPDATE` statement that omits its `WHERE` clause. (co-11)
+- [ ] I can predict what happens to a `DELETE` statement that omits its `WHERE` clause. (co-12)
+- [ ] I can write an inner join and explain what happens to rows on either side with no match.
+      (co-13)
+- [ ] I can write a `LEFT JOIN` and explain how it differs from an inner join for unmatched rows.
+      (co-14)
+- [ ] I can write a `GROUP BY` query using at least three different aggregate functions. (co-15)
+- [ ] I can explain the difference between `WHERE` and `HAVING` in terms of when each one filters.
+      (co-16)
+- [ ] I can explain why `= NULL` never matches and write the correct `IS NULL` test instead. (co-17)
+- [ ] I can write a transaction with a `SAVEPOINT` and explain what `ROLLBACK TO` undoes. (co-18)
+- [ ] I can write the four-step lifecycle of a Python `sqlite3` script, from `connect` to `close`.
+      (co-19)
+- [ ] I can write a parameterized query with `?` and explain why it neutralizes SQL injection.
+      (co-20)
+- [ ] I can explain the difference between `fetchone()`/`fetchall()` and what `sqlite3.Row` changes.
+      (co-21)
+- [ ] I can write an additive `ALTER TABLE ADD COLUMN` migration and explain what
+      `PRAGMA user_version` tracks. (co-22)
+- [ ] I can recognize an N+1 query pattern and name two different fixes for it. (co-23)
+- [ ] I can name at least four `sqlite3` CLI dot-commands and what each one does. (co-24)
+- [ ] I can explain, in one sentence, why SQL lets you declare _what_ result you want and leaves _how_
+      to fetch it entirely to the query planner. (`mechanism-vs-policy`)
+
+## Elaborative interrogation & self-explanation
+
+Six why/why-not prompts. Answer each in your own words before opening the model explanation.
+
+**E1.** Why is SQL declarative -- you describe the result you want -- rather than a step-by-step
+imperative loop over rows the way a general-purpose language would express the same query? Tie your
+answer to `mechanism-vs-policy`.
+
+<details>
+<summary>Model explanation</summary>
+
+SQL asks you to state the _policy_ -- the shape of the result you want ("every book with its author's
+name, ordered by price") -- and leaves the _mechanism_ -- which index to scan, which join algorithm
+to use, in what order to visit the tables -- entirely to the query planner. If SQL were imperative,
+every query would also have to encode a specific execution strategy, and that strategy would need
+rewriting by hand every time the data grew, an index appeared, or the storage engine changed.
+Declarative SQL means the exact same `SELECT ... JOIN ... WHERE ...` text can get faster over years of
+engine improvements and schema changes without a single line of application code changing -- the
+mechanism is free to evolve because it was never specified in the first place. That separation is
+`mechanism-vs-policy` in its purest form.
+
+</details>
+
+**E2.** Why does SQLite ship with foreign key enforcement OFF by default, rather than always-on the
+way most other relational databases behave?
+
+<details>
+<summary>Model explanation</summary>
+
+SQLite predates its own foreign-key support (added years after the file format was already widely
+deployed), and turning enforcement on by default for every existing database file would have silently
+started rejecting writes that had worked for years -- a breaking change hidden inside a routine
+version upgrade. Making enforcement an explicit per-connection `PRAGMA foreign_keys = ON` keeps old
+schemas and scripts working exactly as they always did, while letting any new code opt into the
+stricter guarantee deliberately. The cost, as Kata 5 shows directly, is that forgetting the PRAGMA is
+silent -- an orphaned row inserts without complaint -- so every connection that cares about
+referential integrity has to remember to ask for it explicitly.
+
+</details>
+
+**E3.** Why can `expression = NULL` never evaluate to true under SQL's three-valued logic, instead of
+the engine simply raising an error to warn you the comparison is meaningless?
+
+<details>
+<summary>Model explanation</summary>
+
+NULL represents "unknown," not "empty" or "zero" -- and comparing any value to something genuinely
+unknown can only honestly produce "unknown" as the answer, never a hard true or false. SQL encodes
+that honesty directly into three-valued logic: every comparison involving NULL evaluates to NULL, and
+`WHERE` only keeps rows whose condition evaluates to true, so a NULL result is silently treated the
+same as false. Raising an error instead would treat every accidental `= NULL` as a hard failure, which
+sounds safer, but it would also make NULL impossible to combine into larger boolean expressions
+(`WHERE a = 1 AND b = NULL`) without every such expression crashing the whole query -- three-valued
+logic lets NULL propagate through arbitrarily complex conditions predictably, at the cost of `= NULL`
+being a trap for anyone who reaches for the wrong operator (Kata 2).
+
+</details>
+
+**E4.** Why does normalization trade query complexity -- more joins -- for write-safety, instead of
+keeping data in one wide, easy-to-query table?
+
+<details>
+<summary>Model explanation</summary>
+
+A wide, denormalized table duplicates every fact wherever it is needed for convenient reading, but
+that duplication means a single real-world fact -- an author's name, say -- now lives in as many rows
+as that author has books. Every `UPDATE` to that fact must remember to touch every duplicate copy, and
+any `UPDATE` that misses even one copy leaves the database internally inconsistent with no error
+raised anywhere. Normalization moves each fact back to exactly one row in exactly one table, so an
+`UPDATE` to that fact is a single-row write with no possibility of a stale duplicate elsewhere -- the
+price is that reading the combined view back out now requires a `JOIN` to recombine what normalization
+split apart.
+
+</details>
+
+**E5.** Why must a transaction's `ROLLBACK` undo every write inside it atomically, rather than leaving
+whichever writes had already succeeded in place?
+
+<details>
+<summary>Model explanation</summary>
+
+The entire reason to group writes into a transaction in the first place is that some of them are only
+individually meaningful in combination -- a debit from one account and a credit to another only make
+sense together; a debit with no matching credit is simply money disappearing. If a failure partway
+through could leave some writes applied and others not, every reader querying the database in that
+window would see a state that never should have been observable at all, and no caller could ever
+safely assume "if I see any of this transaction's writes, I see all of them." Atomic rollback is what
+makes a transaction's boundary a real boundary -- readers only ever see the state from before the
+transaction started, or the complete state after it commits, with nothing in between.
+
+</details>
+
+**E6.** Why are parameterized queries safe against SQL injection at the engine level, rather than
+merely "escaping" dangerous characters in the input string?
+
+<details>
+<summary>Model explanation</summary>
+
+Escaping tries to neutralize specific characters (quotes, semicolons) after the fact, inside a string
+that is still ultimately going to be parsed as SQL syntax -- it is a defense that has to anticipate
+every dangerous character an attacker might use, and history is full of escaping schemes that missed
+an edge case. A parameterized query sidesteps the whole category of problem: the SQL text and the
+value are sent to the engine as two entirely separate pieces of information from the start, and the
+value is never parsed as SQL syntax at all, no matter what characters it contains. There is no
+escaping step to get wrong, because there is no point at which the value and the query text are ever
+combined into one string in the first place (Kata 4).
+
+</details>
+
+---
+
+← Previous: [Capstone](../learning/capstone/overview.md)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/_index.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Learning"
+date: 2026-07-14T00:00:00+07:00
+draft: false
+weight: 110
+---
+
+- [Overview](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/overview)
+- [Beginner Examples](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner)
+- [Intermediate Examples](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate)
+- [Advanced Examples](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced)
+- [Capstone](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone)
+  - [Overview](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/overview)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced.md
@@ -1,0 +1,1968 @@
+---
+title: "Advanced Examples"
+date: 2026-07-14T00:00:00+07:00
+draft: false
+weight: 30
+---
+
+Examples 59-80 cover safe additive schema migrations with `PRAGMA user_version` version tracking,
+diagnosing and fixing the N+1 query problem three different ways, composite primary keys, `ON DELETE
+CASCADE`/`RESTRICT`, `SAVEPOINT`/`ROLLBACK TO` partial-transaction undo, a typed Python data-access-layer
+module tested with `pytest`, seeding a database from a separate `.sql` file, CSV export via the CLI,
+integrity-check pragmas, designing a full 3NF schema from scratch, correlated subqueries, and a combined
+join-group-having report. Every example is fully self-contained: each one creates its own table(s) and
+inserts its own rows, so none of them depend on state left behind by an earlier example. Run each `.sql`
+example with `sqlite3 app.db < example.sql` from inside a fresh, empty directory; run each single-file
+`.py` example with `python3 example.py`; run each `pytest`-marked example with `pytest -q` from inside
+its own example directory. Every Python file starts with `# pyright: strict` and was verified with
+`pyright` -- a single file with `pyright example.py`, or the whole example directory with `pyright .`
+for the two examples whose `tests/` package imports a sibling module.
+
+---
+
+### Example 59: Migration Add Column
+
+_ex-59 &middot; exercises co-22_
+
+Adding a column with a `DEFAULT` clause is SQLite's safest schema change: it rewrites only the schema
+catalog, never touches existing row data, and every pre-existing row reads back the declared default
+instead of `NULL` or a table rebuild.
+
+**`learning/code/ex-59-migration-add-column/example.sql`**
+
+```sql
+-- Example 59: Migration Add Column.
+-- An additive migration -- adding a nullable-or-defaulted column -- never breaks existing rows.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => a minimal parent table -- just enough for a book to reference
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02) -- auto-assigned on insert
+    title TEXT NOT NULL,           -- => every book needs a title -- NOT NULL enforced
+    author_id INTEGER NOT NULL REFERENCES author(id),
+                                    -- => the FK link -- declared, though not yet enforced (co-03)
+    price REAL NOT NULL            -- => the schema BEFORE this example's migration runs
+);
+
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace');
+                                    -- => 1 author row -- author_id = 1 will be referenced below
+INSERT INTO book(id, title, author_id, price) VALUES
+    (1, 'Notes on the Analytical Engine', 1, 12.5),
+    (2, 'Sketch of the Analytical Engine', 1, 9.0);
+                                    -- => book now holds 2 rows, written BEFORE the migration below
+
+.headers on
+.mode column
+-- The pre-migration shape -- no "edition" column exists yet.
+SELECT id, title, price FROM book; -- => 2 rows, 3 columns -- the schema before any change
+
+-- ADD COLUMN ... DEFAULT is SQLite's safe, additive migration: no table rewrite,
+-- no downtime, and every EXISTING row reads back with the declared default (co-22).
+ALTER TABLE book ADD COLUMN edition INTEGER DEFAULT 1;
+                                    -- => rewrites ONLY the schema catalog -- row data is untouched
+
+-- Same 2 rows, now with a 4th column -- both pre-existing rows got the default, not NULL.
+SELECT id, title, price, edition FROM book;
+                                    -- => edition is 1 for BOTH rows -- neither was NULL or dropped
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                            price
+--  -------------------------------  -----
+1   Notes on the Analytical Engine   12.5
+2   Sketch of the Analytical Engine  9.0
+id  title                            price  edition
+--  -------------------------------  -----  -------
+1   Notes on the Analytical Engine   12.5   1
+2   Sketch of the Analytical Engine  9.0    1
+```
+
+**Key takeaway**: `ALTER TABLE ... ADD COLUMN ... DEFAULT` is additive, not destructive -- both
+pre-existing rows come back with `edition = 1`, never `NULL` and never dropped.
+
+**Why it matters**: production schemas evolve constantly, and a migration that locks the table or
+requires a maintenance window is a real operational cost. SQLite's `ADD COLUMN` avoids both: it edits
+only the stored schema text, so existing rows are reinterpreted on the next read rather than physically
+rewritten. This is the shape every later migration in this tier builds on -- Example 60 backfills a
+computed value, and Example 61 wraps this exact statement in an idempotent, version-tracked runner.
+
+---
+
+### Example 60: Migration Backfill
+
+_ex-60 &middot; exercises co-22, co-11_
+
+Adding a column is only half a migration when the new column needs a **computed** value, not a static
+default -- this example adds a nullable column, then backfills it with an `UPDATE` that has no `WHERE`
+clause on purpose.
+
+**`learning/code/ex-60-migration-backfill/example.sql`**
+
+```sql
+-- Example 60: Migration Backfill.
+-- Adding a column is only half a migration -- existing rows often need a COMPUTED value,
+-- not just a static DEFAULT (co-11).
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => minimal parent table -- just enough to reference below
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    title TEXT NOT NULL,           -- => NOT NULL -- every book needs a title
+    author_id INTEGER NOT NULL REFERENCES author(id),
+                                    -- => the FK link -- one row per book, per author
+    price REAL NOT NULL,           -- => unit price, before the quantity multiplication below
+    quantity INTEGER NOT NULL      -- => how many copies -- the OTHER input to total_value
+);
+
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace');
+                                    -- => 1 author row -- author_id = 1 is referenced below
+INSERT INTO book(id, title, author_id, price, quantity) VALUES
+    (1, 'Notes on the Analytical Engine', 1, 12.5, 4),
+    (2, 'Sketch of the Analytical Engine', 1, 9.0, 10);
+                                    -- => 2 rows -- price and quantity now set for BOTH
+
+-- .headers on shows column names above every result set below; .mode column aligns them --
+-- both are a display preference only, with no effect on the migration itself.
+.headers on
+.mode column
+-- A nullable ADD COLUMN (no DEFAULT) -- every existing row reads back NULL until backfilled.
+ALTER TABLE book ADD COLUMN total_value REAL;
+                                    -- => no DEFAULT clause -- deliberately NULL, awaiting the backfill
+
+SELECT id, title, total_value FROM book;
+                                    -- => both rows show total_value = <blank> (NULL) -- not yet computed
+
+-- Backfill: compute the derived value for every row that just gained the new column.
+UPDATE book SET total_value = price * quantity;
+                                    -- => no WHERE clause -- every row needs backfilling this time (co-11)
+
+SELECT id, title, price, quantity, total_value FROM book;
+                                    -- => row 1: 12.5 * 4 = 50.0 -- row 2: 9.0 * 10 = 90.0
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                            total_value
+--  -------------------------------  -----------
+1   Notes on the Analytical Engine
+2   Sketch of the Analytical Engine
+id  title                            price  quantity  total_value
+--  -------------------------------  -----  --------  -----------
+1   Notes on the Analytical Engine   12.5   4         50.0
+2   Sketch of the Analytical Engine  9.0    10        90.0
+```
+
+**Key takeaway**: the un-backfilled column prints blank (`NULL`) for both rows immediately after `ADD
+COLUMN`; a follow-up `UPDATE` with no `WHERE` clause fills every row in one statement.
+
+**Why it matters**: a nullable `ADD COLUMN` and its backfill are two separate, sequential
+statements on purpose -- SQLite cannot compute `price * quantity` at column-creation time, so it must
+add the column first and populate it second. Splitting migration structure from migration data this
+way is also what lets a team review the schema change and the backfill logic as two independently
+reviewable diffs, rather than one opaque statement.
+
+---
+
+### Example 61: Migration Version Tracking
+
+_ex-61 &middot; exercises co-22, co-24_
+
+`PRAGMA user_version` stores a plain integer inside the database file's own header, with no extra
+tracking table required -- a thin shell wrapper reads it before deciding whether to apply a migration,
+making the whole runner safe to invoke any number of times.
+
+**`learning/code/ex-61-migration-version-tracking/schema.sql`**
+
+```sql
+-- Example 61: Migration Version Tracking -- initial schema (version 0, the SQLite default).
+CREATE TABLE book (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  price REAL NOT NULL
+);
+
+-- => a fresh database file -- PRAGMA user_version starts at 0
+INSERT INTO
+  book (id, title, price)
+VALUES
+  (1, 'Notes on the Analytical Engine', 12.5),
+  (2, 'Sketch of the Analytical Engine', 9.0);
+
+-- => 2 pre-existing rows -- the migration below must not break them
+```
+
+**`learning/code/ex-61-migration-version-tracking/migration.sql`**
+
+```sql
+-- Example 61: the migration body itself -- only ever meant to run ONCE, guarded by migrate.sh.
+ALTER TABLE book
+ADD COLUMN edition INTEGER DEFAULT 1;
+
+-- => the additive change, identical in shape to Example 59
+-- PRAGMA user_version stores a plain integer INSIDE the database file's header (co-24) --
+-- no extra "schema_migrations" table needed to remember which migration already ran.
+PRAGMA user_version = 1;
+```
+
+**`learning/code/ex-61-migration-version-tracking/migrate.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Example 61: a minimal migration RUNNER -- reads PRAGMA user_version first (co-24),
+# and only applies migration.sql if the database hasn't already been migrated.
+set -euo pipefail                  # => fail fast on any error, unset variable, or pipe failure
+
+DB="app.db"                        # => the single database file this runner targets
+CURRENT=$(sqlite3 "$DB" "PRAGMA user_version;")
+                                    # => reads the CURRENT version straight out of the file header
+
+if [ "$CURRENT" -lt 1 ]; then      # => version 0 (or lower) means migration.sql has NOT run yet
+    sqlite3 "$DB" < migration.sql  # => applies the ALTER TABLE + bumps PRAGMA user_version to 1
+    NEW=$(sqlite3 "$DB" "PRAGMA user_version;")
+                                    # => re-reads the version -- confirms the bump actually landed
+    echo "migrated to version $NEW"
+                                    # => the FIRST-run message -- printed exactly once, ever
+else
+    # => version is ALREADY >= 1 -- re-running would fail with "duplicate column name"
+    echo "already at version $CURRENT, skipping"
+                                    # => the IDEMPOTENT path -- safe to call this script repeatedly
+fi
+```
+
+**Run**: `sqlite3 app.db < schema.sql`, then `chmod +x migrate.sh && ./migrate.sh` twice in a row.
+
+**Output**:
+
+```text
+--- first run ---
+migrated to version 1
+--- second run ---
+already at version 1, skipping
+--- final state ---
+id  title                            price  edition
+--  -------------------------------  -----  -------
+1   Notes on the Analytical Engine   12.5   1
+2   Sketch of the Analytical Engine  9.0    1
+```
+
+**Key takeaway**: the first `migrate.sh` run bumps `PRAGMA user_version` from 0 to 1 and applies the
+migration; the second run reads that same version, sees it is no longer 0, and skips -- no
+`schema_migrations` table was ever needed.
+
+**Why it matters**: a migration script that is not idempotent is a landmine -- rerunning it after a
+deploy hiccup (or a CI retry) either fails outright (`duplicate column name`) or silently corrupts data.
+`PRAGMA user_version` gives every SQLite database a free, built-in place to record "which migration
+already ran," so a thin wrapper script -- not a bespoke tracking table -- is enough to make the whole
+migration pipeline safe to invoke more than once.
+
+---
+
+### Example 62: N+1 Query Problem Demonstrated
+
+_ex-62 &middot; exercises co-23_
+
+A Python loop that issues one `SELECT` per parent row -- once for the list of authors, then once more
+per author to fetch their books -- costs `1 + N` round trips to the database engine; this example counts
+every query as it fires to make that cost visible.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC, Brown #CA9161
+flowchart LR
+    A["SELECT id, name FROM author<br/>query 1 -- the parents"]:::blue
+    A --> B["SELECT title FROM book<br/>WHERE author_id = 1<br/>query 2"]:::orange
+    A --> C["SELECT title FROM book<br/>WHERE author_id = 2<br/>query 3"]:::teal
+    B --> D["queries executed: 3<br/>1 parent query + N child queries"]:::purple
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-62-n-plus-1-demonstrated/example.py`**
+
+```python
+# pyright: strict
+"""Example 62: N+1 Query Problem Demonstrated."""
+
+import sqlite3  # => stdlib DB-API module (co-19) -- no third-party driver needed
+
+
+def setup(conn: sqlite3.Connection) -> None:
+    # A fresh in-memory schema + seed data -- this example needs NO leftover state (self-contained).
+    conn.executescript(
+        """
+        -- a minimal parent table -- just enough to demonstrate the per-parent loop below
+        CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);  -- 1 parent table
+        -- author_id is NOT a foreign key here -- the point is the QUERY PATTERN, not the schema
+        CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL);
+        -- 2 authors -- Ada will end up with 2 books below, Grace with 1
+        INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper');  -- 2 rows
+        -- 3 books total, split 2-and-1 across the 2 authors above
+        INSERT INTO book(id, title, author_id) VALUES  -- a 3-row multi-VALUES insert
+            (1, 'Notes on the Analytical Engine', 1),  -- Ada's first book
+            (2, 'Sketch of the Analytical Engine', 1),  -- Ada's second book
+            (3, 'The First Computer Bug', 2);  -- Grace's only book
+        """
+    )  # => author has 2 rows, book has 3 rows -- 2 belong to author 1, 1 belongs to author 2
+    conn.commit()  # => persists the schema + seed data before any reporting query runs
+
+
+def main() -> None:  # => the entry point -- runs setup(), then the N+1 loop, then a summary
+    conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => a throwaway, process-local DB
+    setup(conn)  # => builds the 2-author, 3-book fixture this whole example reads from
+
+    query_count: int = 0  # => a manual counter -- makes the "N+1" round trips VISIBLE
+    authors: list[tuple[int, str]] = conn.execute(  # => query #1, below -- the parent fetch
+        "SELECT id, name FROM author"  # => no WHERE -- every author row, unconditionally
+    ).fetchall()  # => drains the cursor into a plain Python list right away
+    # => fetchall() drains the cursor into a plain list -- 2 rows, one PER author
+    query_count += 1  # => query #1 -- fetches every parent (author) row, once
+
+    results: list[tuple[str, list[str]]] = []  # => accumulates (author_name, titles) pairs
+    for author_id, author_name in authors:  # => THIS loop is the anti-pattern -- N iterations
+        # A SEPARATE round trip to the engine, PER author -- the "N" in "N+1" (co-23).
+        titles_cur: sqlite3.Cursor = conn.execute(  # => opens a FRESH cursor every iteration
+            "SELECT title FROM book WHERE author_id = ?",  # => filters to ONE author per call
+            (author_id,),  # => the single bound parameter for THIS iteration
+        )  # => runs a fresh query EVERY time the loop body executes
+        titles: list[str] = [row[0] for row in titles_cur.fetchall()]  # => unwraps 1-tuples
+        query_count += 1  # => tallies each per-author query as it fires
+        results.append((author_name, titles))  # => appends this author's (name, titles) pair
+
+    for name, titles in results:  # => a SEPARATE loop -- just prints what was already fetched
+        print(name, titles)  # => Output: one line per author, its titles as a Python list
+    print(f"queries executed: {query_count}")  # => 1 + 2 = 3 total -- co-23's cost, made visible
+    conn.close()  # => releases the in-memory connection -- nothing to clean up on disk
+
+
+if __name__ == "__main__":  # => guards main() so importing this module never runs it
+    main()  # => runs the whole demonstration end to end
+```
+
+**Run**: `python3 example.py`
+
+**Output**:
+
+```text
+Ada Lovelace ['Notes on the Analytical Engine', 'Sketch of the Analytical Engine']
+Grace Hopper ['The First Computer Bug']
+queries executed: 3
+```
+
+**pyright**: `pyright example.py` reports `0 errors, 0 warnings, 0 informations` under `# pyright:
+strict`.
+
+**Key takeaway**: 2 authors turned into 3 total queries -- 1 to fetch every author, plus 1 more per
+author inside the loop -- and that cost grows linearly with the number of parent rows, not the number
+of books.
+
+**Why it matters**: the N+1 pattern is one of the most common real-world performance bugs in
+database-backed applications, and it is easy to write by accident: the loop body looks correct in
+isolation, and it even returns the right data. The bug only shows up as latency once the parent table
+has hundreds or thousands of rows, each triggering its own round trip. Examples 63 and 64 fix the exact
+same output two different ways, without ever looping a query per parent.
+
+---
+
+### Example 63: N+1 Fixed with a Single Join
+
+_ex-63 &middot; exercises co-23, co-13_
+
+Replacing the per-author loop with one `JOIN` query collapses `1 + N` round trips into exactly 1 --
+SQL does the recombination work that Example 62's Python loop did manually, one iteration at a time.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Teal #029E73 -- color-blind friendly, WCAG AA
+flowchart LR
+    A["author JOIN book<br/>ONE query, ONE round trip"]:::blue
+    B["queries executed: 1<br/>not 1 + N"]:::teal
+    A --> B
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-63-n-plus-1-fixed-join/example.py`**
+
+```python
+# pyright: strict
+"""Example 63: N+1 Fixed with a Single JOIN."""
+
+import sqlite3  # => stdlib DB-API module (co-19)
+
+
+def setup(conn: sqlite3.Connection) -> None:  # => builds the SAME fixture as Example 62
+    # Identical schema and seed data to Example 62 -- same problem, different query shape.
+    conn.executescript(
+        """
+        -- same fixture shape as Example 62 -- comparing the FIX, not the data
+        CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);  -- 1 parent table
+        CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL);
+        -- author_id is a plain integer column here too -- the fix is the QUERY, not the schema
+        -- 2 authors, exactly as in Example 62
+        INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper');  -- 2 rows
+        -- 3 books, split 2-and-1, exactly as in Example 62
+        INSERT INTO book(id, title, author_id) VALUES  -- a 3-row multi-VALUES insert
+            (1, 'Notes on the Analytical Engine', 1),  -- Ada's first book
+            (2, 'Sketch of the Analytical Engine', 1),  -- Ada's second book
+            (3, 'The First Computer Bug', 2);  -- Grace's only book
+        """
+    )  # => same fixture as Example 62 -- 2 authors, 3 books, split 2-and-1
+    conn.commit()  # => persists the fixture before the single report query runs
+
+
+def main() -> None:  # => the entry point -- setup(), one JOIN query, then a print summary
+    conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => a throwaway, process-local DB
+    setup(conn)  # => builds the identical fixture Example 62 used
+
+    query_count: int = 0  # => tracks round trips -- watch this stay at 1, unlike Example 62's 3
+    # ONE query -- author JOIN book (co-13) -- replaces the whole per-author loop from Example 62.
+    # No Python for loop issues per-author SELECTs anymore -- the JOIN does that work in SQL.
+    rows: list[tuple[str, str]] = conn.execute(  # => a single multi-line SQL string, one call
+        """
+        -- ONE query does what Example 62 needed 3 separate round trips to do
+        SELECT author.name, book.title
+        FROM author
+        JOIN book ON book.author_id = author.id
+        ORDER BY author.name, book.title
+        """
+    ).fetchall()  # => 3 rows total, one PER BOOK, author name repeated where an author has 2 books
+    query_count += 1  # => the round trip count no longer scales with the number of authors
+
+    # Groups the flat rows back into "author -> list of titles" in PLAIN PYTHON, not another query.
+    grouped: dict[str, list[str]] = {}  # => empty until the loop below fills it in
+    for author_name, title in rows:  # => iterates the 3 FLAT rows returned by the join
+        grouped.setdefault(author_name, []).append(title)  # => builds the grouping in Python
+        # => setdefault(author_name, []) creates the list on first sight, appends every time after
+
+    for name, titles in grouped.items():  # => iterates the GROUPED dict, not the raw rows
+        print(name, titles)  # => Output: identical two lines to Example 62, from ONE query
+    print(f"queries executed: {query_count}")  # => 1 -- versus Example 62's 3
+    conn.close()  # => releases the in-memory connection -- nothing to clean up on disk
+
+
+if __name__ == "__main__":  # => guards main() so importing this module never runs it
+    main()  # => runs the whole demonstration end to end
+```
+
+**Run**: `python3 example.py`
+
+**Output**:
+
+```text
+Ada Lovelace ['Notes on the Analytical Engine', 'Sketch of the Analytical Engine']
+Grace Hopper ['The First Computer Bug']
+queries executed: 1
+```
+
+**pyright**: `pyright example.py` reports `0 errors, 0 warnings, 0 informations` under `# pyright:
+strict`.
+
+**Key takeaway**: the printed data is byte-for-byte identical to Example 62's, but `queries executed`
+drops from 3 to 1 -- the JOIN moved the recombination work from a Python loop into the query engine.
+
+**Why it matters**: `JOIN` exists precisely to answer "give me parent rows together with their related
+child rows" in a single round trip -- it is the database doing, in one pass over indexed or
+sequentially-scanned data, what a client-side loop would otherwise do one network hop at a time. The
+tradeoff is that the flat, one-row-per-book result needs a small amount of Python-side regrouping
+(`setdefault`), which is far cheaper than N extra queries ever were.
+
+---
+
+### Example 64: N+1 Fixed with a Batched Fetch
+
+_ex-64 &middot; exercises co-23, co-20_
+
+A second way to fix the identical N+1 problem: fetch every parent row first, collect their ids, then
+issue exactly one more query with `WHERE author_id IN (?, ?, ...)` to grab every child row in a single
+batched round trip -- 2 total queries, independent of how many authors there are.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73 -- color-blind friendly, WCAG AA
+flowchart LR
+    A["SELECT id, name FROM author<br/>query 1 -- every parent"]:::blue
+    B["collect ids: #91;1, 2#93;"]:::orange
+    C["SELECT ... WHERE author_id IN #40;1, 2#41;<br/>query 2 -- every child, batched"]:::teal
+    A --> B --> C
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-64-n-plus-1-fixed-in/example.py`**
+
+```python
+# pyright: strict
+"""Example 64: N+1 Fixed with a Batched IN(...) Fetch."""
+
+import sqlite3  # => stdlib DB-API module (co-19)
+
+
+def setup(conn: sqlite3.Connection) -> None:
+    # Same schema and seed data as Examples 62-63 -- a third way to fix the identical problem.
+    conn.executescript(
+        """
+        -- same fixture shape as Examples 62-63 -- comparing a THIRD fix to the identical problem
+        CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);  -- 1 parent table
+        CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL);
+        -- author_id is a plain integer column here too -- the fix is a SECOND batched query
+        -- 2 authors, exactly as in Examples 62-63
+        INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper');  -- 2 rows
+        -- 3 books, split 2-and-1, exactly as in Examples 62-63
+        INSERT INTO book(id, title, author_id) VALUES  -- a 3-row multi-VALUES insert
+            (1, 'Notes on the Analytical Engine', 1),  -- Ada's first book
+            (2, 'Sketch of the Analytical Engine', 1),  -- Ada's second book
+            (3, 'The First Computer Bug', 2);  -- Grace's only book
+        """
+    )  # => same fixture as Examples 62-63 -- 2 authors, 3 books, split 2-and-1
+    conn.commit()  # => persists the fixture before the two batched queries run
+
+
+def main() -> None:  # => entry point -- setup(), a parent fetch, a batched IN(...) fetch, print
+    conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => a throwaway, process-local DB
+    setup(conn)  # => builds the identical fixture Examples 62-63 used
+
+    query_count: int = 0  # => tracks round trips -- watch this settle at 2, not 1 or 3
+    authors: list[tuple[int, str]] = conn.execute(  # => query #1 -- the parent fetch
+        "SELECT id, name FROM author"  # => no WHERE -- every author row, unconditionally
+    ).fetchall()  # => drains the cursor -- 2 author rows, exactly like Example 62's first query
+    query_count += 1  # => query #1 -- the parent rows, exactly like Example 62's first query
+
+    author_ids: list[int] = [author_id for author_id, _ in authors]  # => just the ids, in order
+    # => extracts JUST the ids from the (id, name) pairs -- discards name via the _ placeholder
+    # Builds "?, ?, ..." -- ONE placeholder per id -- the values themselves stay fully parameterized.
+    placeholders: str = ",".join("?" for _ in author_ids)  # => "?,?" for 2 authors
+    books: list[tuple[int, str]] = conn.execute(  # => query #2 -- the ONLY child fetch, batched
+        f"SELECT author_id, title FROM book WHERE author_id IN ({placeholders})",
+        # => the f-string only splices in "?,?" placeholder MARKS -- never a real data value
+        author_ids,  # => co-20 -- every id is still bound as a real parameter, never interpolated
+    ).fetchall()  # => query #2 -- ALL children for EVERY parent, in a single batched round trip
+    query_count += 1  # => the second and FINAL query -- independent of how many authors there are
+
+    grouped: dict[int, list[str]] = {}  # => empty until the loop below fills it in
+    for author_id, title in books:  # => groups the flat rows by author_id, in plain Python
+        grouped.setdefault(author_id, []).append(title)  # => builds the grouping in Python
+        # => same setdefault-and-append pattern Example 63 used, applied to a different key
+
+    for author_id, author_name in authors:  # => iterates in the ORIGINAL author order
+        print(author_name, grouped.get(author_id, []))  # => .get(..., []) -- safe for zero books
+        # => Output: identical two lines to Examples 62-63 -- same data, now via 2 total queries
+    print(f"queries executed: {query_count}")  # => 2 -- one parent query PLUS one batched fetch
+    conn.close()  # => releases the in-memory connection
+
+
+if __name__ == "__main__":  # => guards main() so importing this module never runs it
+    main()  # => runs the whole demonstration end to end
+```
+
+**Run**: `python3 example.py`
+
+**Output**:
+
+```text
+Ada Lovelace ['Notes on the Analytical Engine', 'Sketch of the Analytical Engine']
+Grace Hopper ['The First Computer Bug']
+queries executed: 2
+```
+
+**pyright**: `pyright example.py` reports `0 errors, 0 warnings, 0 informations` under `# pyright:
+strict`.
+
+**Key takeaway**: `WHERE author_id IN (?, ?, ...)` fetches every child row for every parent in one
+call, using exactly as many `?` placeholders as there are parent ids -- the ids are still fully
+parameterized, only the placeholder marks themselves are built dynamically.
+
+**Why it matters**: the batched-`IN` fix is useful when a single JOIN either does not fit the access
+pattern (for example, fetching children from a different data source entirely) or would return an
+awkwardly large, heavily-duplicated flat result. Building the `?, ?, ...` placeholder string
+dynamically -- while still binding every value through the parameter list, never through string
+interpolation -- keeps the query injection-safe (co-20) even though its shape depends on how many
+parents were fetched.
+
+---
+
+### Example 65: Composite Primary Key
+
+_ex-65 &middot; exercises co-02, co-05_
+
+A many-to-many junction table's identity is the **pair** of foreign keys it links, not a separate
+surrogate id column -- `PRIMARY KEY (book_id, tag_id)` makes that pair unique, and a duplicate pair is
+rejected by the engine itself.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73 -- color-blind friendly, WCAG AA
+flowchart LR
+    A["book_tag #40;book_id=1, tag_id=1#41;"]:::blue
+    B["PRIMARY KEY #40;book_id, tag_id#41;"]:::orange
+    C["duplicate pair<br/>REJECTED by the engine"]:::teal
+    A --> B --> C
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-65-composite-primary-key/example.sql`**
+
+```sql
+-- Example 65: Composite Primary Key.
+-- A junction table's identity is the PAIR of foreign keys, not a surrogate id column (co-02, co-05).
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL);
+                                    -- => minimal parent -- just enough for book_tag to reference
+CREATE TABLE tag(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => the OTHER parent -- book_tag links book to tag, many-to-many
+CREATE TABLE book_tag(
+    book_id INTEGER NOT NULL REFERENCES book(id),
+                                    -- => FK half of the composite key
+    tag_id INTEGER NOT NULL REFERENCES tag(id),
+                                    -- => the OTHER FK half of the composite key
+    PRIMARY KEY (book_id, tag_id)  -- => the PAIR must be unique -- no separate id column needed
+);
+
+INSERT INTO book(id, title) VALUES (1, 'Notes on the Analytical Engine');
+                                    -- => 1 book row -- book_id = 1 is referenced below
+INSERT INTO tag(id, name) VALUES (1, 'history'), (2, 'computing');
+                                    -- => 2 tag rows -- tag_id 1 and 2 are referenced below
+
+-- .headers on and .mode column below are display preferences only -- no dot-command
+-- takes a trailing comment on its own line, so these two notes live here instead.
+.headers on
+.mode column
+INSERT INTO book_tag(book_id, tag_id) VALUES (1, 1), (1, 2);
+                                    -- => two DIFFERENT pairs -- both accepted
+SELECT * FROM book_tag;            -- => 2 rows -- book 1 tagged 'history' AND 'computing'
+
+-- The SAME (book_id, tag_id) pair a second time -- this violates the composite PRIMARY KEY.
+INSERT INTO book_tag(book_id, tag_id) VALUES (1, 1);
+                                    -- => rejected -- (1, 1) already exists as a row
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output** (the final `INSERT` deliberately fails; exit code `1` is expected):
+
+```text
+book_id  tag_id
+-------  ------
+1        1
+1        2
+Runtime error near line 29: UNIQUE constraint failed: book_tag.book_id, book_tag.tag_id (19)
+```
+
+**Key takeaway**: `PRIMARY KEY (book_id, tag_id)` treats the two-column combination as one composite
+identity -- `(1, 1)` and `(1, 2)` are both accepted as distinct pairs, but a repeated `(1, 1)` is
+rejected exactly like a duplicate single-column primary key would be.
+
+**Why it matters**: a junction table almost never needs its own surrogate id -- the pair of foreign
+keys it links already uniquely identifies each row, and giving that pair a `PRIMARY KEY` constraint
+gets duplicate-prevention for free, enforced by the engine rather than application code. This same
+composite-key pattern reappears in Example 77's `book_tag` table and the capstone's own junction table.
+
+---
+
+### Example 66: Cascade Delete
+
+_ex-66 &middot; exercises co-03_
+
+`ON DELETE CASCADE` propagates a parent row's deletion to every matching child row automatically --
+but only once `PRAGMA foreign_keys = ON` has actually turned on enforcement for the connection.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC, Brown #CA9161
+flowchart LR
+    A["DELETE FROM author<br/>WHERE id = 1"]:::blue
+    A --> B["ON DELETE CASCADE fires<br/>book rows author_id = 1"]:::orange
+    B --> C["books_after: 0<br/>authors_after: 0"]:::teal
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-66-cascade-delete/example.sql`**
+
+```sql
+-- Example 66: Cascade Delete.
+-- SQLite disables foreign-key ENFORCEMENT by default -- ON DELETE actions need it turned on (co-03).
+PRAGMA foreign_keys = ON;          -- => a per-connection setting -- must be re-issued every connect
+
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => the PARENT side of the relationship below
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    title TEXT NOT NULL,           -- => every book needs a title
+    author_id INTEGER REFERENCES author(id) ON DELETE CASCADE
+                                    -- => CASCADE propagates a parent delete to every matching child
+);
+
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace');
+                                    -- => 1 author row -- the parent this example deletes below
+INSERT INTO book(id, title, author_id) VALUES
+    (1, 'Notes on the Analytical Engine', 1),
+    (2, 'Sketch of the Analytical Engine', 1);
+                                    -- => 2 child rows, both pointing at author 1
+
+-- .headers on shows column names above every count(*) result below; .mode column aligns
+-- them for readability -- purely display, unrelated to the CASCADE behavior below.
+.headers on
+.mode column
+SELECT count(*) AS books_before FROM book WHERE author_id = 1;
+                                    -- => 2 -- both books still reference author 1
+
+DELETE FROM author WHERE id = 1;   -- => deletes the PARENT row -- CASCADE fires automatically
+                                    -- => a SINGLE statement triggers both the parent AND child deletes
+
+SELECT count(*) AS books_after FROM book WHERE author_id = 1;
+                                    -- => 0 -- both child rows were removed too, not just orphaned
+SELECT count(*) AS authors_after FROM author;
+                                    -- => 0 -- the author row itself is gone
+                                    -- => contrast Example 67: RESTRICT would have BLOCKED this delete
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+books_before
+------------
+2
+books_after
+-----------
+0
+authors_after
+-------------
+0
+```
+
+**Key takeaway**: one `DELETE FROM author` statement removed both the author row and its two book rows
+-- `books_after` and `authors_after` both land at `0`, with no separate `DELETE FROM book` statement
+ever issued.
+
+**Why it matters**: `ON DELETE CASCADE` is the right choice when child rows have no meaning without
+their parent -- a book without an author is a data-integrity problem, not a valid state, so letting the
+deletion propagate automatically is safer than leaving orphaned rows behind. The tradeoff is that a
+single `DELETE` can now silently remove far more data than the statement itself suggests, which is
+exactly why Example 67 shows the opposite policy for cases where that silent propagation is dangerous.
+
+---
+
+### Example 67: Restrict Delete
+
+_ex-67 &middot; exercises co-03_
+
+`ON DELETE RESTRICT` is the opposite policy from Example 66's `CASCADE`: the engine refuses to delete
+a parent row while any child row still references it, forcing the caller to deal with the dependency
+explicitly.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73 -- color-blind friendly, WCAG AA
+flowchart LR
+    A["DELETE FROM author<br/>WHERE id = 1"]:::blue
+    B{"any book.author_id = 1?"}:::orange
+    C["REJECTED<br/>FOREIGN KEY constraint failed"]:::teal
+    A --> B --> C
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-67-restrict-delete/example.sql`**
+
+```sql
+-- Example 67: Restrict Delete.
+PRAGMA foreign_keys = ON;          -- => enforcement must be on for RESTRICT to actually block anything
+
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => the PARENT side -- the row this example tries to delete
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    title TEXT NOT NULL,           -- => every book needs a title
+    author_id INTEGER REFERENCES author(id) ON DELETE RESTRICT
+                                    -- => RESTRICT is the opposite of CASCADE: blocks the parent delete
+);
+
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace');
+                                    -- => 1 author row -- still referenced by the book below
+INSERT INTO book(id, title, author_id) VALUES (1, 'Notes on the Analytical Engine', 1);
+                                    -- => the ONE child row that makes the delete below illegal
+
+-- .headers on and .mode column below are display preferences, consistent with every other
+-- example in this tier -- they have no bearing on the RESTRICT behavior demonstrated next.
+.headers on
+.mode column
+-- Blocked: author 1 still has a referencing book row -- RESTRICT rejects this delete outright.
+DELETE FROM author WHERE id = 1;   -- => fails -- the engine refuses to orphan the book row above
+                                    -- => contrast Example 66: CASCADE ALLOWS this same shape of delete
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output** (the `DELETE` deliberately fails; exit code `1` is expected):
+
+```text
+Runtime error near line 23: FOREIGN KEY constraint failed (19)
+```
+
+**Key takeaway**: the exact same `DELETE FROM author WHERE id = 1` statement that succeeded in Example
+66 fails here with `FOREIGN KEY constraint failed` -- the only difference is `ON DELETE CASCADE` versus
+`ON DELETE RESTRICT` in the child table's own column definition.
+
+**Why it matters**: `RESTRICT` is the right choice when a silent, cascading deletion would be a bug
+rather than a feature -- deleting a customer account should not silently vaporize their entire order
+history, for example. Forcing the delete to fail makes the dependency visible at the moment it matters,
+so the caller can decide explicitly (reassign the books, archive them, or refuse the delete) rather than
+discovering the missing data days later.
+
+---
+
+### Example 68: Savepoint Partial Rollback
+
+_ex-68 &middot; exercises co-18_
+
+`SAVEPOINT` marks a point inside an already-open transaction; `ROLLBACK TO` that savepoint undoes only
+the work done since it was set, while the outer transaction itself stays open and can keep going.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC -- color-blind friendly, WCAG AA
+flowchart LR
+    A["BEGIN<br/>outer transaction opens"]:::blue
+    B["SAVEPOINT sp1"]:::orange
+    C["INSERT #40;bad row#41;"]:::teal
+    D["ROLLBACK TO sp1<br/>only the bad row undone"]:::purple
+    A --> B --> C --> D
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-68-savepoint-partial-rollback/example.sql`**
+
+```sql
+-- Example 68: Savepoint Partial Rollback.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+                                    -- => a single table -- enough to demonstrate the savepoint dance
+
+-- .headers on shows column names above the final SELECT below; .mode column aligns the
+-- display -- both are readability preferences, set before the transaction even opens.
+.headers on
+.mode column
+BEGIN;                              -- => opens the OUTER transaction (co-18)
+INSERT INTO book(id, title, price) VALUES (1, 'Notes on the Analytical Engine', 12.5);
+                                    -- => row 1 -- committed at the END, along with row 3 below
+
+SAVEPOINT sp;                       -- => marks a point INSIDE the still-open transaction
+INSERT INTO book(id, title, price) VALUES (2, 'Bad Draft', -5.0);
+                                    -- => a mistake we want to undo WITHOUT losing row 1 too
+ROLLBACK TO sp;                     -- => undoes ONLY work since sp -- the outer transaction stays open
+
+INSERT INTO book(id, title, price) VALUES (3, 'Sketch of the Analytical Engine', 9.0);
+                                    -- => row 3 -- inserted AFTER the rollback, in the same transaction
+COMMIT;                             -- => finalizes rows 1 and 3 -- row 2 never existed past the savepoint
+
+SELECT id, title, price FROM book;  -- => 2 rows: ids 1 and 3 -- the bad draft (id 2) is nowhere
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                            price
+--  -------------------------------  -----
+1   Notes on the Analytical Engine   12.5
+3   Sketch of the Analytical Engine  9.0
+```
+
+**Key takeaway**: `ROLLBACK TO sp` erased only the "Bad Draft" insert -- the row inserted before the
+savepoint and the row inserted after `ROLLBACK TO` both survive the final `COMMIT`.
+
+**Why it matters**: a plain `ROLLBACK` throws away an entire transaction's work; a savepoint gives that
+same undo power over just a portion of it, which matters when a transaction legitimately needs to try
+something, discover it was wrong, and keep going without restarting from scratch. This is the same
+mechanism batch-import and multi-step workflow code relies on to skip one bad record without abandoning
+every record already processed in the same transaction.
+
+---
+
+### Example 69: Python Report Function
+
+_ex-69 &middot; exercises co-15, co-21_
+
+Splitting fetch-and-shape logic into a typed function -- `report(conn) -> list[tuple[str, int]]` --
+makes the reporting query independently callable and its return shape visible in the signature itself,
+not just in a comment.
+
+**`learning/code/ex-69-python-report-function/example.py`**
+
+```python
+# pyright: strict
+"""Example 69: Typed report() Function Running a GROUP BY."""
+# Splitting fetch-and-shape logic into a typed function is what makes it independently testable.
+
+import sqlite3  # => stdlib DB-API module (co-19) -- the only import this whole file needs
+
+
+def setup(conn: sqlite3.Connection) -> None:  # => builds the fixture report() reads from
+    conn.executescript(
+        """
+        -- a minimal author/book fixture -- just enough for one GROUP BY report
+        CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);  -- 1 parent table
+        CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL);
+        -- author_id is a plain integer column -- report() below GROUPs by the author's NAME
+        -- 2 authors -- Ada ends up with 2 books, Grace with 1
+        INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper');  -- 2 rows
+        -- 3 books, split 2-and-1 -- the exact counts main()'s hand-computed assert checks
+        INSERT INTO book(id, title, author_id) VALUES  -- a 3-row multi-VALUES insert
+            (1, 'Notes on the Analytical Engine', 1),  -- Ada's first book
+            (2, 'Sketch of the Analytical Engine', 1),  -- Ada's second book
+            (3, 'The First Computer Bug', 2);  -- Grace's only book
+        """
+    )  # => 2 authors, 3 books -- Ada has 2, Grace has 1, the fixture report() summarizes
+    conn.commit()  # => persists the fixture before report() ever runs against it
+
+
+def report(conn: sqlite3.Connection) -> list[tuple[str, int]]:  # => the function under test
+    # A fully typed function signature (co-21): the return shape is documented in the type,
+    # not just in a comment -- any caller sees "name, count" pairs without reading the body.
+    cur: sqlite3.Cursor = conn.execute(  # => a single multi-line SQL string, one call
+        """
+        -- one JOIN, one GROUP BY -- the report's ENTIRE logic lives in this one query
+        SELECT author.name, count(*)
+        FROM author
+        JOIN book ON book.author_id = author.id
+        GROUP BY author.name
+        ORDER BY author.name
+        """
+    )  # => GROUP BY collapses per-book rows into per-author counts (co-15)
+    rows: list[tuple[str, int]] = cur.fetchall()  # => drains the cursor into a typed list
+    return rows  # => e.g. [('Ada Lovelace', 2), ('Grace Hopper', 1)]
+    # Nothing about this function's SHAPE would change for a bigger fixture -- SQL scales, not Python
+
+
+def main() -> None:  # => entry point -- builds the fixture, calls report(), checks the answer
+    conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => a throwaway, process-local DB
+    setup(conn)  # => builds the 2-author, 3-book fixture report() reads from
+
+    rows: list[tuple[str, int]] = report(conn)  # => calls the typed function under test
+    # No caller here needs to know report()'s SQL -- the typed return value is the contract.
+    for name, count in rows:  # => unpacks each (name, count) pair from the returned list
+        print(name, count)  # => Output: one line per author, its book count
+
+    # Hand-computed: Ada has 2 books (ids 1, 2), Grace has 1 book (id 3) -- matches the seed above.
+    expected: list[tuple[str, int]] = [("Ada Lovelace", 2), ("Grace Hopper", 1)]  # => by hand
+    assert rows == expected  # => proves report()'s SQL matches what a human counted by hand
+    print("matches hand-computed expectation")  # => only reached if the assert above passed
+    conn.close()  # => releases the in-memory connection -- nothing to clean up on disk
+
+
+if __name__ == "__main__":  # => guards main() so importing this module never runs it
+    main()  # => runs the whole demonstration end to end
+```
+
+**Run**: `python3 example.py`
+
+**Output**:
+
+```text
+Ada Lovelace 2
+Grace Hopper 1
+matches hand-computed expectation
+```
+
+**pyright**: `pyright example.py` reports `0 errors, 0 warnings, 0 informations` under `# pyright:
+strict`.
+
+**Key takeaway**: `report()`'s return type, `list[tuple[str, int]]`, tells a reader exactly what shape
+of data to expect without reading the SQL inside it -- and the hand-computed `assert` proves that shape
+actually matches reality for this fixture.
+
+**Why it matters**: a bare SQL string scattered through application code is hard to test in isolation;
+a typed function wrapping it can be called directly from a test with a known fixture and a known
+expected result, exactly as `main()` does here. Example 73 takes this one step further by moving
+several such functions into their own module and testing them with `pytest` instead of a bare `assert`.
+
+---
+
+### Example 70: Group Concat
+
+_ex-70 &middot; exercises co-15_
+
+`group_concat(column, separator)` folds every row's value within a `GROUP BY` group into a single,
+separator-joined string -- useful for a one-line summary without a second round trip per group.
+
+**`learning/code/ex-70-group-concat/example.sql`**
+
+```sql
+-- Example 70: group_concat.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => the GROUPing key this example concatenates around
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL);
+                                    -- => the column whose VALUES get folded into one string
+
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace');
+                                    -- => 1 author -- author_id = 1 groups both books below
+INSERT INTO book(id, title, author_id) VALUES
+    (1, 'Notes on the Analytical Engine', 1),
+    (2, 'Sketch of the Analytical Engine', 1);
+                                    -- => 2 books, SAME author -- one group_concat row results
+
+-- .headers on shows the "author_id | titles" header row below. .mode list switches away
+-- from .mode column -- a long concatenated string would WRAP mid-word there (see Example
+-- 65's .mode column note); .separator " | " picks a readable delimiter for list mode.
+.headers on
+.mode list
+.separator " | "
+-- list mode (pipe-separated, no column wrapping) keeps the long concatenated string on one line.
+-- group_concat(X, sep) folds every GROUPed row's X value into ONE string, sep-joined (co-15).
+SELECT author_id, group_concat(title, '; ') AS titles
+FROM book
+GROUP BY author_id;                -- => one row per author_id -- titles collapsed into one string
+                                    -- => the '; ' second argument is the JOINER between titles
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+author_id | titles
+1 | Notes on the Analytical Engine; Sketch of the Analytical Engine
+```
+
+**Key takeaway**: `group_concat(title, '; ')` produced one row per `author_id`, with both of that
+author's book titles folded into a single `;`-joined string -- no client-side loop needed to build
+that summary.
+
+**Why it matters**: `group_concat` is the SQL-native answer to "give me a comma-separated (or any
+separator) summary per group" -- a common reporting need that would otherwise require fetching every
+raw row and joining strings in application code. Because the switch away from `.mode column` here is
+purely a display choice, it is also a reminder that the CLI's output formatting and the underlying
+query result are two separate concerns.
+
+---
+
+### Example 71: Anti-Join Missing Rows
+
+_ex-71 &middot; exercises co-14, co-17_
+
+`LEFT JOIN ... WHERE right.id IS NULL` is the standard "find rows on the left with **no** match on the
+right" pattern -- an `INNER JOIN` would silently drop exactly the rows this query exists to find.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC -- color-blind friendly, WCAG AA
+flowchart LR
+    A["author LEFT JOIN book<br/>unmatched rows get NULL"]:::blue
+    B["WHERE book.id IS NULL"]:::orange
+    C["authors with ZERO books"]:::teal
+    D["INNER JOIN here would<br/>silently drop these rows"]:::purple
+    A --> B --> C
+    A -.->|"NOT this"| D
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-71-anti-join-missing/example.sql`**
+
+```sql
+-- Example 71: Anti-Join -- Missing Rows.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => the LEFT side of the join -- every row here must appear
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL);
+                                    -- => the RIGHT side -- deliberately missing for one author below
+
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper'), (3, 'Alan Turing');
+                                    -- => 3 authors -- only 2 will have a matching book
+INSERT INTO book(id, title, author_id) VALUES
+    (1, 'Notes on the Analytical Engine', 1),
+    (2, 'The First Computer Bug', 2);
+                                    -- => Alan Turing (id 3) intentionally has ZERO books
+
+-- .headers on shows the "name" header row below; .mode column aligns the display --
+-- both are readability preferences only, unrelated to the anti-join logic below.
+.headers on
+.mode column
+-- LEFT JOIN keeps EVERY author row -- unmatched book columns come back NULL (co-14).
+-- WHERE book.id IS NULL then isolates ONLY the authors that never matched anything (co-17).
+SELECT author.name
+FROM author
+LEFT JOIN book ON book.author_id = author.id
+WHERE book.id IS NULL;             -- => Alan Turing only -- the "missing rows" anti-join pattern
+                                    -- => an INNER JOIN here would have DROPPED Alan entirely
+                                    -- => "= NULL" would NOT work here -- co-17's three-valued logic
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+name
+-----------
+Alan Turing
+```
+
+**Key takeaway**: `LEFT JOIN` kept all 3 authors, with `book.id` coming back `NULL` for Alan Turing's
+row specifically because nothing in `book` matched him; `WHERE book.id IS NULL` then filters down to
+exactly that one row.
+
+**Why it matters**: "find customers with no orders" or "find authors with no published books" are
+common real-world questions, and they are structurally impossible to answer with an `INNER JOIN` --
+there is no matching row to return in the first place. The `IS NULL` check (not `= NULL`, which never
+matches anything under SQL's three-valued logic) is the deliberate signal that a `LEFT JOIN` found no
+partner for that row.
+
+---
+
+### Example 72: Atomic Transfer
+
+_ex-72 &middot; exercises co-18_
+
+A two-row debit-and-credit transfer inside a single transaction is either fully visible or not visible
+at all -- this example shows both a transfer that commits successfully and one that is deliberately
+abandoned with `ROLLBACK` before either leg ever lands.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC -- color-blind friendly, WCAG AA
+flowchart LR
+    A["BEGIN"]:::blue
+    B["debit account A"]:::orange
+    C["credit account B"]:::orange
+    D["commit#40;#41; -- both legs visible<br/>OR rollback#40;#41; -- neither leg visible"]:::purple
+    A --> B --> C --> D
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-72-atomic-transfer/example.sql`**
+
+```sql
+-- Example 72: Atomic Transfer.
+CREATE TABLE account(id INTEGER PRIMARY KEY, name TEXT NOT NULL, balance REAL NOT NULL);
+                                    -- => a tiny ledger -- 2 accounts, one debit/credit pair below
+INSERT INTO account(id, name, balance) VALUES (1, 'checking', 100.0), (2, 'savings', 50.0);
+                                    -- => starting balances -- the baseline for every check below
+
+.headers on
+.mode column
+SELECT id, name, balance FROM account;
+                                    -- => checking 100.0, savings 50.0 -- the starting state
+
+-- A successful transfer: BOTH legs (debit + credit) succeed inside ONE transaction (co-18).
+BEGIN;                              -- => opens the transaction -- neither leg is visible yet
+UPDATE account SET balance = balance - 30.0 WHERE id = 1;
+                                    -- => debit leg -- checking drops by 30
+UPDATE account SET balance = balance + 30.0 WHERE id = 2;
+                                    -- => credit leg -- savings gains the SAME 30
+COMMIT;                            -- => both legs land together -- no half-transfer is EVER visible
+
+SELECT id, name, balance FROM account;
+                                    -- => checking 70.0, savings 80.0 -- 30 moved, nothing lost
+
+-- A transfer we DELIBERATELY abandon after detecting a problem, before committing either leg.
+BEGIN;                              -- => opens a SECOND, independent transaction
+UPDATE account SET balance = balance - 1000.0 WHERE id = 1;
+                                    -- => this debit would drive checking NEGATIVE -- a business rule
+                                    -- => violation this application layer checks for itself
+ROLLBACK;                          -- => undoes the just-issued debit -- nothing was ever persisted
+
+SELECT id, name, balance FROM account;
+                                    -- => STILL checking 70.0, savings 80.0 -- all-or-nothing held
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  name      balance
+--  --------  -------
+1   checking  100.0
+2   savings   50.0
+id  name      balance
+--  --------  -------
+1   checking  70.0
+2   savings   80.0
+id  name      balance
+--  --------  -------
+1   checking  70.0
+2   savings   80.0
+```
+
+**Key takeaway**: the successful transfer moved exactly 30 from checking to savings with both legs
+landing together; the abandoned transfer's debit never shows up anywhere, because `ROLLBACK` ran before
+`COMMIT` ever could.
+
+**Why it matters**: a transfer that debits one account and then fails before crediting the other would
+destroy money -- the entire point of wrapping both legs in one transaction is that partial completion
+is not a state the database ever exposes to a reader. The second, abandoned transfer here models an
+application-level business-rule check (an insufficient-funds guard) catching a problem and rolling back
+before any write becomes visible, rather than relying on the database to enforce that rule itself.
+
+---
+
+### Example 73: Python DAL Module
+
+_ex-73 &middot; exercises co-19, co-20_
+
+A small, typed data-access-layer module wraps parameterized CRUD operations behind plain function
+calls -- every SQL string uses `?` placeholders, and a `pytest` suite exercises each function against a
+fresh, seeded in-memory fixture.
+
+**`learning/code/ex-73-python-dal-module/dal.py`**
+
+```python
+# pyright: strict
+"""Example 73: A Typed Data-Access-Layer Module -- Parameterized CRUD."""
+
+import sqlite3  # => stdlib DB-API module (co-19) -- no third-party driver anywhere in this file
+
+
+def create_schema(conn: sqlite3.Connection) -> None:  # => called once per test, in the fixture
+    # Every function in this module takes an ALREADY-OPEN connection -- callers (including
+    # tests) control the connection's lifetime, this module never opens or closes one itself.
+    conn.executescript(  # => executescript, not execute -- runs raw DDL, no placeholders needed
+        "CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);"  # => single DDL statement
+    )  # => the ONLY table this module manages -- a minimal fixture for CRUD demonstration
+
+
+def insert_author(conn: sqlite3.Connection, name: str) -> int:  # => the "C" in CRUD
+    # `?` (qmark) parameterization -- name is BOUND, never string-interpolated (co-20).
+    cur: sqlite3.Cursor = conn.execute(  # => returns a Cursor -- lastrowid is read off it below
+        "INSERT INTO author(name) VALUES (?)",  # => one placeholder, one bound value
+        (name,),  # => a 1-tuple -- the trailing comma is REQUIRED for a single-element tuple
+    )
+    conn.commit()  # => persists the insert before returning the new row's id to the caller
+    new_id: int | None = cur.lastrowid  # => the rowid SQLite just assigned (co-02)
+    assert new_id is not None  # => narrows int | None to int -- always set right after an INSERT
+    return new_id  # => the caller uses this id for every follow-up get/update/delete call
+
+
+def get_author(conn: sqlite3.Connection, author_id: int) -> tuple[int, str] | None:  # "R" in CRUD
+    cur: sqlite3.Cursor = conn.execute(  # => a read -- no conn.commit() needed for a SELECT
+        "SELECT id, name FROM author WHERE id = ?",  # => a single bound parameter
+        (author_id,),  # => co-20 again, this time for a lookup, not an insert
+    )
+    row: tuple[int, str] | None = cur.fetchone()  # => None if no row matched the given id
+    return row  # => the caller must handle the None case -- pyright enforces this via the type
+
+
+def list_authors(conn: sqlite3.Connection) -> list[tuple[int, str]]:  # => reads EVERY row
+    cur: sqlite3.Cursor = conn.execute("SELECT id, name FROM author ORDER BY id")  # => the bulk read
+    # => no WHERE clause -- every row, oldest id first
+    return cur.fetchall()  # => every row by this ONE call -- no filter needed for a full listing
+
+
+def update_author_name(conn: sqlite3.Connection, author_id: int, new_name: str) -> None:  # "U"
+    conn.execute(  # => a write -- conn.commit() below persists it
+        "UPDATE author SET name = ? WHERE id = ?",  # => TWO placeholders -- order matters below
+        (new_name, author_id),  # => the SAME order as the ?s in the SQL text (co-20)
+    )
+    conn.commit()  # => this module commits eagerly -- no long-lived open transaction to forget
+
+
+def delete_author(conn: sqlite3.Connection, author_id: int) -> None:  # => the "D" in CRUD
+    conn.execute("DELETE FROM author WHERE id = ?", (author_id,))
+    # => DELETE ... WHERE with a bound id -- co-20 once more, no string interpolation anywhere
+    conn.commit()  # => a no-op commit if author_id didn't exist -- DELETE ... WHERE is safe to repeat
+```
+
+**`learning/code/ex-73-python-dal-module/tests/__init__.py`**
+
+```python
+
+```
+
+(An empty file. Making `tests/` an importable package causes `pytest`'s default "prepend" import
+mode to walk up to this example's root directory -- the one directory in this tree that has **no**
+`__init__.py` -- and insert that root into `sys.path`, which is what makes `from dal import ...` below
+resolve at all.)
+
+**`learning/code/ex-73-python-dal-module/tests/test_dal.py`**
+
+```python
+"""Example 73: pytest coverage for dal.py against a seeded, in-memory fixture DB."""
+
+import sqlite3  # => stdlib DB-API module -- only needed here to type the fixture's connection
+from collections.abc import Iterator  # => types the fixture's generator return
+
+import pytest  # => the testing framework -- provides the @pytest.fixture decorator below
+
+# tests/__init__.py makes THIS directory a package, so pytest inserts the PARENT dir (the
+# example's root) into sys.path -- that is what makes `from dal import ...` resolve at all.
+from dal import (  # => imports the module UNDER TEST
+    create_schema,  # => builds the schema -- called once per test, via the fixture below
+    delete_author,  # => the "D" in CRUD -- covered by test_delete_author
+    get_author,  # => the "R" in CRUD -- covered by every test below
+    insert_author,  # => the "C" in CRUD -- covered by every test below
+    list_authors,  # => a bulk read -- covered by test_list_authors_returns_every_row
+    update_author_name,  # => the "U" in CRUD -- covered by test_update_author_name
+)  # => closes the import list -- all five dal.py functions under test in this file
+
+
+@pytest.fixture  # => runs before EVERY test function below, fresh each time
+def conn() -> Iterator[sqlite3.Connection]:  # => Iterator, not Connection -- this is a generator
+    # A FRESH in-memory DB per test -- no test can see another test's leftover rows.
+    connection: sqlite3.Connection = sqlite3.connect(":memory:")  # => a throwaway, per-test DB
+    create_schema(connection)  # => builds the ONE table every test below reads and writes
+    yield connection  # => hands the ready connection to the test function below
+    connection.close()  # => runs AFTER the test, whether it passed or failed
+
+
+def test_insert_and_get_author(conn: sqlite3.Connection) -> None:  # => covers insert + get
+    author_id: int = insert_author(conn, "Ada Lovelace")  # => the function under test, first call
+    assert get_author(conn, author_id) == (author_id, "Ada Lovelace")  # => round-trips correctly
+
+
+def test_list_authors_returns_every_row(conn: sqlite3.Connection) -> None:  # => covers the bulk read
+    insert_author(conn, "Ada Lovelace")  # => row 1
+    insert_author(conn, "Grace Hopper")  # => row 2
+    assert list_authors(conn) == [(1, "Ada Lovelace"), (2, "Grace Hopper")]  # => both, in order
+
+
+def test_update_author_name(conn: sqlite3.Connection) -> None:  # => covers the "U" in CRUD
+    author_id: int = insert_author(conn, "Ada")  # => an initial, incomplete name
+    update_author_name(conn, author_id, "Ada Lovelace")  # => the function under test
+    assert get_author(conn, author_id) == (author_id, "Ada Lovelace")  # => the UPDATE persisted
+
+
+def test_delete_author(conn: sqlite3.Connection) -> None:  # => covers the "D" in CRUD
+    author_id: int = insert_author(conn, "Ada Lovelace")  # => the row this test deletes
+    delete_author(conn, author_id)  # => the function under test
+    assert get_author(conn, author_id) is None  # => the row is genuinely gone, not just renamed
+```
+
+**Run**: `pytest -q` (from inside `ex-73-python-dal-module/`)
+
+**Output**:
+
+```text
+....                                                                     [100%]
+4 passed in 0.01s
+```
+
+**pyright**: `pyright dal.py` reports `0 errors, 0 warnings, 0 informations` under `# pyright: strict`.
+Running `pyright .` from inside `ex-73-python-dal-module/` -- rather than pointing `pyright` at
+`tests/test_dal.py` in isolation -- also reports `0 errors, 0 warnings, 0 informations`: analyzing the
+whole directory as one unit lets `pyright` resolve `from dal import ...` the same way `pytest`'s own
+`sys.path` trick does.
+
+**Key takeaway**: every one of `dal.py`'s five functions takes an already-open connection and never
+opens or closes one itself, which is exactly what let 4 independent tests each get a fresh,
+isolated `:memory:` database from the same `conn` fixture without any function in `dal.py` needing to
+know it is under test.
+
+**Why it matters**: separating "how to talk to this table" (`dal.py`) from "how to obtain a
+connection" (the caller, or the test fixture) is the core idea behind a data-access layer -- it makes
+every CRUD operation independently unit-testable against a throwaway fixture, with zero risk of one
+test's rows leaking into another. The capstone's own `dal.py` extends this exact pattern to a
+4-table schema with a reporting query and a rollback-on-failure batch update.
+
+---
+
+### Example 74: Seed from SQL File
+
+_ex-74 &middot; exercises co-24, co-10_
+
+Splitting a database's structure from its data is a common convention: `schema.sql` defines the shape,
+`seed.sql` fills it, and each is applied as its own separate `sqlite3` CLI invocation.
+
+**`learning/code/ex-74-seed-from-sql-file/schema.sql`**
+
+```sql
+-- Example 74: Seed from SQL File -- schema.sql (structure only, no data).
+-- Splitting structure from data is a common convention: schema.sql defines the shape,
+-- seed.sql fills it -- each applied as its own separate sqlite3 CLI invocation (co-24).
+CREATE TABLE author (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+
+-- => the parent table
+CREATE TABLE book (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  author_id INTEGER NOT NULL REFERENCES author (id)
+);
+
+-- => the child table -- zero rows in EITHER table yet
+```
+
+**`learning/code/ex-74-seed-from-sql-file/seed.sql`**
+
+```sql
+-- Example 74: Seed from SQL File -- seed.sql (data only, applied AFTER schema.sql, co-10).
+-- This file assumes schema.sql ALREADY ran -- applying seed.sql alone, first, would fail
+-- with "no such table: author".
+INSERT INTO
+  author (id, name)
+VALUES
+  (1, 'Ada Lovelace'),
+  (2, 'Grace Hopper');
+
+-- => 2 author rows -- author_id 1 and 2 below reference these
+INSERT INTO
+  book (id, title, author_id)
+VALUES
+  (1, 'Notes on the Analytical Engine', 1), -- Ada's first book
+  (2, 'Sketch of the Analytical Engine', 1), -- Ada's second book
+  (3, 'The First Computer Bug', 2);
+
+-- Grace's only book
+-- => 3 book rows -- the count Example 74's verify checks
+```
+
+**Run**: `sqlite3 app.db < schema.sql`, then `sqlite3 app.db < seed.sql`, then
+`sqlite3 app.db ".tables" "SELECT count(*) FROM book;"`
+
+**Output**:
+
+```text
+author  book
+3
+```
+
+**Key takeaway**: `.tables` confirms both tables exist after `schema.sql` runs, and the follow-up
+`SELECT count(*) FROM book` -- run only after `seed.sql` has also applied -- confirms all 3 seeded book
+rows landed.
+
+**Why it matters**: separating structure from data lets a schema be version-controlled and reviewed
+independently of the sample or fixture data that happens to populate it -- the same `schema.sql` can
+be paired with different `seed.sql` files for development, testing, or a demo environment. This is also
+the exact split the capstone uses for its own `schema.sql` + `seed.sql` pair, and the split Example
+61's migration runner assumes when it applies `migration.sql` against an already-schema'd database.
+
+---
+
+### Example 75: Export Query to CSV
+
+_ex-75 &middot; exercises co-24_
+
+`.mode csv` plus `.output <file>` redirects every subsequent query's result into a file instead of the
+terminal, until `.output stdout` switches back -- a full CSV export pipeline in three dot-commands.
+
+**`learning/code/ex-75-export-query-to-csv/example.sql`**
+
+```sql
+-- Example 75: Export Query to CSV.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+                                    -- => a single table -- enough to demonstrate export
+INSERT INTO book(id, title, price) VALUES  -- a 2-row multi-VALUES insert
+    (1, 'Notes on the Analytical Engine', 12.5),  -- row 1 -- exported below
+    (2, 'Sketch of the Analytical Engine', 9.0);   -- row 2 -- exported below
+
+-- .headers on, .mode csv, and .output out.csv below are display/format preferences only.
+.headers on
+.mode csv
+.output out.csv
+-- .output REDIRECTS every subsequent result to the named file -- nothing prints to the terminal
+-- until .output stdout runs again (co-24). Note: no trailing "--" comment on a dot-command line.
+SELECT id, title, price FROM book; -- => written to out.csv, NOT the terminal, while redirected
+.output stdout
+-- Back on the terminal -- confirms the CLI itself is unaffected by the redirect that just ended.
+SELECT 'export done' AS status;    -- => prints on the terminal -- proves .output stdout worked
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output** (printed on the terminal -- the exported `SELECT` above produced no terminal output at all,
+because it ran while `.output` was still redirected):
+
+```text
+status
+"export done"
+```
+
+**`out.csv`** (written to disk while `.output out.csv` was active, never printed to the terminal):
+
+```text
+id,title,price
+1,"Notes on the Analytical Engine",12.5
+2,"Sketch of the Analytical Engine",9.0
+```
+
+**Key takeaway**: only the query issued **after** `.output stdout` printed anything to the terminal --
+the earlier `SELECT` silently went to `out.csv` instead, which is exactly the redirect `.output`
+promises.
+
+**Why it matters**: exporting query results to CSV directly from the CLI, with no external scripting
+language involved, is a common operational task -- generating a report for a spreadsheet, handing data
+to a non-technical stakeholder, or feeding another tool's CSV import. Forgetting to run `.output
+stdout` afterward is a classic footgun: every later query in the same session would keep writing
+silently to the same file instead of the terminal, which is why this example deliberately shows the
+"switch back" step as part of the pattern, not as an afterthought.
+
+---
+
+### Example 76: Integrity Checks
+
+_ex-76 &middot; exercises co-24, co-03_
+
+`PRAGMA integrity_check` walks the database file's own B-tree structure looking for on-disk
+corruption; `PRAGMA foreign_key_check` is a separate pragma that instead scans for foreign-key
+violations -- neither one checks what the other checks.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73 -- color-blind friendly, WCAG AA
+flowchart LR
+    A["database file"]:::blue
+    B["PRAGMA integrity_check<br/>on-disk B-tree corruption"]:::orange
+    C["PRAGMA foreign_key_check<br/>FK reference violations"]:::teal
+    A --> B
+    A --> C
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-76-integrity-checks/example.sql`**
+
+```sql
+-- Example 76: Integrity Checks.
+PRAGMA foreign_keys = ON;          -- => enforcement on -- relevant to foreign_key_check below
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => the parent table foreign_key_check will verify against
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER REFERENCES author(id));
+                                    -- => the child table -- its FK is what gets checked below
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace');
+                                    -- => 1 author row -- author_id = 1 is referenced below
+INSERT INTO book(id, title, author_id) VALUES (1, 'Notes on the Analytical Engine', 1);
+                                    -- => 1 book row, correctly referencing an EXISTING author
+
+-- .headers on and .mode column below are display preferences only -- unrelated to the checks.
+.headers on
+.mode column
+-- integrity_check walks the B-tree structure itself -- page corruption, not foreign keys (co-24).
+PRAGMA integrity_check;            -- => "ok" means the on-disk structure is sound
+
+-- integrity_check deliberately does NOT check foreign keys -- foreign_key_check does that instead.
+PRAGMA foreign_key_check;          -- => zero ROWS returned means zero foreign-key violations (co-03)
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+integrity_check
+---------------
+ok
+```
+
+(`PRAGMA foreign_key_check` printed nothing at all -- zero rows is exactly its "no violations found"
+signal, not an error.)
+
+**Key takeaway**: `integrity_check` returning the single string `"ok"` means the file's own storage
+structure is sound; `foreign_key_check` returning **zero rows** (not the word `"ok"`) means every
+foreign key in the database currently points at a row that actually exists.
+
+**Why it matters**: these two pragmas answer genuinely different questions, and conflating them is a
+real operational mistake -- a database file can be perfectly sound at the storage-engine level while
+still holding foreign-key violations (for example, after a bulk import with `PRAGMA foreign_keys =
+OFF`), or vice versa in the presence of rare on-disk corruption. Running both after a bulk load or a
+migration is a cheap way to catch either failure mode before it reaches a production query.
+
+---
+
+### Example 77: Design a 3NF Schema
+
+_ex-77 &middot; exercises co-05, co-07, co-01_
+
+A 3NF design puts each fact-type in exactly one relation, related to the others purely by key values
+-- this example builds a 5-table schema (author, publisher, book, tag, and the `book_tag` junction)
+with no transitive dependency anywhere in it.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC, Brown #CA9161
+flowchart LR
+    author["author<br/>id, name"]:::blue
+    publisher["publisher<br/>id, name, city"]:::orange
+    book["book<br/>id, title, price,<br/>author_id FK, publisher_id FK"]:::teal
+    tag["tag<br/>id, name UNIQUE"]:::purple
+    book_tag["book_tag<br/>book_id FK, tag_id FK<br/>composite PRIMARY KEY"]:::brown
+
+    author --> book
+    publisher --> book
+    book --> book_tag
+    tag --> book_tag
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef brown fill:#CA9161,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-77-design-3nf-schema/example.sql`**
+
+```sql
+-- Example 77: Design a 3NF Schema.
+-- Four relations, each holding ONE fact-type, related purely by key values (co-01, co-05):
+CREATE TABLE author(                -- => relation 1 of 4 -- one row per author
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    name TEXT NOT NULL             -- => the ONE fact-type this table holds
+);                                  -- => an author's facts live HERE, nowhere else (co-07)
+
+CREATE TABLE publisher(             -- => relation 2 of 4 -- INDEPENDENT of author, no shared row
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    name TEXT NOT NULL,            -- => a SECOND, independent fact-type -- its own table
+    city TEXT                      -- => city depends ONLY on publisher.id -- no transitive path
+);                                  -- => a publisher's facts live HERE, nowhere else
+
+CREATE TABLE book(                  -- => relation 3 of 4 -- the table with the MOST foreign keys
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    title TEXT NOT NULL,           -- => the book's OWN fact -- not duplicated from anywhere
+    author_id INTEGER NOT NULL REFERENCES author(id),
+                                    -- => book POINTS AT an author -- never repeats the author's name
+    publisher_id INTEGER REFERENCES publisher(id),
+                                    -- => book POINTS AT a publisher -- never repeats its city
+    price REAL NOT NULL            -- => a fact about THIS book -- not about its author or publisher
+);                                  -- => a book's facts live HERE, nowhere else
+
+CREATE TABLE tag(                   -- => relation 4 of 4 -- a controlled vocabulary of labels
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    name TEXT NOT NULL UNIQUE      -- => UNIQUE (co-04) -- 'history' can only exist as ONE row
+);                                  -- => a tag's facts live HERE, nowhere else
+
+CREATE TABLE book_tag(              -- => the many-to-many JUNCTION -- not a "5th fact-type" table
+    book_id INTEGER NOT NULL REFERENCES book(id),
+                                    -- => FK half of the composite key (Example 65's pattern)
+    tag_id INTEGER NOT NULL REFERENCES tag(id),
+                                    -- => the OTHER FK half of the composite key
+    PRIMARY KEY (book_id, tag_id)  -- => the many-to-many junction from Example 65, reused here
+);                                  -- => book_tag holds ONLY key pairs -- no other columns at all
+
+-- .schema (no argument) prints EVERY stored CREATE TABLE -- proof the design landed as intended.
+.schema
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output** (`.schema` echoes every stored `CREATE TABLE` back verbatim, comments included):
+
+```text
+CREATE TABLE author(                -- => relation 1 of 4 -- one row per author
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    name TEXT NOT NULL             -- => the ONE fact-type this table holds
+);
+CREATE TABLE publisher(             -- => relation 2 of 4 -- INDEPENDENT of author, no shared row
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    name TEXT NOT NULL,            -- => a SECOND, independent fact-type -- its own table
+    city TEXT                      -- => city depends ONLY on publisher.id -- no transitive path
+);
+CREATE TABLE book(                  -- => relation 3 of 4 -- the table with the MOST foreign keys
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    title TEXT NOT NULL,           -- => the book's OWN fact -- not duplicated from anywhere
+    author_id INTEGER NOT NULL REFERENCES author(id),
+                                    -- => book POINTS AT an author -- never repeats the author's name
+    publisher_id INTEGER REFERENCES publisher(id),
+                                    -- => book POINTS AT a publisher -- never repeats its city
+    price REAL NOT NULL            -- => a fact about THIS book -- not about its author or publisher
+);
+CREATE TABLE tag(                   -- => relation 4 of 4 -- a controlled vocabulary of labels
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    name TEXT NOT NULL UNIQUE      -- => UNIQUE (co-04) -- 'history' can only exist as ONE row
+);
+CREATE TABLE book_tag(              -- => the many-to-many JUNCTION -- not a "5th fact-type" table
+    book_id INTEGER NOT NULL REFERENCES book(id),
+                                    -- => FK half of the composite key (Example 65's pattern)
+    tag_id INTEGER NOT NULL REFERENCES tag(id),
+                                    -- => the OTHER FK half of the composite key
+    PRIMARY KEY (book_id, tag_id)  -- => the many-to-many junction from Example 65, reused here
+);
+```
+
+**Key takeaway**: `.schema`'s output proves SQLite stored the `CREATE TABLE` text verbatim, comments
+included -- and reading through the 5 tables confirms no column anywhere repeats a fact that already
+lives in another table's row (an author's name, a publisher's city).
+
+**Why it matters**: this is the same normalization discipline Intermediate Examples 45-46 walked
+through step by step, applied here as a single, complete design instead of a before-and-after
+transformation. A schema with no transitive dependency means updating one fact (an author's name, a
+publisher's city) never requires hunting down every row that might have repeated it -- the fact lives
+in exactly one place, and every other table merely points at it by key. This is the exact schema shape
+the capstone reuses, extended with `CHECK (price >= 0)` and `ON DELETE CASCADE`.
+
+---
+
+### Example 78: Correlated Subquery
+
+_ex-78 &middot; exercises co-08_
+
+A correlated subquery re-runs once per outer row, with its `WHERE` clause referencing a column from
+the enclosing query -- `r.book_id = book.id` ties the inner `count(*)` to whichever `book` row is
+currently being projected.
+
+**`learning/code/ex-78-correlated-subquery/example.sql`**
+
+```sql
+-- Example 78: Correlated Subquery.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL);
+                                    -- => the OUTER table -- one output row per book
+CREATE TABLE review(id INTEGER PRIMARY KEY, book_id INTEGER NOT NULL REFERENCES book(id), rating INTEGER NOT NULL);
+                                    -- => the table the INNER subquery counts against
+
+INSERT INTO book(id, title) VALUES (1, 'Notes on the Analytical Engine'), (2, 'Sketch of the Analytical Engine');
+                                    -- => 2 books -- 1 gets 2 reviews below, 2 gets 1 review
+INSERT INTO review(id, book_id, rating) VALUES (1, 1, 5), (2, 1, 4), (3, 2, 3);
+                                    -- => book 1 has 2 reviews, book 2 has 1 review
+
+.headers on
+.mode column
+-- The inner SELECT re-runs ONCE PER OUTER ROW -- "r.book_id = book.id" CORRELATES it to
+-- whichever book row is currently being projected (co-08). Not a join -- a per-row scalar.
+SELECT title, (SELECT count(*) FROM review r WHERE r.book_id = book.id) AS review_count
+FROM book;                         -- => 2 rows -- each with its OWN computed review count
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+title                            review_count
+-------------------------------  ------------
+Notes on the Analytical Engine   2
+Sketch of the Analytical Engine  1
+```
+
+**Key takeaway**: the subquery's `WHERE r.book_id = book.id` clause reaches outward into the enclosing
+query's current row -- it is not a standalone query, and its result changes on every one of the 2
+outer-row evaluations.
+
+**Why it matters**: a correlated subquery is the right tool for "one computed scalar value per outer
+row" when a `JOIN` + `GROUP BY` would be awkward or would multiply the outer row for every match (a
+plain join between `book` and `review` would return one row per review, not one row per book).
+Because it re-runs per outer row, it can also be slower than an equivalent join on very large tables --
+a tradeoff worth knowing before reaching for this pattern on a hot query path.
+
+---
+
+### Example 79: Join, Group, and Having Report
+
+_ex-79 &middot; exercises co-15, co-16, co-13_
+
+Three concepts combine in one query here: `JOIN` recombines the normalized `author` and `book` tables,
+`GROUP BY` collapses the joined rows per author, and `HAVING` then filters the **aggregated** groups --
+not the raw rows -- down to authors with more than one book.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC -- color-blind friendly, WCAG AA
+flowchart LR
+    A["author JOIN book"]:::blue
+    B["GROUP BY author.name"]:::orange
+    C["HAVING count#40;*#41; > 1"]:::teal
+    D["authors with 2+ books"]:::purple
+    A --> B --> C --> D
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-79-report-join-group-having/example.sql`**
+
+```sql
+-- Example 79: Report -- Join + Group + Having.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => the GROUPing key for the report below
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL REFERENCES author(id), price REAL NOT NULL);
+                                    -- => the joined-and-aggregated table
+                                    -- => price is what sum(book.price) totals per author, below
+
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper');
+                                    -- => 2 authors -- only Ada survives the HAVING filter below
+INSERT INTO book(id, title, author_id, price) VALUES  -- a 3-row multi-VALUES insert
+    (1, 'Notes on the Analytical Engine', 1, 12.5),  -- Ada's first book
+    (2, 'Sketch of the Analytical Engine', 1, 9.0),   -- Ada's second book
+    (3, 'The First Computer Bug', 2, 15.0);           -- Grace's only book
+                                    -- => Ada has 2 books (21.5 total), Grace has 1 book (15.0)
+
+-- .headers on and .mode column below are display preferences only -- unrelated to the report logic.
+.headers on
+.mode column
+-- Three concepts in ONE query: JOIN recombines normalized rows (co-13), GROUP BY collapses
+-- them per author (co-15), HAVING then filters the AGGREGATED groups, not the raw rows (co-16).
+SELECT author.name, count(*) AS book_count, sum(book.price) AS total_value
+                                    -- => count(*) and sum(book.price) are the AGGREGATES per group
+FROM author
+JOIN book ON book.author_id = author.id
+                                    -- => the JOIN -- recombines the two normalized tables (co-13)
+GROUP BY author.name
+                                    -- => collapses per-book rows into per-author groups (co-15)
+HAVING count(*) > 1;               -- => only Ada survives -- Grace's single-book group is filtered out
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+name          book_count  total_value
+------------  ----------  -----------
+Ada Lovelace  2           21.5
+```
+
+**Key takeaway**: `HAVING count(*) > 1` dropped Grace's row entirely -- `WHERE` cannot express this
+filter, because `count(*)` does not exist until after `GROUP BY` has already collapsed the joined rows.
+
+**Why it matters**: this is the shape of report almost every dashboard or analytics query eventually
+needs -- "give me an aggregate per group, but only the groups meeting some threshold." Keeping `WHERE`
+(filters raw rows, before grouping) and `HAVING` (filters aggregated groups, after grouping) as
+distinct clauses is what makes a query like "authors with more than one book" expressible in SQL at
+all, in a single round trip, rather than as a two-step fetch-then-filter in application code.
+
+---
+
+### Example 80: pytest Rollback Integration
+
+_ex-80 &middot; exercises co-18, co-19_
+
+`transfer()` wraps two writes in `with conn:`, which commits both together on a clean exit and rolls
+back the entire block the instant either write raises -- this example's `pytest` suite proves a
+`CHECK`-violating transfer leaves every row, and every balance, bit-for-bit unchanged.
+
+**`learning/code/ex-80-pytest-rollback-integration/transfer.py`**
+
+```python
+# pyright: strict
+"""Example 80: transfer.py -- a transaction that rolls back when a CHECK constraint fails."""
+
+import sqlite3  # => stdlib DB-API module (co-19)
+
+
+def create_schema(conn: sqlite3.Connection) -> None:  # => called once per test, in the fixture
+    # CHECK(balance >= 0) is the ENGINE-enforced invariant this example deliberately trips.
+    conn.executescript(  # => raw DDL -- no placeholders needed for schema statements
+        """
+        -- a single-table ledger -- just enough to demonstrate a rolled-back transfer
+        CREATE TABLE account(  -- => the ledger this whole test suite exercises
+            id INTEGER PRIMARY KEY,           -- => aliases rowid (co-02)
+            name TEXT NOT NULL,               -- => a human-readable label, not used for logic
+            balance REAL NOT NULL CHECK (balance >= 0)
+                                                -- => co-04 -- the engine itself rejects a negative balance
+        );
+        """
+    )  # => one CHECK constraint is the ENTIRE mechanism this example's rollback relies on
+
+
+def transfer(conn: sqlite3.Connection, from_id: int, to_id: int, amount: float) -> None:  # co-18
+    # `with conn:` opens an implicit transaction on the FIRST write below, commits on a clean
+    # exit, and auto-ROLLBACKs the whole block if ANY statement inside raises (co-18).
+    with conn:  # => the transaction boundary -- everything inside is all-or-nothing
+        conn.execute(  # => the FIRST write -- opens the implicit transaction
+            "UPDATE account SET balance = balance - ? WHERE id = ?",  # => the debit leg
+            (amount, from_id),  # => if this drives balance negative, CHECK fails HERE
+        )  # => the credit below never runs if this statement raises
+        conn.execute(  # => the SECOND write -- only reached if the debit above succeeded
+            "UPDATE account SET balance = balance + ? WHERE id = ?",  # => the credit leg
+            (amount, to_id),  # => co-20 -- every value above is bound, never string-interpolated
+        )  # => both legs commit TOGETHER when the with block exits cleanly
+```
+
+**`learning/code/ex-80-pytest-rollback-integration/tests/__init__.py`**
+
+```python
+
+```
+
+(An empty file, identical in purpose to Example 73's -- it makes `tests/` an importable package so
+`pytest` inserts this example's root directory into `sys.path`, which is what makes `from transfer
+import ...` below resolve at all.)
+
+**`learning/code/ex-80-pytest-rollback-integration/tests/test_transfer.py`**
+
+```python
+"""Example 80: pytest integration test -- a failing transfer leaves the DB unchanged."""
+
+import sqlite3  # => stdlib DB-API module -- only needed here to type the fixture's connection
+from collections.abc import Iterator  # => types the fixture's generator return
+
+import pytest  # => the testing framework -- provides @pytest.fixture and pytest.raises below
+
+# tests/__init__.py makes THIS directory a package, so pytest inserts the PARENT dir (the
+# example's root) into sys.path -- that is what makes `from transfer import ...` resolve at all.
+from transfer import create_schema, transfer  # => imports the module UNDER TEST
+
+
+@pytest.fixture  # => runs before EVERY test function below, fresh each time
+def conn() -> Iterator[sqlite3.Connection]:  # => Iterator, not Connection -- this is a generator
+    connection: sqlite3.Connection = sqlite3.connect(":memory:")  # => a throwaway, per-test DB
+    create_schema(connection)  # => builds the ONE table both tests below read and write
+    connection.execute(  # => a direct execute, not the transfer() function -- just seeding
+        "INSERT INTO account(id, name, balance) VALUES (1, 'checking', 100.0), (2, 'savings', 50.0)"  # seed
+        # => two seeded accounts -- checking starts with exactly 100.0, savings with 50.0
+    )
+    connection.commit()  # => persists the seed before either test's transfer() call runs
+    yield connection  # => hands the ready connection to the test function below
+    connection.close()  # => runs AFTER the test, whether it passed or failed
+
+
+def test_transfer_commits_on_success(conn: sqlite3.Connection) -> None:  # => co-18's happy path
+    transfer(conn, 1, 2, 30.0)  # => the function under test -- a valid, affordable transfer
+    rows: list[tuple[int, float]] = conn.execute(  # => re-reads BOTH accounts, post-transfer
+        "SELECT id, balance FROM account ORDER BY id"  # => ordered so the assertion is deterministic
+    ).fetchall()  # => reads BOTH accounts back, in id order
+    assert rows == [(1, 70.0), (2, 80.0)]  # => both legs landed together -- co-18's happy path
+
+
+def test_failed_transfer_leaves_db_unchanged(conn: sqlite3.Connection) -> None:  # => the ROLLBACK path
+    before: list[tuple[int, float]] = conn.execute(  # => the pre-failure snapshot, read FIRST
+        "SELECT id, balance FROM account ORDER BY id"
+    ).fetchall()  # => captured BEFORE the failing call -- the baseline this test proves is preserved
+
+    # 1000.0 exceeds checking's 100.0 balance -- the debit alone would violate CHECK(balance >= 0).
+    with pytest.raises(sqlite3.IntegrityError):  # => asserts the CHECK violation actually fires
+        transfer(conn, 1, 2, 1000.0)  # => `with conn:` inside transfer() auto-rolls-back on failure
+
+    after: list[tuple[int, float]] = conn.execute(  # => the post-failure snapshot, read SECOND
+        "SELECT id, balance FROM account ORDER BY id"
+    ).fetchall()  # => re-reads BOTH accounts, AFTER the failed call
+    assert before == after  # => the failed debit never persisted -- balances are BIT-for-bit identical
+    count: int = conn.execute("SELECT count(*) FROM account").fetchone()[0]  # co-19 scalar read
+    # => a SEPARATE, independent check -- row count, not just balance values
+    assert count == 2  # => row COUNT is unchanged too -- no half-applied transfer left a trace
+```
+
+**Run**: `pytest -q` (from inside `ex-80-pytest-rollback-integration/`)
+
+**Output**:
+
+```text
+..                                                                       [100%]
+2 passed in 0.01s
+```
+
+**pyright**: `pyright transfer.py` reports `0 errors, 0 warnings, 0 informations` under `# pyright:
+strict`. Running `pyright .` from inside `ex-80-pytest-rollback-integration/` also reports `0 errors, 0
+warnings, 0 informations`, resolving `from transfer import ...` the same way Example 73's `pyright .`
+resolved `from dal import ...`.
+
+**Key takeaway**: `test_failed_transfer_leaves_db_unchanged` checks two independent things after the
+caught `IntegrityError` -- every balance is bit-for-bit identical to before, and the row count itself
+is unchanged -- because a rollback that merely undid the balance change but left a stray row behind
+would still be a bug.
+
+**Why it matters**: `with conn:`'s automatic rollback-on-exception is what makes `transfer()` safe to
+call with untrusted amounts -- the caller never needs a manual `try`/`except`/`rollback()` block around
+every multi-statement write. Testing that safety property with `pytest.raises` and a before/after
+snapshot, rather than only testing the happy path, is exactly the discipline the capstone's own
+`bulk_update_prices` rollback test (Step 2) reuses at a larger scale.
+
+---
+
+← Previous: [Intermediate Examples](./intermediate.md) · Next: [Capstone](./capstone/overview.md) →

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner.md
@@ -1,0 +1,1665 @@
+---
+title: "Beginner Examples"
+date: 2026-07-14T00:00:00+07:00
+draft: false
+weight: 10
+---
+
+Examples 1-30 cover schema declaration (`CREATE TABLE`, `.schema`), the CRUD basics (`INSERT`,
+`SELECT`, `UPDATE`, `DELETE`), `WHERE`/`ORDER BY`/`LIMIT` filtering and paging, the four core
+constraints (`NOT NULL`, `UNIQUE`, `DEFAULT`, `CHECK`), foreign keys, a first `JOIN`, and the first
+two Python `sqlite3` examples. Every example is fully self-contained: each one creates its own table(s)
+and inserts its own rows, so none of them depend on state left behind by an earlier example. Run each
+`.sql` example with `sqlite3 app.db < example.sql` from inside a fresh, empty directory; run each
+`.py` example with `python3 example.py`.
+
+---
+
+### Example 1: Create Author Table
+
+_ex-01 &middot; exercises co-07, co-02, co-01_
+
+`CREATE TABLE` is how a relation (co-01) comes into existence: a name, a column list, and the
+constraints that apply to every future row. `.schema <table>` proves what the engine actually stored,
+byte-for-byte -- SQLite keeps the original `CREATE TABLE` text (including its comments) in its
+internal `sqlite_master` table and echoes it back verbatim.
+
+**`learning/code/ex-01-create-author-table/example.sql`**
+
+```sql
+-- Example 1: Create Author Table.
+-- CREATE TABLE declares a new relation (co-07): a name, a column list, and constraints.
+CREATE TABLE author(
+    id INTEGER PRIMARY KEY,        -- => INTEGER PRIMARY KEY aliases SQLite's rowid (co-02)
+                                    -- => the engine auto-assigns this on insert -- no id needed
+    name TEXT NOT NULL             -- => TEXT column; NOT NULL forbids a missing name value
+);
+
+-- .schema prints the stored definition back verbatim -- proof of what the engine kept.
+-- NOTE: dot-commands take the rest of their line as arguments -- no trailing "--" comment here.
+.schema author
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+CREATE TABLE author(
+    id INTEGER PRIMARY KEY,        -- => INTEGER PRIMARY KEY aliases SQLite's rowid (co-02)
+                                    -- => the engine auto-assigns this on insert -- no id needed
+    name TEXT NOT NULL             -- => TEXT column; NOT NULL forbids a missing name value
+);
+```
+
+**Key takeaway**: `.schema` echoes the exact `CREATE TABLE` text SQLite stored, comments included --
+there is no separate, normalized "schema representation" hiding underneath.
+
+**Why it matters**: Production teams rely on `.schema` (and its programmatic cousin,
+`sqlite_master`) to answer "what does this database actually look like right now?" without trusting
+stale documentation. Because SQLite stores the literal DDL text, a well-commented `CREATE TABLE`
+statement becomes living, self-verifying documentation -- exactly the kind of source of truth
+migration tooling (Example 59, Advanced tier) depends on when deciding whether a column already
+exists.
+
+---
+
+### Example 2: Open Database CLI
+
+_ex-02 &middot; exercises co-24_
+
+The `sqlite3` CLI is the entire toolchain for this topic -- no server process, no GUI, just a binary
+and dot-commands. Opening a database that does not yet exist on disk does not immediately write
+anything; SQLite only touches the filesystem once the first statement actually needs to.
+
+**`learning/code/ex-02-open-database-cli/example.sql`**
+
+```sql
+-- Example 2: Open Database CLI. Dot-commands take the rest of their line as
+-- arguments, so comments here live on their own separate line.
+.databases
+-- => lists attached databases -- shows "main: <path-to-app.db> r/w"
+.tables
+-- => lists table names -- empty: a fresh database starts with zero tables
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output** (path generalized to `/home/user/project/app.db` -- your own path will differ):
+
+```text
+main: /home/user/project/app.db r/w
+```
+
+`.tables` prints nothing at all -- an empty line, not an error. That is the correct, expected result
+for a database with zero tables.
+
+**Key takeaway**: `.databases` confirms which file is attached and in what mode (`r/w`); `.tables`
+with no output means "zero tables," not a failure.
+
+**Why it matters**: Every `sqlite3` session in this topic starts from exactly this state, so knowing
+what "nothing has gone wrong yet" looks like matters as much as knowing what success looks like.
+Production debugging sessions often begin with `.databases`/`.tables` to confirm you are even looking
+at the file you think you are -- a surprisingly common source of "why is my data missing" confusion
+when multiple `.db` files exist in a project.
+
+---
+
+### Example 3: Insert Single Row
+
+_ex-03 &middot; exercises co-10_
+
+`INSERT INTO table(columns) VALUES(...)` adds exactly one row. Omitting the `id` column lets the
+`INTEGER PRIMARY KEY` column auto-assign it, a pattern this entire topic leans on rather than
+hand-managing ids.
+
+**`learning/code/ex-03-insert-single-row/example.sql`**
+
+```sql
+-- Example 3: Insert Single Row.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => author table exists, currently empty (0 rows)
+
+-- INSERT INTO ... VALUES (co-10) adds exactly one new row to the relation.
+INSERT INTO author(name) VALUES('Ada');
+                                    -- => id is omitted -- INTEGER PRIMARY KEY auto-assigns 1
+                                    -- => author now holds exactly one row: (1, 'Ada')
+
+-- dot-commands take the rest of their line as arguments -- comments live on their own line.
+.headers on
+-- => turns on a column-name header row for readability
+.mode column
+-- => aligns SELECT output into fixed-width columns
+SELECT * FROM author;              -- => projects every column of every row -- confirms one row
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  name
+--  ----
+1   Ada
+```
+
+**Key takeaway**: An `INSERT` that leaves out the primary key column, not sets it to `NULL`, is how
+you delegate id assignment to the engine.
+
+**Why it matters**: Hand-assigning primary keys invites duplicate-id bugs the moment two writers
+insert concurrently. Letting SQLite's rowid-backed `INTEGER PRIMARY KEY` assign the next value removes
+an entire class of coordination problems, and every later example in this topic that inserts an
+`author` or `book` row follows this same omit-the-id convention.
+
+---
+
+### Example 4: Insert Multiple Rows
+
+_ex-04 &middot; exercises co-10_
+
+A single `INSERT` statement can carry several comma-separated value tuples, inserting many rows in
+one round-trip to the engine instead of issuing one `INSERT` per row.
+
+**`learning/code/ex-04-insert-multiple-rows/example.sql`**
+
+```sql
+-- Example 4: Insert Multiple Rows.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => author table exists, ready for a bulk insert
+
+-- One INSERT statement, three comma-separated value tuples (co-10) -- a single
+-- round-trip to the engine instead of three separate INSERT statements.
+INSERT INTO author(name) VALUES
+    ('Ada Lovelace'),               -- => row 1: id auto-assigns to 1
+    ('Grace Hopper'),                -- => row 2: id auto-assigns to 2
+    ('Alan Turing');                 -- => row 3: id auto-assigns to 3
+
+.headers on
+.mode column
+-- => the pair above produces an aligned, headered table for readability
+SELECT count(*) FROM author;        -- => count(*) counts every row -- confirms all 3 landed
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+count(*)
+--------
+3
+```
+
+**Key takeaway**: One multi-value `INSERT` is one transaction and one round-trip -- cheaper than
+three separate `INSERT` statements when you already have all the rows in hand.
+
+**Why it matters**: Batch-inserting seed or migration data this way is the difference between a
+seed script that takes milliseconds and one that takes seconds, because every separate `INSERT`
+statement pays its own transaction overhead. Example 74 (Advanced tier) builds directly on this
+pattern to seed a database from a `.sql` file in one shot.
+
+---
+
+### Example 5: Select All Columns
+
+_ex-05 &middot; exercises co-08, co-01_
+
+`SELECT *` projects every declared column of a relation (co-01), in the order the columns were
+declared in `CREATE TABLE`. It is the simplest possible query: no filtering, no column selection,
+just "give me everything."
+
+**`learning/code/ex-05-select-all-columns/example.sql`**
+
+```sql
+-- Example 5: Select All Columns.
+-- SELECT * (co-08) projects every declared column, in declaration order.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty (0 rows)
+INSERT INTO book(id, title, price, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 34.99, 1),  -- => row 1: author_id 1
+    (2, 'Clean Code', 29.99, 1),                -- => row 2: same author_id 1
+    (3, 'The Mythical Man-Month', 24.5, 2);       -- => row 3: a different author_id
+                                    -- => book now holds 3 rows across 4 columns each
+
+.headers on
+.mode column
+SELECT * FROM book;                -- => returns all 3 rows, all 4 columns -- the full relation
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                     price  author_id
+--  ------------------------  -----  ---------
+1   The Pragmatic Programmer  34.99  1
+2   Clean Code                29.99  1
+3   The Mythical Man-Month    24.5   2
+```
+
+**Key takeaway**: `SELECT *` returns every column in declaration order -- convenient for exploring a
+table, but every later example that only needs a subset of columns should project explicitly instead
+(Example 6).
+
+**Why it matters**: `SELECT *` is the natural first query anyone runs against an unfamiliar table,
+and it is exactly how this topic verifies every earlier `INSERT` actually landed. In production code,
+though, `SELECT *` is usually avoided in favor of explicit column lists (Example 6), because a later
+`ALTER TABLE ADD COLUMN` silently changes what `*` returns to every caller.
+
+---
+
+### Example 6: Select Projection
+
+_ex-06 &middot; exercises co-08_
+
+Naming one column instead of `*` is projection: fewer columns come back, the same number of rows.
+`price` and `author_id` never leave the storage engine for this particular query.
+
+**`learning/code/ex-06-select-projection/example.sql`**
+
+```sql
+-- Example 6: Select Projection.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 34.99, 1),  -- => row 1
+    (2, 'Clean Code', 29.99, 1),                -- => row 2
+    (3, 'The Mythical Man-Month', 24.5, 2);       -- => row 3
+
+.headers on
+.mode column
+-- Naming one column instead of * (co-08) is projection -- fewer columns come back,
+-- same number of rows. price/author_id never leave the engine for this query.
+SELECT title FROM book;            -- => returns only the title column, all 3 rows
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+title
+------------------------
+The Pragmatic Programmer
+Clean Code
+The Mythical Man-Month
+```
+
+**Key takeaway**: Projection is choosing columns; it never changes how many rows come back -- only
+`WHERE` (Example 7) changes row count.
+
+**Why it matters**: Requesting only the columns a caller actually needs reduces the bytes the engine
+has to serialize and the client has to parse -- meaningful at scale, and free to adopt from day one.
+It also documents intent: a query that names `title` explicitly tells the next reader exactly what
+the caller depends on, unlike `SELECT *`, which hides that dependency.
+
+---
+
+### Example 7: Where Equality
+
+_ex-07 &middot; exercises co-08_
+
+`WHERE` performs row selection (co-08): the engine evaluates the predicate once per row and keeps
+only the rows where it is true. `=` tests exact equality.
+
+**`learning/code/ex-07-where-equality/example.sql`**
+
+```sql
+-- Example 7: Where Equality.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 34.99, 1),  -- => id 1
+    (2, 'Clean Code', 29.99, 1),                -- => id 2
+    (3, 'The Mythical Man-Month', 24.5, 2);       -- => id 3
+
+-- turn on headers + column alignment so the result below reads as a table
+.headers on
+.mode column
+-- WHERE selects rows (co-08) -- = tests exact equality, evaluated per row before output.
+SELECT * FROM book WHERE id = 1;   -- => keeps only the row whose id equals 1 -- exactly one row
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                     price  author_id
+--  ------------------------  -----  ---------
+1   The Pragmatic Programmer  34.99  1
+```
+
+**Key takeaway**: `WHERE id = 1` filters rows, not columns -- projection (Example 6) and selection
+(this example) are independent, orthogonal operations you combine in a single query.
+
+**Why it matters**: Point lookups by primary key (`WHERE id = ?`) are the single most common query
+shape in production applications -- fetching one record by its identifier backs nearly every "view
+detail" page and API endpoint. Example 30 (Python) reuses this same equality idiom with a bound
+parameter instead of a literal value.
+
+---
+
+### Example 8: Where Comparison
+
+_ex-08 &middot; exercises co-08_
+
+`>` is a comparison operator: it keeps rows where the predicate evaluates true, exactly like `=` in
+Example 7 but for an ordering relationship instead of exact equality.
+
+**`learning/code/ex-08-where-comparison/example.sql`**
+
+```sql
+-- Example 8: Where Comparison.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 34.99, 1),  -- => price above the threshold below
+    (2, 'Clean Code', 29.99, 1),                -- => price above the threshold below
+    (3, 'The Mythical Man-Month', 24.5, 2);       -- => price BELOW the threshold below
+
+.headers on
+.mode column
+-- > is a comparison operator (co-08) -- keeps rows where the predicate is true.
+SELECT * FROM book WHERE price > 25;
+                                    -- => 34.99 and 29.99 pass the threshold; 24.5 does not
+                                    -- => returns 2 rows (ids 1, 2), excludes id 3
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                     price  author_id
+--  ------------------------  -----  ---------
+1   The Pragmatic Programmer  34.99  1
+2   Clean Code                29.99  1
+```
+
+**Key takeaway**: `>`, `<`, `>=`, `<=` all work the same way as `=` in Example 7 -- one predicate,
+evaluated per row, before any output is produced.
+
+**Why it matters**: Threshold filtering (price ranges, date ranges, quantity thresholds) is the
+backbone of report queries and search filters in almost every real application. Because the engine
+evaluates `WHERE` before `ORDER BY` and `LIMIT` (Examples 12-15), understanding predicate evaluation
+order here is a prerequisite for reasoning about paginated, filtered results correctly.
+
+---
+
+### Example 9: Where And Or
+
+_ex-09 &middot; exercises co-08_
+
+`AND` keeps a row only when both predicates evaluate true for that row -- a stricter filter than
+either predicate alone.
+
+**`learning/code/ex-09-where-and-or/example.sql`**
+
+```sql
+-- Example 9: Where And Or.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 34.99, 1),  -- => passes both conditions below
+    (2, 'Clean Code', 29.99, 1),                -- => passes both conditions below
+    (3, 'The Mythical Man-Month', 24.5, 2),      -- => fails author_id = 1
+    (4, 'Cheap Notes', 5.0, 1);                   -- => fails price > 10
+
+.headers on
+.mode column
+-- AND (co-08) keeps a row only when BOTH predicates evaluate true for that row.
+SELECT * FROM book WHERE price > 10 AND author_id = 1;
+                                    -- => id 3 excluded by author_id, id 4 excluded by price
+                                    -- => returns exactly ids 1 and 2
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                     price  author_id
+--  ------------------------  -----  ---------
+1   The Pragmatic Programmer  34.99  1
+2   Clean Code                29.99  1
+```
+
+**Key takeaway**: `AND` narrows a result set -- adding a second condition can only remove rows,
+never add ones a single condition would not already have matched.
+
+**Why it matters**: Multi-condition filters (`AND`) power every "search with filters" UI: price
+range, category, and in-stock status combined. `OR` behaves the opposite way -- it widens a result
+set -- and mixing the two without parentheses is a classic source of logic bugs, since `AND` binds
+tighter than `OR` in SQL's operator precedence, exactly like most programming languages.
+
+---
+
+### Example 10: Where Like Prefix
+
+_ex-10 &middot; exercises co-08_
+
+`LIKE` pattern-matches text; `%` is a wildcard standing in for zero or more characters, making prefix,
+suffix, and substring matching possible without a full text-search engine.
+
+**`learning/code/ex-10-where-like-prefix/example.sql`**
+
+```sql
+-- Example 10: Where Like Prefix.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 34.99, 1),  -- => title starts with "The "
+    (2, 'Clean Code', 29.99, 1),                -- => title does NOT start with "The "
+    (3, 'The Mythical Man-Month', 24.5, 2);       -- => title starts with "The "
+
+.headers on
+.mode column
+-- LIKE (co-08) pattern-matches text -- % is a wildcard for zero-or-more characters.
+SELECT * FROM book WHERE title LIKE 'The %';
+                                    -- => matches any title starting with the literal "The "
+                                    -- => returns ids 1 and 3; "Clean Code" does not match
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                     price  author_id
+--  ------------------------  -----  ---------
+1   The Pragmatic Programmer  34.99  1
+3   The Mythical Man-Month    24.5   2
+```
+
+**Key takeaway**: `'The %'` matches a fixed prefix followed by anything; `'%word%'` (not shown) would
+match `word` anywhere in the text -- both are `LIKE` patterns, only the wildcard placement differs.
+
+**Why it matters**: `LIKE` is the simplest text search SQLite ships with -- no extension, no separate
+index required, though it is a full table scan without one. It is the right tool for small tables or
+exact prefix/suffix matching; SQLite's separate FTS5 extension (out of this topic's scope) is the
+right tool once text search needs to scale or support ranking.
+
+---
+
+### Example 11: Where In Set
+
+_ex-11 &middot; exercises co-08_
+
+`IN` tests set membership -- shorthand for chaining several `OR`-equality checks together into one
+readable clause.
+
+**`learning/code/ex-11-where-in-set/example.sql`**
+
+```sql
+-- Example 11: Where In Set.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 34.99, 1),  -- => id in the set below
+    (2, 'Clean Code', 29.99, 1),                -- => id NOT in the set below
+    (3, 'The Mythical Man-Month', 24.5, 2);       -- => id in the set below
+
+.headers on
+.mode column
+-- IN (co-08) tests set membership -- shorthand for chained OR-equality checks.
+SELECT * FROM book WHERE id IN (1, 3);
+                                    -- => keeps rows whose id matches ANY value in the list
+                                    -- => returns ids 1 and 3, skips id 2
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                     price  author_id
+--  ------------------------  -----  ---------
+1   The Pragmatic Programmer  34.99  1
+3   The Mythical Man-Month    24.5   2
+```
+
+**Key takeaway**: `WHERE id IN (1, 3)` is equivalent to `WHERE id = 1 OR id = 3`, but scales to
+dozens of values without becoming unreadable.
+
+**Why it matters**: `IN (...)` is the standard way to batch-fetch a known set of ids in one query
+instead of one query per id -- exactly the fix Example 64 (Advanced tier) applies to eliminate an
+N+1 query pattern. Recognizing "I am about to loop and issue one query per item" as a signal to
+reach for `IN (...)` instead is one of the highest-leverage habits in this entire topic.
+
+---
+
+### Example 12: Order By Ascending
+
+_ex-12 &middot; exercises co-09_
+
+`ORDER BY` sorts the result set; `ASC` (the default direction) sorts low-to-high for numbers and
+A-to-Z for text. Storage order is never the same thing as output order -- only `ORDER BY` controls
+what order rows come back in.
+
+**`learning/code/ex-12-order-by-ascending/example.sql`**
+
+```sql
+-- Example 12: Order By Ascending.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price) VALUES
+    (1, 'The Pragmatic Programmer', 34.99),  -- => stored first, but storage order != output order
+    (2, 'Clean Code', 29.99),                -- => stored second
+    (3, 'The Mythical Man-Month', 24.5);       -- => stored third
+
+-- turn on headers + column alignment so the sorted result reads as a table
+.headers on
+.mode column
+-- ORDER BY (co-09) sorts the result set; ASC (the default) sorts low-to-high / A-to-Z.
+SELECT * FROM book ORDER BY title ASC;
+                                    -- => "Clean Code" sorts before "The..." titles alphabetically
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                     price
+--  ------------------------  -----
+2   Clean Code                29.99
+3   The Mythical Man-Month    24.5
+1   The Pragmatic Programmer  34.99
+```
+
+**Key takeaway**: Row 1 was inserted first but sorts last -- `ORDER BY` is the only thing that
+determines output order; insertion order gives no guarantee whatsoever.
+
+**Why it matters**: Relying on "rows probably come back in insertion order" is a latent bug: SQLite's
+query planner is free to return rows in whatever order is cheapest, and that order can change between
+runs, SQLite versions, or after an index is added. Every query that needs a predictable order must
+say so explicitly with `ORDER BY` -- there are no exceptions.
+
+---
+
+### Example 13: Order By Descending
+
+_ex-13 &middot; exercises co-09_
+
+`DESC` reverses the sort direction -- highest value first -- the standard shape for "most expensive
+first" or "most recent first" report queries.
+
+**`learning/code/ex-13-order-by-descending/example.sql`**
+
+```sql
+-- Example 13: Order By Descending.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price) VALUES
+    (1, 'The Pragmatic Programmer', 34.99),  -- => the most expensive row
+    (2, 'Clean Code', 29.99),                -- => the middle-priced row
+    (3, 'The Mythical Man-Month', 24.5);       -- => the cheapest row
+
+.headers on
+.mode column
+-- DESC (co-09) reverses the sort direction -- highest value first, most useful
+-- for "most expensive first" or "most recent first" style reports.
+SELECT * FROM book ORDER BY price DESC;
+                                    -- => 34.99, then 29.99, then 24.5 -- strictly decreasing
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                     price
+--  ------------------------  -----
+1   The Pragmatic Programmer  34.99
+2   Clean Code                29.99
+3   The Mythical Man-Month    24.5
+```
+
+**Key takeaway**: `ORDER BY price DESC` is `ASC`'s mirror image -- same clause, opposite direction --
+and this dataset happens to already be in descending price order, which is exactly what the sort
+confirms rather than coincidentally matches.
+
+**Why it matters**: "Newest first" feeds and "highest value first" leaderboards are two of the most
+common report shapes in production software, and both are just `ORDER BY <column> DESC`. Combined
+with `LIMIT` (Example 14), this single clause pair implements the vast majority of "top N" queries
+you will ever write.
+
+---
+
+### Example 14: Limit Rows
+
+_ex-14 &middot; exercises co-09_
+
+`LIMIT` caps how many rows the engine returns. It is evaluated after `ORDER BY`, so pairing the two
+is how "first N" queries get a well-defined, deterministic meaning.
+
+**`learning/code/ex-14-limit-rows/example.sql`**
+
+```sql
+-- Example 14: Limit Rows.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price) VALUES
+    (1, 'The Pragmatic Programmer', 34.99),  -- => row 1 -- kept by LIMIT 2 below
+    (2, 'Clean Code', 29.99),                -- => row 2 -- kept by LIMIT 2 below
+    (3, 'The Mythical Man-Month', 24.5);       -- => row 3 -- cut off by LIMIT 2 below
+
+.headers on
+.mode column
+-- LIMIT (co-09) caps the row count the engine returns -- evaluated AFTER ORDER BY,
+-- so pair it with ORDER BY whenever "first N" needs to mean something specific.
+SELECT * FROM book LIMIT 2;        -- => stops after 2 rows even though 3 rows match overall
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                     price
+--  ------------------------  -----
+1   The Pragmatic Programmer  34.99
+2   Clean Code                29.99
+```
+
+**Key takeaway**: `LIMIT` without `ORDER BY` returns _some_ 2 rows, not a meaningful "first 2" --
+without a sort, "first" has no defined meaning.
+
+**Why it matters**: Every paginated API endpoint and every "show top 10" widget relies on `LIMIT`.
+Used without `ORDER BY`, though, `LIMIT` is a footgun: the engine is free to return whichever rows
+are cheapest to produce, so the same query can return different rows on different runs unless a sort
+pins the order down first.
+
+---
+
+### Example 15: Limit Offset Paging
+
+_ex-15 &middot; exercises co-09_
+
+`OFFSET` skips N rows before `LIMIT` starts counting -- the standard "page 2 of results" pattern:
+page size 2 with `OFFSET 2` skips exactly the first page's rows.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73 -- color-blind friendly, WCAG AA
+flowchart LR
+    A["4 rows, ORDER BY id"]:::blue
+    B["OFFSET 2<br/>skips ids 1-2"]:::orange
+    C["LIMIT 2<br/>returns ids 3-4"]:::teal
+    A --> B --> C
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-15-limit-offset-paging/example.sql`**
+
+```sql
+-- Example 15: Limit Offset Paging.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price) VALUES
+    (1, 'The Pragmatic Programmer', 34.99),  -- => page 1 -- skipped by OFFSET 2 below
+    (2, 'Clean Code', 29.99),                -- => page 1 -- skipped by OFFSET 2 below
+    (3, 'The Mythical Man-Month', 24.5),      -- => page 2 -- returned below
+    (4, 'Refactoring', 39.99);                 -- => page 2 -- returned below
+
+.headers on
+.mode column
+-- OFFSET (co-09) skips N rows before LIMIT starts counting -- the standard
+-- "page 2 of results" pattern: page size 2, OFFSET 2 skips page 1's rows.
+SELECT * FROM book ORDER BY id LIMIT 2 OFFSET 2;
+                                    -- => skips ids 1-2 (page 1), returns ids 3-4 (page 2)
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                   price
+--  ----------------------  -----
+3   The Mythical Man-Month  24.5
+4   Refactoring             39.99
+```
+
+**Key takeaway**: `LIMIT <page-size> OFFSET <page-size * (page-number - 1)>` is the arithmetic behind
+every "page N of results" query -- always paired with `ORDER BY` for a stable, repeatable order.
+
+**Why it matters**: Offset-based pagination is simple to implement and universally supported, though
+it degrades at very high offsets (the engine still has to scan and discard every skipped row) --
+production systems serving deep pagination often switch to keyset ("seek") pagination instead. For
+the row counts most applications actually deal with, `LIMIT`/`OFFSET` remains the pragmatic default.
+
+---
+
+### Example 16: Select Distinct
+
+_ex-16 &middot; exercises co-08_
+
+`DISTINCT` collapses duplicate result rows -- here, two books share the same `author_id`, and
+`DISTINCT` reduces them to one appearance in the output.
+
+**`learning/code/ex-16-select-distinct/example.sql`**
+
+```sql
+-- Example 16: Select Distinct.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 1),  -- => author_id 1 -- first occurrence
+    (2, 'Clean Code', 1),                -- => author_id 1 -- a duplicate value
+    (3, 'The Mythical Man-Month', 2);      -- => author_id 2 -- first occurrence
+
+-- turn on headers + column alignment so the result below reads as a table
+.headers on
+.mode column
+-- DISTINCT (co-08) collapses duplicate result rows -- here, two books share author_id 1.
+SELECT DISTINCT author_id FROM book;
+                                    -- => 3 input rows collapse to 2 distinct author_id values
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+author_id
+---------
+1
+2
+```
+
+**Key takeaway**: `DISTINCT` operates on the projected result, not the underlying table -- three rows
+went in, two distinct `author_id` values came out.
+
+**Why it matters**: "Which distinct values does this column hold?" is a common exploratory question
+when getting to know an unfamiliar dataset -- distinct author ids, distinct status values, distinct
+categories. `DISTINCT` answers it in one line without a `GROUP BY` (Example 34, Intermediate tier),
+though `GROUP BY` becomes necessary the moment you need a count or other aggregate alongside each
+distinct value.
+
+---
+
+### Example 17: Type Affinity
+
+_ex-17 &middot; exercises co-06_
+
+SQLite uses type **affinity**, not rigid enforcement: a declared column type is a storage-class
+preference the engine tries to honor, not a hard runtime barrier the way it is in most other
+relational databases.
+
+**`learning/code/ex-17-type-affinity/example.sql`**
+
+```sql
+-- Example 17: Type Affinity.
+-- SQLite uses type AFFINITY (co-06), not rigid enforcement -- a declared type is a
+-- storage-class preference the engine tries to honor, not a hard runtime barrier.
+CREATE TABLE demo(n INTEGER);
+
+-- '42' is a TEXT literal, but the column's INTEGER affinity converts it on insert.
+INSERT INTO demo(n) VALUES('42');   -- => the string '42' gets stored as the integer 42
+
+.headers on
+.mode column
+-- typeof() reveals the ACTUAL storage class the engine chose, not the declared type.
+SELECT n, typeof(n) FROM demo;     -- => typeof(n) reports "integer" -- affinity coerced it
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+n   typeof(n)
+--  ---------
+42  integer
+```
+
+**Key takeaway**: `typeof()` reveals the actual storage class SQLite chose for a value, which can
+differ from what the declared column type might suggest -- affinity is a preference, not a guarantee.
+
+**Why it matters**: Affinity is a deliberate SQLite design choice, not a bug: it trades the rigid
+type enforcement of PostgreSQL or MySQL for schema flexibility that suits SQLite's embedded,
+zero-configuration use case. Understanding affinity up front prevents surprising debugging sessions
+later, when a numeric-looking string in a TEXT column stays TEXT (no affinity match) while the same
+string in an INTEGER column silently becomes a number.
+
+---
+
+### Example 18: Not Null Constraint
+
+_ex-18 &middot; exercises co-04_
+
+`NOT NULL` is an invariant the engine enforces on every write, not a suggestion: any `INSERT` or
+`UPDATE` that would leave the column `NULL` is rejected outright, and no partial row is ever written.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73 -- color-blind friendly, WCAG AA
+flowchart LR
+    A["INSERT name = NULL"]:::blue
+    B{"NOT NULL check"}:::orange
+    C["REJECTED<br/>row never written"]:::teal
+    A --> B --> C
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-18-not-null-constraint/example.sql`**
+
+```sql
+-- Example 18: Not Null Constraint.
+-- NOT NULL (co-04) is an invariant the engine enforces on EVERY write, not a suggestion.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+
+-- This INSERT explicitly supplies NULL for a column the schema forbids NULL on.
+INSERT INTO author(name) VALUES(NULL);
+                                    -- => the engine rejects the write before it commits
+                                    -- => raises: NOT NULL constraint failed: author.name
+
+.headers on
+.mode column
+SELECT count(*) FROM author;       -- => confirms the rejected row never landed -- table stays empty
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output** (captured for real -- this is SQLite 3.43.2's exact error text):
+
+```text
+Runtime error near line 6: NOT NULL constraint failed: author.name (19)
+count(*)
+--------
+0
+```
+
+**Exit code**: non-zero (`$?` is `1`).
+
+**Key takeaway**: The `sqlite3` CLI does not stop at the first error by default -- it reports the
+failure and keeps processing the rest of the script, which is why the follow-up `SELECT count(*)`
+still runs and confirms the table stayed empty.
+
+**Why it matters**: `NOT NULL` moves a data-integrity rule out of application code and into the
+schema, where it is enforced no matter which code path writes to the table -- a background job, an
+ad-hoc script, or a future feature the original author never anticipated. This is strictly stronger
+than an application-layer "required field" check, which only protects the one code path that
+remembers to run it.
+
+---
+
+### Example 19: Unique Constraint
+
+_ex-19 &middot; exercises co-04_
+
+`UNIQUE` forbids two rows from sharing the same value in that column -- the engine builds an index
+to enforce it, and any write that would create a duplicate is rejected.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC -- color-blind friendly, WCAG AA
+flowchart LR
+    A["INSERT 'ada@example.com'<br/>row 1"]:::blue
+    B["UNIQUE index<br/>on email"]:::orange
+    C["ACCEPTED -- first row"]:::teal
+    D["INSERT 'ada@example.com'<br/>row 2 -- REJECTED"]:::purple
+    A --> B --> C
+    D --> B
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-19-unique-constraint/example.sql`**
+
+```sql
+-- Example 19: Unique Constraint.
+-- UNIQUE (co-04) forbids two rows from sharing the same value in that column.
+CREATE TABLE author(id INTEGER PRIMARY KEY, email TEXT UNIQUE);
+
+INSERT INTO author(email) VALUES('ada@example.com');
+                                    -- => first insert succeeds -- no prior row to conflict with
+
+-- Same email value again -- the UNIQUE index the engine built now blocks this write.
+INSERT INTO author(email) VALUES('ada@example.com');
+                                    -- => the engine rejects the duplicate before it commits
+                                    -- => raises: UNIQUE constraint failed: author.email
+
+.headers on
+.mode column
+SELECT count(*) FROM author;       -- => confirms exactly one row survived -- the duplicate never landed
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output** (captured for real):
+
+```text
+Runtime error near line 9: UNIQUE constraint failed: author.email (19)
+count(*)
+--------
+1
+```
+
+**Exit code**: non-zero (`$?` is `1`).
+
+**Key takeaway**: `UNIQUE` on a single column (rather than `PRIMARY KEY`) is how you enforce "no two
+rows share this value" for columns that are not themselves the row's identity -- an email address,
+a username, a slug. The follow-up count confirms only the first, successful insert survived.
+
+**Why it matters**: "Duplicate email" and "username already taken" errors in production applications
+almost always trace back to a `UNIQUE` constraint firing exactly like this one. Enforcing uniqueness
+at the database layer, not just in application code, is essential once more than one process can
+write to the same table -- a race between two concurrent signups can only be closed reliably by the
+engine itself.
+
+---
+
+### Example 20: Default Value
+
+_ex-20 &middot; exercises co-04_
+
+`DEFAULT` supplies a value automatically whenever an `INSERT` omits that column entirely -- distinct
+from setting the column to `NULL`, which is an explicit choice, not an omission.
+
+**`learning/code/ex-20-default-value/example.sql`**
+
+```sql
+-- Example 20: Default Value.
+-- DEFAULT (co-04) supplies a value automatically when an INSERT omits that column.
+CREATE TABLE account(id INTEGER PRIMARY KEY, status TEXT DEFAULT 'active');
+
+-- This INSERT lists only id -- status is left out entirely, not set to NULL.
+INSERT INTO account(id) VALUES(1);
+                                    -- => the engine substitutes 'active' for the missing column
+
+.headers on
+.mode column
+SELECT * FROM account;             -- => status shows 'active' even though we never wrote it
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  status
+--  ------
+1   active
+```
+
+**Key takeaway**: `DEFAULT` only applies when a column is omitted from the `INSERT`'s column list --
+`INSERT INTO account(id, status) VALUES(1, NULL)` would insert an actual `NULL`, not `'active'`.
+
+**Why it matters**: Defaults keep every INSERT statement from having to repeat boilerplate values
+(a new row's `status`, `created_at`, or `is_active` flag) while still guaranteeing the column is
+never accidentally left `NULL` by a caller that forgot about it. Example 59 (Advanced tier) reuses
+this exact mechanism to add a new column to an already-populated table without breaking existing rows.
+
+---
+
+### Example 21: Check Constraint
+
+_ex-21 &middot; exercises co-04_
+
+`CHECK` enforces an arbitrary boolean expression on every write to that row -- a business invariant
+(here, "price cannot be negative") that the schema itself now guarantees, not just application code.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73 -- color-blind friendly, WCAG AA
+flowchart LR
+    A["INSERT price = -5"]:::blue
+    B{"CHECK price >= 0"}:::orange
+    C["REJECTED<br/>row never written"]:::teal
+    A --> B --> C
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-21-check-constraint/example.sql`**
+
+```sql
+-- Example 21: Check Constraint.
+-- CHECK (co-04) enforces an arbitrary boolean expression on every write to that row.
+CREATE TABLE book(id INTEGER PRIMARY KEY, price REAL CHECK(price >= 0));
+
+-- -5 violates price >= 0 -- a business invariant the schema itself now guarantees.
+INSERT INTO book(price) VALUES(-5);
+                                    -- => the engine evaluates CHECK(price >= 0) as false
+                                    -- => raises: CHECK constraint failed: price >= 0
+
+.headers on
+.mode column
+SELECT count(*) FROM book;         -- => confirms the rejected row never landed -- table stays empty
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output** (captured for real):
+
+```text
+Runtime error near line 6: CHECK constraint failed: price >= 0 (19)
+count(*)
+--------
+0
+```
+
+**Exit code**: non-zero (`$?` is `1`).
+
+**Key takeaway**: `CHECK(<expression>)` can reference any of the row's own columns and any SQL
+expression that evaluates to a boolean -- far more flexible than `NOT NULL` or `UNIQUE` alone.
+
+**Why it matters**: Business rules like "price cannot be negative," "end date must be after start
+date," or "discount cannot exceed 100%" belong in a `CHECK` constraint whenever they can be expressed
+as a single-row condition, because that closes off every write path at once -- the admin console, the
+API, and any future script -- rather than trusting each one to re-implement the same validation.
+
+---
+
+### Example 22: Autoincrement Rowid
+
+_ex-22 &middot; exercises co-02_
+
+`INTEGER PRIMARY KEY` aliases SQLite's internal `rowid` (co-02): omitting it on `INSERT` lets the
+engine pick the next value automatically, one higher than the current maximum.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73 -- color-blind friendly, WCAG AA
+flowchart LR
+    A["INSERT ('Ada')<br/>no id supplied"]:::blue
+    B["engine picks<br/>id = 1"]:::orange
+    C["INSERT ('Grace')<br/>no id supplied"]:::blue
+    D["engine picks<br/>id = 2"]:::teal
+    A --> B
+    C --> D
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-22-autoincrement-rowid/example.sql`**
+
+```sql
+-- Example 22: Autoincrement Rowid.
+-- INTEGER PRIMARY KEY aliases rowid (co-02) -- omitting it lets SQLite pick the next value.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => author table exists, currently empty
+
+INSERT INTO author(name) VALUES('Ada');
+                                    -- => no id supplied -- engine auto-assigns id = 1
+INSERT INTO author(name) VALUES('Grace');
+                                    -- => engine auto-assigns id = 2 (one higher than the max so far)
+
+.headers on
+.mode column
+SELECT * FROM author;              -- => ids came from the engine, not from us: 1, then 2
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  name
+--  -----
+1   Ada
+2   Grace
+```
+
+**Key takeaway**: `INTEGER PRIMARY KEY` id assignment is "one higher than the current maximum," not
+strictly sequential without gaps -- a deleted row's id is never reused unless it happened to be the
+current maximum.
+
+**Why it matters**: This is the exact mechanism behind Example 3's "leave out the id" pattern --
+understanding _why_ it works (rowid aliasing, not magic) matters once you hit edge cases like
+concurrent inserts or explicit id reuse after a `DELETE`. SQLite's separate `AUTOINCREMENT` keyword
+(not shown here, and out of this topic's scope) adds a stricter no-reuse guarantee at a small
+performance cost -- most schemas do not need it.
+
+---
+
+### Example 23: Update One Row
+
+_ex-23 &middot; exercises co-11_
+
+`UPDATE ... SET ... WHERE` mutates only the rows the `WHERE` clause matches -- every other row in the
+table is left completely untouched.
+
+**`learning/code/ex-23-update-one-row/example.sql`**
+
+```sql
+-- Example 23: Update One Row.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price) VALUES
+    (1, 'The Pragmatic Programmer', 34.99),  -- => the row the WHERE clause below will match
+    (2, 'Clean Code', 29.99);                  -- => not matched -- stays untouched below
+
+-- UPDATE ... SET ... WHERE (co-11) mutates only the rows the WHERE clause matches.
+UPDATE book SET price = 15 WHERE id = 1;
+                                    -- => only the row with id = 1 changes -- id 2 is untouched
+
+-- turn on headers + column alignment so the result below reads as a table
+.headers on
+.mode column
+SELECT * FROM book;                -- => id 1 now shows 15.0, id 2 still shows its original 29.99
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                     price
+--  ------------------------  -----
+1   The Pragmatic Programmer  15.0
+2   Clean Code                29.99
+```
+
+**Key takeaway**: `SET price = 15` and `WHERE id = 1` are independent clauses -- `SET` decides what
+changes, `WHERE` decides which rows the change applies to.
+
+**Why it matters**: Targeted single-row updates -- editing one product's price, one user's profile
+field -- are the most common write operation in CRUD applications after inserts. The `WHERE` clause
+is what makes an `UPDATE` surgical rather than catastrophic, which is exactly the contrast Example 24
+demonstrates by omitting it.
+
+---
+
+### Example 24: Update All Rows
+
+_ex-24 &middot; exercises co-11_
+
+No `WHERE` clause means the predicate is implicitly "true for every row" -- `UPDATE` then touches the
+entire table. This is easy to trigger by accident, so it deserves its own worked example.
+
+**`learning/code/ex-24-update-all-rows/example.sql`**
+
+```sql
+-- Example 24: Update All Rows.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, in_stock INTEGER NOT NULL DEFAULT 0);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, in_stock) VALUES
+    (1, 'The Pragmatic Programmer', 0),  -- => starts out of stock
+    (2, 'Clean Code', 0);                  -- => starts out of stock
+
+-- No WHERE clause (co-11) means the predicate is implicitly "true for every row" --
+-- UPDATE touches the entire table. This is easy to do by accident -- always double-check.
+UPDATE book SET in_stock = 1;
+                                    -- => every row's in_stock flips from 0 to 1, no exceptions
+
+.headers on
+.mode column
+SELECT * FROM book;                -- => both rows now show in_stock = 1
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                     in_stock
+--  ------------------------  --------
+1   The Pragmatic Programmer  1
+2   Clean Code                1
+```
+
+**Key takeaway**: An `UPDATE` (or `DELETE`) with no `WHERE` clause is valid SQL, not an error -- the
+engine has no way to know you forgot the clause versus meant to update everything.
+
+**Why it matters**: A missing `WHERE` clause on `UPDATE` or `DELETE` is one of the most common
+catastrophic mistakes in production database work -- it is syntactically identical to "update
+everything on purpose." Many teams mitigate this with a linter rule, a code-review checklist item, or
+running ad-hoc mutations inside an explicit transaction (Example 51, Intermediate tier) that can be
+rolled back before committing.
+
+---
+
+### Example 25: Delete Row
+
+_ex-25 &middot; exercises co-12_
+
+`DELETE FROM ... WHERE` removes only the matching rows -- the table itself, its schema, and every
+other row remain exactly as they were.
+
+**`learning/code/ex-25-delete-row/example.sql`**
+
+```sql
+-- Example 25: Delete Row.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title) VALUES
+    (1, 'The Pragmatic Programmer'),  -- => survives the DELETE below
+    (2, 'Clean Code'),                  -- => targeted by the DELETE below
+    (3, 'The Mythical Man-Month');       -- => survives the DELETE below
+
+-- DELETE FROM ... WHERE (co-12) removes only the matching rows -- the table stays.
+DELETE FROM book WHERE id = 2;     -- => row id 2 is gone permanently; ids 1 and 3 remain
+
+-- turn on headers + column alignment so the result below reads as a table
+.headers on
+.mode column
+SELECT * FROM book;                -- => only ids 1 and 3 remain, in that order
+SELECT count(*) FROM book;         -- => count drops from 3 to 2 -- exactly one row removed
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title
+--  ------------------------
+1   The Pragmatic Programmer
+3   The Mythical Man-Month
+count(*)
+--------
+2
+```
+
+**Key takeaway**: `DELETE FROM book WHERE id = 2` removes exactly one row -- `DELETE FROM book` alone
+(no `WHERE`) would remove every row, the `DELETE` equivalent of Example 24's unqualified `UPDATE`.
+
+**Why it matters**: `DELETE` without a `WHERE` clause is, if anything, more dangerous than an
+unqualified `UPDATE`, because there is no "previous value" left to recover from once every row is
+gone (short of restoring a backup or replaying a transaction log). Production teams frequently favor
+a "soft delete" pattern -- an `UPDATE` that sets a `deleted_at` flag instead of a real `DELETE` -- for
+exactly this reason, trading storage for recoverability.
+
+---
+
+### Example 26: Declare Foreign Key
+
+_ex-26 &middot; exercises co-03_
+
+`REFERENCES` declares that `book.author_id` must point at a real `author.id` -- a static,
+self-documenting invariant that lives directly in the schema. Declaring it is a separate step from
+enforcing it (Example 27).
+
+```mermaid
+%% Color Palette: Blue #0173B2, Teal #029E73 -- color-blind friendly, WCAG AA
+graph LR
+    A["author<br/>id, name"]:::blue -->|"book.author_id<br/>REFERENCES author#40;id#41;"| B["book<br/>id, title, author_id"]:::teal
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-26-declare-foreign-key/example.sql`**
+
+```sql
+-- Example 26: Declare Foreign Key.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => author table exists -- the FK below will point at it
+
+-- REFERENCES (co-03) declares that book.author_id must point at a real author.id --
+-- a static, self-documenting invariant that lives in the schema itself.
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,        -- => book's own primary key
+    title TEXT NOT NULL,           -- => every book must have a title
+    author_id INTEGER REFERENCES author(id)
+                                    -- => declares the FK -- enforcement is a SEPARATE step (Example 27)
+);
+
+-- .schema prints back the stored definition -- proof the REFERENCES clause was kept.
+.schema book
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,        -- => book's own primary key
+    title TEXT NOT NULL,           -- => every book must have a title
+    author_id INTEGER REFERENCES author(id)
+                                    -- => declares the FK -- enforcement is a SEPARATE step (Example 27)
+);
+```
+
+**Key takeaway**: `REFERENCES author(id)` is purely declarative in this example -- it documents the
+relationship and shows up in `.schema`, but by itself it does not yet stop an orphaned `author_id`
+from being inserted (that requires Example 27's pragma).
+
+**Why it matters**: Declaring foreign keys, even before enforcing them, documents the shape of your
+data model directly in the schema where every developer, migration tool, and ER-diagram generator can
+read it. This is the mechanism that makes Example 28's `JOIN` meaningful: `book.author_id` and
+`author.id` are related columns by design, not by coincidence of naming.
+
+---
+
+### Example 27: Enforce Foreign Key
+
+_ex-27 &middot; exercises co-03_
+
+**CRITICAL**: foreign keys are **off by default** in SQLite. `PRAGMA foreign_keys=ON` must run on
+every connection, every time, or `REFERENCES` clauses are decoration only -- exactly as Example 26
+demonstrated.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73 -- color-blind friendly, WCAG AA
+flowchart LR
+    A["PRAGMA foreign_keys=ON"]:::blue
+    B["INSERT book<br/>author_id = 99 #40;orphan#41;"]:::orange
+    C["REJECTED<br/>FOREIGN KEY constraint failed"]:::teal
+    A --> B --> C
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-27-enforce-foreign-key/example.sql`**
+
+```sql
+-- Example 27: Enforce Foreign Key.
+-- CRITICAL: foreign keys are OFF by default in SQLite -- this pragma must run per
+-- connection, every time, or REFERENCES clauses are decoration only (co-03).
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => author table exists, currently empty -- no id 99 in it
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,        -- => book's own primary key
+    title TEXT NOT NULL,           -- => every book must have a title
+    author_id INTEGER REFERENCES author(id)
+    -- => REFERENCES alone does nothing without the PRAGMA above -- both are required
+);
+
+-- author_id 99 does not exist in the author table -- an orphan reference.
+INSERT INTO book(title, author_id) VALUES('Ghost Book', 99);
+                                    -- => with the pragma ON, the engine checks the reference first
+                                    -- => raises: FOREIGN KEY constraint failed
+
+.headers on
+.mode column
+SELECT count(*) FROM book;         -- => confirms the rejected row never landed -- table stays empty
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output** (captured for real):
+
+```text
+Runtime error near line 16: FOREIGN KEY constraint failed (19)
+count(*)
+--------
+0
+```
+
+**Exit code**: non-zero (`$?` is `1`).
+
+**Key takeaway**: Without `PRAGMA foreign_keys=ON`, the identical `INSERT` with `author_id = 99`
+would succeed silently, leaving an orphaned row -- the pragma is not optional if referential integrity
+matters to your application, and the follow-up count confirms the orphan never landed.
+
+**Why it matters**: SQLite's foreign-key-off-by-default design is a documented, verified fact from
+[sqlite.org's Foreign Key Support page](https://www.sqlite.org/foreignkeys.html) ("Foreign key
+constraints are disabled by default"), and it surprises developers coming from PostgreSQL or MySQL,
+where they are always on. Every application that cares about referential integrity must set this
+pragma explicitly on every single connection -- typically right after `sqlite3.connect()` in Python
+(Example 29) -- because it does not persist as a database-level setting.
+
+---
+
+### Example 28: Inner Join Two Tables
+
+_ex-28 &middot; exercises co-13_
+
+`JOIN ... ON` recombines normalized data: the engine matches `book.author_id` to `author.id`, row by
+row, and only rows with a match on both sides appear in the output -- the workhorse operation for
+undoing normalization (co-05) at query time.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73 -- color-blind friendly, WCAG AA
+graph LR
+    A["author<br/>#40;1, Ada Lovelace#41;<br/>#40;2, Grace Hopper#41;"]:::blue
+    B["book<br/>#40;title, author_id: 1#41;<br/>#40;title, author_id: 2#41;"]:::orange
+    C["JOIN result<br/>title + matching author name"]:::teal
+
+    A -->|"author.id = book.author_id"| C
+    B -->|"author.id = book.author_id"| C
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-28-inner-join-two-tables/example.sql`**
+
+```sql
+-- Example 28: Inner Join Two Tables.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => author table exists, currently empty
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER REFERENCES author(id));
+                                    -- => book table exists, currently empty
+INSERT INTO author(id, name) VALUES
+    (1, 'Ada Lovelace'),            -- => referenced by book row 1 below
+    (2, 'Grace Hopper');             -- => referenced by book row 2 below
+INSERT INTO book(title, author_id) VALUES
+    ('Notes on the Analytical Engine', 1),  -- => author_id 1 -- pairs with Ada Lovelace
+    ('Compilers and Computers', 2);           -- => author_id 2 -- pairs with Grace Hopper
+
+-- turn on headers + column alignment so the joined result reads as a table
+.headers on
+.mode column
+-- JOIN ... ON (co-13) recombines normalized data -- matches book.author_id to author.id,
+-- row by row, and only rows with a match on BOTH sides appear in the output.
+SELECT book.title, author.name
+FROM book                          -- => the left side of the join -- one row per book
+JOIN author ON book.author_id = author.id;
+                                    -- => the ON clause -- the exact key equality the join tests
+                                    -- => each book row pairs with exactly its own author's name
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+title                           name
+------------------------------  ------------
+Notes on the Analytical Engine  Ada Lovelace
+Compilers and Computers         Grace Hopper
+```
+
+**Key takeaway**: `JOIN` (with no qualifier) means **inner join**: only rows with a matching key on
+both sides survive -- an author with zero books, or a book with a nonexistent `author_id`, would
+simply not appear in this result (Example 31, Intermediate tier, covers the `LEFT JOIN` alternative
+that keeps unmatched rows).
+
+**Why it matters**: Splitting `author` and `book` into separate tables (normalization, co-05) avoids
+repeating the author's name on every one of their books, but that same split means almost every
+useful query needs a `JOIN` to recombine the data for display. `JOIN` is, without exaggeration, the
+single most important operation in relational SQL -- everything from a blog's "post with author name"
+page to a financial report joining transactions to accounts depends on it.
+
+---
+
+### Example 29: Python Connect And Query
+
+_ex-29 &middot; exercises co-19, co-21_
+
+Python's stdlib `sqlite3` module drives the exact same SQL engine the CLI examples used -- no
+separate database, no separate dialect. `sqlite3.connect()` opens a typed `Connection`, and
+`fetchall()` pulls every remaining row back as a list of tuples.
+
+**`learning/code/ex-29-python-connect-and-query/example.py`**
+
+```python
+# pyright: strict
+"""Example 29: Python Connect And Query."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed (co-19)
+
+
+def fetch_authors(conn: sqlite3.Connection) -> list[tuple[int, str]]:  # => a reusable helper
+    # => typed signature (DD-39): takes a Connection, returns a list of (int, str) tuples
+    """Return every author row as (id, name) tuples, ordered by id."""
+    cur: sqlite3.Cursor = conn.cursor()  # => a Cursor runs statements against conn
+    cur.execute("SELECT id, name FROM author ORDER BY id")
+    # => sends the SQL text to the engine -- nothing is fetched into Python yet
+    rows: list[tuple[int, str]] = cur.fetchall()
+    # => fetchall() (co-21) pulls every remaining row as a list of tuples at once
+    return rows  # => hands the fully-materialized list back to the caller
+
+
+def main() -> None:  # => the script's entry point
+    conn: sqlite3.Connection = sqlite3.connect(":memory:")
+    # => connect() (co-19) opens a Connection -- ":memory:" avoids touching disk here
+    cur: sqlite3.Cursor = conn.cursor()  # => a cursor scoped to this connection
+    cur.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+    # => same DDL as the CLI examples -- Python drives the identical SQL engine
+    cur.execute(  # => passes a single multi-value INSERT string
+        "INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper')"
+    )  # => inserts 2 rows in one round-trip
+    conn.commit()  # => commit() (co-19) makes the write durable and visible
+
+    rows: list[tuple[int, str]] = fetch_authors(conn)
+    # => calls the typed helper above -- rows is [(1, 'Ada Lovelace'), (2, 'Grace Hopper')]
+    for row in rows:  # => iterates the list of (id, name) tuples
+        print(row)  # => Output: (1, 'Ada Lovelace') then (2, 'Grace Hopper')
+
+    conn.close()  # => releases the connection's resources
+    # => always close what you open -- especially before the process exits
+
+
+if __name__ == "__main__":  # => guards against running main() on `import example`
+    main()  # => entry point -- runs everything above when executed as a script
+```
+
+**Run**: `python3 example.py`
+
+**Output**:
+
+```text
+(1, 'Ada Lovelace')
+(2, 'Grace Hopper')
+```
+
+**Type check**: `pyright example.py` (under the file's own `# pyright: strict` directive -- there is
+no separate `--strict` CLI flag):
+
+```text
+0 errors, 0 warnings, 0 informations
+```
+
+**Key takeaway**: `sqlite3.Connection`, `sqlite3.Cursor`, and `fetchall() -> list[tuple[...]]` type
+exactly the way you would expect from the stdlib's own type stubs -- no extra type-stub package
+required for `pyright` to check this file strictly.
+
+**Why it matters**: The `sqlite3` module ships in every CPython install, so any script that needs a
+local, file-backed (or in-memory) relational database gets one with zero extra dependencies --
+exactly the DD-34 "type every Python example" and DD-39 "static typing as much as possible"
+conventions this topic follows. Production Python services often graduate to PostgreSQL or a
+dedicated ORM, but the connect/cursor/execute/fetch shape learned here transfers directly, since most
+Python database drivers implement the same DB-API 2.0 interface `sqlite3` does.
+
+---
+
+### Example 30: Python Parameterized Insert
+
+_ex-30 &middot; exercises co-20_
+
+`?` is a positional placeholder: passing a value as a bound parameter, never as interpolated string
+text, is how Python's `sqlite3` module neutralizes SQL injection -- the value is sent to the engine
+as pure data, never parsed as SQL syntax.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73 -- color-blind friendly, WCAG AA
+flowchart LR
+    A["name = 'Ada Lovelace'"]:::blue
+    B["? placeholder<br/>bound as DATA"]:::orange
+    C["INSERT ... VALUES #40;?#41;<br/>structure fixed, value opaque"]:::teal
+    A --> B --> C
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-30-python-parameterized-insert/example.py`**
+
+```python
+# pyright: strict
+"""Example 30: Python Parameterized Insert."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed (co-19)
+
+
+def insert_author(conn: sqlite3.Connection, name: str) -> int:  # => a reusable helper
+    # => typed signature (DD-39): takes a Connection and a str, returns the new row's id
+    """Insert one author by name using a ?-placeholder and return its new id."""
+    cur: sqlite3.Cursor = conn.cursor()  # => a cursor scoped to this connection
+    cur.execute("INSERT INTO author(name) VALUES (?)", (name,))
+    # => ? is a positional placeholder (co-20) -- name is bound as DATA, never as SQL text
+    conn.commit()  # => makes the insert durable before we report success
+    new_id: int = cur.lastrowid if cur.lastrowid is not None else -1
+    # => lastrowid is the rowid the engine just assigned -- Optional[int], so we narrow it
+    return new_id  # => hands the concrete int id back to the caller
+
+
+def main() -> None:  # => the script's entry point
+    conn: sqlite3.Connection = sqlite3.connect(":memory:")
+    # => a fresh in-memory database for this script run
+    conn.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+    # => execute() on the Connection directly, without a separate cursor object
+
+    # A value containing SQL syntax -- proves the placeholder binds it as DATA, not code.
+    name: str = "Ada Lovelace; DROP TABLE author;--"
+    # => if this string were interpolated into raw SQL text, it would drop the table
+    new_id: int = insert_author(conn, name)
+    # => calls the typed helper above -- the ? placeholder neutralizes the injection attempt
+    print(f"inserted id={new_id}")  # => Output: inserted id=1
+
+    cur: sqlite3.Cursor = conn.cursor()  # => a fresh cursor to verify the stored row
+    cur.execute("SELECT id, name FROM author")  # => reads the table back to prove it survived
+    rows: list[tuple[int, str]] = cur.fetchall()
+    # => rows is [(1, 'Ada Lovelace; DROP TABLE author;--')] -- table still exists, untouched
+    for row in rows:  # => iterates the single result row
+        print(row)  # => Output: (1, 'Ada Lovelace; DROP TABLE author;--')
+
+    conn.close()  # => releases the connection's resources
+
+
+if __name__ == "__main__":  # => guards against running main() on `import example`
+    main()  # => entry point -- runs everything above when executed as a script
+```
+
+**Run**: `python3 example.py`
+
+**Output**:
+
+```text
+inserted id=1
+(1, 'Ada Lovelace; DROP TABLE author;--')
+```
+
+**Type check**: `pyright example.py`:
+
+```text
+0 errors, 0 warnings, 0 informations
+```
+
+**Key takeaway**: The malicious-looking string `"Ada Lovelace; DROP TABLE author;--"` lands in the
+`name` column completely intact -- the `?` placeholder treats it as one opaque value, never as SQL to
+execute, and the `author` table survives.
+
+**Why it matters**: SQL injection remains one of the most consequential and preventable
+vulnerability classes in production software, and parameterized queries (never string interpolation
+or f-strings for values) are the complete, well-verified fix -- confirmed current per
+[docs.python.org's sqlite3 Placeholders documentation](https://docs.python.org/3/library/sqlite3.html).
+This same `?`-placeholder discipline extends to `:name` named placeholders (Example 47, Intermediate
+tier) and to `executemany()` (Example 48) for bulk parameterized writes.
+
+---
+
+← Previous: [Overview](./overview.md) · Next: [Intermediate Examples](./intermediate.md) →

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/_index.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Capstone"
+date: 2026-07-14T00:00:00+07:00
+draft: false
+weight: 900
+---
+
+- [Overview](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/overview)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/code/dal.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/code/dal.py
@@ -1,0 +1,98 @@
+# pyright: strict
+"""Capstone: dal.py -- typed, parameterized data-access layer over schema.sql's tables.
+
+Every function here takes an ALREADY-OPEN sqlite3.Connection -- callers (the CLI, or the
+pytest fixture below) own the connection's lifetime, this module never opens or closes one
+itself. Every SQL string uses `?` placeholders (co-20) -- nothing here is ever string-built
+from untrusted input, which is the whole point of a data-access layer existing at all.
+"""
+
+import sqlite3  # => stdlib DB-API module (co-19) -- no third-party driver anywhere in this file
+
+
+def create_book(
+    conn: sqlite3.Connection,
+    title: str,
+    author_id: int,
+    publisher_id: int | None,
+    price: float,
+) -> int:
+    # publisher_id: int | None mirrors schema.sql's OPTIONAL publisher_id FK exactly.
+    cur: sqlite3.Cursor = conn.execute(
+        "INSERT INTO book(title, author_id, publisher_id, price) VALUES (?, ?, ?, ?)",
+        (
+            title,
+            author_id,
+            publisher_id,
+            price,
+        ),  # => 4 bound parameters, positional order matters
+    )
+    conn.commit()
+    new_id: int | None = cur.lastrowid  # => the rowid SQLite just assigned (co-02)
+    assert (
+        new_id is not None
+    )  # => narrows int | None to int -- always set right after an INSERT
+    return new_id
+
+
+def get_book(
+    conn: sqlite3.Connection, book_id: int
+) -> tuple[int, str, int, int | None, float] | None:
+    cur: sqlite3.Cursor = conn.execute(
+        "SELECT id, title, author_id, publisher_id, price FROM book WHERE id = ?",
+        (book_id,),
+    )
+    row: tuple[int, str, int, int | None, float] | None = cur.fetchone()
+    return (
+        row  # => None if book_id doesn't exist -- callers must handle the missing case
+    )
+
+
+def list_books_by_author(
+    conn: sqlite3.Connection, author_id: int
+) -> list[tuple[int, str, float]]:
+    cur: sqlite3.Cursor = conn.execute(
+        "SELECT id, title, price FROM book WHERE author_id = ? ORDER BY id",
+        (author_id,),
+    )
+    return cur.fetchall()  # => every book by this ONE author, oldest id first
+
+
+def update_book_price(conn: sqlite3.Connection, book_id: int, new_price: float) -> None:
+    conn.execute("UPDATE book SET price = ? WHERE id = ?", (new_price, book_id))
+    conn.commit()  # => a single-row update commits immediately -- see bulk_update_prices for a batch
+
+
+def delete_book(conn: sqlite3.Connection, book_id: int) -> None:
+    conn.execute("DELETE FROM book WHERE id = ?", (book_id,))
+    conn.commit()  # => ON DELETE CASCADE (schema.sql) also removes this book's book_tag rows
+
+
+def report_by_author(conn: sqlite3.Connection) -> list[tuple[str, int, float]]:
+    # The capstone's reporting aggregation: JOIN + GROUP BY in ONE query (co-15, co-13),
+    # exactly like Example 79's join-group-having report, minus the HAVING filter.
+    cur: sqlite3.Cursor = conn.execute(
+        """
+        SELECT author.name, count(*), sum(book.price)
+        FROM author
+        JOIN book ON book.author_id = author.id
+        GROUP BY author.name
+        ORDER BY author.name
+        """
+    )
+    rows: list[tuple[str, int, float]] = cur.fetchall()
+    return rows  # => [(name, book_count, total_price), ...] -- one row per author WITH books
+
+
+def bulk_update_prices(
+    conn: sqlite3.Connection, updates: list[tuple[int, float]]
+) -> None:
+    # The capstone's rollback-on-failure transaction (co-18): `with conn:` opens an implicit
+    # transaction on the FIRST write, commits if every update succeeds, and auto-ROLLBACKs
+    # the WHOLE batch the instant any single update violates schema.sql's CHECK(price >= 0).
+    with conn:
+        for (
+            book_id,
+            new_price,
+        ) in updates:  # => co-20 -- book_id/new_price stay bound, never spliced
+            conn.execute("UPDATE book SET price = ? WHERE id = ?", (new_price, book_id))

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/code/demo_bulk_update.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/code/demo_bulk_update.py
@@ -1,0 +1,64 @@
+# pyright: strict
+"""Capstone: demo_bulk_update.py -- proves a partially-failing batch leaves every row
+untouched (co-18), against a real on-disk database built from schema.sql + seed.sql.
+
+This is a runnable demonstration for Step 3 of the capstone walkthrough -- the same
+rollback behavior test_bulk_update_prices_rolls_back_the_whole_batch_on_failure asserts
+in tests/test_dal.py, shown here end to end against a real file, not an in-memory fixture.
+"""
+
+import sqlite3
+from pathlib import Path
+
+from dal import bulk_update_prices, list_books_by_author
+
+CODE_DIR: Path = Path(
+    __file__
+).parent  # => this script's own directory -- schema.sql/seed.sql live here
+DB_PATH: Path = CODE_DIR / "demo.db"  # => a throwaway file, rebuilt fresh on every run
+
+
+def main() -> None:
+    DB_PATH.unlink(
+        missing_ok=True
+    )  # => deletes any leftover demo.db from a prior run first
+    conn: sqlite3.Connection = sqlite3.connect(
+        DB_PATH
+    )  # => a real on-disk file, not :memory:
+    conn.execute("PRAGMA foreign_keys = ON")  # => matches schema.sql's own PRAGMA line
+    conn.executescript(
+        (CODE_DIR / "schema.sql").read_text()
+    )  # => applies the 4-table 3NF design
+    conn.executescript(
+        (CODE_DIR / "seed.sql").read_text()
+    )  # => applies the same seed rows as Step 1
+
+    before: list[tuple[int, str, float]] = list_books_by_author(
+        conn, 1
+    )  # => Ada's 2 seeded books
+    print("before:", before)  # => the baseline this script proves is preserved below
+
+    try:
+        # book 1's price update is VALID; book 2's -1.0 violates CHECK(price >= 0) in schema.sql.
+        bulk_update_prices(
+            conn, [(1, 99.0), (2, -1.0)]
+        )  # => `with conn:` inside rolls back BOTH
+    except (
+        sqlite3.IntegrityError
+    ) as err:  # => the CHECK violation surfaces as this exact error type
+        print(
+            "caught:", err
+        )  # => confirms the failure was DETECTED, not silently swallowed
+
+    after: list[tuple[int, str, float]] = list_books_by_author(
+        conn, 1
+    )  # => re-reads the SAME rows
+    print("after:", after)  # => compared against `before` on the next line
+    print(
+        "unchanged:", before == after
+    )  # => True proves book 1's VALID update never persisted either
+    conn.close()  # => releases the connection -- demo.db itself is left on disk for inspection
+
+
+if __name__ == "__main__":  # => guards main() so importing this module never runs it
+    main()  # => runs the whole demonstration end to end

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/code/migrate_add_column.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/code/migrate_add_column.sql
@@ -1,0 +1,9 @@
+-- Capstone: migrate_add_column.sql -- an additive migration, Example 59's exact pattern (co-22),
+-- applied AFTER schema.sql + seed.sql have already populated book with 3 rows.
+ALTER TABLE book ADD COLUMN edition INTEGER DEFAULT 1;
+                                    -- => no table rewrite, no downtime -- existing rows read DEFAULT
+
+.headers on
+.mode column
+SELECT id, title, price, edition FROM book;
+                                    -- => all 3 pre-existing rows show edition = 1 -- none broke

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/code/schema.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/code/schema.sql
@@ -1,0 +1,36 @@
+-- Capstone: schema.sql -- a 3NF, 4-table design (author/publisher/book/tag) with PK/FK
+-- constraints throughout, following the exact shape Example 77 taught (co-01, co-05, co-07).
+PRAGMA foreign_keys = ON;          -- => enforcement on -- CASCADE below actually fires (co-03)
+
+CREATE TABLE author(
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE publisher(
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,
+    title TEXT NOT NULL,
+    author_id INTEGER NOT NULL REFERENCES author(id),
+                                    -- => every book MUST have an author -- NOT NULL, not optional
+    publisher_id INTEGER REFERENCES publisher(id),
+                                    -- => publisher is OPTIONAL -- self-published books have none
+    price REAL NOT NULL CHECK (price >= 0)
+                                    -- => co-04 -- the engine itself rejects a negative price
+);
+
+CREATE TABLE tag(
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE book_tag(
+    book_id INTEGER NOT NULL REFERENCES book(id) ON DELETE CASCADE,
+                                    -- => deleting a book cleans up its own tag links automatically
+    tag_id INTEGER NOT NULL REFERENCES tag(id) ON DELETE CASCADE,
+    PRIMARY KEY (book_id, tag_id)  -- => the composite PK from Example 65 -- no duplicate pairs
+);

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/code/seed.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/code/seed.sql
@@ -1,0 +1,10 @@
+-- Capstone: seed.sql -- applied AFTER schema.sql, exactly like Example 74's split (co-10, co-24).
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper');
+INSERT INTO publisher(id, name) VALUES (1, 'Analytical Press');
+INSERT INTO book(id, title, author_id, publisher_id, price) VALUES
+    (1, 'Notes on the Analytical Engine', 1, 1, 12.5),
+    (2, 'Sketch of the Analytical Engine', 1, 1, 9.0),
+    (3, 'The First Computer Bug', 2, NULL, 15.0);
+                                    -- => book 3 has NO publisher -- proves publisher_id's optionality
+INSERT INTO tag(id, name) VALUES (1, 'history'), (2, 'computing');
+INSERT INTO book_tag(book_id, tag_id) VALUES (1, 1), (1, 2), (2, 2);

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/code/tests/test_dal.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/code/tests/test_dal.py
@@ -1,0 +1,115 @@
+"""Capstone: pytest coverage for dal.py, seeded from the SAME schema.sql + seed.sql the CLI uses.
+
+Reading the real .sql files (rather than re-typing the schema in Python) keeps this fixture
+byte-identical to what a reader actually applies with `sqlite3 app.db < schema.sql` -- the
+tests exercise the exact same relations, constraints, and seed rows Step 1 verifies.
+"""
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from dal import (
+    bulk_update_prices,
+    create_book,
+    delete_book,
+    get_book,
+    list_books_by_author,
+    report_by_author,
+    update_book_price,
+)
+
+CODE_DIR: Path = Path(
+    __file__
+).parent.parent  # => this file lives in tests/, code/ is its parent
+
+
+@pytest.fixture
+def conn() -> Iterator[sqlite3.Connection]:
+    # A FRESH in-memory DB per test, built from the real schema.sql + seed.sql on disk.
+    connection: sqlite3.Connection = sqlite3.connect(":memory:")
+    connection.execute(
+        "PRAGMA foreign_keys = ON"
+    )  # => matches schema.sql's own PRAGMA line
+    connection.executescript((CODE_DIR / "schema.sql").read_text())
+    connection.executescript((CODE_DIR / "seed.sql").read_text())
+    yield connection
+    connection.close()
+
+
+def test_get_book_returns_seeded_row(conn: sqlite3.Connection) -> None:
+    row: tuple[int, str, int, int | None, float] | None = get_book(conn, 1)
+    assert row == (1, "Notes on the Analytical Engine", 1, 1, 12.5)
+
+
+def test_get_book_missing_id_returns_none(conn: sqlite3.Connection) -> None:
+    assert get_book(conn, 999) is None
+
+
+def test_create_book_with_no_publisher(conn: sqlite3.Connection) -> None:
+    # publisher_id=None exercises the OPTIONAL FK -- exactly like seed.sql's book 3.
+    new_id: int = create_book(
+        conn, "A New Draft", author_id=2, publisher_id=None, price=5.0
+    )
+    assert get_book(conn, new_id) == (new_id, "A New Draft", 2, None, 5.0)
+
+
+def test_list_books_by_author(conn: sqlite3.Connection) -> None:
+    # Author 1 (Ada Lovelace) has exactly 2 seeded books: ids 1 and 2.
+    assert list_books_by_author(conn, 1) == [
+        (1, "Notes on the Analytical Engine", 12.5),
+        (2, "Sketch of the Analytical Engine", 9.0),
+    ]
+
+
+def test_update_book_price(conn: sqlite3.Connection) -> None:
+    update_book_price(conn, 1, 20.0)
+    row: tuple[int, str, int, int | None, float] | None = get_book(conn, 1)
+    assert row is not None
+    assert (
+        row[4] == 20.0
+    )  # => index 4 is price -- confirms the update actually persisted
+
+
+def test_delete_book_removes_it(conn: sqlite3.Connection) -> None:
+    delete_book(conn, 3)
+    assert get_book(conn, 3) is None
+
+
+def test_report_by_author_matches_hand_computed_values(
+    conn: sqlite3.Connection,
+) -> None:
+    # Hand-computed from seed.sql: Ada has 2 books (12.5 + 9.0 = 21.5), Grace has 1 (15.0).
+    expected: list[tuple[str, int, float]] = [
+        ("Ada Lovelace", 2, 21.5),
+        ("Grace Hopper", 1, 15.0),
+    ]
+    assert report_by_author(conn) == expected
+
+
+def test_bulk_update_prices_commits_when_all_succeed(conn: sqlite3.Connection) -> None:
+    bulk_update_prices(conn, [(1, 13.0), (2, 10.0)])
+    assert list_books_by_author(conn, 1) == [
+        (1, "Notes on the Analytical Engine", 13.0),
+        (2, "Sketch of the Analytical Engine", 10.0),
+    ]
+
+
+def test_bulk_update_prices_rolls_back_the_whole_batch_on_failure(
+    conn: sqlite3.Connection,
+) -> None:
+    before: list[tuple[int, str, float]] = list_books_by_author(
+        conn, 1
+    )  # => baseline, both books
+
+    # book 1's price update is VALID; book 2's -1.0 violates CHECK(price >= 0) -- the WHOLE
+    # batch must roll back, including the (already-applied) valid update to book 1.
+    with pytest.raises(sqlite3.IntegrityError):
+        bulk_update_prices(conn, [(1, 99.0), (2, -1.0)])
+
+    after: list[tuple[int, str, float]] = list_books_by_author(conn, 1)
+    assert (
+        before == after
+    )  # => book 1's price is UNCHANGED too -- no partial write survived

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/overview.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/capstone/overview.md
@@ -1,0 +1,519 @@
+---
+title: "Overview"
+date: 2026-07-14T00:00:00+07:00
+draft: false
+weight: 1
+---
+
+## Goal
+
+Design and populate a small, normalized SQLite database (4 tables: `author`, `publisher`, `book`,
+`tag`, plus the `book_tag` junction) and ship a Python data-access layer with parameterized queries, a
+`GROUP BY` reporting aggregation, a batch update that rolls back atomically on failure, and a safe
+additive migration -- runnable from the CLI end to end. Every mechanism this capstone combines was
+already taught, individually, somewhere in this topic's Beginner, Intermediate, or Advanced tiers.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC, Brown #CA9161
+flowchart LR
+    A["schema.sql + seed.sql<br/>4-table 3NF design"]:::blue
+    B["dal.py<br/>parameterized CRUD + report"]:::orange
+    C["pytest -q<br/>9 tests, seeded fixture DB"]:::teal
+    D["bulk_update_prices()<br/>rolls back on CHECK failure"]:::purple
+    E["migrate_add_column.sql<br/>additive ALTER TABLE"]:::brown
+    A --> B --> C
+    B --> D
+    A --> E
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef brown fill:#CA9161,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+## Concepts exercised
+
+- [x] 3NF schema with `PRIMARY KEY`/`FOREIGN KEY` constraints (Example 77's pattern)
+- [x] `CREATE TABLE` DDL, applied from a separate `schema.sql` file (Example 74's split)
+- [x] joins + `GROUP BY`/`HAVING`-style report (Example 79's pattern, minus the `HAVING`)
+- [x] parameterized queries -- no string interpolation anywhere (co-20)
+- [x] commit/rollback transaction via `with conn:` (Example 80's pattern)
+- [x] a safe additive migration (Example 59's pattern)
+
+All colocated code lives under `learning/capstone/code/`: `schema.sql` and `seed.sql` (the database
+structure and its seed data), `dal.py` (the typed data-access layer), `demo_bulk_update.py` (a runnable
+rollback demonstration), `migrate_add_column.sql` (the additive migration), and the test suite in
+`tests/test_dal.py`. Every listing below is the complete, verbatim file -- nothing on this page is
+truncated or paraphrased.
+
+## Step 1: `schema.sql` + `seed.sql` -- a 3NF design, applied via the CLI
+
+_exercises co-01, co-02, co-03, co-04, co-05, co-07, co-10_
+
+Four fact-type tables (`author`, `publisher`, `book`, `tag`) plus one composite-key junction table
+(`book_tag`), following Example 77's exact 3NF shape: `book.author_id` is a required foreign key,
+`book.publisher_id` is an optional one (a self-published book has no publisher row to point at), and
+`price` carries a `CHECK (price >= 0)` constraint the same way Example 80's `account.balance` does.
+`seed.sql` is applied as a second, separate CLI invocation, exactly like Example 74's split.
+
+**`learning/capstone/code/schema.sql`** (complete file)
+
+```sql
+-- Capstone: schema.sql -- a 3NF, 4-table design (author/publisher/book/tag) with PK/FK
+-- constraints throughout, following the exact shape Example 77 taught (co-01, co-05, co-07).
+PRAGMA foreign_keys = ON;
+
+-- => enforcement on -- CASCADE below actually fires (co-03)
+CREATE TABLE author (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+
+CREATE TABLE publisher (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+
+CREATE TABLE book (
+  id INTEGER PRIMARY KEY,
+  title TEXT NOT NULL,
+  author_id INTEGER NOT NULL REFERENCES author (id),
+  -- => every book MUST have an author -- NOT NULL, not optional
+  publisher_id INTEGER REFERENCES publisher (id),
+  -- => publisher is OPTIONAL -- self-published books have none
+  price REAL NOT NULL CHECK (price >= 0)
+  -- => co-04 -- the engine itself rejects a negative price
+);
+
+CREATE TABLE tag (id INTEGER PRIMARY KEY, name TEXT NOT NULL UNIQUE);
+
+CREATE TABLE book_tag (
+  book_id INTEGER NOT NULL REFERENCES book (id) ON DELETE CASCADE,
+  -- => deleting a book cleans up its own tag links automatically
+  tag_id INTEGER NOT NULL REFERENCES tag (id) ON DELETE CASCADE,
+  PRIMARY KEY (book_id, tag_id) -- => the composite PK from Example 65 -- no duplicate pairs
+);
+```
+
+**`learning/capstone/code/seed.sql`** (complete file)
+
+```sql
+-- Capstone: seed.sql -- applied AFTER schema.sql, exactly like Example 74's split (co-10, co-24).
+INSERT INTO
+  author (id, name)
+VALUES
+  (1, 'Ada Lovelace'),
+  (2, 'Grace Hopper');
+
+INSERT INTO
+  publisher (id, name)
+VALUES
+  (1, 'Analytical Press');
+
+INSERT INTO
+  book (id, title, author_id, publisher_id, price)
+VALUES
+  (1, 'Notes on the Analytical Engine', 1, 1, 12.5),
+  (2, 'Sketch of the Analytical Engine', 1, 1, 9.0),
+  (3, 'The First Computer Bug', 2, NULL, 15.0);
+
+-- => book 3 has NO publisher -- proves publisher_id's optionality
+INSERT INTO
+  tag (id, name)
+VALUES
+  (1, 'history'),
+  (2, 'computing');
+
+INSERT INTO
+  book_tag (book_id, tag_id)
+VALUES
+  (1, 1),
+  (1, 2),
+  (2, 2);
+```
+
+**Verify**
+
+```text
+$ sqlite3 app.db < schema.sql
+$ sqlite3 app.db < seed.sql
+$ sqlite3 app.db ".tables"
+author     book       book_tag   publisher  tag
+$ sqlite3 app.db ".schema book"
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,
+    title TEXT NOT NULL,
+    author_id INTEGER NOT NULL REFERENCES author(id),
+                                    -- => every book MUST have an author -- NOT NULL, not optional
+    publisher_id INTEGER REFERENCES publisher(id),
+                                    -- => publisher is OPTIONAL -- self-published books have none
+    price REAL NOT NULL CHECK (price >= 0)
+                                    -- => co-04 -- the engine itself rejects a negative price
+);
+```
+
+All 5 tables exist after `schema.sql` runs, and `.schema book` confirms `book`'s foreign keys and
+`CHECK` constraint landed exactly as written -- including the inline comments, since SQLite stores the
+original `CREATE TABLE` text verbatim.
+
+## Step 2: `dal.py` -- parameterized CRUD + a `GROUP BY` report, tested with `pytest`
+
+_exercises co-13, co-15, co-19, co-20_
+
+Every function takes an already-open `sqlite3.Connection` -- callers (the CLI, or the `pytest` fixture
+below) own the connection's lifetime, this module never opens or closes one itself -- and every SQL
+string uses `?` placeholders (co-20), the same discipline Example 73's `dal.py` established.
+`report_by_author` reuses Example 79's join-plus-`GROUP BY` shape, minus the `HAVING` filter.
+`tests/test_dal.py` builds its fixture DB from the **real** `schema.sql` and `seed.sql` files on disk
+(via `Path(__file__).parent.parent`), rather than re-typing the schema in Python, so the tests exercise
+the exact same relations, constraints, and seed rows Step 1 verified.
+
+**`learning/capstone/code/dal.py`** (complete file)
+
+```python
+# pyright: strict
+"""Capstone: dal.py -- typed, parameterized data-access layer over schema.sql's tables.
+
+Every function here takes an ALREADY-OPEN sqlite3.Connection -- callers (the CLI, or the
+pytest fixture below) own the connection's lifetime, this module never opens or closes one
+itself. Every SQL string uses `?` placeholders (co-20) -- nothing here is ever string-built
+from untrusted input, which is the whole point of a data-access layer existing at all.
+"""
+
+import sqlite3  # => stdlib DB-API module (co-19) -- no third-party driver anywhere in this file
+
+
+def create_book(
+    conn: sqlite3.Connection, title: str, author_id: int, publisher_id: int | None, price: float
+) -> int:
+    # publisher_id: int | None mirrors schema.sql's OPTIONAL publisher_id FK exactly.
+    cur: sqlite3.Cursor = conn.execute(
+        "INSERT INTO book(title, author_id, publisher_id, price) VALUES (?, ?, ?, ?)",
+        (title, author_id, publisher_id, price),  # => 4 bound parameters, positional order matters
+    )
+    conn.commit()
+    new_id: int | None = cur.lastrowid  # => the rowid SQLite just assigned (co-02)
+    assert new_id is not None  # => narrows int | None to int -- always set right after an INSERT
+    return new_id
+
+
+def get_book(conn: sqlite3.Connection, book_id: int) -> tuple[int, str, int, int | None, float] | None:
+    cur: sqlite3.Cursor = conn.execute(
+        "SELECT id, title, author_id, publisher_id, price FROM book WHERE id = ?", (book_id,)
+    )
+    row: tuple[int, str, int, int | None, float] | None = cur.fetchone()
+    return row  # => None if book_id doesn't exist -- callers must handle the missing case
+
+
+def list_books_by_author(conn: sqlite3.Connection, author_id: int) -> list[tuple[int, str, float]]:
+    cur: sqlite3.Cursor = conn.execute(
+        "SELECT id, title, price FROM book WHERE author_id = ? ORDER BY id", (author_id,)
+    )
+    return cur.fetchall()  # => every book by this ONE author, oldest id first
+
+
+def update_book_price(conn: sqlite3.Connection, book_id: int, new_price: float) -> None:
+    conn.execute("UPDATE book SET price = ? WHERE id = ?", (new_price, book_id))
+    conn.commit()  # => a single-row update commits immediately -- see bulk_update_prices for a batch
+
+
+def delete_book(conn: sqlite3.Connection, book_id: int) -> None:
+    conn.execute("DELETE FROM book WHERE id = ?", (book_id,))
+    conn.commit()  # => ON DELETE CASCADE (schema.sql) also removes this book's book_tag rows
+
+
+def report_by_author(conn: sqlite3.Connection) -> list[tuple[str, int, float]]:
+    # The capstone's reporting aggregation: JOIN + GROUP BY in ONE query (co-15, co-13),
+    # exactly like Example 79's join-group-having report, minus the HAVING filter.
+    cur: sqlite3.Cursor = conn.execute(
+        """
+        SELECT author.name, count(*), sum(book.price)
+        FROM author
+        JOIN book ON book.author_id = author.id
+        GROUP BY author.name
+        ORDER BY author.name
+        """
+    )
+    rows: list[tuple[str, int, float]] = cur.fetchall()
+    return rows  # => [(name, book_count, total_price), ...] -- one row per author WITH books
+
+
+def bulk_update_prices(conn: sqlite3.Connection, updates: list[tuple[int, float]]) -> None:
+    # The capstone's rollback-on-failure transaction (co-18): `with conn:` opens an implicit
+    # transaction on the FIRST write, commits if every update succeeds, and auto-ROLLBACKs
+    # the WHOLE batch the instant any single update violates schema.sql's CHECK(price >= 0).
+    with conn:
+        for book_id, new_price in updates:  # => co-20 -- book_id/new_price stay bound, never spliced
+            conn.execute("UPDATE book SET price = ? WHERE id = ?", (new_price, book_id))
+```
+
+**`learning/capstone/code/tests/__init__.py`** (complete file, empty)
+
+```python
+
+```
+
+(Empty on purpose -- making `tests/` an importable package is what makes `pytest`'s default "prepend"
+import mode insert `learning/capstone/code/` itself into `sys.path`, which is what lets
+`tests/test_dal.py` resolve `from dal import ...`.)
+
+**`learning/capstone/code/tests/test_dal.py`** (complete file)
+
+```python
+"""Capstone: pytest coverage for dal.py, seeded from the SAME schema.sql + seed.sql the CLI uses.
+
+Reading the real .sql files (rather than re-typing the schema in Python) keeps this fixture
+byte-identical to what a reader actually applies with `sqlite3 app.db < schema.sql` -- the
+tests exercise the exact same relations, constraints, and seed rows Step 1 verifies.
+"""
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from dal import (
+    bulk_update_prices,
+    create_book,
+    delete_book,
+    get_book,
+    list_books_by_author,
+    report_by_author,
+    update_book_price,
+)
+
+CODE_DIR: Path = Path(__file__).parent.parent  # => this file lives in tests/, code/ is its parent
+
+
+@pytest.fixture
+def conn() -> Iterator[sqlite3.Connection]:
+    # A FRESH in-memory DB per test, built from the real schema.sql + seed.sql on disk.
+    connection: sqlite3.Connection = sqlite3.connect(":memory:")
+    connection.execute("PRAGMA foreign_keys = ON")  # => matches schema.sql's own PRAGMA line
+    connection.executescript((CODE_DIR / "schema.sql").read_text())
+    connection.executescript((CODE_DIR / "seed.sql").read_text())
+    yield connection
+    connection.close()
+
+
+def test_get_book_returns_seeded_row(conn: sqlite3.Connection) -> None:
+    row: tuple[int, str, int, int | None, float] | None = get_book(conn, 1)
+    assert row == (1, "Notes on the Analytical Engine", 1, 1, 12.5)
+
+
+def test_get_book_missing_id_returns_none(conn: sqlite3.Connection) -> None:
+    assert get_book(conn, 999) is None
+
+
+def test_create_book_with_no_publisher(conn: sqlite3.Connection) -> None:
+    # publisher_id=None exercises the OPTIONAL FK -- exactly like seed.sql's book 3.
+    new_id: int = create_book(conn, "A New Draft", author_id=2, publisher_id=None, price=5.0)
+    assert get_book(conn, new_id) == (new_id, "A New Draft", 2, None, 5.0)
+
+
+def test_list_books_by_author(conn: sqlite3.Connection) -> None:
+    # Author 1 (Ada Lovelace) has exactly 2 seeded books: ids 1 and 2.
+    assert list_books_by_author(conn, 1) == [
+        (1, "Notes on the Analytical Engine", 12.5),
+        (2, "Sketch of the Analytical Engine", 9.0),
+    ]
+
+
+def test_update_book_price(conn: sqlite3.Connection) -> None:
+    update_book_price(conn, 1, 20.0)
+    row: tuple[int, str, int, int | None, float] | None = get_book(conn, 1)
+    assert row is not None
+    assert row[4] == 20.0  # => index 4 is price -- confirms the update actually persisted
+
+
+def test_delete_book_removes_it(conn: sqlite3.Connection) -> None:
+    delete_book(conn, 3)
+    assert get_book(conn, 3) is None
+
+
+def test_report_by_author_matches_hand_computed_values(conn: sqlite3.Connection) -> None:
+    # Hand-computed from seed.sql: Ada has 2 books (12.5 + 9.0 = 21.5), Grace has 1 (15.0).
+    expected: list[tuple[str, int, float]] = [
+        ("Ada Lovelace", 2, 21.5),
+        ("Grace Hopper", 1, 15.0),
+    ]
+    assert report_by_author(conn) == expected
+
+
+def test_bulk_update_prices_commits_when_all_succeed(conn: sqlite3.Connection) -> None:
+    bulk_update_prices(conn, [(1, 13.0), (2, 10.0)])
+    assert list_books_by_author(conn, 1) == [
+        (1, "Notes on the Analytical Engine", 13.0),
+        (2, "Sketch of the Analytical Engine", 10.0),
+    ]
+
+
+def test_bulk_update_prices_rolls_back_the_whole_batch_on_failure(conn: sqlite3.Connection) -> None:
+    before: list[tuple[int, str, float]] = list_books_by_author(conn, 1)  # => baseline, both books
+
+    # book 1's price update is VALID; book 2's -1.0 violates CHECK(price >= 0) -- the WHOLE
+    # batch must roll back, including the (already-applied) valid update to book 1.
+    with pytest.raises(sqlite3.IntegrityError):
+        bulk_update_prices(conn, [(1, 99.0), (2, -1.0)])
+
+    after: list[tuple[int, str, float]] = list_books_by_author(conn, 1)
+    assert before == after  # => book 1's price is UNCHANGED too -- no partial write survived
+```
+
+**Verify**
+
+```text
+$ pytest -q
+.........                                                                [100%]
+9 passed in 0.02s
+$ pyright dal.py
+0 errors, 0 warnings, 0 informations
+```
+
+All 9 tests pass against the real, on-disk `schema.sql` + `seed.sql` fixture -- including
+`test_report_by_author_matches_hand_computed_values`, which checks `report_by_author`'s `JOIN` +
+`GROUP BY` output against numbers computed by hand from `seed.sql`.
+
+## Step 3: a transaction that partially fails and rolls back
+
+_exercises co-18_
+
+`bulk_update_prices` wraps every update in a `with conn:` block (Example 80's exact pattern): the
+first update in a batch can succeed, but if a later update in the **same** batch violates `schema.sql`'s
+`CHECK (price >= 0)`, the whole batch -- including the already-applied, individually-valid update --
+rolls back together. `demo_bulk_update.py` runs this end to end against a real on-disk database file
+built from `schema.sql` + `seed.sql`, capturing the database's state before and after the failure.
+
+**`learning/capstone/code/demo_bulk_update.py`** (complete file)
+
+```python
+# pyright: strict
+"""Capstone: demo_bulk_update.py -- proves a partially-failing batch leaves every row
+untouched (co-18), against a real on-disk database built from schema.sql + seed.sql.
+
+This is a runnable demonstration for Step 3 of the capstone walkthrough -- the same
+rollback behavior test_bulk_update_prices_rolls_back_the_whole_batch_on_failure asserts
+in tests/test_dal.py, shown here end to end against a real file, not an in-memory fixture.
+"""
+
+import sqlite3
+from pathlib import Path
+
+from dal import bulk_update_prices, list_books_by_author
+
+CODE_DIR: Path = Path(__file__).parent  # => this script's own directory -- schema.sql/seed.sql live here
+DB_PATH: Path = CODE_DIR / "demo.db"  # => a throwaway file, rebuilt fresh on every run
+
+
+def main() -> None:
+    DB_PATH.unlink(missing_ok=True)  # => deletes any leftover demo.db from a prior run first
+    conn: sqlite3.Connection = sqlite3.connect(DB_PATH)  # => a real on-disk file, not :memory:
+    conn.execute("PRAGMA foreign_keys = ON")  # => matches schema.sql's own PRAGMA line
+    conn.executescript((CODE_DIR / "schema.sql").read_text())  # => applies the 4-table 3NF design
+    conn.executescript((CODE_DIR / "seed.sql").read_text())  # => applies the same seed rows as Step 1
+
+    before: list[tuple[int, str, float]] = list_books_by_author(conn, 1)  # => Ada's 2 seeded books
+    print("before:", before)  # => the baseline this script proves is preserved below
+
+    try:
+        # book 1's price update is VALID; book 2's -1.0 violates CHECK(price >= 0) in schema.sql.
+        bulk_update_prices(conn, [(1, 99.0), (2, -1.0)])  # => `with conn:` inside rolls back BOTH
+    except sqlite3.IntegrityError as err:  # => the CHECK violation surfaces as this exact error type
+        print("caught:", err)  # => confirms the failure was DETECTED, not silently swallowed
+
+    after: list[tuple[int, str, float]] = list_books_by_author(conn, 1)  # => re-reads the SAME rows
+    print("after:", after)  # => compared against `before` on the next line
+    print("unchanged:", before == after)  # => True proves book 1's VALID update never persisted either
+    conn.close()  # => releases the connection -- demo.db itself is left on disk for inspection
+
+
+if __name__ == "__main__":  # => guards main() so importing this module never runs it
+    main()  # => runs the whole demonstration end to end
+```
+
+**Verify**
+
+```text
+$ python3 demo_bulk_update.py
+before: [(1, 'Notes on the Analytical Engine', 12.5), (2, 'Sketch of the Analytical Engine', 9.0)]
+caught: CHECK constraint failed: price >= 0
+after: [(1, 'Notes on the Analytical Engine', 12.5), (2, 'Sketch of the Analytical Engine', 9.0)]
+unchanged: True
+$ pyright .
+0 errors, 0 warnings, 0 informations
+```
+
+`before` and `after` are identical -- book 1's individually-valid price update (`99.0`) never persisted
+either, because it shared a transaction with book 2's `CHECK`-violating update. `unchanged: True` is the
+same all-or-nothing guarantee `tests/test_dal.py`'s
+`test_bulk_update_prices_rolls_back_the_whole_batch_on_failure` already proved, shown here against a
+real database file instead of an in-memory fixture.
+
+## Step 4: `migrate_add_column.sql` -- an additive migration, applied last
+
+_exercises co-22, co-24_
+
+Applied against the **same** database `schema.sql` and `seed.sql` already populated in Step 1 -- not a
+fresh one -- `migrate_add_column.sql` adds an `edition` column with a `DEFAULT`, following Example 59's
+exact pattern, and proves all 3 pre-existing book rows still read back correctly afterward.
+
+**`learning/capstone/code/migrate_add_column.sql`** (complete file)
+
+```sql
+-- Capstone: migrate_add_column.sql -- an additive migration, Example 59's exact pattern (co-22),
+-- applied AFTER schema.sql + seed.sql have already populated book with 3 rows.
+ALTER TABLE book ADD COLUMN edition INTEGER DEFAULT 1;
+                                    -- => no table rewrite, no downtime -- existing rows read DEFAULT
+
+.headers on
+.mode column
+SELECT id, title, price, edition FROM book;
+                                    -- => all 3 pre-existing rows show edition = 1 -- none broke
+```
+
+**Verify**
+
+```text
+$ sqlite3 app.db < migrate_add_column.sql
+id  title                            price  edition
+--  -------------------------------  -----  -------
+1   Notes on the Analytical Engine   12.5   1
+2   Sketch of the Analytical Engine  9.0    1
+3   The First Computer Bug           15.0   1
+```
+
+All 3 rows seeded back in Step 1 -- including book 3, which has no publisher -- read back with
+`edition = 1`. No row was dropped, and no row came back `NULL`, confirming the migration is safe to run
+against a database that already has real data in it.
+
+## Acceptance criteria
+
+- `pytest -q` reports `9 passed` against `tests/test_dal.py`, covering every CRUD function, the
+  optional-`publisher_id` path, `report_by_author`, and both the success and rollback paths of
+  `bulk_update_prices`.
+- `report_by_author`'s output matches the hand-computed expected values from `seed.sql`: Ada Lovelace
+  has 2 books totaling `21.5`, Grace Hopper has 1 book totaling `15.0`.
+- `demo_bulk_update.py` proves the rollback leaves no partial write: `before == after` for every
+  account row involved in the failed batch, and the CLI's own exit is clean (the `IntegrityError` is
+  caught, not left to crash the script).
+- No query anywhere in `dal.py`, `demo_bulk_update.py`, or `tests/test_dal.py` uses string
+  interpolation to build SQL -- every value is bound through a `?` placeholder (co-20).
+- `migrate_add_column.sql` runs cleanly against the already-seeded database from Step 1, and every
+  pre-existing row -- including the one with a `NULL` `publisher_id` -- still reads back valid.
+- `pyright dal.py` and `pyright .` (run from inside `learning/capstone/code/`) both report `0 errors, 0
+warnings, 0 informations`.
+- Every listing on this page (`schema.sql`, `seed.sql`, `dal.py`, `tests/__init__.py`,
+  `tests/test_dal.py`, `demo_bulk_update.py`, `migrate_add_column.sql`) is the complete file, runnable
+  exactly as shown -- nothing here is a fragment that depends on code the page does not also show.
+
+## Done bar
+
+This capstone is runnable end to end: a reader who copies the files above into a
+`learning/capstone/code/`-shaped tree, applies `schema.sql` then `seed.sql` with the `sqlite3` CLI, runs
+`pytest -q`, runs `demo_bulk_update.py`, and finally applies `migrate_add_column.sql` reaches the
+identical output blocks shown in Steps 1 through 4, verified against a real SQLite 3.53.3 engine and a
+real CPython interpreter run (not merely described). Every mechanism combined here -- a 3NF schema with
+PK/FK constraints (co-01, co-05, co-07), parameterized CRUD (co-19, co-20), a `JOIN` + `GROUP BY` report
+(co-13, co-15), a `with conn:` rollback-on-failure transaction (co-18), and a safe additive migration
+(co-22, co-24) -- traces to a primary source already cited in this topic's Accuracy notes; no new fact
+was needed to write this page.
+
+---
+
+← Previous: [Advanced Examples](../advanced.md)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-01-create-author-table/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-01-create-author-table/example.sql
@@ -1,0 +1,11 @@
+-- Example 1: Create Author Table.
+-- CREATE TABLE declares a new relation (co-07): a name, a column list, and constraints.
+CREATE TABLE author(
+    id INTEGER PRIMARY KEY,        -- => INTEGER PRIMARY KEY aliases SQLite's rowid (co-02)
+                                    -- => the engine auto-assigns this on insert -- no id needed
+    name TEXT NOT NULL             -- => TEXT column; NOT NULL forbids a missing name value
+);
+
+-- .schema prints the stored definition back verbatim -- proof of what the engine kept.
+-- NOTE: dot-commands take the rest of their line as arguments -- no trailing "--" comment here.
+.schema author

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-02-open-database-cli/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-02-open-database-cli/example.sql
@@ -1,0 +1,6 @@
+-- Example 2: Open Database CLI. Dot-commands take the rest of their line as
+-- arguments, so comments here live on their own separate line.
+.databases
+-- => lists attached databases -- shows "main: <path-to-app.db> r/w"
+.tables
+-- => lists table names -- empty: a fresh database starts with zero tables

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-03-insert-single-row/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-03-insert-single-row/example.sql
@@ -1,0 +1,15 @@
+-- Example 3: Insert Single Row.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => author table exists, currently empty (0 rows)
+
+-- INSERT INTO ... VALUES (co-10) adds exactly one new row to the relation.
+INSERT INTO author(name) VALUES('Ada');
+                                    -- => id is omitted -- INTEGER PRIMARY KEY auto-assigns 1
+                                    -- => author now holds exactly one row: (1, 'Ada')
+
+-- dot-commands take the rest of their line as arguments -- comments live on their own line.
+.headers on
+-- => turns on a column-name header row for readability
+.mode column
+-- => aligns SELECT output into fixed-width columns
+SELECT * FROM author;              -- => projects every column of every row -- confirms one row

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-04-insert-multiple-rows/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-04-insert-multiple-rows/example.sql
@@ -1,0 +1,15 @@
+-- Example 4: Insert Multiple Rows.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => author table exists, ready for a bulk insert
+
+-- One INSERT statement, three comma-separated value tuples (co-10) -- a single
+-- round-trip to the engine instead of three separate INSERT statements.
+INSERT INTO author(name) VALUES
+    ('Ada Lovelace'),               -- => row 1: id auto-assigns to 1
+    ('Grace Hopper'),                -- => row 2: id auto-assigns to 2
+    ('Alan Turing');                 -- => row 3: id auto-assigns to 3
+
+.headers on
+.mode column
+-- => the pair above produces an aligned, headered table for readability
+SELECT count(*) FROM author;        -- => count(*) counts every row -- confirms all 3 landed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-05-select-all-columns/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-05-select-all-columns/example.sql
@@ -1,0 +1,13 @@
+-- Example 5: Select All Columns.
+-- SELECT * (co-08) projects every declared column, in declaration order.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty (0 rows)
+INSERT INTO book(id, title, price, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 34.99, 1),  -- => row 1: author_id 1
+    (2, 'Clean Code', 29.99, 1),                -- => row 2: same author_id 1
+    (3, 'The Mythical Man-Month', 24.5, 2);       -- => row 3: a different author_id
+                                    -- => book now holds 3 rows across 4 columns each
+
+.headers on
+.mode column
+SELECT * FROM book;                -- => returns all 3 rows, all 4 columns -- the full relation

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-06-select-projection/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-06-select-projection/example.sql
@@ -1,0 +1,13 @@
+-- Example 6: Select Projection.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 34.99, 1),  -- => row 1
+    (2, 'Clean Code', 29.99, 1),                -- => row 2
+    (3, 'The Mythical Man-Month', 24.5, 2);       -- => row 3
+
+.headers on
+.mode column
+-- Naming one column instead of * (co-08) is projection -- fewer columns come back,
+-- same number of rows. price/author_id never leave the engine for this query.
+SELECT title FROM book;            -- => returns only the title column, all 3 rows

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-07-where-equality/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-07-where-equality/example.sql
@@ -1,0 +1,13 @@
+-- Example 7: Where Equality.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 34.99, 1),  -- => id 1
+    (2, 'Clean Code', 29.99, 1),                -- => id 2
+    (3, 'The Mythical Man-Month', 24.5, 2);       -- => id 3
+
+-- turn on headers + column alignment so the result below reads as a table
+.headers on
+.mode column
+-- WHERE selects rows (co-08) -- = tests exact equality, evaluated per row before output.
+SELECT * FROM book WHERE id = 1;   -- => keeps only the row whose id equals 1 -- exactly one row

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-08-where-comparison/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-08-where-comparison/example.sql
@@ -1,0 +1,14 @@
+-- Example 8: Where Comparison.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 34.99, 1),  -- => price above the threshold below
+    (2, 'Clean Code', 29.99, 1),                -- => price above the threshold below
+    (3, 'The Mythical Man-Month', 24.5, 2);       -- => price BELOW the threshold below
+
+.headers on
+.mode column
+-- > is a comparison operator (co-08) -- keeps rows where the predicate is true.
+SELECT * FROM book WHERE price > 25;
+                                    -- => 34.99 and 29.99 pass the threshold; 24.5 does not
+                                    -- => returns 2 rows (ids 1, 2), excludes id 3

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-09-where-and-or/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-09-where-and-or/example.sql
@@ -1,0 +1,15 @@
+-- Example 9: Where And Or.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 34.99, 1),  -- => passes both conditions below
+    (2, 'Clean Code', 29.99, 1),                -- => passes both conditions below
+    (3, 'The Mythical Man-Month', 24.5, 2),      -- => fails author_id = 1
+    (4, 'Cheap Notes', 5.0, 1);                   -- => fails price > 10
+
+.headers on
+.mode column
+-- AND (co-08) keeps a row only when BOTH predicates evaluate true for that row.
+SELECT * FROM book WHERE price > 10 AND author_id = 1;
+                                    -- => id 3 excluded by author_id, id 4 excluded by price
+                                    -- => returns exactly ids 1 and 2

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-10-where-like-prefix/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-10-where-like-prefix/example.sql
@@ -1,0 +1,14 @@
+-- Example 10: Where Like Prefix.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 34.99, 1),  -- => title starts with "The "
+    (2, 'Clean Code', 29.99, 1),                -- => title does NOT start with "The "
+    (3, 'The Mythical Man-Month', 24.5, 2);       -- => title starts with "The "
+
+.headers on
+.mode column
+-- LIKE (co-08) pattern-matches text -- % is a wildcard for zero-or-more characters.
+SELECT * FROM book WHERE title LIKE 'The %';
+                                    -- => matches any title starting with the literal "The "
+                                    -- => returns ids 1 and 3; "Clean Code" does not match

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-11-where-in-set/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-11-where-in-set/example.sql
@@ -1,0 +1,14 @@
+-- Example 11: Where In Set.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 34.99, 1),  -- => id in the set below
+    (2, 'Clean Code', 29.99, 1),                -- => id NOT in the set below
+    (3, 'The Mythical Man-Month', 24.5, 2);       -- => id in the set below
+
+.headers on
+.mode column
+-- IN (co-08) tests set membership -- shorthand for chained OR-equality checks.
+SELECT * FROM book WHERE id IN (1, 3);
+                                    -- => keeps rows whose id matches ANY value in the list
+                                    -- => returns ids 1 and 3, skips id 2

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-12-order-by-ascending/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-12-order-by-ascending/example.sql
@@ -1,0 +1,14 @@
+-- Example 12: Order By Ascending.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price) VALUES
+    (1, 'The Pragmatic Programmer', 34.99),  -- => stored first, but storage order != output order
+    (2, 'Clean Code', 29.99),                -- => stored second
+    (3, 'The Mythical Man-Month', 24.5);       -- => stored third
+
+-- turn on headers + column alignment so the sorted result reads as a table
+.headers on
+.mode column
+-- ORDER BY (co-09) sorts the result set; ASC (the default) sorts low-to-high / A-to-Z.
+SELECT * FROM book ORDER BY title ASC;
+                                    -- => "Clean Code" sorts before "The..." titles alphabetically

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-13-order-by-descending/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-13-order-by-descending/example.sql
@@ -1,0 +1,14 @@
+-- Example 13: Order By Descending.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price) VALUES
+    (1, 'The Pragmatic Programmer', 34.99),  -- => the most expensive row
+    (2, 'Clean Code', 29.99),                -- => the middle-priced row
+    (3, 'The Mythical Man-Month', 24.5);       -- => the cheapest row
+
+.headers on
+.mode column
+-- DESC (co-09) reverses the sort direction -- highest value first, most useful
+-- for "most expensive first" or "most recent first" style reports.
+SELECT * FROM book ORDER BY price DESC;
+                                    -- => 34.99, then 29.99, then 24.5 -- strictly decreasing

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-14-limit-rows/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-14-limit-rows/example.sql
@@ -1,0 +1,13 @@
+-- Example 14: Limit Rows.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price) VALUES
+    (1, 'The Pragmatic Programmer', 34.99),  -- => row 1 -- kept by LIMIT 2 below
+    (2, 'Clean Code', 29.99),                -- => row 2 -- kept by LIMIT 2 below
+    (3, 'The Mythical Man-Month', 24.5);       -- => row 3 -- cut off by LIMIT 2 below
+
+.headers on
+.mode column
+-- LIMIT (co-09) caps the row count the engine returns -- evaluated AFTER ORDER BY,
+-- so pair it with ORDER BY whenever "first N" needs to mean something specific.
+SELECT * FROM book LIMIT 2;        -- => stops after 2 rows even though 3 rows match overall

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-15-limit-offset-paging/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-15-limit-offset-paging/example.sql
@@ -1,0 +1,15 @@
+-- Example 15: Limit Offset Paging.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price) VALUES
+    (1, 'The Pragmatic Programmer', 34.99),  -- => page 1 -- skipped by OFFSET 2 below
+    (2, 'Clean Code', 29.99),                -- => page 1 -- skipped by OFFSET 2 below
+    (3, 'The Mythical Man-Month', 24.5),      -- => page 2 -- returned below
+    (4, 'Refactoring', 39.99);                 -- => page 2 -- returned below
+
+.headers on
+.mode column
+-- OFFSET (co-09) skips N rows before LIMIT starts counting -- the standard
+-- "page 2 of results" pattern: page size 2, OFFSET 2 skips page 1's rows.
+SELECT * FROM book ORDER BY id LIMIT 2 OFFSET 2;
+                                    -- => skips ids 1-2 (page 1), returns ids 3-4 (page 2)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-16-select-distinct/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-16-select-distinct/example.sql
@@ -1,0 +1,14 @@
+-- Example 16: Select Distinct.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, author_id) VALUES
+    (1, 'The Pragmatic Programmer', 1),  -- => author_id 1 -- first occurrence
+    (2, 'Clean Code', 1),                -- => author_id 1 -- a duplicate value
+    (3, 'The Mythical Man-Month', 2);      -- => author_id 2 -- first occurrence
+
+-- turn on headers + column alignment so the result below reads as a table
+.headers on
+.mode column
+-- DISTINCT (co-08) collapses duplicate result rows -- here, two books share author_id 1.
+SELECT DISTINCT author_id FROM book;
+                                    -- => 3 input rows collapse to 2 distinct author_id values

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-17-type-affinity/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-17-type-affinity/example.sql
@@ -1,0 +1,12 @@
+-- Example 17: Type Affinity.
+-- SQLite uses type AFFINITY (co-06), not rigid enforcement -- a declared type is a
+-- storage-class preference the engine tries to honor, not a hard runtime barrier.
+CREATE TABLE demo(n INTEGER);
+
+-- '42' is a TEXT literal, but the column's INTEGER affinity converts it on insert.
+INSERT INTO demo(n) VALUES('42');   -- => the string '42' gets stored as the integer 42
+
+.headers on
+.mode column
+-- typeof() reveals the ACTUAL storage class the engine chose, not the declared type.
+SELECT n, typeof(n) FROM demo;     -- => typeof(n) reports "integer" -- affinity coerced it

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-18-not-null-constraint/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-18-not-null-constraint/example.sql
@@ -1,0 +1,12 @@
+-- Example 18: Not Null Constraint.
+-- NOT NULL (co-04) is an invariant the engine enforces on EVERY write, not a suggestion.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+
+-- This INSERT explicitly supplies NULL for a column the schema forbids NULL on.
+INSERT INTO author(name) VALUES(NULL);
+                                    -- => the engine rejects the write before it commits
+                                    -- => raises: NOT NULL constraint failed: author.name
+
+.headers on
+.mode column
+SELECT count(*) FROM author;       -- => confirms the rejected row never landed -- table stays empty

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-19-unique-constraint/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-19-unique-constraint/example.sql
@@ -1,0 +1,15 @@
+-- Example 19: Unique Constraint.
+-- UNIQUE (co-04) forbids two rows from sharing the same value in that column.
+CREATE TABLE author(id INTEGER PRIMARY KEY, email TEXT UNIQUE);
+
+INSERT INTO author(email) VALUES('ada@example.com');
+                                    -- => first insert succeeds -- no prior row to conflict with
+
+-- Same email value again -- the UNIQUE index the engine built now blocks this write.
+INSERT INTO author(email) VALUES('ada@example.com');
+                                    -- => the engine rejects the duplicate before it commits
+                                    -- => raises: UNIQUE constraint failed: author.email
+
+.headers on
+.mode column
+SELECT count(*) FROM author;       -- => confirms exactly one row survived -- the duplicate never landed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-20-default-value/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-20-default-value/example.sql
@@ -1,0 +1,11 @@
+-- Example 20: Default Value.
+-- DEFAULT (co-04) supplies a value automatically when an INSERT omits that column.
+CREATE TABLE account(id INTEGER PRIMARY KEY, status TEXT DEFAULT 'active');
+
+-- This INSERT lists only id -- status is left out entirely, not set to NULL.
+INSERT INTO account(id) VALUES(1);
+                                    -- => the engine substitutes 'active' for the missing column
+
+.headers on
+.mode column
+SELECT * FROM account;             -- => status shows 'active' even though we never wrote it

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-21-check-constraint/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-21-check-constraint/example.sql
@@ -1,0 +1,12 @@
+-- Example 21: Check Constraint.
+-- CHECK (co-04) enforces an arbitrary boolean expression on every write to that row.
+CREATE TABLE book(id INTEGER PRIMARY KEY, price REAL CHECK(price >= 0));
+
+-- -5 violates price >= 0 -- a business invariant the schema itself now guarantees.
+INSERT INTO book(price) VALUES(-5);
+                                    -- => the engine evaluates CHECK(price >= 0) as false
+                                    -- => raises: CHECK constraint failed: price >= 0
+
+.headers on
+.mode column
+SELECT count(*) FROM book;         -- => confirms the rejected row never landed -- table stays empty

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-22-autoincrement-rowid/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-22-autoincrement-rowid/example.sql
@@ -1,0 +1,13 @@
+-- Example 22: Autoincrement Rowid.
+-- INTEGER PRIMARY KEY aliases rowid (co-02) -- omitting it lets SQLite pick the next value.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => author table exists, currently empty
+
+INSERT INTO author(name) VALUES('Ada');
+                                    -- => no id supplied -- engine auto-assigns id = 1
+INSERT INTO author(name) VALUES('Grace');
+                                    -- => engine auto-assigns id = 2 (one higher than the max so far)
+
+.headers on
+.mode column
+SELECT * FROM author;              -- => ids came from the engine, not from us: 1, then 2

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-23-update-one-row/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-23-update-one-row/example.sql
@@ -1,0 +1,15 @@
+-- Example 23: Update One Row.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, price) VALUES
+    (1, 'The Pragmatic Programmer', 34.99),  -- => the row the WHERE clause below will match
+    (2, 'Clean Code', 29.99);                  -- => not matched -- stays untouched below
+
+-- UPDATE ... SET ... WHERE (co-11) mutates only the rows the WHERE clause matches.
+UPDATE book SET price = 15 WHERE id = 1;
+                                    -- => only the row with id = 1 changes -- id 2 is untouched
+
+-- turn on headers + column alignment so the result below reads as a table
+.headers on
+.mode column
+SELECT * FROM book;                -- => id 1 now shows 15.0, id 2 still shows its original 29.99

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-24-update-all-rows/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-24-update-all-rows/example.sql
@@ -1,0 +1,15 @@
+-- Example 24: Update All Rows.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, in_stock INTEGER NOT NULL DEFAULT 0);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title, in_stock) VALUES
+    (1, 'The Pragmatic Programmer', 0),  -- => starts out of stock
+    (2, 'Clean Code', 0);                  -- => starts out of stock
+
+-- No WHERE clause (co-11) means the predicate is implicitly "true for every row" --
+-- UPDATE touches the entire table. This is easy to do by accident -- always double-check.
+UPDATE book SET in_stock = 1;
+                                    -- => every row's in_stock flips from 0 to 1, no exceptions
+
+.headers on
+.mode column
+SELECT * FROM book;                -- => both rows now show in_stock = 1

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-25-delete-row/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-25-delete-row/example.sql
@@ -1,0 +1,16 @@
+-- Example 25: Delete Row.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL);
+                                    -- => book table exists, currently empty
+INSERT INTO book(id, title) VALUES
+    (1, 'The Pragmatic Programmer'),  -- => survives the DELETE below
+    (2, 'Clean Code'),                  -- => targeted by the DELETE below
+    (3, 'The Mythical Man-Month');       -- => survives the DELETE below
+
+-- DELETE FROM ... WHERE (co-12) removes only the matching rows -- the table stays.
+DELETE FROM book WHERE id = 2;     -- => row id 2 is gone permanently; ids 1 and 3 remain
+
+-- turn on headers + column alignment so the result below reads as a table
+.headers on
+.mode column
+SELECT * FROM book;                -- => only ids 1 and 3 remain, in that order
+SELECT count(*) FROM book;         -- => count drops from 3 to 2 -- exactly one row removed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-26-declare-foreign-key/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-26-declare-foreign-key/example.sql
@@ -1,0 +1,15 @@
+-- Example 26: Declare Foreign Key.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => author table exists -- the FK below will point at it
+
+-- REFERENCES (co-03) declares that book.author_id must point at a real author.id --
+-- a static, self-documenting invariant that lives in the schema itself.
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,        -- => book's own primary key
+    title TEXT NOT NULL,           -- => every book must have a title
+    author_id INTEGER REFERENCES author(id)
+                                    -- => declares the FK -- enforcement is a SEPARATE step (Example 27)
+);
+
+-- .schema prints back the stored definition -- proof the REFERENCES clause was kept.
+.schema book

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-27-enforce-foreign-key/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-27-enforce-foreign-key/example.sql
@@ -1,0 +1,22 @@
+-- Example 27: Enforce Foreign Key.
+-- CRITICAL: foreign keys are OFF by default in SQLite -- this pragma must run per
+-- connection, every time, or REFERENCES clauses are decoration only (co-03).
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => author table exists, currently empty -- no id 99 in it
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,        -- => book's own primary key
+    title TEXT NOT NULL,           -- => every book must have a title
+    author_id INTEGER REFERENCES author(id)
+    -- => REFERENCES alone does nothing without the PRAGMA above -- both are required
+);
+
+-- author_id 99 does not exist in the author table -- an orphan reference.
+INSERT INTO book(title, author_id) VALUES('Ghost Book', 99);
+                                    -- => with the pragma ON, the engine checks the reference first
+                                    -- => raises: FOREIGN KEY constraint failed
+
+.headers on
+.mode column
+SELECT count(*) FROM book;         -- => confirms the rejected row never landed -- table stays empty

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-28-inner-join-two-tables/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-28-inner-join-two-tables/example.sql
@@ -1,0 +1,22 @@
+-- Example 28: Inner Join Two Tables.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => author table exists, currently empty
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER REFERENCES author(id));
+                                    -- => book table exists, currently empty
+INSERT INTO author(id, name) VALUES
+    (1, 'Ada Lovelace'),            -- => referenced by book row 1 below
+    (2, 'Grace Hopper');             -- => referenced by book row 2 below
+INSERT INTO book(title, author_id) VALUES
+    ('Notes on the Analytical Engine', 1),  -- => author_id 1 -- pairs with Ada Lovelace
+    ('Compilers and Computers', 2);           -- => author_id 2 -- pairs with Grace Hopper
+
+-- turn on headers + column alignment so the joined result reads as a table
+.headers on
+.mode column
+-- JOIN ... ON (co-13) recombines normalized data -- matches book.author_id to author.id,
+-- row by row, and only rows with a match on BOTH sides appear in the output.
+SELECT book.title, author.name
+FROM book                          -- => the left side of the join -- one row per book
+JOIN author ON book.author_id = author.id;
+                                    -- => the ON clause -- the exact key equality the join tests
+                                    -- => each book row pairs with exactly its own author's name

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-29-python-connect-and-query/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-29-python-connect-and-query/example.py
@@ -1,0 +1,41 @@
+# pyright: strict
+"""Example 29: Python Connect And Query."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed (co-19)
+
+
+def fetch_authors(
+    conn: sqlite3.Connection,
+) -> list[tuple[int, str]]:  # => a reusable helper
+    # => typed signature (DD-39): takes a Connection, returns a list of (int, str) tuples
+    """Return every author row as (id, name) tuples, ordered by id."""
+    cur: sqlite3.Cursor = conn.cursor()  # => a Cursor runs statements against conn
+    cur.execute("SELECT id, name FROM author ORDER BY id")
+    # => sends the SQL text to the engine -- nothing is fetched into Python yet
+    rows: list[tuple[int, str]] = cur.fetchall()
+    # => fetchall() (co-21) pulls every remaining row as a list of tuples at once
+    return rows  # => hands the fully-materialized list back to the caller
+
+
+def main() -> None:  # => the script's entry point
+    conn: sqlite3.Connection = sqlite3.connect(":memory:")
+    # => connect() (co-19) opens a Connection -- ":memory:" avoids touching disk here
+    cur: sqlite3.Cursor = conn.cursor()  # => a cursor scoped to this connection
+    cur.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+    # => same DDL as the CLI examples -- Python drives the identical SQL engine
+    cur.execute(  # => passes a single multi-value INSERT string
+        "INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper')"
+    )  # => inserts 2 rows in one round-trip
+    conn.commit()  # => commit() (co-19) makes the write durable and visible
+
+    rows: list[tuple[int, str]] = fetch_authors(conn)
+    # => calls the typed helper above -- rows is [(1, 'Ada Lovelace'), (2, 'Grace Hopper')]
+    for row in rows:  # => iterates the list of (id, name) tuples
+        print(row)  # => Output: (1, 'Ada Lovelace') then (2, 'Grace Hopper')
+
+    conn.close()  # => releases the connection's resources
+    # => always close what you open -- especially before the process exits
+
+
+if __name__ == "__main__":  # => guards against running main() on `import example`
+    main()  # => entry point -- runs everything above when executed as a script

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-30-python-parameterized-insert/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-30-python-parameterized-insert/example.py
@@ -1,0 +1,45 @@
+# pyright: strict
+"""Example 30: Python Parameterized Insert."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed (co-19)
+
+
+def insert_author(conn: sqlite3.Connection, name: str) -> int:  # => a reusable helper
+    # => typed signature (DD-39): takes a Connection and a str, returns the new row's id
+    """Insert one author by name using a ?-placeholder and return its new id."""
+    cur: sqlite3.Cursor = conn.cursor()  # => a cursor scoped to this connection
+    cur.execute("INSERT INTO author(name) VALUES (?)", (name,))
+    # => ? is a positional placeholder (co-20) -- name is bound as DATA, never as SQL text
+    conn.commit()  # => makes the insert durable before we report success
+    new_id: int = cur.lastrowid if cur.lastrowid is not None else -1
+    # => lastrowid is the rowid the engine just assigned -- Optional[int], so we narrow it
+    return new_id  # => hands the concrete int id back to the caller
+
+
+def main() -> None:  # => the script's entry point
+    conn: sqlite3.Connection = sqlite3.connect(":memory:")
+    # => a fresh in-memory database for this script run
+    conn.execute("CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+    # => execute() on the Connection directly, without a separate cursor object
+
+    # A value containing SQL syntax -- proves the placeholder binds it as DATA, not code.
+    name: str = "Ada Lovelace; DROP TABLE author;--"
+    # => if this string were interpolated into raw SQL text, it would drop the table
+    new_id: int = insert_author(conn, name)
+    # => calls the typed helper above -- the ? placeholder neutralizes the injection attempt
+    print(f"inserted id={new_id}")  # => Output: inserted id=1
+
+    cur: sqlite3.Cursor = conn.cursor()  # => a fresh cursor to verify the stored row
+    cur.execute(
+        "SELECT id, name FROM author"
+    )  # => reads the table back to prove it survived
+    rows: list[tuple[int, str]] = cur.fetchall()
+    # => rows is [(1, 'Ada Lovelace; DROP TABLE author;--')] -- table still exists, untouched
+    for row in rows:  # => iterates the single result row
+        print(row)  # => Output: (1, 'Ada Lovelace; DROP TABLE author;--')
+
+    conn.close()  # => releases the connection's resources
+
+
+if __name__ == "__main__":  # => guards against running main() on `import example`
+    main()  # => entry point -- runs everything above when executed as a script

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-31-left-join-unmatched/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-31-left-join-unmatched/example.sql
@@ -1,0 +1,43 @@
+-- Example 31: Left Join Unmatched
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands (CLI-only, no trailing comment allowed on their own line):
+-- print column headers, align into columns, and spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+-- Schema: author (parent) and book (child, referencing author via author_id).
+CREATE TABLE author (                          -- => parent table -- referenced by book below
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned on insert
+  name TEXT NOT NULL,                         -- => every author needs a name
+  country TEXT                                -- => nullable -- not used in this example
+);
+
+CREATE TABLE book (                            -- => child table -- author_id links back up
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned on insert
+  title TEXT NOT NULL,                        -- => every book needs a title
+  author_id INTEGER REFERENCES author(id)     -- => FK -- not enforced without PRAGMA foreign_keys=ON
+);
+
+-- 4 authors -- Margaret Hamilton (id 4) deliberately has ZERO books below.
+INSERT INTO author (id, name, country) VALUES
+  (1, 'Ada Lovelace', 'UK'),                  -- => author 1 -- has 1 book below
+  (2, 'Grace Hopper', 'US'),                  -- => author 2 -- has 2 books below
+  (3, 'Alan Turing', 'UK'),                   -- => author 3 -- has 2 books below
+  (4, 'Margaret Hamilton', 'US');              -- => no book row references author_id 4
+
+-- Only 5 books, spread across authors 1-3 -- author 4 is never referenced.
+INSERT INTO book (id, title, author_id) VALUES
+  (1, 'Notes on the Analytical Engine', 1),   -- => author_id 1
+  (2, 'Introduction to Computing', 2),        -- => author_id 2
+  (3, 'Compilers and Common Sense', 2),       -- => author_id 2, same author as row above
+  (4, 'On Computable Numbers', 3),            -- => author_id 3
+  (5, 'The Enigma Papers', 3);                -- => author_id 3, same author as row above
+
+-- An INNER JOIN here would silently DROP Margaret Hamilton -- she has no match.
+-- LEFT JOIN keeps every row from the LEFT table (author), regardless of a match.
+SELECT author.name, book.title                -- => columns pulled from BOTH tables
+FROM author                                    -- => left table -- every row is kept
+LEFT JOIN book ON book.author_id = author.id   -- => right side (book) may be all-NULL per row
+ORDER BY author.id;                             -- => deterministic, stable row order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-32-join-with-aliases/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-32-join-with-aliases/example.sql
@@ -1,0 +1,35 @@
+-- Example 32: Join with Aliases
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE author (                          -- => parent table -- referenced by book below
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  name TEXT NOT NULL                          -- => author's name, required
+);
+
+CREATE TABLE book (                            -- => child table -- author_id links back up
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER REFERENCES author(id)     -- => FK, matched against author.id below
+);
+
+INSERT INTO author (id, name) VALUES           -- => 2 authors, joined against book below
+  (1, 'Ada Lovelace'),                        -- => author 1 -- has 1 book below
+  (2, 'Grace Hopper');                        -- => author 2 -- has 2 books below
+
+INSERT INTO book (id, title, author_id) VALUES -- => 3 books, referencing the 2 authors above
+  (1, 'Notes on the Analytical Engine', 1),   -- => author_id 1
+  (2, 'Introduction to Computing', 2),        -- => author_id 2
+  (3, 'Compilers and Common Sense', 2);       -- => author_id 2, same author as row above
+
+-- Same query as Example 31's join, written with table aliases -- `b` and `a`.
+-- Aliases shorten `FROM book b JOIN author a` so `b.author_id = a.id` reads cleanly
+-- without repeating the full table names in every qualified column reference.
+SELECT b.title, a.name                         -- => columns pulled through both aliases
+FROM book b                                    -- => `b` now stands in for `book`
+JOIN author a ON b.author_id = a.id            -- => `a` now stands in for `author`
+ORDER BY b.id;                                 -- => deterministic row order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-33-three-table-join/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-33-three-table-join/example.sql
@@ -1,0 +1,48 @@
+-- Example 33: Three-Table Join
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+-- Three related tables: author and publisher are both parents of book.
+CREATE TABLE author (                          -- => first parent table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  name TEXT NOT NULL                          -- => author's name, required
+);
+
+CREATE TABLE publisher (                       -- => second parent table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  name TEXT NOT NULL                          -- => publisher's name, required
+);
+
+CREATE TABLE book (                            -- => hub table -- has TWO parents
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER REFERENCES author(id),     -- => FK #1 -- links to author
+  publisher_id INTEGER REFERENCES publisher(id) -- => FK #2 -- links to publisher
+);
+-- Both FKs are simple (single-column), unlike Example 65's composite key.
+
+INSERT INTO author (id, name) VALUES           -- => 2 authors, both referenced below
+  (1, 'Ada Lovelace'),                        -- => author 1 -- writes 1 book below
+  (2, 'Alan Turing');                         -- => author 2 -- writes 2 books below
+
+INSERT INTO publisher (id, name) VALUES        -- => 2 publishers, both referenced below
+  (1, 'Oxford Press'),                        -- => publisher 1 -- publishes 2 books below
+  (2, 'Harbor Books');                        -- => publisher 2 -- publishes 1 book below
+
+INSERT INTO book (id, title, author_id, publisher_id) VALUES -- => links both parent FKs
+  (1, 'Notes on the Analytical Engine', 1, 1),   -- => Ada Lovelace, Oxford Press
+  (2, 'On Computable Numbers', 2, 1),            -- => Alan Turing, Oxford Press
+  (3, 'The Enigma Papers', 2, 2);                -- => Alan Turing, Harbor Books
+
+-- Two JOIN clauses chain together -- book is the hub, author and publisher are
+-- both its parents. Each JOIN adds one more parent table's columns to the row.
+SELECT book.title, author.name AS author_name, publisher.name AS publisher_name
+                                                 -- => columns pulled from all three tables
+FROM book                                       -- => hub table -- the join starts here
+JOIN author ON author.id = book.author_id          -- => pulls in the author's columns
+JOIN publisher ON publisher.id = book.publisher_id  -- => pulls in the publisher's columns
+ORDER BY book.id;                                    -- => deterministic row order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-34-group-by-count/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-34-group-by-count/example.sql
@@ -1,0 +1,31 @@
+-- Example 34: Group By Count
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => single flat table -- no author table here
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER,                          -- => no FK needed -- just a grouping key here
+  price REAL,                                 -- => not used by this example's query
+  in_stock INTEGER,                           -- => not used by this example's query
+  published_year INTEGER                      -- => not used by this example's query
+);
+
+-- 5 books: author_id 1 has 1 book, author_id 2 has 2, author_id 3 has 2.
+INSERT INTO book (id, title, author_id, price, in_stock, published_year) VALUES
+  (1, 'Notes on the Analytical Engine', 1, 25.00, 1, 1843),  -- => author_id 1, group of 1
+  (2, 'Introduction to Computing',       2, 18.50, 1, 1952), -- => author_id 2, group of 2
+  (3, 'Compilers and Common Sense',      2, 22.00, 0, NULL), -- => author_id 2, group of 2
+  (4, 'On Computable Numbers',           3, 30.00, 1, 1936), -- => author_id 3, group of 2
+  (5, 'The Enigma Papers',               3, 15.00, 1, NULL); -- => author_id 3, group of 2
+
+-- GROUP BY collapses rows sharing the same author_id into one row per group;
+-- count(*) then counts how many original rows collapsed into each group.
+SELECT author_id, count(*) AS book_count       -- => count(*) per group, computed below
+FROM book                                       -- => the 5-row source table above
+GROUP BY author_id                             -- => one output row per distinct author_id
+ORDER BY author_id;                            -- => deterministic group order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-35-group-by-sum/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-35-group-by-sum/example.sql
@@ -1,0 +1,31 @@
+-- Example 35: Group By Sum
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => single flat table, same shape as Example 34
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER,                          -- => the grouping key for sum() below
+  price REAL,                                 -- => summed per group below
+  in_stock INTEGER,                           -- => not used by this example's query
+  published_year INTEGER                      -- => not used by this example's query
+);
+
+-- Same 5-book dataset used across this tier's aggregation examples.
+INSERT INTO book (id, title, author_id, price, in_stock, published_year) VALUES
+  (1, 'Notes on the Analytical Engine', 1, 25.00, 1, 1843),  -- => author_id 1, price 25.00
+  (2, 'Introduction to Computing',       2, 18.50, 1, 1952), -- => author_id 2, price 18.50
+  (3, 'Compilers and Common Sense',      2, 22.00, 0, NULL), -- => author_id 2, price 22.00
+  (4, 'On Computable Numbers',           3, 30.00, 1, 1936), -- => author_id 3, price 30.00
+  (5, 'The Enigma Papers',               3, 15.00, 1, NULL); -- => author_id 3, price 15.00
+
+-- sum(price) totals the price column WITHIN each author_id group -- author_id 2's
+-- two books (18.50 + 22.00) collapse into one summed row, same for author_id 3.
+SELECT author_id, sum(price) AS total_price    -- => sum(price) per group, computed below
+FROM book                                       -- => the 5-row source table above
+GROUP BY author_id                             -- => one output row per distinct author_id
+ORDER BY author_id;                            -- => deterministic group order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-36-group-by-avg/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-36-group-by-avg/example.sql
@@ -1,0 +1,31 @@
+-- Example 36: Group By Avg
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => single flat table, same shape as Example 34
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER,                          -- => the grouping key for avg() below
+  price REAL,                                 -- => averaged per group below
+  in_stock INTEGER,                           -- => not used by this example's query
+  published_year INTEGER                      -- => not used by this example's query
+);
+
+-- Same 5-book dataset used across this tier's aggregation examples.
+INSERT INTO book (id, title, author_id, price, in_stock, published_year) VALUES
+  (1, 'Notes on the Analytical Engine', 1, 25.00, 1, 1843),  -- => author_id 1, price 25.00
+  (2, 'Introduction to Computing',       2, 18.50, 1, 1952), -- => author_id 2, price 18.50
+  (3, 'Compilers and Common Sense',      2, 22.00, 0, NULL), -- => author_id 2, price 22.00
+  (4, 'On Computable Numbers',           3, 30.00, 1, 1936), -- => author_id 3, price 30.00
+  (5, 'The Enigma Papers',               3, 15.00, 1, NULL); -- => author_id 3, price 15.00
+
+-- avg(price) computes the mean price WITHIN each author_id group -- author_id 2's
+-- (18.50 + 22.00) / 2 = 20.25, author_id 3's (30.00 + 15.00) / 2 = 22.5.
+SELECT author_id, avg(price) AS avg_price      -- => avg(price) per group, computed below
+FROM book                                       -- => the 5-row source table above
+GROUP BY author_id                             -- => one output row per distinct author_id
+ORDER BY author_id;                            -- => deterministic group order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-37-min-max-aggregate/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-37-min-max-aggregate/example.sql
@@ -1,0 +1,26 @@
+-- Example 37: Min Max Aggregate
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table, no grouping key here
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  price REAL                                  -- => min/max computed over this column
+);
+
+-- 5 books with distinct prices, ranging from 15.00 to 30.00.
+INSERT INTO book (id, title, price) VALUES     -- => 5 rows, no author_id this time
+  (1, 'Notes on the Analytical Engine', 25.00), -- => neither the min nor the max
+  (2, 'Introduction to Computing', 18.50),      -- => neither the min nor the max
+  (3, 'Compilers and Common Sense', 22.00),     -- => neither the min nor the max
+  (4, 'On Computable Numbers', 30.00),          -- => the max -- priciest book
+  (5, 'The Enigma Papers', 15.00);              -- => the min -- cheapest book
+
+-- With NO GROUP BY, min()/max() collapse the ENTIRE table into a single row --
+-- the cheapest and priciest book across all 5 rows, not per-group like Examples 34-36.
+SELECT min(price) AS cheapest, max(price) AS priciest -- => one summary row, no grouping key
+FROM book;                                      -- => the 5-row source table above

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-38-having-filter-groups/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-38-having-filter-groups/example.sql
@@ -1,0 +1,30 @@
+-- Example 38: Having Filter Groups
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER                           -- => the grouping key HAVING filters on
+);
+
+-- author_id 1 has 1 book, author_id 2 has 2 books, author_id 3 has 2 books.
+INSERT INTO book (id, title, author_id) VALUES -- => 5 books across 3 author_id groups
+  (1, 'Notes on the Analytical Engine', 1),   -- => author_id 1, group of 1 -- fails HAVING
+  (2, 'Introduction to Computing', 2),        -- => author_id 2, group of 2 -- passes HAVING
+  (3, 'Compilers and Common Sense', 2),       -- => author_id 2, group of 2 -- passes HAVING
+  (4, 'On Computable Numbers', 3),            -- => author_id 3, group of 2 -- passes HAVING
+  (5, 'The Enigma Papers', 3);                -- => author_id 3, group of 2 -- passes HAVING
+
+-- HAVING filters GROUPS after aggregation -- the opposite of WHERE, which filters
+-- ROWS before aggregation. count(*) > 1 keeps only groups with more than one book,
+-- so author_id 1 (exactly 1 book) is dropped from the result entirely.
+SELECT author_id, count(*) AS book_count       -- => count(*) per surviving group
+FROM book                                       -- => the 5-row source table above
+GROUP BY author_id                             -- => first, collapse rows into groups
+HAVING count(*) > 1                            -- => then, keep only groups matching this
+ORDER BY author_id;                            -- => deterministic group order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-39-where-plus-having/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-39-where-plus-having/example.sql
@@ -1,0 +1,34 @@
+-- Example 39: Where Plus Having
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER,                          -- => the grouping key for sum() below
+  price REAL,                                 -- => summed per group after WHERE filters
+  in_stock INTEGER                            -- => 1 = in stock, 0 = out of stock
+);
+
+-- Book id 3 is the ONLY out-of-stock row -- watch it disappear before grouping.
+INSERT INTO book (id, title, author_id, price, in_stock) VALUES -- => 5 rows, 1 out-of-stock
+  (1, 'Notes on the Analytical Engine', 1, 25.00, 1),   -- => in stock -- survives WHERE
+  (2, 'Introduction to Computing',       2, 18.50, 1),  -- => in stock -- survives WHERE
+  (3, 'Compilers and Common Sense',      2, 22.00, 0),   -- => dropped by WHERE, first
+  (4, 'On Computable Numbers',           3, 30.00, 1),  -- => in stock -- survives WHERE
+  (5, 'The Enigma Papers',               3, 15.00, 1);  -- => in stock -- survives WHERE
+
+-- Two filters, two different phases. WHERE runs FIRST, on individual rows, before
+-- any grouping happens -- it removes book id 3 (in_stock = 0) entirely. GROUP BY
+-- then collapses the SURVIVING rows. HAVING runs LAST, on the resulting groups --
+-- author_id 2's remaining sum (18.50, book id 3 already gone) fails the > 20 test.
+SELECT author_id, sum(price) AS total_price    -- => sum(price) per surviving group
+FROM book                                       -- => the 5-row source table above
+WHERE in_stock = 1                             -- => row filter -- BEFORE aggregation
+GROUP BY author_id                             -- => collapse the surviving rows
+HAVING sum(price) > 20                         -- => group filter -- AFTER aggregation
+ORDER BY author_id;                            -- => deterministic group order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-40-count-star-vs-column/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-40-count-star-vs-column/example.sql
@@ -1,0 +1,28 @@
+-- Example 40: Count Star vs Column
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  published_year INTEGER                      -- => 2 of the 5 rows leave this NULL
+);
+
+-- Books 3 and 5 have an unknown (NULL) published_year.
+INSERT INTO book (id, title, published_year) VALUES -- => 5 rows, 2 with a NULL year
+  (1, 'Notes on the Analytical Engine', 1843), -- => known year -- counted by both forms
+  (2, 'Introduction to Computing', 1952),      -- => known year -- counted by both forms
+  (3, 'Compilers and Common Sense', NULL),      -- => unknown year -- excluded below
+  (4, 'On Computable Numbers', 1936),          -- => known year -- counted by both forms
+  (5, 'The Enigma Papers', NULL);               -- => unknown year -- excluded below
+
+-- count(*) counts ROWS, full stop -- NULLs included. count(column) counts only
+-- NON-NULL values in that specific column -- the two forms diverge whenever the
+-- counted column itself can hold NULL, exactly like published_year here.
+SELECT count(*) AS row_count, count(published_year) AS known_year_count
+                                                 -- => two different counts, same table
+FROM book;                                      -- => the 5-row source table above

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-41-null-is-null/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-41-null-is-null/example.sql
@@ -1,0 +1,27 @@
+-- Example 41: Null Is Null
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  published_year INTEGER                      -- => unknown for 2 of the 5 rows
+);
+
+INSERT INTO book (id, title, published_year) VALUES -- => 5 rows, 2 with a NULL year
+  (1, 'Notes on the Analytical Engine', 1843), -- => known year -- excluded from result
+  (2, 'Introduction to Computing', 1952),      -- => known year -- excluded from result
+  (3, 'Compilers and Common Sense', NULL),      -- => year genuinely unknown
+  (4, 'On Computable Numbers', 1936),          -- => known year -- excluded from result
+  (5, 'The Enigma Papers', NULL);               -- => year genuinely unknown
+
+-- NULL means "unknown", not zero or empty string -- so testing for it needs its
+-- own operator. IS NULL is that operator; Example 43 shows why `= NULL` fails.
+SELECT id, title                                -- => the two columns shown for matches
+FROM book                                       -- => the 5-row source table above
+WHERE published_year IS NULL                   -- => matches exactly the 2 unknown rows
+ORDER BY id;                                    -- => deterministic row order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-42-null-coalesce/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-42-null-coalesce/example.sql
@@ -1,0 +1,27 @@
+-- Example 42: Null Coalesce
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  published_year INTEGER                      -- => unknown for 2 of the 5 rows
+);
+
+INSERT INTO book (id, title, published_year) VALUES -- => 5 rows, 2 with a NULL year
+  (1, 'Notes on the Analytical Engine', 1843), -- => known year -- coalesce() passes it through
+  (2, 'Introduction to Computing', 1952),      -- => known year -- coalesce() passes it through
+  (3, 'Compilers and Common Sense', NULL),      -- => becomes 0 below, not left blank
+  (4, 'On Computable Numbers', 1936),          -- => known year -- coalesce() passes it through
+  (5, 'The Enigma Papers', NULL);               -- => becomes 0 below, not left blank
+
+-- coalesce(a, b, ...) returns the FIRST non-NULL argument, left to right -- here,
+-- published_year if it exists, otherwise the literal 0 as a placeholder value.
+SELECT id, title, coalesce(published_year, 0) AS year_or_zero
+                                                 -- => year_or_zero never shows NULL
+FROM book                                       -- => the 5-row source table above
+ORDER BY id;                                    -- => deterministic row order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-43-null-three-valued/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-43-null-three-valued/example.sql
@@ -1,0 +1,29 @@
+-- Example 43: Null Three-Valued
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  published_year INTEGER                      -- => 2 of 5 rows leave this NULL
+);
+
+INSERT INTO book (id, title, published_year) VALUES -- => 5 rows, 2 with a NULL year
+  (1, 'Notes on the Analytical Engine', 1843), -- => known year -- still never matches = NULL
+  (2, 'Introduction to Computing', 1952),      -- => known year -- still never matches = NULL
+  (3, 'Compilers and Common Sense', NULL),      -- => year genuinely unknown
+  (4, 'On Computable Numbers', 1936),          -- => known year -- still never matches = NULL
+  (5, 'The Enigma Papers', NULL);               -- => year genuinely unknown
+
+-- SQL comparisons are three-valued: TRUE, FALSE, or UNKNOWN. Any comparison
+-- against NULL (even `NULL = NULL`) evaluates to UNKNOWN, never TRUE -- so a
+-- WHERE clause built on `= NULL` can NEVER match a row, no matter the data.
+-- This returns ZERO rows, even though books 3 and 5 genuinely have a NULL year.
+SELECT id, title                                -- => never reached -- WHERE matches nothing
+FROM book                                       -- => the 5-row source table above
+WHERE published_year = NULL                    -- => WRONG -- always UNKNOWN, never TRUE
+ORDER BY id;                                    -- => deterministic row order, if any rows matched

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-44-aggregate-over-join/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-44-aggregate-over-join/example.sql
@@ -1,0 +1,41 @@
+-- Example 44: Aggregate Over Join
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE author (                          -- => parent table -- referenced by book below
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  name TEXT NOT NULL                          -- => author's name, required
+);
+
+CREATE TABLE book (                            -- => child table -- author_id links back up
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER REFERENCES author(id),     -- => FK, joined against author.id below
+  price REAL                                  -- => summed per author after the join
+);
+
+INSERT INTO author (id, name) VALUES           -- => 3 authors, all referenced below
+  (1, 'Ada Lovelace'),                        -- => author 1 -- has 1 book below
+  (2, 'Grace Hopper'),                        -- => author 2 -- has 2 books below
+  (3, 'Alan Turing');                         -- => author 3 -- has 2 books below
+
+-- Grace Hopper (id 2) and Alan Turing (id 3) each have TWO books -- their totals
+-- sum across the join, unlike Ada Lovelace's single-book total.
+INSERT INTO book (id, title, author_id, price) VALUES -- => 5 books across 3 authors
+  (1, 'Notes on the Analytical Engine', 1, 25.00),  -- => author_id 1, price 25.00
+  (2, 'Introduction to Computing',       2, 18.50), -- => author_id 2, price 18.50
+  (3, 'Compilers and Common Sense',      2, 22.00), -- => author_id 2, price 22.00
+  (4, 'On Computable Numbers',           3, 30.00), -- => author_id 3, price 30.00
+  (5, 'The Enigma Papers',               3, 15.00); -- => author_id 3, price 15.00
+
+-- JOIN recombines the normalized tables FIRST; GROUP BY/sum() aggregate the
+-- JOINED result SECOND -- this is exactly how a per-author revenue report works.
+SELECT a.name, sum(b.price) AS total_price     -- => sum(price) per author, after the join
+FROM author a                                   -- => left side of the join -- one row per author
+JOIN book b ON b.author_id = a.id              -- => recombine author with its books
+GROUP BY a.name                                 -- => then collapse into per-author totals
+ORDER BY a.id;                                  -- => deterministic group order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-45-normalize-repeating-group/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-45-normalize-repeating-group/example.sql
@@ -1,0 +1,57 @@
+-- Example 45: Normalize Repeating Group (1NF)
+-- Run: sqlite3 app.db < example.sql
+--
+-- IMPORTANT: this split fixes 1NF (atomicity) specifically -- NOT 2NF. 2NF is
+-- about partial dependency on a COMPOSITE key, a different problem this single
+-- split does not address.
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+-- PROBLEM: `tags` packs a variable-length list into ONE text column -- a
+-- "repeating group". This column is NOT atomic (1NF requires atomic values).
+CREATE TABLE book_flat (                       -- => the BEFORE table -- not yet 1NF
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  tags TEXT                                   -- => e.g. 'mathematics,history' -- not atomic
+);
+
+INSERT INTO book_flat (id, title, tags) VALUES -- => 2 rows, each packing multiple tags
+  (1, 'Notes on the Analytical Engine', 'mathematics,history'),          -- => 2 tags packed
+  (2, 'On Computable Numbers', 'mathematics,computer-science');          -- => 2 tags packed
+
+-- Finding "every book tagged mathematics" here needs a fragile LIKE '%mathematics%'
+-- pattern -- and it would also false-match a hypothetical tag like 'mathematics-history'.
+SELECT * FROM book_flat;                        -- => shows the packed, non-atomic tags column
+
+-- FIX: split the repeating group into its own child table, one row PER TAG.
+-- Now every value in every column is a single, atomic fact -- 1NF satisfied.
+CREATE TABLE book (                            -- => the AFTER hub table -- tags moved out
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL                         -- => book title, required
+);
+
+CREATE TABLE book_tag (                        -- => the AFTER child table -- one row per tag
+  book_id INTEGER REFERENCES book(id),        -- => FK back to the owning book
+  tag TEXT NOT NULL,                          -- => exactly ONE atomic tag per row
+  PRIMARY KEY (book_id, tag)                  -- => a composite key -- no duplicate pairs
+);
+
+INSERT INTO book (id, title) VALUES            -- => same 2 books, tags no longer inline
+  (1, 'Notes on the Analytical Engine'),      -- => book 1 -- 2 tags in book_tag below
+  (2, 'On Computable Numbers');                -- => book 2 -- 2 tags in book_tag below
+
+INSERT INTO book_tag (book_id, tag) VALUES     -- => 4 rows -- one row PER atomic tag
+  (1, 'mathematics'),                         -- => book 1's first tag
+  (1, 'history'),                             -- => book 1's second tag
+  (2, 'mathematics'),                         -- => book 2's first tag
+  (2, 'computer-science');                     -- => book 2's second tag
+
+-- Now "every book tagged mathematics" is a plain, exact WHERE tag = 'mathematics'
+-- on book_tag -- no string-pattern hack, no false-positive risk.
+SELECT book.title, book_tag.tag                -- => one output row PER book/tag pair
+FROM book                                       -- => left side of the join
+JOIN book_tag ON book_tag.book_id = book.id    -- => recombines book with its atomic tags
+ORDER BY book.id, book_tag.tag;                 -- => deterministic row order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-46-normalize-transitive-dep/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-46-normalize-transitive-dep/example.sql
@@ -1,0 +1,55 @@
+-- Example 46: Normalize Transitive Dependency (3NF)
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+-- PROBLEM: publisher_city depends on publisher_name, NOT directly on id -- a
+-- TRANSITIVE dependency (id -> publisher_name -> publisher_city). Both books
+-- from 'Oxford Press' repeat 'Oxford' -- change one city and the other silently
+-- goes stale, an update anomaly 3NF exists specifically to prevent.
+CREATE TABLE book_wide (                       -- => the BEFORE table -- not yet 3NF
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  publisher_name TEXT NOT NULL,               -- => repeated fact, one copy per book row
+  publisher_city TEXT NOT NULL                -- => repeated fact, one copy per book row
+);
+
+INSERT INTO book_wide (id, title, publisher_name, publisher_city) VALUES -- => 3 rows
+  (1, 'Notes on the Analytical Engine', 'Oxford Press', 'Oxford'),        -- => 'Oxford' repeated below
+  (2, 'On Computable Numbers', 'Oxford Press', 'Oxford'),      -- => 'Oxford' repeated
+  (3, 'Introduction to Computing', 'Harbor Books', 'Boston');  -- => a different publisher
+
+SELECT * FROM book_wide;                        -- => shows publisher_city repeated twice
+
+-- FIX: extract publisher into its own table -- publisher_city now lives in
+-- exactly ONE row per publisher, referenced by id instead of copied by value.
+CREATE TABLE publisher (                       -- => the AFTER lookup table -- one row per publisher
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  name TEXT NOT NULL,                         -- => publisher's name, required
+  city TEXT NOT NULL                          -- => one fact, one place -- 3NF
+);
+
+CREATE TABLE book (                            -- => the AFTER hub table -- FK instead of copies
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  publisher_id INTEGER REFERENCES publisher(id) -- => FK -- no more repeated publisher text
+);
+
+INSERT INTO publisher (id, name, city) VALUES  -- => 2 publishers, each stored exactly once
+  (1, 'Oxford Press', 'Oxford'),               -- => publisher 1 -- referenced by 2 books below
+  (2, 'Harbor Books', 'Boston');                -- => publisher 2 -- referenced by 1 book below
+
+INSERT INTO book (id, title, publisher_id) VALUES -- => same 3 books, publisher_city no longer inline
+  (1, 'Notes on the Analytical Engine', 1),   -- => publisher_id 1
+  (2, 'On Computable Numbers', 1),             -- => shares publisher_id 1, not the city text
+  (3, 'Introduction to Computing', 2);         -- => publisher_id 2
+
+-- Updating Oxford Press's city now means changing ONE row (publisher.city) --
+-- both of its books pick up the change automatically through the join.
+SELECT book.title, publisher.name, publisher.city -- => city now read through the join
+FROM book                                       -- => left side of the join
+JOIN publisher ON publisher.id = book.publisher_id -- => recombines book with its publisher
+ORDER BY book.id;                               -- => deterministic row order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-47-python-named-params/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-47-python-named-params/example.py
@@ -1,0 +1,28 @@
+# pyright: strict
+"""Example 47: Python Named Params."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+# ":memory:" is an ephemeral, file-less database -- perfect for a self-contained
+# example that needs no cleanup and leaves nothing on disk.
+conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => opens an in-memory database
+conn.execute(  # => a minimal one-table schema
+    "CREATE TABLE author (id INTEGER PRIMARY KEY, name TEXT NOT NULL)"  # => id + name only
+)  # => defines a minimal one-table schema
+conn.execute("INSERT INTO author (id, name) VALUES (1, 'Ada Lovelace')")  # => author 1
+conn.execute("INSERT INTO author (id, name) VALUES (2, 'Grace Hopper')")  # => author 2
+conn.commit()  # => persists both inserts to this connection's database
+
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+
+# :name is a NAMED placeholder -- bound from a dict KEY, not positional order.
+# This is the exact same injection-safety guarantee as `?` (Example 30), just
+# addressed by name instead of position -- useful when a query has many params.
+params: dict[str, str] = {"name": "Grace Hopper"}  # => the dict key MUST match :name
+cur.execute(
+    "SELECT id, name FROM author WHERE name = :name", params
+)  # => :name bound from params
+row: tuple[int, str] | None = cur.fetchone()  # => None if no row matched
+print(row)  # => Output: (2, 'Grace Hopper')
+
+conn.close()  # => releases the connection -- irrelevant here since it's in-memory

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-48-python-executemany/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-48-python-executemany/example.py
@@ -1,0 +1,25 @@
+# pyright: strict
+"""Example 48: Python Executemany."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => opens an in-memory database
+conn.execute(  # => a single-column-of-interest table, ideal for a bulk-insert demo
+    "CREATE TABLE author (id INTEGER PRIMARY KEY, name TEXT NOT NULL)"  # => id + name only
+)  # => a single-column-of-interest table, ideal for a bulk-insert demo
+
+# executemany() runs the SAME statement once PER tuple in this list -- one bulk
+# call instead of a Python loop issuing N separate .execute() round-trips.
+rows: list[tuple[str]] = [("Ada Lovelace",), ("Grace Hopper",), ("Alan Turing",)]
+# => 3 single-element tuples -- one tuple per row to insert
+conn.executemany(  # => one bulk call, not 3 separate .execute() calls
+    "INSERT INTO author (name) VALUES (?)", rows
+)  # => 3 rows inserted in one call -- id auto-assigns 1, 2, 3
+conn.commit()  # => persists all 3 inserts together
+
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+cur.execute("SELECT count(*) FROM author")  # => confirms all 3 rows landed
+count: tuple[int] = cur.fetchone()  # => a 1-tuple: (row_count,)
+print(count[0])  # => Output: 3
+
+conn.close()  # => releases the connection -- irrelevant here since it's in-memory

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-49-python-fetchone-loop/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-49-python-fetchone-loop/example.py
@@ -1,0 +1,27 @@
+# pyright: strict
+"""Example 49: Python Fetchone Loop."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => opens an in-memory database
+conn.execute(
+    "CREATE TABLE book (id INTEGER PRIMARY KEY, title TEXT NOT NULL)"
+)  # => id + title
+conn.execute(
+    "INSERT INTO book (title) VALUES ('Notes on the Analytical Engine')"
+)  # => book 1
+conn.execute("INSERT INTO book (title) VALUES ('On Computable Numbers')")  # => book 2
+conn.commit()  # => persists both inserts
+
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+cur.execute("SELECT id, title FROM book ORDER BY id")  # => 2 rows, not yet fetched
+
+# fetchall() would load every row into memory at once; fetchone() streams ONE
+# row per call instead -- the := walrus operator both assigns row AND checks
+# it against None in the same expression, ending the loop at the sentinel.
+row: tuple[int, str] | None  # => declared before the loop -- streamed one row at a time
+while (row := cur.fetchone()) is not None:  # => None marks "no more rows"
+    book_id, title = row  # => unpacks the 2-tuple into two typed names
+    print(book_id, title)  # => one line printed per row, streamed
+
+conn.close()  # => releases the connection -- irrelevant here since it's in-memory

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-50-python-row-factory/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-50-python-row-factory/example.py
@@ -1,0 +1,27 @@
+# pyright: strict
+"""Example 50: Python Row Factory."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => opens an in-memory database
+# row_factory swaps the default plain-tuple row shape for sqlite3.Row -- every
+# row returned from now on supports BOTH positional AND column-name access.
+conn.row_factory = sqlite3.Row  # => applies to every cursor opened after this line
+
+conn.execute(
+    "CREATE TABLE author (id INTEGER PRIMARY KEY, name TEXT NOT NULL)"
+)  # => id + name
+conn.execute(
+    "INSERT INTO author (name) VALUES ('Ada Lovelace')"
+)  # => id auto-assigns to 1
+conn.commit()  # => persists the insert
+
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+cur.execute("SELECT id, name FROM author")  # => 1 row, not yet fetched
+row: sqlite3.Row | None = cur.fetchone()  # => a sqlite3.Row, not a plain tuple
+if row is not None:  # => narrows away None so indexing below is type-safe
+    # row["name"] reads by COLUMN NAME -- no need to remember column ORDER,
+    # unlike the plain-tuple row[1] this same query would otherwise return.
+    print(row["id"], row["name"])  # => Output: 1 Ada Lovelace
+
+conn.close()  # => releases the connection -- irrelevant here since it's in-memory

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-51-transaction-commit/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-51-transaction-commit/example.py
@@ -1,0 +1,35 @@
+# pyright: strict
+"""Example 51: Transaction Commit."""
+
+import os  # => stdlib -- used below to reset the file between runs
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+DB_PATH: str = "app.db"  # => a real file, unlike Examples 47-50's ":memory:"
+if os.path.exists(DB_PATH):  # => start from a clean file every run
+    os.remove(DB_PATH)
+
+# A FILE-based database (not ":memory:") is required here -- only a real file
+# on disk can be reopened by a SECOND, independent connection below.
+conn: sqlite3.Connection = sqlite3.connect(DB_PATH)  # => opens/creates the file
+conn.execute(
+    "CREATE TABLE author (id INTEGER PRIMARY KEY, name TEXT NOT NULL)"
+)  # => id + name
+conn.execute("BEGIN")  # => explicitly opens a transaction
+conn.execute(
+    "INSERT INTO author (name) VALUES ('Ada Lovelace')"
+)  # => id auto-assigns to 1
+conn.commit()  # => makes the insert PERMANENT -- durable across connections
+conn.close()  # => close the FIRST connection entirely
+
+# A brand-new, independent connection to the SAME file -- proves the write
+# survived past the original connection's lifetime, not just in its own cache.
+conn2: sqlite3.Connection = sqlite3.connect(
+    DB_PATH
+)  # => a SECOND, independent connection
+cur: sqlite3.Cursor = conn2.cursor()  # => a cursor executes SQL and holds results
+cur.execute("SELECT count(*) FROM author")  # => reads through the second connection
+count: tuple[int] = cur.fetchone()  # => a 1-tuple: (row_count,)
+print(count[0])  # => Output: 1 -- the committed write persisted
+
+conn2.close()  # => releases the second connection
+os.remove(DB_PATH)  # => tidy up the file this script created

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-52-transaction-rollback/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-52-transaction-rollback/example.py
@@ -1,0 +1,33 @@
+# pyright: strict
+"""Example 52: Transaction Rollback."""
+
+import os  # => stdlib -- used below to reset the file between runs
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+DB_PATH: str = "app.db"  # => a real file -- rollback needs a durable baseline first
+if os.path.exists(DB_PATH):  # => start from a clean file every run
+    os.remove(DB_PATH)  # => wipes any leftover file from a previous run
+
+conn: sqlite3.Connection = sqlite3.connect(DB_PATH)  # => opens/creates the file
+conn.execute(
+    "CREATE TABLE author (id INTEGER PRIMARY KEY, name TEXT NOT NULL)"
+)  # => id + name
+conn.execute(
+    "INSERT INTO author (name) VALUES ('Ada Lovelace')"
+)  # => id auto-assigns to 1
+conn.commit()  # => this ONE row is the durable baseline -- 1 row
+
+conn.execute("BEGIN")  # => opens a new transaction around the next insert
+conn.execute(  # => second insert, about to be rolled back
+    "INSERT INTO author (name) VALUES ('Grace Hopper')"  # => the row about to be undone
+)  # => this insert is visible WITHIN this connection right now
+conn.rollback()  # => discards everything since BEGIN -- Grace Hopper is undone
+
+# a fresh cursor verifies the post-rollback state matches the pre-transaction baseline
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+cur.execute("SELECT count(*) FROM author")  # => re-checks the row count after rollback
+count: tuple[int] = cur.fetchone()  # => a 1-tuple: (row_count,)
+print(count[0])  # => Output: 1 -- back to the pre-transaction baseline, not 2
+
+conn.close()  # => releases the connection
+os.remove(DB_PATH)  # => tidy up the file this script created

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-53-transaction-context-manager/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-53-transaction-context-manager/example.py
@@ -1,0 +1,39 @@
+# pyright: strict
+"""Example 53: Transaction Context Manager."""
+
+import os  # => stdlib -- used below to reset the file between runs
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+DB_PATH: str = "app.db"  # => a real file -- automatic rollback needs a durable baseline
+if os.path.exists(DB_PATH):  # => start from a clean file every run
+    os.remove(DB_PATH)  # => wipes any leftover file from a previous run
+
+conn: sqlite3.Connection = sqlite3.connect(DB_PATH)  # => opens/creates the file
+conn.execute(
+    "CREATE TABLE author (id INTEGER PRIMARY KEY, name TEXT NOT NULL)"
+)  # => id + name
+conn.execute(
+    "INSERT INTO author (name) VALUES ('Ada Lovelace')"
+)  # => id auto-assigns to 1
+conn.commit()  # => durable baseline -- exactly 1 row
+
+# `with conn:` (unlike `with open(...)`) does NOT close the connection -- it
+# commits on a clean exit, or ROLLS BACK automatically if the block raises.
+try:  # => opens a block that may raise
+    with conn:  # => opens an implicit transaction for this block
+        conn.execute(  # => second insert, about to be rolled back
+            "INSERT INTO author (name) VALUES ('Grace Hopper')"  # => the row about to be undone
+        )  # => visible inside the block, but not yet committed
+        raise ValueError("simulated mid-transaction failure")  # => triggers rollback
+except ValueError:  # => catches the simulated failure, after auto-rollback already ran
+    print("caught: simulated mid-transaction failure")  # => Output line 1
+
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+cur.execute(
+    "SELECT count(*) FROM author"
+)  # => re-checks the row count after auto-rollback
+count: tuple[int] = cur.fetchone()  # => a 1-tuple: (row_count,)
+print(count[0])  # => Output line 2: 1 -- the failed insert left no partial write
+
+conn.close()  # => releases the connection -- `with conn:` above did NOT close it
+os.remove(DB_PATH)  # => tidy up the file this script created

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-54-injection-safe-vs-unsafe/safe.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-54-injection-safe-vs-unsafe/safe.py
@@ -1,0 +1,31 @@
+# pyright: strict
+"""Example 54: injection-SAFE query, built via a `?` bound parameter."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+# The identical payload from unsafe.py -- same attacker input, different result.
+PAYLOAD: str = "'; DROP TABLE book;--"
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => opens an in-memory database
+conn.execute(
+    "CREATE TABLE book (id INTEGER PRIMARY KEY, title TEXT NOT NULL)"
+)  # => id + title
+conn.execute(
+    "INSERT INTO book (title) VALUES ('Alpha')"
+)  # => one seed row, id auto-assigns to 1
+conn.commit()  # => persists the seed row
+
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+# SAFE: `?` passes PAYLOAD as a bound VALUE, never as SQL text -- the query's
+# structure is fixed at prepare time, before SQLite ever inspects the value.
+cur.execute(
+    "SELECT * FROM book WHERE title = ?", (PAYLOAD,)
+)  # => PAYLOAD bound, not spliced
+rows: list[tuple[int, str]] = cur.fetchall()  # => every matching row, fetched at once
+print(rows)  # => Output: [] -- no title literally equals the payload string
+
+cur.execute("SELECT count(*) FROM book")  # => confirms the table is fully intact
+count: tuple[int] = cur.fetchone()  # => a 1-tuple: (row_count,)
+print(count[0])  # => Output: 1 -- book table is fully intact, unaffected
+
+conn.close()  # => releases the connection -- irrelevant here since it's in-memory

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-54-injection-safe-vs-unsafe/unsafe.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-54-injection-safe-vs-unsafe/unsafe.py
@@ -1,0 +1,41 @@
+# pyright: strict
+"""Example 54: injection-UNSAFE query, built via f-string interpolation."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+# The classic attack payload: it tries to CLOSE the current string literal,
+# then chain a second, attacker-controlled statement onto the query.
+PAYLOAD: str = "'; DROP TABLE book;--"
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => opens an in-memory database
+conn.execute(
+    "CREATE TABLE book (id INTEGER PRIMARY KEY, title TEXT NOT NULL)"
+)  # => id + title
+conn.execute(
+    "INSERT INTO book (title) VALUES ('Alpha')"
+)  # => one seed row, id auto-assigns to 1
+conn.commit()  # => persists the seed row
+
+# UNSAFE: f-string interpolation splices PAYLOAD directly into the SQL text --
+# the query's STRUCTURE now depends on attacker-controlled input, not just its
+# data. Whatever the attacker types becomes part of the statement itself.
+unsafe_query: str = f"SELECT * FROM book WHERE title = '{PAYLOAD}'"
+print(unsafe_query)  # => the query text now literally contains a 2nd statement
+
+try:  # => attempts to run the attacker-shaped query text
+    conn.execute(unsafe_query)  # => may raise, depending on the payload shape
+except sqlite3.ProgrammingError as exc:
+    # This Python 3.13.12 sqlite3 build refuses to run more than one SQL
+    # statement per execute() call -- it blocks THIS specific payload shape.
+    # That is NOT proof f-string interpolation is safe: it only means this
+    # particular stacked-statement attack collides with an UNRELATED guard.
+    # A same-statement payload (e.g. `' OR '1'='1`) still bypasses the
+    # intended WHERE filter entirely when the query is built by interpolation.
+    print(f"blocked: {exc}")  # => real sqlite3 error text, captured verbatim
+
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+cur.execute("SELECT count(*) FROM book")  # => confirms whether the table survived
+count: tuple[int] = cur.fetchone()  # => a 1-tuple: (row_count,)
+print(count[0])  # => Output: 1 -- the table happened to survive THIS attempt
+
+conn.close()  # => releases the connection -- irrelevant here since it's in-memory

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-55-upsert-on-conflict/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-55-upsert-on-conflict/example.sql
@@ -1,0 +1,28 @@
+-- Example 55: Upsert On Conflict
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => the conflict target below
+  title TEXT NOT NULL,                        -- => book title, required
+  price REAL                                  -- => the column the upsert corrects
+);
+
+-- First insert: a plain new row, id 1.
+INSERT INTO book (id, title, price) VALUES (1, 'On Computable Numbers', 30.00); -- => row exists now
+
+SELECT * FROM book;                             -- => one row, price 30.00
+
+-- Second "insert" targets the SAME id (1) -- a plain INSERT here would raise a
+-- UNIQUE/PRIMARY KEY constraint error. ON CONFLICT(id) DO UPDATE turns that
+-- error into an UPDATE instead: an "upsert" -- insert if new, update if it exists.
+INSERT INTO book (id, title, price)             -- => targets the same id as the first insert
+VALUES (1, 'On Computable Numbers', 32.50)      -- => same id 1, a corrected price
+ON CONFLICT (id) DO UPDATE SET                  -- => fires because id 1 already exists
+  price = excluded.price;                       -- => excluded.price is the NEW attempted value
+
+SELECT * FROM book;                             -- => still ONE row, price now 32.50

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-56-subquery-in-where/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-56-subquery-in-where/example.sql
@@ -1,0 +1,41 @@
+-- Example 56: Subquery in Where
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE author (                          -- => parent table -- referenced by book below
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  name TEXT NOT NULL,                         -- => author's name, required
+  country TEXT                                -- => filtered by the subquery below
+);
+
+CREATE TABLE book (                            -- => child table -- author_id links back up
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER REFERENCES author(id)     -- => FK, matched against the subquery result
+);
+
+-- Two UK authors, one US author -- Grace Hopper's book should NOT appear below.
+INSERT INTO author (id, name, country) VALUES  -- => 3 authors, 2 in the subquery's result set
+  (1, 'Ada Lovelace', 'UK'),                  -- => UK -- id 1 IS in the subquery result
+  (2, 'Grace Hopper', 'US'),                  -- => US -- id 2 is NOT in the subquery result
+  (3, 'Alan Turing', 'UK');                   -- => UK -- id 3 IS in the subquery result
+
+INSERT INTO book (id, title, author_id) VALUES -- => 4 books across the 3 authors
+  (1, 'Notes on the Analytical Engine', 1),   -- => author_id 1 -- kept by the outer filter
+  (2, 'Introduction to Computing', 2),        -- => author_id 2 -- excluded by the outer filter
+  (3, 'On Computable Numbers', 3),            -- => author_id 3 -- kept by the outer filter
+  (4, 'The Enigma Papers', 3);                -- => author_id 3 -- kept by the outer filter
+
+-- The inner SELECT runs FIRST, producing a list of UK author ids (1, 3). The
+-- outer WHERE ... IN (...) then keeps only book rows whose author_id is in
+-- that list -- Grace Hopper's book (author_id 2, country US) is excluded.
+SELECT title                                    -- => only the title column is needed
+FROM book                                       -- => the 4-row source table above
+WHERE author_id IN (                            -- => subquery result: {1, 3}
+  SELECT id FROM author WHERE country = 'UK'    -- => runs first, before the outer filter
+)
+ORDER BY id;                                    -- => deterministic row order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-57-self-join/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-57-self-join/example.sql
@@ -1,0 +1,30 @@
+-- Example 57: Self Join
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+-- A self-join relates a table to ITSELF -- manager_id points back into the
+-- SAME employee table, so every row can reference another row in that table.
+CREATE TABLE employee (                        -- => a single table -- no separate manager table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  name TEXT NOT NULL,                         -- => employee's name, required
+  manager_id INTEGER REFERENCES employee(id)  -- => FK to this SAME table's id
+);
+
+-- Ada has no manager (NULL) -- she's the top of the tree. Grace and Alan both
+-- report to Ada; nobody reports to Grace or Alan.
+INSERT INTO employee (id, name, manager_id) VALUES -- => 3 employees, 1 at the top
+  (1, 'Ada Lovelace', NULL),                  -- => top of the tree -- no manager
+  (2, 'Grace Hopper', 1),                     -- => reports to employee id 1 (Ada)
+  (3, 'Alan Turing', 1);                      -- => reports to employee id 1 (Ada)
+
+-- Join the table to a SECOND aliased copy of itself -- `e` for the employee
+-- row, `m` for that same row's manager (also a row in employee). A plain JOIN
+-- (not LEFT JOIN) drops Ada here since her manager_id is NULL -- no match in `m`.
+SELECT e.name AS employee_name, m.name AS manager_name -- => two names, from the same table
+FROM employee e                                 -- => `e` -- the employee's own row
+JOIN employee m ON e.manager_id = m.id          -- => `m` is `e`'s manager row
+ORDER BY e.id;                                  -- => deterministic row order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-58-case-expression/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-58-case-expression/example.sql
@@ -1,0 +1,32 @@
+-- Example 58: Case Expression
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  price REAL                                  -- => drives the CASE branch below
+);
+
+-- Prices straddle the 20.00 threshold on both sides, plus exactly ON it (book 5).
+INSERT INTO book (id, title, price) VALUES     -- => 5 rows spanning the 20.00 threshold
+  (1, 'Notes on the Analytical Engine', 25.00), -- => above 20 -- lands in 'premium'
+  (2, 'Introduction to Computing', 18.50),      -- => below 20 -- lands in 'standard'
+  (3, 'On Computable Numbers', 30.00),          -- => above 20 -- lands in 'premium'
+  (4, 'The Enigma Papers', 15.00),              -- => below 20 -- lands in 'standard'
+  (5, 'Compilers and Common Sense', 20.00);    -- => exactly 20.00 -- NOT > 20, so 'standard'
+
+-- CASE WHEN ... THEN ... ELSE ... END is an inline conditional expression --
+-- it derives a brand-new column value per row, without a separate UPDATE or
+-- a client-side loop. WHEN conditions are checked top to bottom, first match wins.
+SELECT title, price,                            -- => the raw columns, plus a derived one below
+  CASE                                           -- => the derived tier column starts here
+    WHEN price > 20 THEN 'premium'              -- => strictly greater than 20
+    ELSE 'standard'                              -- => everything else, including = 20
+  END AS tier
+FROM book                                       -- => the 5-row source table above
+ORDER BY id;                                    -- => deterministic row order

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-59-migration-add-column/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-59-migration-add-column/example.sql
@@ -1,0 +1,32 @@
+-- Example 59: Migration Add Column.
+-- An additive migration -- adding a nullable-or-defaulted column -- never breaks existing rows.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => a minimal parent table -- just enough for a book to reference
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02) -- auto-assigned on insert
+    title TEXT NOT NULL,           -- => every book needs a title -- NOT NULL enforced
+    author_id INTEGER NOT NULL REFERENCES author(id),
+                                    -- => the FK link -- declared, though not yet enforced (co-03)
+    price REAL NOT NULL            -- => the schema BEFORE this example's migration runs
+);
+
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace');
+                                    -- => 1 author row -- author_id = 1 will be referenced below
+INSERT INTO book(id, title, author_id, price) VALUES
+    (1, 'Notes on the Analytical Engine', 1, 12.5),
+    (2, 'Sketch of the Analytical Engine', 1, 9.0);
+                                    -- => book now holds 2 rows, written BEFORE the migration below
+
+.headers on
+.mode column
+-- The pre-migration shape -- no "edition" column exists yet.
+SELECT id, title, price FROM book; -- => 2 rows, 3 columns -- the schema before any change
+
+-- ADD COLUMN ... DEFAULT is SQLite's safe, additive migration: no table rewrite,
+-- no downtime, and every EXISTING row reads back with the declared default (co-22).
+ALTER TABLE book ADD COLUMN edition INTEGER DEFAULT 1;
+                                    -- => rewrites ONLY the schema catalog -- row data is untouched
+
+-- Same 2 rows, now with a 4th column -- both pre-existing rows got the default, not NULL.
+SELECT id, title, price, edition FROM book;
+                                    -- => edition is 1 for BOTH rows -- neither was NULL or dropped

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-60-migration-backfill/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-60-migration-backfill/example.sql
@@ -1,0 +1,38 @@
+-- Example 60: Migration Backfill.
+-- Adding a column is only half a migration -- existing rows often need a COMPUTED value,
+-- not just a static DEFAULT (co-11).
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => minimal parent table -- just enough to reference below
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    title TEXT NOT NULL,           -- => NOT NULL -- every book needs a title
+    author_id INTEGER NOT NULL REFERENCES author(id),
+                                    -- => the FK link -- one row per book, per author
+    price REAL NOT NULL,           -- => unit price, before the quantity multiplication below
+    quantity INTEGER NOT NULL      -- => how many copies -- the OTHER input to total_value
+);
+
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace');
+                                    -- => 1 author row -- author_id = 1 is referenced below
+INSERT INTO book(id, title, author_id, price, quantity) VALUES
+    (1, 'Notes on the Analytical Engine', 1, 12.5, 4),
+    (2, 'Sketch of the Analytical Engine', 1, 9.0, 10);
+                                    -- => 2 rows -- price and quantity now set for BOTH
+
+-- .headers on shows column names above every result set below; .mode column aligns them --
+-- both are a display preference only, with no effect on the migration itself.
+.headers on
+.mode column
+-- A nullable ADD COLUMN (no DEFAULT) -- every existing row reads back NULL until backfilled.
+ALTER TABLE book ADD COLUMN total_value REAL;
+                                    -- => no DEFAULT clause -- deliberately NULL, awaiting the backfill
+
+SELECT id, title, total_value FROM book;
+                                    -- => both rows show total_value = <blank> (NULL) -- not yet computed
+
+-- Backfill: compute the derived value for every row that just gained the new column.
+UPDATE book SET total_value = price * quantity;
+                                    -- => no WHERE clause -- every row needs backfilling this time (co-11)
+
+SELECT id, title, price, quantity, total_value FROM book;
+                                    -- => row 1: 12.5 * 4 = 50.0 -- row 2: 9.0 * 10 = 90.0

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-61-migration-version-tracking/migrate.sh
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-61-migration-version-tracking/migrate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Example 61: a minimal migration RUNNER -- reads PRAGMA user_version first (co-24),
+# and only applies migration.sql if the database hasn't already been migrated.
+set -euo pipefail # => fail fast on any error, unset variable, or pipe failure
+
+DB="app.db" # => the single database file this runner targets
+CURRENT=$(sqlite3 "$DB" "PRAGMA user_version;")
+# => reads the CURRENT version straight out of the file header
+
+if [ "$CURRENT" -lt 1 ]; then # => version 0 (or lower) means migration.sql has NOT run yet
+	sqlite3 "$DB" <migration.sql # => applies the ALTER TABLE + bumps PRAGMA user_version to 1
+	NEW=$(sqlite3 "$DB" "PRAGMA user_version;")
+	# => re-reads the version -- confirms the bump actually landed
+	echo "migrated to version $NEW"
+	# => the FIRST-run message -- printed exactly once, ever
+else
+	# => version is ALREADY >= 1 -- re-running would fail with "duplicate column name"
+	echo "already at version $CURRENT, skipping"
+	# => the IDEMPOTENT path -- safe to call this script repeatedly
+fi

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-61-migration-version-tracking/migration.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-61-migration-version-tracking/migration.sql
@@ -1,0 +1,7 @@
+-- Example 61: the migration body itself -- only ever meant to run ONCE, guarded by migrate.sh.
+ALTER TABLE book ADD COLUMN edition INTEGER DEFAULT 1;
+                                    -- => the additive change, identical in shape to Example 59
+
+-- PRAGMA user_version stores a plain integer INSIDE the database file's header (co-24) --
+-- no extra "schema_migrations" table needed to remember which migration already ran.
+PRAGMA user_version = 1;

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-61-migration-version-tracking/schema.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-61-migration-version-tracking/schema.sql
@@ -1,0 +1,7 @@
+-- Example 61: Migration Version Tracking -- initial schema (version 0, the SQLite default).
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+                                    -- => a fresh database file -- PRAGMA user_version starts at 0
+INSERT INTO book(id, title, price) VALUES
+    (1, 'Notes on the Analytical Engine', 12.5),
+    (2, 'Sketch of the Analytical Engine', 9.0);
+                                    -- => 2 pre-existing rows -- the migration below must not break them

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-62-n-plus-1-demonstrated/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-62-n-plus-1-demonstrated/example.py
@@ -1,0 +1,78 @@
+# pyright: strict
+"""Example 62: N+1 Query Problem Demonstrated."""
+
+import sqlite3  # => stdlib DB-API module (co-19) -- no third-party driver needed
+
+
+def setup(conn: sqlite3.Connection) -> None:
+    # A fresh in-memory schema + seed data -- this example needs NO leftover state (self-contained).
+    conn.executescript(
+        """
+        -- a minimal parent table -- just enough to demonstrate the per-parent loop below
+        CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);  -- 1 parent table
+        -- author_id is NOT a foreign key here -- the point is the QUERY PATTERN, not the schema
+        CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL);
+        -- 2 authors -- Ada will end up with 2 books below, Grace with 1
+        INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper');  -- 2 rows
+        -- 3 books total, split 2-and-1 across the 2 authors above
+        INSERT INTO book(id, title, author_id) VALUES  -- a 3-row multi-VALUES insert
+            (1, 'Notes on the Analytical Engine', 1),  -- Ada's first book
+            (2, 'Sketch of the Analytical Engine', 1),  -- Ada's second book
+            (3, 'The First Computer Bug', 2);  -- Grace's only book
+        """
+    )  # => author has 2 rows, book has 3 rows -- 2 belong to author 1, 1 belongs to author 2
+    conn.commit()  # => persists the schema + seed data before any reporting query runs
+
+
+def main() -> (
+    None
+):  # => the entry point -- runs setup(), then the N+1 loop, then a summary
+    conn: sqlite3.Connection = sqlite3.connect(
+        ":memory:"
+    )  # => a throwaway, process-local DB
+    setup(conn)  # => builds the 2-author, 3-book fixture this whole example reads from
+
+    query_count: int = 0  # => a manual counter -- makes the "N+1" round trips VISIBLE
+    authors: list[tuple[int, str]] = (
+        conn.execute(  # => query #1, below -- the parent fetch
+            "SELECT id, name FROM author"  # => no WHERE -- every author row, unconditionally
+        ).fetchall()
+    )  # => drains the cursor into a plain Python list right away
+    # => fetchall() drains the cursor into a plain list -- 2 rows, one PER author
+    query_count += 1  # => query #1 -- fetches every parent (author) row, once
+
+    results: list[
+        tuple[str, list[str]]
+    ] = []  # => accumulates (author_name, titles) pairs
+    for (
+        author_id,
+        author_name,
+    ) in authors:  # => THIS loop is the anti-pattern -- N iterations
+        # A SEPARATE round trip to the engine, PER author -- the "N" in "N+1" (co-23).
+        titles_cur: sqlite3.Cursor = conn.execute(  # => opens a FRESH cursor every iteration
+            "SELECT title FROM book WHERE author_id = ?",  # => filters to ONE author per call
+            (author_id,),  # => the single bound parameter for THIS iteration
+        )  # => runs a fresh query EVERY time the loop body executes
+        titles: list[str] = [
+            row[0] for row in titles_cur.fetchall()
+        ]  # => unwraps 1-tuples
+        query_count += 1  # => tallies each per-author query as it fires
+        results.append(
+            (author_name, titles)
+        )  # => appends this author's (name, titles) pair
+
+    for (
+        name,
+        titles,
+    ) in results:  # => a SEPARATE loop -- just prints what was already fetched
+        print(
+            name, titles
+        )  # => Output: one line per author, its titles as a Python list
+    print(
+        f"queries executed: {query_count}"
+    )  # => 1 + 2 = 3 total -- co-23's cost, made visible
+    conn.close()  # => releases the in-memory connection -- nothing to clean up on disk
+
+
+if __name__ == "__main__":  # => guards main() so importing this module never runs it
+    main()  # => runs the whole demonstration end to end

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-63-n-plus-1-fixed-join/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-63-n-plus-1-fixed-join/example.py
@@ -1,0 +1,75 @@
+# pyright: strict
+"""Example 63: N+1 Fixed with a Single JOIN."""
+
+import sqlite3  # => stdlib DB-API module (co-19)
+
+
+def setup(conn: sqlite3.Connection) -> None:  # => builds the SAME fixture as Example 62
+    # Identical schema and seed data to Example 62 -- same problem, different query shape.
+    conn.executescript(
+        """
+        -- same fixture shape as Example 62 -- comparing the FIX, not the data
+        CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);  -- 1 parent table
+        CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL);
+        -- author_id is a plain integer column here too -- the fix is the QUERY, not the schema
+        -- 2 authors, exactly as in Example 62
+        INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper');  -- 2 rows
+        -- 3 books, split 2-and-1, exactly as in Example 62
+        INSERT INTO book(id, title, author_id) VALUES  -- a 3-row multi-VALUES insert
+            (1, 'Notes on the Analytical Engine', 1),  -- Ada's first book
+            (2, 'Sketch of the Analytical Engine', 1),  -- Ada's second book
+            (3, 'The First Computer Bug', 2);  -- Grace's only book
+        """
+    )  # => same fixture as Example 62 -- 2 authors, 3 books, split 2-and-1
+    conn.commit()  # => persists the fixture before the single report query runs
+
+
+def main() -> (
+    None
+):  # => the entry point -- setup(), one JOIN query, then a print summary
+    conn: sqlite3.Connection = sqlite3.connect(
+        ":memory:"
+    )  # => a throwaway, process-local DB
+    setup(conn)  # => builds the identical fixture Example 62 used
+
+    query_count: int = (
+        0  # => tracks round trips -- watch this stay at 1, unlike Example 62's 3
+    )
+    # ONE query -- author JOIN book (co-13) -- replaces the whole per-author loop from Example 62.
+    # No Python for loop issues per-author SELECTs anymore -- the JOIN does that work in SQL.
+    rows: list[tuple[str, str]] = (
+        conn.execute(  # => a single multi-line SQL string, one call
+            """
+        -- ONE query does what Example 62 needed 3 separate round trips to do
+        SELECT author.name, book.title
+        FROM author
+        JOIN book ON book.author_id = author.id
+        ORDER BY author.name, book.title
+        """
+        ).fetchall()
+    )  # => 3 rows total, one PER BOOK, author name repeated where an author has 2 books
+    query_count += (
+        1  # => the round trip count no longer scales with the number of authors
+    )
+
+    # Groups the flat rows back into "author -> list of titles" in PLAIN PYTHON, not another query.
+    grouped: dict[str, list[str]] = {}  # => empty until the loop below fills it in
+    for author_name, title in rows:  # => iterates the 3 FLAT rows returned by the join
+        grouped.setdefault(author_name, []).append(
+            title
+        )  # => builds the grouping in Python
+        # => setdefault(author_name, []) creates the list on first sight, appends every time after
+
+    for (
+        name,
+        titles,
+    ) in grouped.items():  # => iterates the GROUPED dict, not the raw rows
+        print(
+            name, titles
+        )  # => Output: identical two lines to Example 62, from ONE query
+    print(f"queries executed: {query_count}")  # => 1 -- versus Example 62's 3
+    conn.close()  # => releases the in-memory connection -- nothing to clean up on disk
+
+
+if __name__ == "__main__":  # => guards main() so importing this module never runs it
+    main()  # => runs the whole demonstration end to end

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-64-n-plus-1-fixed-in/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-64-n-plus-1-fixed-in/example.py
@@ -1,0 +1,82 @@
+# pyright: strict
+"""Example 64: N+1 Fixed with a Batched IN(...) Fetch."""
+
+import sqlite3  # => stdlib DB-API module (co-19)
+
+
+def setup(conn: sqlite3.Connection) -> None:
+    # Same schema and seed data as Examples 62-63 -- a third way to fix the identical problem.
+    conn.executescript(
+        """
+        -- same fixture shape as Examples 62-63 -- comparing a THIRD fix to the identical problem
+        CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);  -- 1 parent table
+        CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL);
+        -- author_id is a plain integer column here too -- the fix is a SECOND batched query
+        -- 2 authors, exactly as in Examples 62-63
+        INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper');  -- 2 rows
+        -- 3 books, split 2-and-1, exactly as in Examples 62-63
+        INSERT INTO book(id, title, author_id) VALUES  -- a 3-row multi-VALUES insert
+            (1, 'Notes on the Analytical Engine', 1),  -- Ada's first book
+            (2, 'Sketch of the Analytical Engine', 1),  -- Ada's second book
+            (3, 'The First Computer Bug', 2);  -- Grace's only book
+        """
+    )  # => same fixture as Examples 62-63 -- 2 authors, 3 books, split 2-and-1
+    conn.commit()  # => persists the fixture before the two batched queries run
+
+
+def main() -> (
+    None
+):  # => entry point -- setup(), a parent fetch, a batched IN(...) fetch, print
+    conn: sqlite3.Connection = sqlite3.connect(
+        ":memory:"
+    )  # => a throwaway, process-local DB
+    setup(conn)  # => builds the identical fixture Examples 62-63 used
+
+    query_count: int = 0  # => tracks round trips -- watch this settle at 2, not 1 or 3
+    authors: list[tuple[int, str]] = conn.execute(  # => query #1 -- the parent fetch
+        "SELECT id, name FROM author"  # => no WHERE -- every author row, unconditionally
+    ).fetchall()  # => drains the cursor -- 2 author rows, exactly like Example 62's first query
+    query_count += (
+        1  # => query #1 -- the parent rows, exactly like Example 62's first query
+    )
+
+    author_ids: list[int] = [
+        author_id for author_id, _ in authors
+    ]  # => just the ids, in order
+    # => extracts JUST the ids from the (id, name) pairs -- discards name via the _ placeholder
+    # Builds "?, ?, ..." -- ONE placeholder per id -- the values themselves stay fully parameterized.
+    placeholders: str = ",".join("?" for _ in author_ids)  # => "?,?" for 2 authors
+    books: list[tuple[int, str]] = (
+        conn.execute(  # => query #2 -- the ONLY child fetch, batched
+            f"SELECT author_id, title FROM book WHERE author_id IN ({placeholders})",
+            # => the f-string only splices in "?,?" placeholder MARKS -- never a real data value
+            author_ids,  # => co-20 -- every id is still bound as a real parameter, never interpolated
+        ).fetchall()
+    )  # => query #2 -- ALL children for EVERY parent, in a single batched round trip
+    query_count += (
+        1  # => the second and FINAL query -- independent of how many authors there are
+    )
+
+    grouped: dict[int, list[str]] = {}  # => empty until the loop below fills it in
+    for (
+        author_id,
+        title,
+    ) in books:  # => groups the flat rows by author_id, in plain Python
+        grouped.setdefault(author_id, []).append(
+            title
+        )  # => builds the grouping in Python
+        # => same setdefault-and-append pattern Example 63 used, applied to a different key
+
+    for author_id, author_name in authors:  # => iterates in the ORIGINAL author order
+        print(
+            author_name, grouped.get(author_id, [])
+        )  # => .get(..., []) -- safe for zero books
+        # => Output: identical two lines to Examples 62-63 -- same data, now via 2 total queries
+    print(
+        f"queries executed: {query_count}"
+    )  # => 2 -- one parent query PLUS one batched fetch
+    conn.close()  # => releases the in-memory connection
+
+
+if __name__ == "__main__":  # => guards main() so importing this module never runs it
+    main()  # => runs the whole demonstration end to end

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-65-composite-primary-key/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-65-composite-primary-key/example.sql
@@ -1,0 +1,30 @@
+-- Example 65: Composite Primary Key.
+-- A junction table's identity is the PAIR of foreign keys, not a surrogate id column (co-02, co-05).
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL);
+                                    -- => minimal parent -- just enough for book_tag to reference
+CREATE TABLE tag(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => the OTHER parent -- book_tag links book to tag, many-to-many
+CREATE TABLE book_tag(
+    book_id INTEGER NOT NULL REFERENCES book(id),
+                                    -- => FK half of the composite key
+    tag_id INTEGER NOT NULL REFERENCES tag(id),
+                                    -- => the OTHER FK half of the composite key
+    PRIMARY KEY (book_id, tag_id)  -- => the PAIR must be unique -- no separate id column needed
+);
+
+INSERT INTO book(id, title) VALUES (1, 'Notes on the Analytical Engine');
+                                    -- => 1 book row -- book_id = 1 is referenced below
+INSERT INTO tag(id, name) VALUES (1, 'history'), (2, 'computing');
+                                    -- => 2 tag rows -- tag_id 1 and 2 are referenced below
+
+-- .headers on and .mode column below are display preferences only -- no dot-command
+-- takes a trailing comment on its own line, so these two notes live here instead.
+.headers on
+.mode column
+INSERT INTO book_tag(book_id, tag_id) VALUES (1, 1), (1, 2);
+                                    -- => two DIFFERENT pairs -- both accepted
+SELECT * FROM book_tag;            -- => 2 rows -- book 1 tagged 'history' AND 'computing'
+
+-- The SAME (book_id, tag_id) pair a second time -- this violates the composite PRIMARY KEY.
+INSERT INTO book_tag(book_id, tag_id) VALUES (1, 1);
+                                    -- => rejected -- (1, 1) already exists as a row

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-66-cascade-delete/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-66-cascade-delete/example.sql
@@ -1,0 +1,35 @@
+-- Example 66: Cascade Delete.
+-- SQLite disables foreign-key ENFORCEMENT by default -- ON DELETE actions need it turned on (co-03).
+PRAGMA foreign_keys = ON;          -- => a per-connection setting -- must be re-issued every connect
+
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => the PARENT side of the relationship below
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    title TEXT NOT NULL,           -- => every book needs a title
+    author_id INTEGER REFERENCES author(id) ON DELETE CASCADE
+                                    -- => CASCADE propagates a parent delete to every matching child
+);
+
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace');
+                                    -- => 1 author row -- the parent this example deletes below
+INSERT INTO book(id, title, author_id) VALUES
+    (1, 'Notes on the Analytical Engine', 1),
+    (2, 'Sketch of the Analytical Engine', 1);
+                                    -- => 2 child rows, both pointing at author 1
+
+-- .headers on shows column names above every count(*) result below; .mode column aligns
+-- them for readability -- purely display, unrelated to the CASCADE behavior below.
+.headers on
+.mode column
+SELECT count(*) AS books_before FROM book WHERE author_id = 1;
+                                    -- => 2 -- both books still reference author 1
+
+DELETE FROM author WHERE id = 1;   -- => deletes the PARENT row -- CASCADE fires automatically
+                                    -- => a SINGLE statement triggers both the parent AND child deletes
+
+SELECT count(*) AS books_after FROM book WHERE author_id = 1;
+                                    -- => 0 -- both child rows were removed too, not just orphaned
+SELECT count(*) AS authors_after FROM author;
+                                    -- => 0 -- the author row itself is gone
+                                    -- => contrast Example 67: RESTRICT would have BLOCKED this delete

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-67-restrict-delete/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-67-restrict-delete/example.sql
@@ -1,0 +1,24 @@
+-- Example 67: Restrict Delete.
+PRAGMA foreign_keys = ON;          -- => enforcement must be on for RESTRICT to actually block anything
+
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => the PARENT side -- the row this example tries to delete
+CREATE TABLE book(
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    title TEXT NOT NULL,           -- => every book needs a title
+    author_id INTEGER REFERENCES author(id) ON DELETE RESTRICT
+                                    -- => RESTRICT is the opposite of CASCADE: blocks the parent delete
+);
+
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace');
+                                    -- => 1 author row -- still referenced by the book below
+INSERT INTO book(id, title, author_id) VALUES (1, 'Notes on the Analytical Engine', 1);
+                                    -- => the ONE child row that makes the delete below illegal
+
+-- .headers on and .mode column below are display preferences, consistent with every other
+-- example in this tier -- they have no bearing on the RESTRICT behavior demonstrated next.
+.headers on
+.mode column
+-- Blocked: author 1 still has a referencing book row -- RESTRICT rejects this delete outright.
+DELETE FROM author WHERE id = 1;   -- => fails -- the engine refuses to orphan the book row above
+                                    -- => contrast Example 66: CASCADE ALLOWS this same shape of delete

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-68-savepoint-partial-rollback/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-68-savepoint-partial-rollback/example.sql
@@ -1,0 +1,22 @@
+-- Example 68: Savepoint Partial Rollback.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+                                    -- => a single table -- enough to demonstrate the savepoint dance
+
+-- .headers on shows column names above the final SELECT below; .mode column aligns the
+-- display -- both are readability preferences, set before the transaction even opens.
+.headers on
+.mode column
+BEGIN;                              -- => opens the OUTER transaction (co-18)
+INSERT INTO book(id, title, price) VALUES (1, 'Notes on the Analytical Engine', 12.5);
+                                    -- => row 1 -- committed at the END, along with row 3 below
+
+SAVEPOINT sp;                       -- => marks a point INSIDE the still-open transaction
+INSERT INTO book(id, title, price) VALUES (2, 'Bad Draft', -5.0);
+                                    -- => a mistake we want to undo WITHOUT losing row 1 too
+ROLLBACK TO sp;                     -- => undoes ONLY work since sp -- the outer transaction stays open
+
+INSERT INTO book(id, title, price) VALUES (3, 'Sketch of the Analytical Engine', 9.0);
+                                    -- => row 3 -- inserted AFTER the rollback, in the same transaction
+COMMIT;                             -- => finalizes rows 1 and 3 -- row 2 never existed past the savepoint
+
+SELECT id, title, price FROM book;  -- => 2 rows: ids 1 and 3 -- the bad draft (id 2) is nowhere

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-69-python-report-function/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-69-python-report-function/example.py
@@ -1,0 +1,82 @@
+# pyright: strict
+"""Example 69: Typed report() Function Running a GROUP BY."""
+# Splitting fetch-and-shape logic into a typed function is what makes it independently testable.
+
+import sqlite3  # => stdlib DB-API module (co-19) -- the only import this whole file needs
+
+
+def setup(
+    conn: sqlite3.Connection,
+) -> None:  # => builds the fixture report() reads from
+    conn.executescript(
+        """
+        -- a minimal author/book fixture -- just enough for one GROUP BY report
+        CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);  -- 1 parent table
+        CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL);
+        -- author_id is a plain integer column -- report() below GROUPs by the author's NAME
+        -- 2 authors -- Ada ends up with 2 books, Grace with 1
+        INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper');  -- 2 rows
+        -- 3 books, split 2-and-1 -- the exact counts main()'s hand-computed assert checks
+        INSERT INTO book(id, title, author_id) VALUES  -- a 3-row multi-VALUES insert
+            (1, 'Notes on the Analytical Engine', 1),  -- Ada's first book
+            (2, 'Sketch of the Analytical Engine', 1),  -- Ada's second book
+            (3, 'The First Computer Bug', 2);  -- Grace's only book
+        """
+    )  # => 2 authors, 3 books -- Ada has 2, Grace has 1, the fixture report() summarizes
+    conn.commit()  # => persists the fixture before report() ever runs against it
+
+
+def report(
+    conn: sqlite3.Connection,
+) -> list[tuple[str, int]]:  # => the function under test
+    # A fully typed function signature (co-21): the return shape is documented in the type,
+    # not just in a comment -- any caller sees "name, count" pairs without reading the body.
+    cur: sqlite3.Cursor = conn.execute(  # => a single multi-line SQL string, one call
+        """
+        -- one JOIN, one GROUP BY -- the report's ENTIRE logic lives in this one query
+        SELECT author.name, count(*)
+        FROM author
+        JOIN book ON book.author_id = author.id
+        GROUP BY author.name
+        ORDER BY author.name
+        """
+    )  # => GROUP BY collapses per-book rows into per-author counts (co-15)
+    rows: list[tuple[str, int]] = (
+        cur.fetchall()
+    )  # => drains the cursor into a typed list
+    return rows  # => e.g. [('Ada Lovelace', 2), ('Grace Hopper', 1)]
+    # Nothing about this function's SHAPE would change for a bigger fixture -- SQL scales, not Python
+
+
+def main() -> (
+    None
+):  # => entry point -- builds the fixture, calls report(), checks the answer
+    conn: sqlite3.Connection = sqlite3.connect(
+        ":memory:"
+    )  # => a throwaway, process-local DB
+    setup(conn)  # => builds the 2-author, 3-book fixture report() reads from
+
+    rows: list[tuple[str, int]] = report(conn)  # => calls the typed function under test
+    # No caller here needs to know report()'s SQL -- the typed return value is the contract.
+    for (
+        name,
+        count,
+    ) in rows:  # => unpacks each (name, count) pair from the returned list
+        print(name, count)  # => Output: one line per author, its book count
+
+    # Hand-computed: Ada has 2 books (ids 1, 2), Grace has 1 book (id 3) -- matches the seed above.
+    expected: list[tuple[str, int]] = [
+        ("Ada Lovelace", 2),
+        ("Grace Hopper", 1),
+    ]  # => by hand
+    assert (
+        rows == expected
+    )  # => proves report()'s SQL matches what a human counted by hand
+    print(
+        "matches hand-computed expectation"
+    )  # => only reached if the assert above passed
+    conn.close()  # => releases the in-memory connection -- nothing to clean up on disk
+
+
+if __name__ == "__main__":  # => guards main() so importing this module never runs it
+    main()  # => runs the whole demonstration end to end

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-70-group-concat/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-70-group-concat/example.sql
@@ -1,0 +1,25 @@
+-- Example 70: group_concat.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => the GROUPing key this example concatenates around
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL);
+                                    -- => the column whose VALUES get folded into one string
+
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace');
+                                    -- => 1 author -- author_id = 1 groups both books below
+INSERT INTO book(id, title, author_id) VALUES
+    (1, 'Notes on the Analytical Engine', 1),
+    (2, 'Sketch of the Analytical Engine', 1);
+                                    -- => 2 books, SAME author -- one group_concat row results
+
+-- .headers on shows the "author_id | titles" header row below. .mode list switches away
+-- from .mode column -- a long concatenated string would WRAP mid-word there (see Example
+-- 65's .mode column note); .separator " | " picks a readable delimiter for list mode.
+.headers on
+.mode list
+.separator " | "
+-- list mode (pipe-separated, no column wrapping) keeps the long concatenated string on one line.
+-- group_concat(X, sep) folds every GROUPed row's X value into ONE string, sep-joined (co-15).
+SELECT author_id, group_concat(title, '; ') AS titles
+FROM book
+GROUP BY author_id;                -- => one row per author_id -- titles collapsed into one string
+                                    -- => the '; ' second argument is the JOINER between titles

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-71-anti-join-missing/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-71-anti-join-missing/example.sql
@@ -1,0 +1,25 @@
+-- Example 71: Anti-Join -- Missing Rows.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => the LEFT side of the join -- every row here must appear
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL);
+                                    -- => the RIGHT side -- deliberately missing for one author below
+
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper'), (3, 'Alan Turing');
+                                    -- => 3 authors -- only 2 will have a matching book
+INSERT INTO book(id, title, author_id) VALUES
+    (1, 'Notes on the Analytical Engine', 1),
+    (2, 'The First Computer Bug', 2);
+                                    -- => Alan Turing (id 3) intentionally has ZERO books
+
+-- .headers on shows the "name" header row below; .mode column aligns the display --
+-- both are readability preferences only, unrelated to the anti-join logic below.
+.headers on
+.mode column
+-- LEFT JOIN keeps EVERY author row -- unmatched book columns come back NULL (co-14).
+-- WHERE book.id IS NULL then isolates ONLY the authors that never matched anything (co-17).
+SELECT author.name
+FROM author
+LEFT JOIN book ON book.author_id = author.id
+WHERE book.id IS NULL;             -- => Alan Turing only -- the "missing rows" anti-join pattern
+                                    -- => an INNER JOIN here would have DROPPED Alan entirely
+                                    -- => "= NULL" would NOT work here -- co-17's three-valued logic

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-72-atomic-transfer/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-72-atomic-transfer/example.sql
@@ -1,0 +1,31 @@
+-- Example 72: Atomic Transfer.
+CREATE TABLE account(id INTEGER PRIMARY KEY, name TEXT NOT NULL, balance REAL NOT NULL);
+                                    -- => a tiny ledger -- 2 accounts, one debit/credit pair below
+INSERT INTO account(id, name, balance) VALUES (1, 'checking', 100.0), (2, 'savings', 50.0);
+                                    -- => starting balances -- the baseline for every check below
+
+.headers on
+.mode column
+SELECT id, name, balance FROM account;
+                                    -- => checking 100.0, savings 50.0 -- the starting state
+
+-- A successful transfer: BOTH legs (debit + credit) succeed inside ONE transaction (co-18).
+BEGIN;                              -- => opens the transaction -- neither leg is visible yet
+UPDATE account SET balance = balance - 30.0 WHERE id = 1;
+                                    -- => debit leg -- checking drops by 30
+UPDATE account SET balance = balance + 30.0 WHERE id = 2;
+                                    -- => credit leg -- savings gains the SAME 30
+COMMIT;                            -- => both legs land together -- no half-transfer is EVER visible
+
+SELECT id, name, balance FROM account;
+                                    -- => checking 70.0, savings 80.0 -- 30 moved, nothing lost
+
+-- A transfer we DELIBERATELY abandon after detecting a problem, before committing either leg.
+BEGIN;                              -- => opens a SECOND, independent transaction
+UPDATE account SET balance = balance - 1000.0 WHERE id = 1;
+                                    -- => this debit would drive checking NEGATIVE -- a business rule
+                                    -- => violation this application layer checks for itself
+ROLLBACK;                          -- => undoes the just-issued debit -- nothing was ever persisted
+
+SELECT id, name, balance FROM account;
+                                    -- => STILL checking 70.0, savings 80.0 -- all-or-nothing held

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-73-python-dal-module/dal.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-73-python-dal-module/dal.py
@@ -1,0 +1,77 @@
+# pyright: strict
+"""Example 73: A Typed Data-Access-Layer Module -- Parameterized CRUD."""
+
+import sqlite3  # => stdlib DB-API module (co-19) -- no third-party driver anywhere in this file
+
+
+def create_schema(
+    conn: sqlite3.Connection,
+) -> None:  # => called once per test, in the fixture
+    # Every function in this module takes an ALREADY-OPEN connection -- callers (including
+    # tests) control the connection's lifetime, this module never opens or closes one itself.
+    conn.executescript(  # => executescript, not execute -- runs raw DDL, no placeholders needed
+        "CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);"  # => single DDL statement
+    )  # => the ONLY table this module manages -- a minimal fixture for CRUD demonstration
+
+
+def insert_author(conn: sqlite3.Connection, name: str) -> int:  # => the "C" in CRUD
+    # `?` (qmark) parameterization -- name is BOUND, never string-interpolated (co-20).
+    cur: sqlite3.Cursor = conn.execute(  # => returns a Cursor -- lastrowid is read off it below
+        "INSERT INTO author(name) VALUES (?)",  # => one placeholder, one bound value
+        (
+            name,
+        ),  # => a 1-tuple -- the trailing comma is REQUIRED for a single-element tuple
+    )
+    conn.commit()  # => persists the insert before returning the new row's id to the caller
+    new_id: int | None = cur.lastrowid  # => the rowid SQLite just assigned (co-02)
+    assert (
+        new_id is not None
+    )  # => narrows int | None to int -- always set right after an INSERT
+    return (
+        new_id  # => the caller uses this id for every follow-up get/update/delete call
+    )
+
+
+def get_author(
+    conn: sqlite3.Connection, author_id: int
+) -> tuple[int, str] | None:  # "R" in CRUD
+    cur: sqlite3.Cursor = (
+        conn.execute(  # => a read -- no conn.commit() needed for a SELECT
+            "SELECT id, name FROM author WHERE id = ?",  # => a single bound parameter
+            (author_id,),  # => co-20 again, this time for a lookup, not an insert
+        )
+    )
+    row: tuple[int, str] | None = (
+        cur.fetchone()
+    )  # => None if no row matched the given id
+    return row  # => the caller must handle the None case -- pyright enforces this via the type
+
+
+def list_authors(
+    conn: sqlite3.Connection,
+) -> list[tuple[int, str]]:  # => reads EVERY row
+    cur: sqlite3.Cursor = conn.execute(
+        "SELECT id, name FROM author ORDER BY id"
+    )  # => the bulk read
+    # => no WHERE clause -- every row, oldest id first
+    return (
+        cur.fetchall()
+    )  # => every row by this ONE call -- no filter needed for a full listing
+
+
+def update_author_name(
+    conn: sqlite3.Connection, author_id: int, new_name: str
+) -> None:  # "U"
+    conn.execute(  # => a write -- conn.commit() below persists it
+        "UPDATE author SET name = ? WHERE id = ?",  # => TWO placeholders -- order matters below
+        (new_name, author_id),  # => the SAME order as the ?s in the SQL text (co-20)
+    )
+    conn.commit()  # => this module commits eagerly -- no long-lived open transaction to forget
+
+
+def delete_author(
+    conn: sqlite3.Connection, author_id: int
+) -> None:  # => the "D" in CRUD
+    conn.execute("DELETE FROM author WHERE id = ?", (author_id,))
+    # => DELETE ... WHERE with a bound id -- co-20 once more, no string interpolation anywhere
+    conn.commit()  # => a no-op commit if author_id didn't exist -- DELETE ... WHERE is safe to repeat

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-73-python-dal-module/tests/test_dal.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-73-python-dal-module/tests/test_dal.py
@@ -1,0 +1,74 @@
+"""Example 73: pytest coverage for dal.py against a seeded, in-memory fixture DB."""
+
+import sqlite3  # => stdlib DB-API module -- only needed here to type the fixture's connection
+from collections.abc import Iterator  # => types the fixture's generator return
+
+import pytest  # => the testing framework -- provides the @pytest.fixture decorator below
+
+# tests/__init__.py makes THIS directory a package, so pytest inserts the PARENT dir (the
+# example's root) into sys.path -- that is what makes `from dal import ...` resolve at all.
+from dal import (  # => imports the module UNDER TEST
+    create_schema,  # => builds the schema -- called once per test, via the fixture below
+    delete_author,  # => the "D" in CRUD -- covered by test_delete_author
+    get_author,  # => the "R" in CRUD -- covered by every test below
+    insert_author,  # => the "C" in CRUD -- covered by every test below
+    list_authors,  # => a bulk read -- covered by test_list_authors_returns_every_row
+    update_author_name,  # => the "U" in CRUD -- covered by test_update_author_name
+)  # => closes the import list -- all five dal.py functions under test in this file
+
+
+@pytest.fixture  # => runs before EVERY test function below, fresh each time
+def conn() -> Iterator[
+    sqlite3.Connection
+]:  # => Iterator, not Connection -- this is a generator
+    # A FRESH in-memory DB per test -- no test can see another test's leftover rows.
+    connection: sqlite3.Connection = sqlite3.connect(
+        ":memory:"
+    )  # => a throwaway, per-test DB
+    create_schema(
+        connection
+    )  # => builds the ONE table every test below reads and writes
+    yield connection  # => hands the ready connection to the test function below
+    connection.close()  # => runs AFTER the test, whether it passed or failed
+
+
+def test_insert_and_get_author(
+    conn: sqlite3.Connection,
+) -> None:  # => covers insert + get
+    author_id: int = insert_author(
+        conn, "Ada Lovelace"
+    )  # => the function under test, first call
+    assert get_author(conn, author_id) == (
+        author_id,
+        "Ada Lovelace",
+    )  # => round-trips correctly
+
+
+def test_list_authors_returns_every_row(
+    conn: sqlite3.Connection,
+) -> None:  # => covers the bulk read
+    insert_author(conn, "Ada Lovelace")  # => row 1
+    insert_author(conn, "Grace Hopper")  # => row 2
+    assert list_authors(conn) == [
+        (1, "Ada Lovelace"),
+        (2, "Grace Hopper"),
+    ]  # => both, in order
+
+
+def test_update_author_name(
+    conn: sqlite3.Connection,
+) -> None:  # => covers the "U" in CRUD
+    author_id: int = insert_author(conn, "Ada")  # => an initial, incomplete name
+    update_author_name(conn, author_id, "Ada Lovelace")  # => the function under test
+    assert get_author(conn, author_id) == (
+        author_id,
+        "Ada Lovelace",
+    )  # => the UPDATE persisted
+
+
+def test_delete_author(conn: sqlite3.Connection) -> None:  # => covers the "D" in CRUD
+    author_id: int = insert_author(conn, "Ada Lovelace")  # => the row this test deletes
+    delete_author(conn, author_id)  # => the function under test
+    assert (
+        get_author(conn, author_id) is None
+    )  # => the row is genuinely gone, not just renamed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-74-seed-from-sql-file/schema.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-74-seed-from-sql-file/schema.sql
@@ -1,0 +1,6 @@
+-- Example 74: Seed from SQL File -- schema.sql (structure only, no data).
+-- Splitting structure from data is a common convention: schema.sql defines the shape,
+-- seed.sql fills it -- each applied as its own separate sqlite3 CLI invocation (co-24).
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);  -- => the parent table
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL REFERENCES author(id));
+                                    -- => the child table -- zero rows in EITHER table yet

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-74-seed-from-sql-file/seed.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-74-seed-from-sql-file/seed.sql
@@ -1,0 +1,10 @@
+-- Example 74: Seed from SQL File -- seed.sql (data only, applied AFTER schema.sql, co-10).
+-- This file assumes schema.sql ALREADY ran -- applying seed.sql alone, first, would fail
+-- with "no such table: author".
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper');
+                                    -- => 2 author rows -- author_id 1 and 2 below reference these
+INSERT INTO book(id, title, author_id) VALUES
+    (1, 'Notes on the Analytical Engine', 1),  -- Ada's first book
+    (2, 'Sketch of the Analytical Engine', 1),  -- Ada's second book
+    (3, 'The First Computer Bug', 2);           -- Grace's only book
+                                    -- => 3 book rows -- the count Example 74's verify checks

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-75-export-query-to-csv/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-75-export-query-to-csv/example.sql
@@ -1,0 +1,17 @@
+-- Example 75: Export Query to CSV.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, price REAL NOT NULL);
+                                    -- => a single table -- enough to demonstrate export
+INSERT INTO book(id, title, price) VALUES  -- a 2-row multi-VALUES insert
+    (1, 'Notes on the Analytical Engine', 12.5),  -- row 1 -- exported below
+    (2, 'Sketch of the Analytical Engine', 9.0);   -- row 2 -- exported below
+
+-- .headers on, .mode csv, and .output out.csv below are display/format preferences only.
+.headers on
+.mode csv
+.output out.csv
+-- .output REDIRECTS every subsequent result to the named file -- nothing prints to the terminal
+-- until .output stdout runs again (co-24). Note: no trailing "--" comment on a dot-command line.
+SELECT id, title, price FROM book; -- => written to out.csv, NOT the terminal, while redirected
+.output stdout
+-- Back on the terminal -- confirms the CLI itself is unaffected by the redirect that just ended.
+SELECT 'export done' AS status;    -- => prints on the terminal -- proves .output stdout worked

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-76-integrity-checks/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-76-integrity-checks/example.sql
@@ -1,0 +1,19 @@
+-- Example 76: Integrity Checks.
+PRAGMA foreign_keys = ON;          -- => enforcement on -- relevant to foreign_key_check below
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => the parent table foreign_key_check will verify against
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER REFERENCES author(id));
+                                    -- => the child table -- its FK is what gets checked below
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace');
+                                    -- => 1 author row -- author_id = 1 is referenced below
+INSERT INTO book(id, title, author_id) VALUES (1, 'Notes on the Analytical Engine', 1);
+                                    -- => 1 book row, correctly referencing an EXISTING author
+
+-- .headers on and .mode column below are display preferences only -- unrelated to the checks.
+.headers on
+.mode column
+-- integrity_check walks the B-tree structure itself -- page corruption, not foreign keys (co-24).
+PRAGMA integrity_check;            -- => "ok" means the on-disk structure is sound
+
+-- integrity_check deliberately does NOT check foreign keys -- foreign_key_check does that instead.
+PRAGMA foreign_key_check;          -- => zero ROWS returned means zero foreign-key violations (co-03)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-77-design-3nf-schema/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-77-design-3nf-schema/example.sql
@@ -1,0 +1,38 @@
+-- Example 77: Design a 3NF Schema.
+-- Four relations, each holding ONE fact-type, related purely by key values (co-01, co-05):
+CREATE TABLE author(                -- => relation 1 of 4 -- one row per author
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    name TEXT NOT NULL             -- => the ONE fact-type this table holds
+);                                  -- => an author's facts live HERE, nowhere else (co-07)
+
+CREATE TABLE publisher(             -- => relation 2 of 4 -- INDEPENDENT of author, no shared row
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    name TEXT NOT NULL,            -- => a SECOND, independent fact-type -- its own table
+    city TEXT                      -- => city depends ONLY on publisher.id -- no transitive path
+);                                  -- => a publisher's facts live HERE, nowhere else
+
+CREATE TABLE book(                  -- => relation 3 of 4 -- the table with the MOST foreign keys
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    title TEXT NOT NULL,           -- => the book's OWN fact -- not duplicated from anywhere
+    author_id INTEGER NOT NULL REFERENCES author(id),
+                                    -- => book POINTS AT an author -- never repeats the author's name
+    publisher_id INTEGER REFERENCES publisher(id),
+                                    -- => book POINTS AT a publisher -- never repeats its city
+    price REAL NOT NULL            -- => a fact about THIS book -- not about its author or publisher
+);                                  -- => a book's facts live HERE, nowhere else
+
+CREATE TABLE tag(                   -- => relation 4 of 4 -- a controlled vocabulary of labels
+    id INTEGER PRIMARY KEY,        -- => aliases rowid (co-02)
+    name TEXT NOT NULL UNIQUE      -- => UNIQUE (co-04) -- 'history' can only exist as ONE row
+);                                  -- => a tag's facts live HERE, nowhere else
+
+CREATE TABLE book_tag(              -- => the many-to-many JUNCTION -- not a "5th fact-type" table
+    book_id INTEGER NOT NULL REFERENCES book(id),
+                                    -- => FK half of the composite key (Example 65's pattern)
+    tag_id INTEGER NOT NULL REFERENCES tag(id),
+                                    -- => the OTHER FK half of the composite key
+    PRIMARY KEY (book_id, tag_id)  -- => the many-to-many junction from Example 65, reused here
+);                                  -- => book_tag holds ONLY key pairs -- no other columns at all
+
+-- .schema (no argument) prints EVERY stored CREATE TABLE -- proof the design landed as intended.
+.schema

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-78-correlated-subquery/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-78-correlated-subquery/example.sql
@@ -1,0 +1,17 @@
+-- Example 78: Correlated Subquery.
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL);
+                                    -- => the OUTER table -- one output row per book
+CREATE TABLE review(id INTEGER PRIMARY KEY, book_id INTEGER NOT NULL REFERENCES book(id), rating INTEGER NOT NULL);
+                                    -- => the table the INNER subquery counts against
+
+INSERT INTO book(id, title) VALUES (1, 'Notes on the Analytical Engine'), (2, 'Sketch of the Analytical Engine');
+                                    -- => 2 books -- 1 gets 2 reviews below, 2 gets 1 review
+INSERT INTO review(id, book_id, rating) VALUES (1, 1, 5), (2, 1, 4), (3, 2, 3);
+                                    -- => book 1 has 2 reviews, book 2 has 1 review
+
+.headers on
+.mode column
+-- The inner SELECT re-runs ONCE PER OUTER ROW -- "r.book_id = book.id" CORRELATES it to
+-- whichever book row is currently being projected (co-08). Not a join -- a per-row scalar.
+SELECT title, (SELECT count(*) FROM review r WHERE r.book_id = book.id) AS review_count
+FROM book;                         -- => 2 rows -- each with its OWN computed review count

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-79-report-join-group-having/example.sql
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-79-report-join-group-having/example.sql
@@ -1,0 +1,28 @@
+-- Example 79: Report -- Join + Group + Having.
+CREATE TABLE author(id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                                    -- => the GROUPing key for the report below
+CREATE TABLE book(id INTEGER PRIMARY KEY, title TEXT NOT NULL, author_id INTEGER NOT NULL REFERENCES author(id), price REAL NOT NULL);
+                                    -- => the joined-and-aggregated table
+                                    -- => price is what sum(book.price) totals per author, below
+
+INSERT INTO author(id, name) VALUES (1, 'Ada Lovelace'), (2, 'Grace Hopper');
+                                    -- => 2 authors -- only Ada survives the HAVING filter below
+INSERT INTO book(id, title, author_id, price) VALUES  -- a 3-row multi-VALUES insert
+    (1, 'Notes on the Analytical Engine', 1, 12.5),  -- Ada's first book
+    (2, 'Sketch of the Analytical Engine', 1, 9.0),   -- Ada's second book
+    (3, 'The First Computer Bug', 2, 15.0);           -- Grace's only book
+                                    -- => Ada has 2 books (21.5 total), Grace has 1 book (15.0)
+
+-- .headers on and .mode column below are display preferences only -- unrelated to the report logic.
+.headers on
+.mode column
+-- Three concepts in ONE query: JOIN recombines normalized rows (co-13), GROUP BY collapses
+-- them per author (co-15), HAVING then filters the AGGREGATED groups, not the raw rows (co-16).
+SELECT author.name, count(*) AS book_count, sum(book.price) AS total_value
+                                    -- => count(*) and sum(book.price) are the AGGREGATES per group
+FROM author
+JOIN book ON book.author_id = author.id
+                                    -- => the JOIN -- recombines the two normalized tables (co-13)
+GROUP BY author.name
+                                    -- => collapses per-book rows into per-author groups (co-15)
+HAVING count(*) > 1;               -- => only Ada survives -- Grace's single-book group is filtered out

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-80-pytest-rollback-integration/tests/test_transfer.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-80-pytest-rollback-integration/tests/test_transfer.py
@@ -1,0 +1,78 @@
+"""Example 80: pytest integration test -- a failing transfer leaves the DB unchanged."""
+
+import sqlite3  # => stdlib DB-API module -- only needed here to type the fixture's connection
+from collections.abc import Iterator  # => types the fixture's generator return
+
+import pytest  # => the testing framework -- provides @pytest.fixture and pytest.raises below
+
+# tests/__init__.py makes THIS directory a package, so pytest inserts the PARENT dir (the
+# example's root) into sys.path -- that is what makes `from transfer import ...` resolve at all.
+from transfer import create_schema, transfer  # => imports the module UNDER TEST
+
+
+@pytest.fixture  # => runs before EVERY test function below, fresh each time
+def conn() -> Iterator[
+    sqlite3.Connection
+]:  # => Iterator, not Connection -- this is a generator
+    connection: sqlite3.Connection = sqlite3.connect(
+        ":memory:"
+    )  # => a throwaway, per-test DB
+    create_schema(connection)  # => builds the ONE table both tests below read and write
+    connection.execute(  # => a direct execute, not the transfer() function -- just seeding
+        "INSERT INTO account(id, name, balance) VALUES (1, 'checking', 100.0), (2, 'savings', 50.0)"  # seed
+        # => two seeded accounts -- checking starts with exactly 100.0, savings with 50.0
+    )
+    connection.commit()  # => persists the seed before either test's transfer() call runs
+    yield connection  # => hands the ready connection to the test function below
+    connection.close()  # => runs AFTER the test, whether it passed or failed
+
+
+def test_transfer_commits_on_success(
+    conn: sqlite3.Connection,
+) -> None:  # => co-18's happy path
+    transfer(
+        conn, 1, 2, 30.0
+    )  # => the function under test -- a valid, affordable transfer
+    rows: list[tuple[int, float]] = (
+        conn.execute(  # => re-reads BOTH accounts, post-transfer
+            "SELECT id, balance FROM account ORDER BY id"  # => ordered so the assertion is deterministic
+        ).fetchall()
+    )  # => reads BOTH accounts back, in id order
+    assert rows == [
+        (1, 70.0),
+        (2, 80.0),
+    ]  # => both legs landed together -- co-18's happy path
+
+
+def test_failed_transfer_leaves_db_unchanged(
+    conn: sqlite3.Connection,
+) -> None:  # => the ROLLBACK path
+    before: list[tuple[int, float]] = (
+        conn.execute(  # => the pre-failure snapshot, read FIRST
+            "SELECT id, balance FROM account ORDER BY id"
+        ).fetchall()
+    )  # => captured BEFORE the failing call -- the baseline this test proves is preserved
+
+    # 1000.0 exceeds checking's 100.0 balance -- the debit alone would violate CHECK(balance >= 0).
+    with pytest.raises(
+        sqlite3.IntegrityError
+    ):  # => asserts the CHECK violation actually fires
+        transfer(
+            conn, 1, 2, 1000.0
+        )  # => `with conn:` inside transfer() auto-rolls-back on failure
+
+    after: list[tuple[int, float]] = (
+        conn.execute(  # => the post-failure snapshot, read SECOND
+            "SELECT id, balance FROM account ORDER BY id"
+        ).fetchall()
+    )  # => re-reads BOTH accounts, AFTER the failed call
+    assert (
+        before == after
+    )  # => the failed debit never persisted -- balances are BIT-for-bit identical
+    count: int = conn.execute("SELECT count(*) FROM account").fetchone()[
+        0
+    ]  # co-19 scalar read
+    # => a SEPARATE, independent check -- row count, not just balance values
+    assert (
+        count == 2
+    )  # => row COUNT is unchanged too -- no half-applied transfer left a trace

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-80-pytest-rollback-integration/transfer.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/code/ex-80-pytest-rollback-integration/transfer.py
@@ -1,0 +1,40 @@
+# pyright: strict
+"""Example 80: transfer.py -- a transaction that rolls back when a CHECK constraint fails."""
+
+import sqlite3  # => stdlib DB-API module (co-19)
+
+
+def create_schema(
+    conn: sqlite3.Connection,
+) -> None:  # => called once per test, in the fixture
+    # CHECK(balance >= 0) is the ENGINE-enforced invariant this example deliberately trips.
+    conn.executescript(  # => raw DDL -- no placeholders needed for schema statements
+        """
+        -- a single-table ledger -- just enough to demonstrate a rolled-back transfer
+        CREATE TABLE account(  -- => the ledger this whole test suite exercises
+            id INTEGER PRIMARY KEY,           -- => aliases rowid (co-02)
+            name TEXT NOT NULL,               -- => a human-readable label, not used for logic
+            balance REAL NOT NULL CHECK (balance >= 0)
+                                                -- => co-04 -- the engine itself rejects a negative balance
+        );
+        """
+    )  # => one CHECK constraint is the ENTIRE mechanism this example's rollback relies on
+
+
+def transfer(
+    conn: sqlite3.Connection, from_id: int, to_id: int, amount: float
+) -> None:  # co-18
+    # `with conn:` opens an implicit transaction on the FIRST write below, commits on a clean
+    # exit, and auto-ROLLBACKs the whole block if ANY statement inside raises (co-18).
+    with conn:  # => the transaction boundary -- everything inside is all-or-nothing
+        conn.execute(  # => the FIRST write -- opens the implicit transaction
+            "UPDATE account SET balance = balance - ? WHERE id = ?",  # => the debit leg
+            (amount, from_id),  # => if this drives balance negative, CHECK fails HERE
+        )  # => the credit below never runs if this statement raises
+        conn.execute(  # => the SECOND write -- only reached if the debit above succeeded
+            "UPDATE account SET balance = balance + ? WHERE id = ?",  # => the credit leg
+            (
+                amount,
+                to_id,
+            ),  # => co-20 -- every value above is bound, never string-interpolated
+        )  # => both legs commit TOGETHER when the with block exits cleanly

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate.md
@@ -1,0 +1,2151 @@
+---
+title: "Intermediate Examples"
+date: 2026-07-14T00:00:00+07:00
+draft: false
+weight: 20
+---
+
+Examples 31-58 cover multi-table joins and aliasing, `GROUP BY`/`HAVING` aggregation, NULL's
+three-valued logic, splitting a schema toward 1NF and 3NF, more of Python's `sqlite3` module (named
+parameters, `executemany`, a `fetchone` loop, and the `Row` factory), transactions
+(`commit`/`rollback`/context-manager), injection safety, upsert, a subquery, a self-join, and `CASE`
+expressions. Run each `.sql` example with `sqlite3 app.db < example.sql` and each `.py` example with
+`python3 <file>.py`, from inside its own directory, unless a caption says otherwise.
+
+---
+
+### Example 31: Left Join Unmatched
+
+_ex-31 &middot; exercises co-14_
+
+An inner join silently drops any row with no match on the other side. `LEFT JOIN` keeps every row from
+the left table regardless, filling any unmatched right-side columns with NULL -- exactly what a
+"which authors have zero books" report needs.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC
+flowchart LR
+    A["author #40;LEFT table#41;<br/>4 rows"]:::blue
+    B["book #40;RIGHT table#41;<br/>5 rows, 3 distinct author_id"]:::orange
+    C["LEFT JOIN result<br/>6 rows -- ALL 4 authors kept"]:::teal
+    D["Margaret Hamilton row<br/>book columns = NULL"]:::purple
+    A --> C
+    B --> C
+    C --> D
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-31-left-join-unmatched/example.sql`**
+
+```sql
+-- Example 31: Left Join Unmatched
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands (CLI-only, no trailing comment allowed on their own line):
+-- print column headers, align into columns, and spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+-- Schema: author (parent) and book (child, referencing author via author_id).
+CREATE TABLE author (                          -- => parent table -- referenced by book below
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned on insert
+  name TEXT NOT NULL,                         -- => every author needs a name
+  country TEXT                                -- => nullable -- not used in this example
+);
+
+CREATE TABLE book (                            -- => child table -- author_id links back up
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned on insert
+  title TEXT NOT NULL,                        -- => every book needs a title
+  author_id INTEGER REFERENCES author(id)     -- => FK -- not enforced without PRAGMA foreign_keys=ON
+);
+
+-- 4 authors -- Margaret Hamilton (id 4) deliberately has ZERO books below.
+INSERT INTO author (id, name, country) VALUES
+  (1, 'Ada Lovelace', 'UK'),                  -- => author 1 -- has 1 book below
+  (2, 'Grace Hopper', 'US'),                  -- => author 2 -- has 2 books below
+  (3, 'Alan Turing', 'UK'),                   -- => author 3 -- has 2 books below
+  (4, 'Margaret Hamilton', 'US');              -- => no book row references author_id 4
+
+-- Only 5 books, spread across authors 1-3 -- author 4 is never referenced.
+INSERT INTO book (id, title, author_id) VALUES
+  (1, 'Notes on the Analytical Engine', 1),   -- => author_id 1
+  (2, 'Introduction to Computing', 2),        -- => author_id 2
+  (3, 'Compilers and Common Sense', 2),       -- => author_id 2, same author as row above
+  (4, 'On Computable Numbers', 3),            -- => author_id 3
+  (5, 'The Enigma Papers', 3);                -- => author_id 3, same author as row above
+
+-- An INNER JOIN here would silently DROP Margaret Hamilton -- she has no match.
+-- LEFT JOIN keeps every row from the LEFT table (author), regardless of a match.
+SELECT author.name, book.title                -- => columns pulled from BOTH tables
+FROM author                                    -- => left table -- every row is kept
+LEFT JOIN book ON book.author_id = author.id   -- => right side (book) may be all-NULL per row
+ORDER BY author.id;                             -- => deterministic, stable row order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+name               title
+-----------------  ------------------------------
+Ada Lovelace       Notes on the Analytical Engine
+Grace Hopper       Compilers and Common Sense
+Grace Hopper       Introduction to Computing
+Alan Turing        On Computable Numbers
+Alan Turing        The Enigma Papers
+Margaret Hamilton  NULL
+```
+
+**Key takeaway**: `LEFT JOIN` keeps every left-table row even without a match -- Margaret Hamilton
+appears with a literal NULL in place of `book.title`, instead of vanishing the way an inner join would
+silently drop her.
+
+**Why it matters**: "Show me every X, including ones with zero related Y" is one of the most common
+reporting shapes in real applications -- authors with no books, customers with no orders, users with no
+logins. `LEFT JOIN` is the standard tool for it, and Example 71 (advanced tier) builds directly on this
+same NULL-detection pattern to isolate exactly the unmatched rows via `WHERE ... IS NULL`.
+
+---
+
+### Example 32: Join with Aliases
+
+_ex-32 &middot; exercises co-13_
+
+Table aliases give a table a short, temporary name for the rest of the query -- `FROM book b JOIN
+author a` lets every later reference use `b.` and `a.` instead of the full table names.
+
+**`learning/code/ex-32-join-with-aliases/example.sql`**
+
+```sql
+-- Example 32: Join with Aliases
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE author (                          -- => parent table -- referenced by book below
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  name TEXT NOT NULL                          -- => author's name, required
+);
+
+CREATE TABLE book (                            -- => child table -- author_id links back up
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER REFERENCES author(id)     -- => FK, matched against author.id below
+);
+
+INSERT INTO author (id, name) VALUES           -- => 2 authors, joined against book below
+  (1, 'Ada Lovelace'),                        -- => author 1 -- has 1 book below
+  (2, 'Grace Hopper');                        -- => author 2 -- has 2 books below
+
+INSERT INTO book (id, title, author_id) VALUES -- => 3 books, referencing the 2 authors above
+  (1, 'Notes on the Analytical Engine', 1),   -- => author_id 1
+  (2, 'Introduction to Computing', 2),        -- => author_id 2
+  (3, 'Compilers and Common Sense', 2);       -- => author_id 2, same author as row above
+
+-- Same query as Example 31's join, written with table aliases -- `b` and `a`.
+-- Aliases shorten `FROM book b JOIN author a` so `b.author_id = a.id` reads cleanly
+-- without repeating the full table names in every qualified column reference.
+SELECT b.title, a.name                         -- => columns pulled through both aliases
+FROM book b                                    -- => `b` now stands in for `book`
+JOIN author a ON b.author_id = a.id            -- => `a` now stands in for `author`
+ORDER BY b.id;                                 -- => deterministic row order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+title                           name
+------------------------------  ------------
+Notes on the Analytical Engine  Ada Lovelace
+Introduction to Computing       Grace Hopper
+Compilers and Common Sense      Grace Hopper
+```
+
+**Key takeaway**: `book b JOIN author a` binds `b` and `a` as short-lived names for the duration of the
+query -- every later column reference uses the alias, never the original table name.
+
+**Why it matters**: Aliases stop being cosmetic the moment a query joins three or more tables, or joins
+a table to itself (Example 57) -- at that point, short aliases are the only readable way to say which
+occurrence of a column you mean. Getting comfortable with `t.col` syntax here pays off immediately in
+Example 33's three-table join.
+
+---
+
+### Example 33: Three-Table Join
+
+_ex-33 &middot; exercises co-13_
+
+`book` has two parent tables -- `author` and `publisher` -- so recombining the full picture takes two
+chained `JOIN` clauses, one per parent, both keyed off `book`'s two foreign keys.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC -- color-blind friendly, WCAG AA
+flowchart LR
+    A["author"]:::blue
+    B["book<br/>hub table -- 2 FKs"]:::orange
+    C["publisher"]:::teal
+    D["joined result<br/>title + author_name + publisher_name"]:::purple
+    A -->|"author.id = book.author_id"| B
+    C -->|"publisher.id = book.publisher_id"| B
+    B --> D
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-33-three-table-join/example.sql`**
+
+```sql
+-- Example 33: Three-Table Join
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+-- Three related tables: author and publisher are both parents of book.
+CREATE TABLE author (                          -- => first parent table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  name TEXT NOT NULL                          -- => author's name, required
+);
+
+CREATE TABLE publisher (                       -- => second parent table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  name TEXT NOT NULL                          -- => publisher's name, required
+);
+
+CREATE TABLE book (                            -- => hub table -- has TWO parents
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER REFERENCES author(id),     -- => FK #1 -- links to author
+  publisher_id INTEGER REFERENCES publisher(id) -- => FK #2 -- links to publisher
+);
+-- Both FKs are simple (single-column), unlike Example 65's composite key.
+
+INSERT INTO author (id, name) VALUES           -- => 2 authors, both referenced below
+  (1, 'Ada Lovelace'),                        -- => author 1 -- writes 1 book below
+  (2, 'Alan Turing');                         -- => author 2 -- writes 2 books below
+
+INSERT INTO publisher (id, name) VALUES        -- => 2 publishers, both referenced below
+  (1, 'Oxford Press'),                        -- => publisher 1 -- publishes 2 books below
+  (2, 'Harbor Books');                        -- => publisher 2 -- publishes 1 book below
+
+INSERT INTO book (id, title, author_id, publisher_id) VALUES -- => links both parent FKs
+  (1, 'Notes on the Analytical Engine', 1, 1),   -- => Ada Lovelace, Oxford Press
+  (2, 'On Computable Numbers', 2, 1),            -- => Alan Turing, Oxford Press
+  (3, 'The Enigma Papers', 2, 2);                -- => Alan Turing, Harbor Books
+
+-- Two JOIN clauses chain together -- book is the hub, author and publisher are
+-- both its parents. Each JOIN adds one more parent table's columns to the row.
+SELECT book.title, author.name AS author_name, publisher.name AS publisher_name
+                                                 -- => columns pulled from all three tables
+FROM book                                       -- => hub table -- the join starts here
+JOIN author ON author.id = book.author_id          -- => pulls in the author's columns
+JOIN publisher ON publisher.id = book.publisher_id  -- => pulls in the publisher's columns
+ORDER BY book.id;                                    -- => deterministic row order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+title                           author_name   publisher_name
+------------------------------  ------------  --------------
+Notes on the Analytical Engine  Ada Lovelace  Oxford Press
+On Computable Numbers           Alan Turing   Oxford Press
+The Enigma Papers               Alan Turing   Harbor Books
+```
+
+**Key takeaway**: each additional `JOIN` clause pulls in one more table's columns -- book stays the
+single hub table, and author/publisher each attach independently through their own `ON` condition.
+
+**Why it matters**: Real schemas rarely stop at two tables -- a normalized design (co-05) deliberately
+splits facts into many small tables, and joins are how a query stitches them back into one readable
+row. Chaining `JOIN` clauses like this scales to four, five, or more tables with no new syntax --
+Example 77 (advanced tier) designs a full 3-4 table schema built on exactly this pattern.
+
+---
+
+### Example 34: Group By Count
+
+_ex-34 &middot; exercises co-15_
+
+`GROUP BY` collapses rows that share the same value in a column into a single group; `count(*)` then
+reports how many original rows fell into each group.
+
+**`learning/code/ex-34-group-by-count/example.sql`**
+
+```sql
+-- Example 34: Group By Count
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => single flat table -- no author table here
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER,                          -- => no FK needed -- just a grouping key here
+  price REAL,                                 -- => not used by this example's query
+  in_stock INTEGER,                           -- => not used by this example's query
+  published_year INTEGER                      -- => not used by this example's query
+);
+
+-- 5 books: author_id 1 has 1 book, author_id 2 has 2, author_id 3 has 2.
+INSERT INTO book (id, title, author_id, price, in_stock, published_year) VALUES
+  (1, 'Notes on the Analytical Engine', 1, 25.00, 1, 1843),  -- => author_id 1, group of 1
+  (2, 'Introduction to Computing',       2, 18.50, 1, 1952), -- => author_id 2, group of 2
+  (3, 'Compilers and Common Sense',      2, 22.00, 0, NULL), -- => author_id 2, group of 2
+  (4, 'On Computable Numbers',           3, 30.00, 1, 1936), -- => author_id 3, group of 2
+  (5, 'The Enigma Papers',               3, 15.00, 1, NULL); -- => author_id 3, group of 2
+
+-- GROUP BY collapses rows sharing the same author_id into one row per group;
+-- count(*) then counts how many original rows collapsed into each group.
+SELECT author_id, count(*) AS book_count       -- => count(*) per group, computed below
+FROM book                                       -- => the 5-row source table above
+GROUP BY author_id                             -- => one output row per distinct author_id
+ORDER BY author_id;                            -- => deterministic group order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+author_id  book_count
+---------  ----------
+1          1
+2          2
+3          2
+```
+
+**Key takeaway**: `GROUP BY author_id` produces exactly one output row per distinct `author_id` value
+-- `count(*)` inside that group reports how many source rows collapsed into it.
+
+**Why it matters**: `GROUP BY` plus an aggregate function is how a database answers "how many per
+category" without pulling every row back to the client and counting there -- the engine does the
+counting where the data already lives. This is the foundation Examples 35-40 build on, each swapping
+in a different aggregate function over the same grouping mechanism.
+
+---
+
+### Example 35: Group By Sum
+
+_ex-35 &middot; exercises co-15_
+
+`sum(price)` totals a numeric column within each group, the same way `count(*)` counted rows in
+Example 34 -- swap the aggregate function, keep the identical `GROUP BY` shape.
+
+**`learning/code/ex-35-group-by-sum/example.sql`**
+
+```sql
+-- Example 35: Group By Sum
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => single flat table, same shape as Example 34
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER,                          -- => the grouping key for sum() below
+  price REAL,                                 -- => summed per group below
+  in_stock INTEGER,                           -- => not used by this example's query
+  published_year INTEGER                      -- => not used by this example's query
+);
+
+-- Same 5-book dataset used across this tier's aggregation examples.
+INSERT INTO book (id, title, author_id, price, in_stock, published_year) VALUES
+  (1, 'Notes on the Analytical Engine', 1, 25.00, 1, 1843),  -- => author_id 1, price 25.00
+  (2, 'Introduction to Computing',       2, 18.50, 1, 1952), -- => author_id 2, price 18.50
+  (3, 'Compilers and Common Sense',      2, 22.00, 0, NULL), -- => author_id 2, price 22.00
+  (4, 'On Computable Numbers',           3, 30.00, 1, 1936), -- => author_id 3, price 30.00
+  (5, 'The Enigma Papers',               3, 15.00, 1, NULL); -- => author_id 3, price 15.00
+
+-- sum(price) totals the price column WITHIN each author_id group -- author_id 2's
+-- two books (18.50 + 22.00) collapse into one summed row, same for author_id 3.
+SELECT author_id, sum(price) AS total_price    -- => sum(price) per group, computed below
+FROM book                                       -- => the 5-row source table above
+GROUP BY author_id                             -- => one output row per distinct author_id
+ORDER BY author_id;                            -- => deterministic group order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+author_id  total_price
+---------  -----------
+1          25.0
+2          40.5
+3          45.0
+```
+
+**Key takeaway**: `sum(price)` adds up every `price` value inside a group -- author_id 2's two books
+(18.50 + 22.00) become the single value 40.5, not two separate rows.
+
+**Why it matters**: `sum` per group is the exact query behind a revenue-per-customer or
+spend-per-category report -- swap `author_id` for `customer_id` and the shape barely changes. Example
+44 later layers this same `GROUP BY sum()` on top of a join, computing per-author totals across
+recombined normalized tables instead of one flat table.
+
+---
+
+### Example 36: Group By Avg
+
+_ex-36 &middot; exercises co-15_
+
+`avg(price)` computes the arithmetic mean of a column within each group -- the sum from Example 35
+divided by that group's row count, done in a single aggregate call.
+
+**`learning/code/ex-36-group-by-avg/example.sql`**
+
+```sql
+-- Example 36: Group By Avg
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => single flat table, same shape as Example 34
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER,                          -- => the grouping key for avg() below
+  price REAL,                                 -- => averaged per group below
+  in_stock INTEGER,                           -- => not used by this example's query
+  published_year INTEGER                      -- => not used by this example's query
+);
+
+-- Same 5-book dataset used across this tier's aggregation examples.
+INSERT INTO book (id, title, author_id, price, in_stock, published_year) VALUES
+  (1, 'Notes on the Analytical Engine', 1, 25.00, 1, 1843),  -- => author_id 1, price 25.00
+  (2, 'Introduction to Computing',       2, 18.50, 1, 1952), -- => author_id 2, price 18.50
+  (3, 'Compilers and Common Sense',      2, 22.00, 0, NULL), -- => author_id 2, price 22.00
+  (4, 'On Computable Numbers',           3, 30.00, 1, 1936), -- => author_id 3, price 30.00
+  (5, 'The Enigma Papers',               3, 15.00, 1, NULL); -- => author_id 3, price 15.00
+
+-- avg(price) computes the mean price WITHIN each author_id group -- author_id 2's
+-- (18.50 + 22.00) / 2 = 20.25, author_id 3's (30.00 + 15.00) / 2 = 22.5.
+SELECT author_id, avg(price) AS avg_price      -- => avg(price) per group, computed below
+FROM book                                       -- => the 5-row source table above
+GROUP BY author_id                             -- => one output row per distinct author_id
+ORDER BY author_id;                            -- => deterministic group order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+author_id  avg_price
+---------  ---------
+1          25.0
+2          20.25
+3          22.5
+```
+
+**Key takeaway**: `avg(price)` returns each group's mean directly -- `(18.50 + 22.00) / 2 = 20.25` for
+author_id 2 -- with no separate `sum() / count()` division needed in the query.
+
+**Why it matters**: `count`, `sum`, `avg`, and Example 37's `min`/`max` are SQLite's core aggregate
+functions (co-15) -- they all share the identical `GROUP BY` mechanics shown across Examples 34-36,
+differing only in which single number each summarizes per group.
+
+---
+
+### Example 37: Min-Max Aggregate
+
+_ex-37 &middot; exercises co-15_
+
+With no `GROUP BY` clause at all, `min()`/`max()` collapse the **entire table** into a single summary
+row -- the global cheapest and priciest values, not one pair per group.
+
+**`learning/code/ex-37-min-max-aggregate/example.sql`**
+
+```sql
+-- Example 37: Min Max Aggregate
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table, no grouping key here
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  price REAL                                  -- => min/max computed over this column
+);
+
+-- 5 books with distinct prices, ranging from 15.00 to 30.00.
+INSERT INTO book (id, title, price) VALUES     -- => 5 rows, no author_id this time
+  (1, 'Notes on the Analytical Engine', 25.00), -- => neither the min nor the max
+  (2, 'Introduction to Computing', 18.50),      -- => neither the min nor the max
+  (3, 'Compilers and Common Sense', 22.00),     -- => neither the min nor the max
+  (4, 'On Computable Numbers', 30.00),          -- => the max -- priciest book
+  (5, 'The Enigma Papers', 15.00);              -- => the min -- cheapest book
+
+-- With NO GROUP BY, min()/max() collapse the ENTIRE table into a single row --
+-- the cheapest and priciest book across all 5 rows, not per-group like Examples 34-36.
+SELECT min(price) AS cheapest, max(price) AS priciest -- => one summary row, no grouping key
+FROM book;                                      -- => the 5-row source table above
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+cheapest  priciest
+--------  --------
+15.0      30.0
+```
+
+**Key takeaway**: an aggregate function with no `GROUP BY` treats the whole table as one implicit
+group -- exactly one output row summarizing all 5 source rows, never one row per book.
+
+**Why it matters**: Forgetting whether a query has a `GROUP BY` clause is a common source of confusion
+-- with it, an aggregate summarizes per group; without it, the aggregate summarizes everything. Reading
+`SELECT min(price), max(price) FROM book;` correctly (a single-row price-range summary) versus
+misreading it as per-book output is exactly the distinction this example isolates.
+
+---
+
+### Example 38: Having Filter Groups
+
+_ex-38 &middot; exercises co-16_
+
+`WHERE` cannot filter on an aggregate result -- by the time `WHERE` runs, no aggregation has happened
+yet. `HAVING` exists specifically to filter groups **after** `GROUP BY` has collapsed them.
+
+**`learning/code/ex-38-having-filter-groups/example.sql`**
+
+```sql
+-- Example 38: Having Filter Groups
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER                           -- => the grouping key HAVING filters on
+);
+
+-- author_id 1 has 1 book, author_id 2 has 2 books, author_id 3 has 2 books.
+INSERT INTO book (id, title, author_id) VALUES -- => 5 books across 3 author_id groups
+  (1, 'Notes on the Analytical Engine', 1),   -- => author_id 1, group of 1 -- fails HAVING
+  (2, 'Introduction to Computing', 2),        -- => author_id 2, group of 2 -- passes HAVING
+  (3, 'Compilers and Common Sense', 2),       -- => author_id 2, group of 2 -- passes HAVING
+  (4, 'On Computable Numbers', 3),            -- => author_id 3, group of 2 -- passes HAVING
+  (5, 'The Enigma Papers', 3);                -- => author_id 3, group of 2 -- passes HAVING
+
+-- HAVING filters GROUPS after aggregation -- the opposite of WHERE, which filters
+-- ROWS before aggregation. count(*) > 1 keeps only groups with more than one book,
+-- so author_id 1 (exactly 1 book) is dropped from the result entirely.
+SELECT author_id, count(*) AS book_count       -- => count(*) per surviving group
+FROM book                                       -- => the 5-row source table above
+GROUP BY author_id                             -- => first, collapse rows into groups
+HAVING count(*) > 1                            -- => then, keep only groups matching this
+ORDER BY author_id;                            -- => deterministic group order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+author_id  book_count
+---------  ----------
+2          2
+3          2
+```
+
+**Key takeaway**: `HAVING count(*) > 1` runs strictly after `GROUP BY` has produced group summaries --
+author_id 1's single book means its group fails the test and never reaches the output.
+
+**Why it matters**: `HAVING` is the piece that makes "authors with more than N books" or "products
+selling above a revenue threshold" possible in a single query -- `WHERE` physically cannot express
+either, since the value being tested (`count(*)`) does not exist until after aggregation. Example 39
+next contrasts both filters working together in the same query.
+
+---
+
+### Example 39: Where Plus Having
+
+_ex-39 &middot; exercises co-16, co-08_
+
+`WHERE` and `HAVING` can appear in the same query, filtering at two different phases: `WHERE` removes
+individual rows first, then `GROUP BY` aggregates the survivors, then `HAVING` filters the resulting
+groups.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC, Brown #CA9161
+flowchart LR
+    A["5 book rows"]:::blue
+    B["WHERE in_stock = 1<br/>row filter -- BEFORE aggregation"]:::orange
+    C["GROUP BY author_id<br/>collapse survivors"]:::teal
+    D["HAVING sum#40;price#41; > 20<br/>group filter -- AFTER aggregation"]:::purple
+    E["2 result rows"]:::brown
+    A --> B --> C --> D --> E
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef brown fill:#CA9161,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-39-where-plus-having/example.sql`**
+
+```sql
+-- Example 39: Where Plus Having
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER,                          -- => the grouping key for sum() below
+  price REAL,                                 -- => summed per group after WHERE filters
+  in_stock INTEGER                            -- => 1 = in stock, 0 = out of stock
+);
+
+-- Book id 3 is the ONLY out-of-stock row -- watch it disappear before grouping.
+INSERT INTO book (id, title, author_id, price, in_stock) VALUES -- => 5 rows, 1 out-of-stock
+  (1, 'Notes on the Analytical Engine', 1, 25.00, 1),   -- => in stock -- survives WHERE
+  (2, 'Introduction to Computing',       2, 18.50, 1),  -- => in stock -- survives WHERE
+  (3, 'Compilers and Common Sense',      2, 22.00, 0),   -- => dropped by WHERE, first
+  (4, 'On Computable Numbers',           3, 30.00, 1),  -- => in stock -- survives WHERE
+  (5, 'The Enigma Papers',               3, 15.00, 1);  -- => in stock -- survives WHERE
+
+-- Two filters, two different phases. WHERE runs FIRST, on individual rows, before
+-- any grouping happens -- it removes book id 3 (in_stock = 0) entirely. GROUP BY
+-- then collapses the SURVIVING rows. HAVING runs LAST, on the resulting groups --
+-- author_id 2's remaining sum (18.50, book id 3 already gone) fails the > 20 test.
+SELECT author_id, sum(price) AS total_price    -- => sum(price) per surviving group
+FROM book                                       -- => the 5-row source table above
+WHERE in_stock = 1                             -- => row filter -- BEFORE aggregation
+GROUP BY author_id                             -- => collapse the surviving rows
+HAVING sum(price) > 20                         -- => group filter -- AFTER aggregation
+ORDER BY author_id;                            -- => deterministic group order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+author_id  total_price
+---------  -----------
+1          25.0
+3          45.0
+```
+
+**Key takeaway**: author_id 2 disappears from the result for two DIFFERENT reasons stacked together --
+its out-of-stock book is removed by `WHERE` first, and what remains (18.50) then fails the `HAVING
+sum(price) > 20` test.
+
+**Why it matters**: Knowing exactly which clause runs when -- `WHERE` before aggregation, `HAVING`
+after -- prevents a common class of bug: writing `WHERE count(*) > 1` (a syntax error, since `count(*)`
+does not exist yet at `WHERE` time) or writing `HAVING in_stock = 1` (technically legal but wasteful,
+since it filters late instead of early). Example 79 (advanced tier) combines this exact join +
+`GROUP BY` + `HAVING` shape into a full report query.
+
+---
+
+### Example 40: Count Star vs Column
+
+_ex-40 &middot; exercises co-15, co-17_
+
+`count(*)` counts every row, full stop. `count(column)` counts only the rows where that specific
+column is **not** NULL -- the two forms diverge the moment the counted column can hold NULL.
+
+**`learning/code/ex-40-count-star-vs-column/example.sql`**
+
+```sql
+-- Example 40: Count Star vs Column
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  published_year INTEGER                      -- => 2 of the 5 rows leave this NULL
+);
+
+-- Books 3 and 5 have an unknown (NULL) published_year.
+INSERT INTO book (id, title, published_year) VALUES -- => 5 rows, 2 with a NULL year
+  (1, 'Notes on the Analytical Engine', 1843), -- => known year -- counted by both forms
+  (2, 'Introduction to Computing', 1952),      -- => known year -- counted by both forms
+  (3, 'Compilers and Common Sense', NULL),      -- => unknown year -- excluded below
+  (4, 'On Computable Numbers', 1936),          -- => known year -- counted by both forms
+  (5, 'The Enigma Papers', NULL);               -- => unknown year -- excluded below
+
+-- count(*) counts ROWS, full stop -- NULLs included. count(column) counts only
+-- NON-NULL values in that specific column -- the two forms diverge whenever the
+-- counted column itself can hold NULL, exactly like published_year here.
+SELECT count(*) AS row_count, count(published_year) AS known_year_count
+                                                 -- => two different counts, same table
+FROM book;                                      -- => the 5-row source table above
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+row_count  known_year_count
+---------  ----------------
+5          3
+```
+
+**Key takeaway**: `count(*)` returns 5 (every row); `count(published_year)` returns 3 (only the rows
+where `published_year` is not NULL) -- the same table, two genuinely different answers.
+
+**Why it matters**: This distinction quietly breaks a lot of "percentage complete" or "data quality"
+reports -- if you want "how many rows have a known year", `count(published_year)` is correct;
+`count(*)` would silently overcount by including the unknowns. Example 42's `coalesce()` shows the
+complementary technique: substituting a placeholder instead of excluding the NULL.
+
+---
+
+### Example 41: Null Is Null
+
+_ex-41 &middot; exercises co-17_
+
+NULL means "unknown", not zero or empty string -- testing for it needs the dedicated `IS NULL`
+operator, since ordinary comparison operators cannot detect it (Example 43 shows exactly why).
+
+**`learning/code/ex-41-null-is-null/example.sql`**
+
+```sql
+-- Example 41: Null Is Null
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  published_year INTEGER                      -- => unknown for 2 of the 5 rows
+);
+
+INSERT INTO book (id, title, published_year) VALUES -- => 5 rows, 2 with a NULL year
+  (1, 'Notes on the Analytical Engine', 1843), -- => known year -- excluded from result
+  (2, 'Introduction to Computing', 1952),      -- => known year -- excluded from result
+  (3, 'Compilers and Common Sense', NULL),      -- => year genuinely unknown
+  (4, 'On Computable Numbers', 1936),          -- => known year -- excluded from result
+  (5, 'The Enigma Papers', NULL);               -- => year genuinely unknown
+
+-- NULL means "unknown", not zero or empty string -- so testing for it needs its
+-- own operator. IS NULL is that operator; Example 43 shows why `= NULL` fails.
+SELECT id, title                                -- => the two columns shown for matches
+FROM book                                       -- => the 5-row source table above
+WHERE published_year IS NULL                   -- => matches exactly the 2 unknown rows
+ORDER BY id;                                    -- => deterministic row order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title
+--  --------------------------
+3   Compilers and Common Sense
+5   The Enigma Papers
+```
+
+**Key takeaway**: `IS NULL` correctly matches both books with an unknown `published_year` -- the one
+operator built specifically to test for NULL, unlike `=` (Example 43).
+
+**Why it matters**: Every schema eventually has optional data -- an unset deadline, an unknown
+publication year, a customer who never entered a phone number. `IS NULL`/`IS NOT NULL` are the only
+reliable way to query for "unknown" versus "known" values, and getting this right from the start avoids
+the silent zero-row bug Example 43 demonstrates.
+
+---
+
+### Example 42: Null Coalesce
+
+_ex-42 &middot; exercises co-17_
+
+`coalesce(a, b, ...)` returns the first non-NULL argument, scanning left to right -- a one-line way to
+substitute a fallback value wherever a column might be NULL.
+
+**`learning/code/ex-42-null-coalesce/example.sql`**
+
+```sql
+-- Example 42: Null Coalesce
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  published_year INTEGER                      -- => unknown for 2 of the 5 rows
+);
+
+INSERT INTO book (id, title, published_year) VALUES -- => 5 rows, 2 with a NULL year
+  (1, 'Notes on the Analytical Engine', 1843), -- => known year -- coalesce() passes it through
+  (2, 'Introduction to Computing', 1952),      -- => known year -- coalesce() passes it through
+  (3, 'Compilers and Common Sense', NULL),      -- => becomes 0 below, not left blank
+  (4, 'On Computable Numbers', 1936),          -- => known year -- coalesce() passes it through
+  (5, 'The Enigma Papers', NULL);               -- => becomes 0 below, not left blank
+
+-- coalesce(a, b, ...) returns the FIRST non-NULL argument, left to right -- here,
+-- published_year if it exists, otherwise the literal 0 as a placeholder value.
+SELECT id, title, coalesce(published_year, 0) AS year_or_zero
+                                                 -- => year_or_zero never shows NULL
+FROM book                                       -- => the 5-row source table above
+ORDER BY id;                                    -- => deterministic row order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+id  title                           year_or_zero
+--  ------------------------------  ------------
+1   Notes on the Analytical Engine  1843
+2   Introduction to Computing       1952
+3   Compilers and Common Sense      0
+4   On Computable Numbers           1936
+5   The Enigma Papers               0
+```
+
+**Key takeaway**: `coalesce(published_year, 0)` leaves known years untouched and substitutes `0`
+wherever `published_year` was NULL -- a single expression, no `CASE WHEN ... IS NULL` needed.
+
+**Why it matters**: `coalesce()` is the standard SQL way to give NULL a display-friendly fallback --
+"Unknown" for a missing name, `0` for a missing count, an empty string for a missing note -- without
+excluding the row the way Example 40's `count(column)` does. It composes with any expression, including
+another `coalesce()` call for a chain of fallbacks.
+
+---
+
+### Example 43: Null Three-Valued
+
+_ex-43 &middot; exercises co-17_
+
+SQL comparisons are three-valued -- TRUE, FALSE, or UNKNOWN -- and any comparison against NULL,
+including `NULL = NULL`, evaluates to UNKNOWN, never TRUE. A `WHERE` clause built on `= NULL` can
+therefore never match a single row.
+
+**`learning/code/ex-43-null-three-valued/example.sql`**
+
+```sql
+-- Example 43: Null Three-Valued
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  published_year INTEGER                      -- => 2 of 5 rows leave this NULL
+);
+
+INSERT INTO book (id, title, published_year) VALUES -- => 5 rows, 2 with a NULL year
+  (1, 'Notes on the Analytical Engine', 1843), -- => known year -- still never matches = NULL
+  (2, 'Introduction to Computing', 1952),      -- => known year -- still never matches = NULL
+  (3, 'Compilers and Common Sense', NULL),      -- => year genuinely unknown
+  (4, 'On Computable Numbers', 1936),          -- => known year -- still never matches = NULL
+  (5, 'The Enigma Papers', NULL);               -- => year genuinely unknown
+
+-- SQL comparisons are three-valued: TRUE, FALSE, or UNKNOWN. Any comparison
+-- against NULL (even `NULL = NULL`) evaluates to UNKNOWN, never TRUE -- so a
+-- WHERE clause built on `= NULL` can NEVER match a row, no matter the data.
+-- This returns ZERO rows, even though books 3 and 5 genuinely have a NULL year.
+SELECT id, title                                -- => never reached -- WHERE matches nothing
+FROM book                                       -- => the 5-row source table above
+WHERE published_year = NULL                    -- => WRONG -- always UNKNOWN, never TRUE
+ORDER BY id;                                    -- => deterministic row order, if any rows matched
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+
+```
+
+**Key takeaway**: `WHERE published_year = NULL` returns **zero rows** on this exact data set, even
+though two rows genuinely have a NULL year -- `=` can never evaluate to TRUE when either side is NULL.
+
+**Why it matters**: This is one of SQL's most common silent bugs -- the query runs without error, just
+returns the wrong (empty) answer, with nothing in the output to hint that `= NULL` was the mistake.
+Every SQL style guide flags this identically: always use `IS NULL`/`IS NOT NULL` (Example 41) to test
+for NULL, never `=` or `!=`.
+
+---
+
+### Example 44: Aggregate Over Join
+
+_ex-44 &middot; exercises co-15, co-13_
+
+`JOIN` and `GROUP BY` compose freely -- the join recombines normalized tables first, and the
+aggregation then summarizes the joined result, exactly how a per-author revenue report works.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73 -- color-blind friendly, WCAG AA
+flowchart LR
+    A["author JOIN book<br/>5 joined rows"]:::blue
+    B["GROUP BY a.name<br/>collapse into 3 groups"]:::orange
+    C["sum#40;price#41; per group<br/>3 totals"]:::teal
+    A --> B --> C
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-44-aggregate-over-join/example.sql`**
+
+```sql
+-- Example 44: Aggregate Over Join
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE author (                          -- => parent table -- referenced by book below
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  name TEXT NOT NULL                          -- => author's name, required
+);
+
+CREATE TABLE book (                            -- => child table -- author_id links back up
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER REFERENCES author(id),     -- => FK, joined against author.id below
+  price REAL                                  -- => summed per author after the join
+);
+
+INSERT INTO author (id, name) VALUES           -- => 3 authors, all referenced below
+  (1, 'Ada Lovelace'),                        -- => author 1 -- has 1 book below
+  (2, 'Grace Hopper'),                        -- => author 2 -- has 2 books below
+  (3, 'Alan Turing');                         -- => author 3 -- has 2 books below
+
+-- Grace Hopper (id 2) and Alan Turing (id 3) each have TWO books -- their totals
+-- sum across the join, unlike Ada Lovelace's single-book total.
+INSERT INTO book (id, title, author_id, price) VALUES -- => 5 books across 3 authors
+  (1, 'Notes on the Analytical Engine', 1, 25.00),  -- => author_id 1, price 25.00
+  (2, 'Introduction to Computing',       2, 18.50), -- => author_id 2, price 18.50
+  (3, 'Compilers and Common Sense',      2, 22.00), -- => author_id 2, price 22.00
+  (4, 'On Computable Numbers',           3, 30.00), -- => author_id 3, price 30.00
+  (5, 'The Enigma Papers',               3, 15.00); -- => author_id 3, price 15.00
+
+-- JOIN recombines the normalized tables FIRST; GROUP BY/sum() aggregate the
+-- JOINED result SECOND -- this is exactly how a per-author revenue report works.
+SELECT a.name, sum(b.price) AS total_price     -- => sum(price) per author, after the join
+FROM author a                                   -- => left side of the join -- one row per author
+JOIN book b ON b.author_id = a.id              -- => recombine author with its books
+GROUP BY a.name                                 -- => then collapse into per-author totals
+ORDER BY a.id;                                  -- => deterministic group order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+name          total_price
+------------  -----------
+Ada Lovelace  25.0
+Grace Hopper  40.5
+Alan Turing   45.0
+```
+
+**Key takeaway**: the `JOIN` runs first, recombining each book with its author; `GROUP BY a.name` then
+collapses the joined rows into one total per author -- the two operations compose in that order, not
+in parallel.
+
+**Why it matters**: This exact pattern -- join to recombine normalized data, then aggregate the result
+-- is how the vast majority of real reporting queries are built. A normalized schema (co-05) splits
+facts across tables specifically so each fact lives in one place; joins and aggregation are how you get
+a summarized answer back out without denormalizing the storage itself.
+
+---
+
+### Example 45: Normalize Repeating Group (1NF)
+
+_ex-45 &middot; exercises co-05_
+
+A comma-separated list packed into one text column is a "repeating group" -- not an atomic value, and
+therefore not 1NF. Splitting it into a child table, one row per tag, is specifically a **1NF** fix
+(atomicity) -- not 2NF, which concerns partial dependency on a composite key, a different problem this
+split alone does not address.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Teal #029E73, Orange #DE8F05
+flowchart LR
+    A["book_flat<br/>tags: 'mathematics,history'<br/>NOT atomic"]:::blue
+    B["book<br/>id, title"]:::teal
+    C["book_tag<br/>book_id, tag<br/>ONE atomic tag per row"]:::orange
+    A -->|split into| B
+    A -->|split into| C
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-45-normalize-repeating-group/example.sql`**
+
+```sql
+-- Example 45: Normalize Repeating Group (1NF)
+-- Run: sqlite3 app.db < example.sql
+--
+-- IMPORTANT: this split fixes 1NF (atomicity) specifically -- NOT 2NF. 2NF is
+-- about partial dependency on a COMPOSITE key, a different problem this single
+-- split does not address.
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+-- PROBLEM: `tags` packs a variable-length list into ONE text column -- a
+-- "repeating group". This column is NOT atomic (1NF requires atomic values).
+CREATE TABLE book_flat (                       -- => the BEFORE table -- not yet 1NF
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  tags TEXT                                   -- => e.g. 'mathematics,history' -- not atomic
+);
+
+INSERT INTO book_flat (id, title, tags) VALUES -- => 2 rows, each packing multiple tags
+  (1, 'Notes on the Analytical Engine', 'mathematics,history'),          -- => 2 tags packed
+  (2, 'On Computable Numbers', 'mathematics,computer-science');          -- => 2 tags packed
+
+-- Finding "every book tagged mathematics" here needs a fragile LIKE '%mathematics%'
+-- pattern -- and it would also false-match a hypothetical tag like 'mathematics-history'.
+SELECT * FROM book_flat;                        -- => shows the packed, non-atomic tags column
+
+-- FIX: split the repeating group into its own child table, one row PER TAG.
+-- Now every value in every column is a single, atomic fact -- 1NF satisfied.
+CREATE TABLE book (                            -- => the AFTER hub table -- tags moved out
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL                         -- => book title, required
+);
+
+CREATE TABLE book_tag (                        -- => the AFTER child table -- one row per tag
+  book_id INTEGER REFERENCES book(id),        -- => FK back to the owning book
+  tag TEXT NOT NULL,                          -- => exactly ONE atomic tag per row
+  PRIMARY KEY (book_id, tag)                  -- => a composite key -- no duplicate pairs
+);
+
+INSERT INTO book (id, title) VALUES            -- => same 2 books, tags no longer inline
+  (1, 'Notes on the Analytical Engine'),      -- => book 1 -- 2 tags in book_tag below
+  (2, 'On Computable Numbers');                -- => book 2 -- 2 tags in book_tag below
+
+INSERT INTO book_tag (book_id, tag) VALUES     -- => 4 rows -- one row PER atomic tag
+  (1, 'mathematics'),                         -- => book 1's first tag
+  (1, 'history'),                             -- => book 1's second tag
+  (2, 'mathematics'),                         -- => book 2's first tag
+  (2, 'computer-science');                     -- => book 2's second tag
+
+-- Now "every book tagged mathematics" is a plain, exact WHERE tag = 'mathematics'
+-- on book_tag -- no string-pattern hack, no false-positive risk.
+SELECT book.title, book_tag.tag                -- => one output row PER book/tag pair
+FROM book                                       -- => left side of the join
+JOIN book_tag ON book_tag.book_id = book.id    -- => recombines book with its atomic tags
+ORDER BY book.id, book_tag.tag;                 -- => deterministic row order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output** (sqlite3 prints consecutive result sets back-to-back, with no blank line between them):
+
+```text
+id  title                           tags
+--  ------------------------------  ----------------------------
+1   Notes on the Analytical Engine  mathematics,history
+2   On Computable Numbers           mathematics,computer-science
+title                           tag
+------------------------------  ----------------
+Notes on the Analytical Engine  history
+Notes on the Analytical Engine  mathematics
+On Computable Numbers           computer-science
+On Computable Numbers           mathematics
+```
+
+**Key takeaway**: splitting `tags` into a `book_tag` child table (one row per tag) fixes **1NF**
+specifically -- every column value is now atomic -- and is a different, narrower fix than 2NF, which
+addresses partial dependency on a composite key.
+
+**Why it matters**: a comma-packed column is one of the most common denormalization mistakes in
+real schemas -- it looks convenient until you need to filter, count, or join on an individual item
+inside the list, at which point every query becomes a fragile string-pattern hack. Recognizing "this
+column holds more than one fact" is the first step toward 1NF; Example 46 tackles the next kind of
+normalization problem, a transitive dependency.
+
+---
+
+### Example 46: Normalize Transitive Dependency (3NF)
+
+_ex-46 &middot; exercises co-05_
+
+When a non-key column depends on another non-key column rather than on the primary key directly
+(`id -> publisher_name -> publisher_city`), that's a transitive dependency -- extracting the dependent
+fact into its own lookup table is the 3NF fix.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Teal #029E73, Orange #DE8F05
+flowchart LR
+    A["book_wide<br/>publisher_name + publisher_city<br/>repeated per book row"]:::blue
+    B["publisher<br/>name, city -- ONE row per publisher"]:::teal
+    C["book<br/>publisher_id FK only"]:::orange
+    A -->|extract lookup| B
+    A -->|keep only FK| C
+    C -->|references| B
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-46-normalize-transitive-dep/example.sql`**
+
+```sql
+-- Example 46: Normalize Transitive Dependency (3NF)
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+-- PROBLEM: publisher_city depends on publisher_name, NOT directly on id -- a
+-- TRANSITIVE dependency (id -> publisher_name -> publisher_city). Both books
+-- from 'Oxford Press' repeat 'Oxford' -- change one city and the other silently
+-- goes stale, an update anomaly 3NF exists specifically to prevent.
+CREATE TABLE book_wide (                       -- => the BEFORE table -- not yet 3NF
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  publisher_name TEXT NOT NULL,               -- => repeated fact, one copy per book row
+  publisher_city TEXT NOT NULL                -- => repeated fact, one copy per book row
+);
+
+INSERT INTO book_wide (id, title, publisher_name, publisher_city) VALUES -- => 3 rows
+  (1, 'Notes on the Analytical Engine', 'Oxford Press', 'Oxford'),        -- => 'Oxford' repeated below
+  (2, 'On Computable Numbers', 'Oxford Press', 'Oxford'),      -- => 'Oxford' repeated
+  (3, 'Introduction to Computing', 'Harbor Books', 'Boston');  -- => a different publisher
+
+SELECT * FROM book_wide;                        -- => shows publisher_city repeated twice
+
+-- FIX: extract publisher into its own table -- publisher_city now lives in
+-- exactly ONE row per publisher, referenced by id instead of copied by value.
+CREATE TABLE publisher (                       -- => the AFTER lookup table -- one row per publisher
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  name TEXT NOT NULL,                         -- => publisher's name, required
+  city TEXT NOT NULL                          -- => one fact, one place -- 3NF
+);
+
+CREATE TABLE book (                            -- => the AFTER hub table -- FK instead of copies
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  publisher_id INTEGER REFERENCES publisher(id) -- => FK -- no more repeated publisher text
+);
+
+INSERT INTO publisher (id, name, city) VALUES  -- => 2 publishers, each stored exactly once
+  (1, 'Oxford Press', 'Oxford'),               -- => publisher 1 -- referenced by 2 books below
+  (2, 'Harbor Books', 'Boston');                -- => publisher 2 -- referenced by 1 book below
+
+INSERT INTO book (id, title, publisher_id) VALUES -- => same 3 books, publisher_city no longer inline
+  (1, 'Notes on the Analytical Engine', 1),   -- => publisher_id 1
+  (2, 'On Computable Numbers', 1),             -- => shares publisher_id 1, not the city text
+  (3, 'Introduction to Computing', 2);         -- => publisher_id 2
+
+-- Updating Oxford Press's city now means changing ONE row (publisher.city) --
+-- both of its books pick up the change automatically through the join.
+SELECT book.title, publisher.name, publisher.city -- => city now read through the join
+FROM book                                       -- => left side of the join
+JOIN publisher ON publisher.id = book.publisher_id -- => recombines book with its publisher
+ORDER BY book.id;                               -- => deterministic row order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output** (two consecutive result sets, no blank line between them):
+
+```text
+id  title                           publisher_name  publisher_city
+--  ------------------------------  --------------  --------------
+1   Notes on the Analytical Engine  Oxford Press    Oxford
+2   On Computable Numbers           Oxford Press    Oxford
+3   Introduction to Computing       Harbor Books    Boston
+title                           name          city
+------------------------------  ------------  ------
+Notes on the Analytical Engine  Oxford Press  Oxford
+On Computable Numbers           Oxford Press  Oxford
+Introduction to Computing       Harbor Books  Boston
+```
+
+**Key takeaway**: `publisher_city` moves from being copied on every `book_wide` row into exactly one
+row per publisher -- a single `UPDATE publisher SET city = ...` now corrects every book from that
+publisher at once, instead of needing to find and fix every repeated copy.
+
+**Why it matters**: transitive dependencies are the classic source of update anomalies -- data that
+looks consistent today silently drifts out of sync the first time someone updates one copy and forgets
+the others. 3NF's rule ("every non-key column depends on the key, the whole key, and nothing but the
+key") is precisely the discipline that prevents this; Example 77 (advanced tier) applies both this and
+Example 45's 1NF fix together in one from-scratch schema design.
+
+---
+
+### Example 47: Python Named Params
+
+_ex-47 &middot; exercises co-20_
+
+`:name` is a **named** placeholder, bound from a dictionary key instead of positional order -- the same
+injection-safety guarantee as `?` (Beginner Example 30), useful when a query has several parameters and
+positional order would be easy to get wrong.
+
+**`learning/code/ex-47-python-named-params/example.py`**
+
+```python
+# pyright: strict
+"""Example 47: Python Named Params."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+# ":memory:" is an ephemeral, file-less database -- perfect for a self-contained
+# example that needs no cleanup and leaves nothing on disk.
+conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => opens an in-memory database
+conn.execute(  # => a minimal one-table schema
+    "CREATE TABLE author (id INTEGER PRIMARY KEY, name TEXT NOT NULL)"  # => id + name only
+)  # => defines a minimal one-table schema
+conn.execute("INSERT INTO author (id, name) VALUES (1, 'Ada Lovelace')")  # => author 1
+conn.execute("INSERT INTO author (id, name) VALUES (2, 'Grace Hopper')")  # => author 2
+conn.commit()  # => persists both inserts to this connection's database
+
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+
+# :name is a NAMED placeholder -- bound from a dict KEY, not positional order.
+# This is the exact same injection-safety guarantee as `?` (Example 30), just
+# addressed by name instead of position -- useful when a query has many params.
+params: dict[str, str] = {"name": "Grace Hopper"}  # => the dict key MUST match :name
+cur.execute("SELECT id, name FROM author WHERE name = :name", params)  # => :name bound from params
+row: tuple[int, str] | None = cur.fetchone()  # => None if no row matched
+print(row)  # => Output: (2, 'Grace Hopper')
+
+conn.close()  # => releases the connection -- irrelevant here since it's in-memory
+```
+
+**Run**: `python3 example.py`
+
+**Output**:
+
+```text
+(2, 'Grace Hopper')
+```
+
+**pyright**: `pyright example.py` reports `0 errors, 0 warnings, 0 informations` under `# pyright:
+strict`.
+
+**Key takeaway**: `:name` in the SQL text pairs with a dict key of the identical name in the second
+argument to `execute()` -- SQLite substitutes the bound value at execution time, never at Python
+string-formatting time.
+
+**Why it matters**: named parameters read far more clearly than `?` once a query has three or more
+bound values -- `WHERE name = :name AND country = :country` self-documents which value goes where,
+unlike a row of `?`s that depends entirely on positional order matching a separate tuple. Example 54
+later shows exactly what goes wrong when parameterization is skipped altogether.
+
+---
+
+### Example 48: Python Executemany
+
+_ex-48 &middot; exercises co-21, co-10_
+
+`executemany()` runs the same parameterized statement once per item in a list -- one bulk call instead
+of a Python loop issuing a separate `.execute()` round-trip for every row.
+
+**`learning/code/ex-48-python-executemany/example.py`**
+
+```python
+# pyright: strict
+"""Example 48: Python Executemany."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => opens an in-memory database
+conn.execute(  # => a single-column-of-interest table, ideal for a bulk-insert demo
+    "CREATE TABLE author (id INTEGER PRIMARY KEY, name TEXT NOT NULL)"  # => id + name only
+)  # => a single-column-of-interest table, ideal for a bulk-insert demo
+
+# executemany() runs the SAME statement once PER tuple in this list -- one bulk
+# call instead of a Python loop issuing N separate .execute() round-trips.
+rows: list[tuple[str]] = [("Ada Lovelace",), ("Grace Hopper",), ("Alan Turing",)]
+# => 3 single-element tuples -- one tuple per row to insert
+conn.executemany(  # => one bulk call, not 3 separate .execute() calls
+    "INSERT INTO author (name) VALUES (?)", rows
+)  # => 3 rows inserted in one call -- id auto-assigns 1, 2, 3
+conn.commit()  # => persists all 3 inserts together
+
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+cur.execute("SELECT count(*) FROM author")  # => confirms all 3 rows landed
+count: tuple[int] = cur.fetchone()  # => a 1-tuple: (row_count,)
+print(count[0])  # => Output: 3
+
+conn.close()  # => releases the connection -- irrelevant here since it's in-memory
+```
+
+**Run**: `python3 example.py`
+
+**Output**:
+
+```text
+3
+```
+
+**pyright**: `pyright example.py` reports `0 errors, 0 warnings, 0 informations` under `# pyright:
+strict`.
+
+**Key takeaway**: `rows: list[tuple[str]]` paired with `executemany("INSERT ... VALUES (?)", rows)`
+inserts every tuple in the list in a single call -- each tuple binds to the statement's one `?`
+placeholder, once per row.
+
+**Why it matters**: `executemany()` is the standard tool for bulk-loading data -- a CSV import, a
+seed script, a batch of API results -- without paying the round-trip cost of one `.execute()` call per
+row. Example 64 (advanced tier) applies the same batching instinct to reads, replacing a per-row `SELECT`
+loop with a single `WHERE id IN (...)` fetch.
+
+---
+
+### Example 49: Python Fetchone Loop
+
+_ex-49 &middot; exercises co-21_
+
+`fetchall()` loads every row into memory at once; `fetchone()` streams exactly one row per call --
+combined with the walrus operator, a `while` loop can both fetch and check for the end-of-results
+sentinel (`None`) in a single expression.
+
+**`learning/code/ex-49-python-fetchone-loop/example.py`**
+
+```python
+# pyright: strict
+"""Example 49: Python Fetchone Loop."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => opens an in-memory database
+conn.execute("CREATE TABLE book (id INTEGER PRIMARY KEY, title TEXT NOT NULL)")  # => id + title
+conn.execute("INSERT INTO book (title) VALUES ('Notes on the Analytical Engine')")  # => book 1
+conn.execute("INSERT INTO book (title) VALUES ('On Computable Numbers')")  # => book 2
+conn.commit()  # => persists both inserts
+
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+cur.execute("SELECT id, title FROM book ORDER BY id")  # => 2 rows, not yet fetched
+
+# fetchall() would load every row into memory at once; fetchone() streams ONE
+# row per call instead -- the := walrus operator both assigns row AND checks
+# it against None in the same expression, ending the loop at the sentinel.
+row: tuple[int, str] | None  # => declared before the loop -- streamed one row at a time
+while (row := cur.fetchone()) is not None:  # => None marks "no more rows"
+    book_id, title = row  # => unpacks the 2-tuple into two typed names
+    print(book_id, title)  # => one line printed per row, streamed
+
+conn.close()  # => releases the connection -- irrelevant here since it's in-memory
+```
+
+**Run**: `python3 example.py`
+
+**Output**:
+
+```text
+1 Notes on the Analytical Engine
+2 On Computable Numbers
+```
+
+**pyright**: `pyright example.py` reports `0 errors, 0 warnings, 0 informations` under `# pyright:
+strict`.
+
+**Key takeaway**: `while (row := cur.fetchone()) is not None:` both retrieves the next row and tests
+for the end of the result set in one expression -- the loop naturally terminates the moment `fetchone()`
+returns `None`.
+
+**Why it matters**: `fetchone()` in a loop keeps memory usage constant regardless of result-set size --
+a genuinely important property once a query might return millions of rows, where `fetchall()` would try
+to materialize the entire result set in memory before your code sees the first row.
+
+---
+
+### Example 50: Python Row Factory
+
+_ex-50 &middot; exercises co-21_
+
+Setting `conn.row_factory = sqlite3.Row` changes every subsequent row from a plain tuple into a
+`sqlite3.Row` object -- one that supports both positional indexing **and** lookup by column name.
+
+**`learning/code/ex-50-python-row-factory/example.py`**
+
+```python
+# pyright: strict
+"""Example 50: Python Row Factory."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => opens an in-memory database
+# row_factory swaps the default plain-tuple row shape for sqlite3.Row -- every
+# row returned from now on supports BOTH positional AND column-name access.
+conn.row_factory = sqlite3.Row  # => applies to every cursor opened after this line
+
+conn.execute("CREATE TABLE author (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")  # => id + name
+conn.execute("INSERT INTO author (name) VALUES ('Ada Lovelace')")  # => id auto-assigns to 1
+conn.commit()  # => persists the insert
+
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+cur.execute("SELECT id, name FROM author")  # => 1 row, not yet fetched
+row: sqlite3.Row | None = cur.fetchone()  # => a sqlite3.Row, not a plain tuple
+if row is not None:  # => narrows away None so indexing below is type-safe
+    # row["name"] reads by COLUMN NAME -- no need to remember column ORDER,
+    # unlike the plain-tuple row[1] this same query would otherwise return.
+    print(row["id"], row["name"])  # => Output: 1 Ada Lovelace
+
+conn.close()  # => releases the connection -- irrelevant here since it's in-memory
+```
+
+**Run**: `python3 example.py`
+
+**Output**:
+
+```text
+1 Ada Lovelace
+```
+
+**pyright**: `pyright example.py` reports `0 errors, 0 warnings, 0 informations` under `# pyright:
+strict`.
+
+**Key takeaway**: after `conn.row_factory = sqlite3.Row`, `row["name"]` reads by column name instead of
+`row[1]` by position -- the query's column order can change without breaking code that reads by name.
+
+**Why it matters**: column-name access makes code resilient to a `SELECT *` column reorder, and it is
+dramatically more readable at the call site than remembering "column 1 is the price, column 3 is the
+stock flag." Most real-world Python `sqlite3` code sets `row_factory` once, right after opening the
+connection, and uses name access everywhere after that.
+
+---
+
+### Example 51: Transaction Commit
+
+_ex-51 &middot; exercises co-18_
+
+`BEGIN` opens an explicit transaction; `.commit()` makes every write inside it permanent. Opening a
+**second, independent** connection to the same file afterward proves the write survived past the
+original connection's lifetime.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC -- color-blind friendly, WCAG AA
+flowchart LR
+    A["conn: BEGIN, INSERT, commit#40;#41;"]:::blue
+    B["conn.close#40;#41;"]:::orange
+    C["conn2: fresh connection<br/>same file"]:::teal
+    D["count#40;*#41; = 1<br/>write survived"]:::purple
+    A --> B --> C --> D
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-51-transaction-commit/example.py`**
+
+```python
+# pyright: strict
+"""Example 51: Transaction Commit."""
+
+import os  # => stdlib -- used below to reset the file between runs
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+DB_PATH: str = "app.db"  # => a real file, unlike Examples 47-50's ":memory:"
+if os.path.exists(DB_PATH):  # => start from a clean file every run
+    os.remove(DB_PATH)
+
+# A FILE-based database (not ":memory:") is required here -- only a real file
+# on disk can be reopened by a SECOND, independent connection below.
+conn: sqlite3.Connection = sqlite3.connect(DB_PATH)  # => opens/creates the file
+conn.execute("CREATE TABLE author (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")  # => id + name
+conn.execute("BEGIN")  # => explicitly opens a transaction
+conn.execute("INSERT INTO author (name) VALUES ('Ada Lovelace')")  # => id auto-assigns to 1
+conn.commit()  # => makes the insert PERMANENT -- durable across connections
+conn.close()  # => close the FIRST connection entirely
+
+# A brand-new, independent connection to the SAME file -- proves the write
+# survived past the original connection's lifetime, not just in its own cache.
+conn2: sqlite3.Connection = sqlite3.connect(DB_PATH)  # => a SECOND, independent connection
+cur: sqlite3.Cursor = conn2.cursor()  # => a cursor executes SQL and holds results
+cur.execute("SELECT count(*) FROM author")  # => reads through the second connection
+count: tuple[int] = cur.fetchone()  # => a 1-tuple: (row_count,)
+print(count[0])  # => Output: 1 -- the committed write persisted
+
+conn2.close()  # => releases the second connection
+os.remove(DB_PATH)  # => tidy up the file this script created
+```
+
+**Run**: `python3 example.py`
+
+**Output**:
+
+```text
+1
+```
+
+**pyright**: `pyright example.py` reports `0 errors, 0 warnings, 0 informations` under `# pyright:
+strict`.
+
+**Key takeaway**: the second connection (`conn2`) sees the insert made by the first connection only
+because `.commit()` ran -- a durable write, not something scoped to a single in-process connection
+object.
+
+**Why it matters**: this is the property that makes a database useful across process restarts,
+multiple application instances, or a crashed process reconnecting -- committed data outlives the
+connection object that wrote it. Example 52 next shows the opposite path: what happens when
+`.rollback()` runs instead of `.commit()`.
+
+---
+
+### Example 52: Transaction Rollback
+
+_ex-52 &middot; exercises co-18_
+
+`.rollback()` discards every write made since the transaction began, as if it never happened --
+verified here by re-checking the row count returns to its pre-transaction baseline.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73 -- color-blind friendly, WCAG AA
+flowchart LR
+    A["baseline: 1 row, committed"]:::blue
+    B["BEGIN, INSERT 2nd row<br/>visible inside transaction"]:::orange
+    C["rollback#40;#41;<br/>back to 1 row"]:::teal
+    A --> B --> C
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-52-transaction-rollback/example.py`**
+
+```python
+# pyright: strict
+"""Example 52: Transaction Rollback."""
+
+import os  # => stdlib -- used below to reset the file between runs
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+DB_PATH: str = "app.db"  # => a real file -- rollback needs a durable baseline first
+if os.path.exists(DB_PATH):  # => start from a clean file every run
+    os.remove(DB_PATH)  # => wipes any leftover file from a previous run
+
+conn: sqlite3.Connection = sqlite3.connect(DB_PATH)  # => opens/creates the file
+conn.execute("CREATE TABLE author (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")  # => id + name
+conn.execute("INSERT INTO author (name) VALUES ('Ada Lovelace')")  # => id auto-assigns to 1
+conn.commit()  # => this ONE row is the durable baseline -- 1 row
+
+conn.execute("BEGIN")  # => opens a new transaction around the next insert
+conn.execute(  # => second insert, about to be rolled back
+    "INSERT INTO author (name) VALUES ('Grace Hopper')"  # => the row about to be undone
+)  # => this insert is visible WITHIN this connection right now
+conn.rollback()  # => discards everything since BEGIN -- Grace Hopper is undone
+
+# a fresh cursor verifies the post-rollback state matches the pre-transaction baseline
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+cur.execute("SELECT count(*) FROM author")  # => re-checks the row count after rollback
+count: tuple[int] = cur.fetchone()  # => a 1-tuple: (row_count,)
+print(count[0])  # => Output: 1 -- back to the pre-transaction baseline, not 2
+
+conn.close()  # => releases the connection
+os.remove(DB_PATH)  # => tidy up the file this script created
+```
+
+**Run**: `python3 example.py`
+
+**Output**:
+
+```text
+1
+```
+
+**pyright**: `pyright example.py` reports `0 errors, 0 warnings, 0 informations` under `# pyright:
+strict`.
+
+**Key takeaway**: the count stays at 1 (not 2) after `.rollback()` -- Grace Hopper's insert was visible
+inside the transaction while it was open, but `.rollback()` erases it as though it never ran.
+
+**Why it matters**: `.rollback()` is what makes "try this write, and undo it if something goes wrong"
+possible -- the exact capability every multi-step write operation (a bank transfer, a multi-table
+insert, a batch import) depends on. Example 53 next shows the more common real-world shape: an
+automatic rollback triggered by an exception, not a manual `.rollback()` call.
+
+---
+
+### Example 53: Transaction Context Manager
+
+_ex-53 &middot; exercises co-18_
+
+`with conn:` (unlike `with open(...)`) does not close the connection -- it commits automatically on a
+clean exit, or rolls back automatically the moment an exception propagates out of the block.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Purple #CC78BC, Teal #029E73, Brown #CA9161
+flowchart TD
+    A["with conn: block begins"]:::blue
+    B["INSERT Grace Hopper<br/>visible inside the block"]:::orange
+    C["raise ValueError"]:::purple
+    D["conn ROLLS BACK automatically<br/>Grace Hopper undone"]:::teal
+    E["except ValueError: caught<br/>count#40;*#41; still 1"]:::brown
+    A --> B --> C --> D --> E
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef brown fill:#CA9161,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-53-transaction-context-manager/example.py`**
+
+```python
+# pyright: strict
+"""Example 53: Transaction Context Manager."""
+
+import os  # => stdlib -- used below to reset the file between runs
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+DB_PATH: str = "app.db"  # => a real file -- automatic rollback needs a durable baseline
+if os.path.exists(DB_PATH):  # => start from a clean file every run
+    os.remove(DB_PATH)  # => wipes any leftover file from a previous run
+
+conn: sqlite3.Connection = sqlite3.connect(DB_PATH)  # => opens/creates the file
+conn.execute("CREATE TABLE author (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")  # => id + name
+conn.execute("INSERT INTO author (name) VALUES ('Ada Lovelace')")  # => id auto-assigns to 1
+conn.commit()  # => durable baseline -- exactly 1 row
+
+# `with conn:` (unlike `with open(...)`) does NOT close the connection -- it
+# commits on a clean exit, or ROLLS BACK automatically if the block raises.
+try:  # => opens a block that may raise
+    with conn:  # => opens an implicit transaction for this block
+        conn.execute(  # => second insert, about to be rolled back
+            "INSERT INTO author (name) VALUES ('Grace Hopper')"  # => the row about to be undone
+        )  # => visible inside the block, but not yet committed
+        raise ValueError("simulated mid-transaction failure")  # => triggers rollback
+except ValueError:  # => catches the simulated failure, after auto-rollback already ran
+    print("caught: simulated mid-transaction failure")  # => Output line 1
+
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+cur.execute("SELECT count(*) FROM author")  # => re-checks the row count after auto-rollback
+count: tuple[int] = cur.fetchone()  # => a 1-tuple: (row_count,)
+print(count[0])  # => Output line 2: 1 -- the failed insert left no partial write
+
+conn.close()  # => releases the connection -- `with conn:` above did NOT close it
+os.remove(DB_PATH)  # => tidy up the file this script created
+```
+
+**Run**: `python3 example.py`
+
+**Output**:
+
+```text
+caught: simulated mid-transaction failure
+1
+```
+
+**pyright**: `pyright example.py` reports `0 errors, 0 warnings, 0 informations` under `# pyright:
+strict`.
+
+**Key takeaway**: the raised `ValueError` triggers an automatic rollback of the `with conn:` block --
+Grace Hopper's insert never becomes permanent, and the connection itself stays open and usable
+afterward (unlike a `with open(...)` file handle, which the block would have closed).
+
+**Why it matters**: this is the idiomatic, safest way to write a transaction in Python's `sqlite3` --
+no risk of forgetting a manual `.rollback()` call on the failure path, since the context manager
+handles both outcomes (commit or rollback) automatically based on whether the block raised. Example 72
+(advanced tier) applies this exact pattern to a two-row debit/credit transfer that must be all-or-nothing.
+
+---
+
+### Example 54: Injection Safe vs Unsafe
+
+_ex-54 &middot; exercises co-20_
+
+Building a query with f-string interpolation lets attacker-controlled input change the query's
+**structure**, not just its data. Passing the identical payload as a `?` bound parameter instead keeps
+the query structure fixed and treats the input as a plain value, no matter what it contains.
+
+**`learning/code/ex-54-injection-safe-vs-unsafe/unsafe.py`**
+
+```python
+# pyright: strict
+"""Example 54: injection-UNSAFE query, built via f-string interpolation."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+# The classic attack payload: it tries to CLOSE the current string literal,
+# then chain a second, attacker-controlled statement onto the query.
+PAYLOAD: str = "'; DROP TABLE book;--"
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => opens an in-memory database
+conn.execute("CREATE TABLE book (id INTEGER PRIMARY KEY, title TEXT NOT NULL)")  # => id + title
+conn.execute("INSERT INTO book (title) VALUES ('Alpha')")  # => one seed row, id auto-assigns to 1
+conn.commit()  # => persists the seed row
+
+# UNSAFE: f-string interpolation splices PAYLOAD directly into the SQL text --
+# the query's STRUCTURE now depends on attacker-controlled input, not just its
+# data. Whatever the attacker types becomes part of the statement itself.
+unsafe_query: str = f"SELECT * FROM book WHERE title = '{PAYLOAD}'"
+print(unsafe_query)  # => the query text now literally contains a 2nd statement
+
+try:  # => attempts to run the attacker-shaped query text
+    conn.execute(unsafe_query)  # => may raise, depending on the payload shape
+except sqlite3.ProgrammingError as exc:
+    # This Python 3.13.12 sqlite3 build refuses to run more than one SQL
+    # statement per execute() call -- it blocks THIS specific payload shape.
+    # That is NOT proof f-string interpolation is safe: it only means this
+    # particular stacked-statement attack collides with an UNRELATED guard.
+    # A same-statement payload (e.g. `' OR '1'='1`) still bypasses the
+    # intended WHERE filter entirely when the query is built by interpolation.
+    print(f"blocked: {exc}")  # => real sqlite3 error text, captured verbatim
+
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+cur.execute("SELECT count(*) FROM book")  # => confirms whether the table survived
+count: tuple[int] = cur.fetchone()  # => a 1-tuple: (row_count,)
+print(count[0])  # => Output: 1 -- the table happened to survive THIS attempt
+
+conn.close()  # => releases the connection -- irrelevant here since it's in-memory
+```
+
+**Run**: `python3 unsafe.py`
+
+**Output**:
+
+```text
+SELECT * FROM book WHERE title = ''; DROP TABLE book;--'
+blocked: You can only execute one statement at a time.
+1
+```
+
+**pyright**: `pyright unsafe.py` reports `0 errors, 0 warnings, 0 informations` under `# pyright:
+strict`.
+
+Note how the query text itself changed shape once `PAYLOAD` was spliced in -- it now contains a
+`DROP TABLE` statement chained onto the original `SELECT`. This exact attempt happens to be blocked by
+Python's own `sqlite3.ProgrammingError: You can only execute one statement at a time.` guard, which is
+unrelated to whether the input was "safe" -- it merely refuses to run more than one statement per
+`execute()` call. A same-statement payload (`' OR '1'='1`, for example) has no second statement to
+trigger that guard, and would still silently defeat the intended `WHERE` filter when built this way.
+
+**`learning/code/ex-54-injection-safe-vs-unsafe/safe.py`**
+
+```python
+# pyright: strict
+"""Example 54: injection-SAFE query, built via a `?` bound parameter."""
+
+import sqlite3  # => sqlite3 is stdlib -- no pip install needed
+
+# The identical payload from unsafe.py -- same attacker input, different result.
+PAYLOAD: str = "'; DROP TABLE book;--"
+
+conn: sqlite3.Connection = sqlite3.connect(":memory:")  # => opens an in-memory database
+conn.execute("CREATE TABLE book (id INTEGER PRIMARY KEY, title TEXT NOT NULL)")  # => id + title
+conn.execute("INSERT INTO book (title) VALUES ('Alpha')")  # => one seed row, id auto-assigns to 1
+conn.commit()  # => persists the seed row
+
+cur: sqlite3.Cursor = conn.cursor()  # => a cursor executes SQL and holds results
+# SAFE: `?` passes PAYLOAD as a bound VALUE, never as SQL text -- the query's
+# structure is fixed at prepare time, before SQLite ever inspects the value.
+cur.execute("SELECT * FROM book WHERE title = ?", (PAYLOAD,))  # => PAYLOAD bound, not spliced
+rows: list[tuple[int, str]] = cur.fetchall()  # => every matching row, fetched at once
+print(rows)  # => Output: [] -- no title literally equals the payload string
+
+cur.execute("SELECT count(*) FROM book")  # => confirms the table is fully intact
+count: tuple[int] = cur.fetchone()  # => a 1-tuple: (row_count,)
+print(count[0])  # => Output: 1 -- book table is fully intact, unaffected
+
+conn.close()  # => releases the connection -- irrelevant here since it's in-memory
+```
+
+**Run**: `python3 safe.py`
+
+**Output**:
+
+```text
+[]
+1
+```
+
+**pyright**: `pyright safe.py` reports `0 errors, 0 warnings, 0 informations` under `# pyright: strict`.
+
+**Key takeaway**: the `?` version treats the entire malicious payload as one opaque string value --
+`title = ?` compares literally against a title nobody has, returning an empty result -- while the
+f-string version let the same input change what SQL actually ran.
+
+**Why it matters**: "this one attempt got blocked" is not the same claim as "this approach is safe" --
+`unsafe.py`'s payload happened to collide with an unrelated single-statement guard in this Python
+version, but string interpolation remains structurally unsafe: any single-statement payload that
+doesn't need a second statement (a tautology like `' OR '1'='1`, for instance) sails straight through.
+Parameterized queries (`?` or `:name`, Example 47) are the only construct that closes this entire class
+of bug, by design, regardless of payload shape.
+
+---
+
+### Example 55: Upsert On Conflict
+
+_ex-55 &middot; exercises co-10, co-11_
+
+A plain `INSERT` targeting an existing primary key raises a constraint error. `INSERT ... ON
+CONFLICT(id) DO UPDATE SET ...` turns that error into an update instead -- insert if the row is new,
+update if it already exists, in one statement.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC -- color-blind friendly, WCAG AA
+flowchart LR
+    A["INSERT id = 1"]:::blue
+    B{"id 1 already exists?"}:::orange
+    C["INSERT -- new row"]:::teal
+    D["ON CONFLICT DO UPDATE<br/>price = excluded.price"]:::purple
+    A --> B
+    B -->|"no"| C
+    B -->|"yes"| D
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-55-upsert-on-conflict/example.sql`**
+
+```sql
+-- Example 55: Upsert On Conflict
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => the conflict target below
+  title TEXT NOT NULL,                        -- => book title, required
+  price REAL                                  -- => the column the upsert corrects
+);
+
+-- First insert: a plain new row, id 1.
+INSERT INTO book (id, title, price) VALUES (1, 'On Computable Numbers', 30.00); -- => row exists now
+
+SELECT * FROM book;                             -- => one row, price 30.00
+
+-- Second "insert" targets the SAME id (1) -- a plain INSERT here would raise a
+-- UNIQUE/PRIMARY KEY constraint error. ON CONFLICT(id) DO UPDATE turns that
+-- error into an UPDATE instead: an "upsert" -- insert if new, update if it exists.
+INSERT INTO book (id, title, price)             -- => targets the same id as the first insert
+VALUES (1, 'On Computable Numbers', 32.50)      -- => same id 1, a corrected price
+ON CONFLICT (id) DO UPDATE SET                  -- => fires because id 1 already exists
+  price = excluded.price;                       -- => excluded.price is the NEW attempted value
+
+SELECT * FROM book;                             -- => still ONE row, price now 32.50
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output** (two consecutive result sets, no blank line between them):
+
+```text
+id  title                   price
+--  ----------------------  -----
+1   On Computable Numbers  30.0
+id  title                   price
+--  ----------------------  -----
+1   On Computable Numbers  32.5
+```
+
+**Key takeaway**: the second `INSERT` never creates a second row -- `ON CONFLICT (id) DO UPDATE SET
+price = excluded.price` detects the primary-key collision and updates the existing row's `price`
+instead, leaving the table with exactly one row throughout.
+
+**Why it matters**: "insert if new, otherwise update" is an extremely common data-loading shape --
+syncing an external feed, re-running a seed script safely, or caching a computed value -- and without
+`ON CONFLICT`, that logic needs a separate `SELECT` to check existence first, then branch between
+`INSERT` and `UPDATE`, with a race condition between the check and the write. `excluded.<column>`
+refers to the row values the failed `INSERT` was attempting, available specifically inside the
+`DO UPDATE SET` clause.
+
+---
+
+### Example 56: Subquery in Where
+
+_ex-56 &middot; exercises co-08_
+
+A subquery inside `WHERE ... IN (...)` runs first, producing a list of values; the outer query then
+filters rows against that list -- here, books whose author is based in the UK.
+
+**`learning/code/ex-56-subquery-in-where/example.sql`**
+
+```sql
+-- Example 56: Subquery in Where
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE author (                          -- => parent table -- referenced by book below
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  name TEXT NOT NULL,                         -- => author's name, required
+  country TEXT                                -- => filtered by the subquery below
+);
+
+CREATE TABLE book (                            -- => child table -- author_id links back up
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  author_id INTEGER REFERENCES author(id)     -- => FK, matched against the subquery result
+);
+
+-- Two UK authors, one US author -- Grace Hopper's book should NOT appear below.
+INSERT INTO author (id, name, country) VALUES  -- => 3 authors, 2 in the subquery's result set
+  (1, 'Ada Lovelace', 'UK'),                  -- => UK -- id 1 IS in the subquery result
+  (2, 'Grace Hopper', 'US'),                  -- => US -- id 2 is NOT in the subquery result
+  (3, 'Alan Turing', 'UK');                   -- => UK -- id 3 IS in the subquery result
+
+INSERT INTO book (id, title, author_id) VALUES -- => 4 books across the 3 authors
+  (1, 'Notes on the Analytical Engine', 1),   -- => author_id 1 -- kept by the outer filter
+  (2, 'Introduction to Computing', 2),        -- => author_id 2 -- excluded by the outer filter
+  (3, 'On Computable Numbers', 3),            -- => author_id 3 -- kept by the outer filter
+  (4, 'The Enigma Papers', 3);                -- => author_id 3 -- kept by the outer filter
+
+-- The inner SELECT runs FIRST, producing a list of UK author ids (1, 3). The
+-- outer WHERE ... IN (...) then keeps only book rows whose author_id is in
+-- that list -- Grace Hopper's book (author_id 2, country US) is excluded.
+SELECT title                                    -- => only the title column is needed
+FROM book                                       -- => the 4-row source table above
+WHERE author_id IN (                            -- => subquery result: {1, 3}
+  SELECT id FROM author WHERE country = 'UK'    -- => runs first, before the outer filter
+)
+ORDER BY id;                                    -- => deterministic row order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+title
+------------------------------
+Notes on the Analytical Engine
+On Computable Numbers
+The Enigma Papers
+```
+
+**Key takeaway**: the subquery `SELECT id FROM author WHERE country = 'UK'` evaluates to the set `{1,
+3}` before the outer query runs -- `WHERE author_id IN (...)` then filters `book` against that fixed
+set, excluding Grace Hopper's book without a `JOIN` at all.
+
+**Why it matters**: a subquery in `WHERE ... IN (...)` is often more readable than an equivalent join
+when the outer query only needs to filter, not pull in extra columns from the related table -- there is
+no need to `SELECT author.country` here, so no join columns are wasted. Example 78 (advanced tier)
+extends this into a correlated subquery, one that re-evaluates once per outer row instead of once
+overall.
+
+---
+
+### Example 57: Self Join
+
+_ex-57 &middot; exercises co-13_
+
+A self-join relates a table to itself -- `manager_id` points back into the same `employee` table, so
+joining `employee` to a second aliased copy of itself pairs every employee with their manager's row.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73 -- color-blind friendly, WCAG AA
+flowchart LR
+    A["employee e<br/>#40;the row itself#41;"]:::blue
+    B["employee m<br/>#40;same table, 2nd alias#41;"]:::orange
+    C["e.manager_id = m.id<br/>employee paired with manager"]:::teal
+    A --> C
+    B --> C
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**`learning/code/ex-57-self-join/example.sql`**
+
+```sql
+-- Example 57: Self Join
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+-- A self-join relates a table to ITSELF -- manager_id points back into the
+-- SAME employee table, so every row can reference another row in that table.
+CREATE TABLE employee (                        -- => a single table -- no separate manager table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  name TEXT NOT NULL,                         -- => employee's name, required
+  manager_id INTEGER REFERENCES employee(id)  -- => FK to this SAME table's id
+);
+
+-- Ada has no manager (NULL) -- she's the top of the tree. Grace and Alan both
+-- report to Ada; nobody reports to Grace or Alan.
+INSERT INTO employee (id, name, manager_id) VALUES -- => 3 employees, 1 at the top
+  (1, 'Ada Lovelace', NULL),                  -- => top of the tree -- no manager
+  (2, 'Grace Hopper', 1),                     -- => reports to employee id 1 (Ada)
+  (3, 'Alan Turing', 1);                      -- => reports to employee id 1 (Ada)
+
+-- Join the table to a SECOND aliased copy of itself -- `e` for the employee
+-- row, `m` for that same row's manager (also a row in employee). A plain JOIN
+-- (not LEFT JOIN) drops Ada here since her manager_id is NULL -- no match in `m`.
+SELECT e.name AS employee_name, m.name AS manager_name -- => two names, from the same table
+FROM employee e                                 -- => `e` -- the employee's own row
+JOIN employee m ON e.manager_id = m.id          -- => `m` is `e`'s manager row
+ORDER BY e.id;                                  -- => deterministic row order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+employee_name  manager_name
+-------------  ------------
+Grace Hopper   Ada Lovelace
+Alan Turing    Ada Lovelace
+```
+
+**Key takeaway**: aliasing the same table twice (`employee e` and `employee m`) is what makes a
+self-join possible -- SQLite treats `e` and `m` as two independent references to `employee`, joined on
+`e.manager_id = m.id`. Ada Lovelace never appears as an `employee_name` here because her `manager_id`
+is NULL, and a plain `JOIN` (not `LEFT JOIN`) drops any row with no match.
+
+**Why it matters**: hierarchical data -- an org chart, a category tree, a comment-reply thread -- is
+almost always modeled with a self-referencing foreign key like `manager_id`, and a self-join is the
+standard single-level way to query it ("show me everyone's direct manager"). Deeper hierarchies (every
+ancestor, not just the direct manager) need a recursive query, out of scope for this topic (see the
+Scope note on `26-advanced-sql-and-query-performance`).
+
+---
+
+### Example 58: Case Expression
+
+_ex-58 &middot; exercises co-08_
+
+`CASE WHEN ... THEN ... ELSE ... END` is an inline conditional expression -- it derives a brand-new
+column value per row, directly inside a `SELECT`, without a separate `UPDATE` or client-side branching.
+
+**`learning/code/ex-58-case-expression/example.sql`**
+
+```sql
+-- Example 58: Case Expression
+-- Run: sqlite3 app.db < example.sql
+
+-- Dot-commands: print headers, align columns, spell out NULL instead of blank.
+.headers on
+.mode column
+.nullvalue NULL
+
+CREATE TABLE book (                            -- => a single flat table
+  id INTEGER PRIMARY KEY,                     -- => aliases rowid, auto-assigned
+  title TEXT NOT NULL,                        -- => book title, required
+  price REAL                                  -- => drives the CASE branch below
+);
+
+-- Prices straddle the 20.00 threshold on both sides, plus exactly ON it (book 5).
+INSERT INTO book (id, title, price) VALUES     -- => 5 rows spanning the 20.00 threshold
+  (1, 'Notes on the Analytical Engine', 25.00), -- => above 20 -- lands in 'premium'
+  (2, 'Introduction to Computing', 18.50),      -- => below 20 -- lands in 'standard'
+  (3, 'On Computable Numbers', 30.00),          -- => above 20 -- lands in 'premium'
+  (4, 'The Enigma Papers', 15.00),              -- => below 20 -- lands in 'standard'
+  (5, 'Compilers and Common Sense', 20.00);    -- => exactly 20.00 -- NOT > 20, so 'standard'
+
+-- CASE WHEN ... THEN ... ELSE ... END is an inline conditional expression --
+-- it derives a brand-new column value per row, without a separate UPDATE or
+-- a client-side loop. WHEN conditions are checked top to bottom, first match wins.
+SELECT title, price,                            -- => the raw columns, plus a derived one below
+  CASE                                           -- => the derived tier column starts here
+    WHEN price > 20 THEN 'premium'              -- => strictly greater than 20
+    ELSE 'standard'                              -- => everything else, including = 20
+  END AS tier
+FROM book                                       -- => the 5-row source table above
+ORDER BY id;                                    -- => deterministic row order
+```
+
+**Run**: `sqlite3 app.db < example.sql`
+
+**Output**:
+
+```text
+title                           price  tier
+------------------------------  -----  --------
+Notes on the Analytical Engine  25.0   premium
+Introduction to Computing       18.5   standard
+On Computable Numbers           30.0   premium
+The Enigma Papers               15.0   standard
+Compilers and Common Sense      20.0   standard
+```
+
+**Key takeaway**: book id 5, priced at exactly 20.00, lands in `'standard'` -- `price > 20` is a strict
+inequality, so a value equal to the threshold falls through to the `ELSE` branch, not the `THEN`
+branch.
+
+**Why it matters**: `CASE` is how derived, conditional columns get computed inside the database itself
+-- a price tier, a pass/fail label, a bucketed age range -- instead of pulling raw values back to the
+client and branching there. It also composes with aggregates (`SUM(CASE WHEN ... THEN 1 ELSE 0 END)`
+is a common conditional-count idiom), though that combination is out of this topic's scope.
+
+---
+
+← Previous: [Beginner Examples](./beginner.md) · Next: [Advanced Examples](./advanced.md) →

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/overview.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/sql-essentials/learning/overview.md
@@ -1,0 +1,166 @@
+---
+title: "Overview"
+date: 2026-07-14T00:00:00+07:00
+draft: false
+weight: 1
+---
+
+## Prerequisites
+
+- **Prior topics**: [4 · Just Enough Python](../../just-enough-python/learning/overview.md) -- Python
+  drives every database-access example in this topic's Python-marked (†) examples, and by this point
+  you should be comfortable running a `.py` script and reading typed function signatures.
+- **Tools & environment**: a macOS/Linux terminal; **SQLite** (`sqlite3 --version` confirms it is
+  installed -- the same engine Python's stdlib `sqlite3` module embeds); **Python 3.x** with `pytest`
+  installed in a `venv`. `psql`/PostgreSQL is only referenced for cross-checking dialect-agnostic SQL
+  semantics (JOIN/GROUP BY/HAVING/NULL behavior) -- it is not required to complete this topic.
+- **Assumed knowledge**: basic Python (variables, functions, running a script). No prior SQL or
+  database background is assumed -- this topic is your SQL starting point.
+
+## Why this exists -- the big idea
+
+Application data outlives the process that created it. A list or dictionary in memory vanishes the
+moment your program exits; a table in a database survives restarts, crashes, and years of accumulated
+history. That durability comes with a cost: the data has to be queried, related to other data, and
+kept internally consistent -- exactly the problems the relational model and SQL were built to solve.
+
+**Keep-this-if-you-forget-everything**: declare _what_ result you want and let the engine decide _how_
+to get it. This is the `mechanism-vs-policy` big idea in concrete form: SQL is declarative policy (the
+result you describe), and the query planner is the mechanism (how it actually fetches rows) -- you
+never write a loop to find "every book over $25," you just say `WHERE price > 25` and the engine
+figures out the rest. Normalization -- splitting data into related tables instead of repeating it --
+is the other half of this topic's foundation: it keeps one fact in exactly one place, so updating an
+author's name never means hunting down every book row that repeated it.
+
+## How this topic is organized
+
+- **Beginner** (Examples 1-30) -- schema declaration (`CREATE TABLE`, `.schema`), the CRUD basics
+  (`INSERT`, `SELECT`, `UPDATE`, `DELETE`), `WHERE`/`ORDER BY`/`LIMIT` filtering and paging, the four
+  core constraints (`NOT NULL`, `UNIQUE`, `DEFAULT`, `CHECK`), foreign keys (declaring and enforcing),
+  a first `JOIN`, and the first two Python `sqlite3` examples (connecting, querying, and
+  parameterized inserts).
+- **Intermediate** (Examples 31-58) -- multi-table joins with aliases, `LEFT JOIN` and anti-joins,
+  `GROUP BY`/`HAVING` aggregation, NULL's three-valued logic and `COALESCE`, normalization walkthroughs
+  (1NF and 3NF), more Python `sqlite3` (named parameters, `executemany`, `fetchone` streaming,
+  `sqlite3.Row`), transactions (commit/rollback/context-manager), injection-safe vs. injection-unsafe
+  queries side by side, upsert (`ON CONFLICT`), subqueries, self-joins, and `CASE` expressions.
+- **Advanced** (Examples 59-80) -- additive schema migrations with `PRAGMA user_version` tracking,
+  diagnosing and fixing the N+1 query problem, composite primary keys, `ON DELETE CASCADE`/`RESTRICT`,
+  `SAVEPOINT`/`ROLLBACK TO` partial-transaction undo, a typed Python data-access-layer module tested
+  with `pytest`, CSV export via the CLI, integrity-check pragmas, designing a 3NF schema from scratch,
+  and correlated subqueries.
+
+Every example cites the concept (`co-NN`) it exercises, and every example is fully self-contained --
+none of them depend on state left behind by an earlier example, so you can run any single one from a
+clean, empty directory.
+
+## Scope: the usable slice
+
+This topic covers the **usable slice**: schema design, core queries, and safe database access from
+Python, entirely from the CLI. Window functions, common table expressions (CTEs), indexing strategy,
+and transaction isolation levels are **deliberately out of scope** here -- they are deferred to a
+later Advanced SQL topic in this curriculum. If a SQL feature is not exercised by an example in this
+topic, it is out of scope on purpose, not by oversight.
+
+**Accuracy**: current SQLite is **3.53.3** (2026-06-26), **public domain** (no license required).
+Note that the SQLite version bundled with a given Python install varies -- this topic reads
+`sqlite3.sqlite_version` at runtime rather than asserting a fixed bundled version wherever that
+matters. Every concrete, checkable claim in this topic (constraint error text, CLI dot-command
+behavior, `PRAGMA` semantics, Python `sqlite3` API surface) was verified against sqlite.org and
+docs.python.org primary documentation on 2026-07-12, and re-verified with no drift found on
+2026-07-14.
+
+## Examples by Level
+
+### Beginner (Examples 1–30)
+
+- [Example 1: Create Author Table](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-1-create-author-table)
+- [Example 2: Open Database CLI](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-2-open-database-cli)
+- [Example 3: Insert Single Row](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-3-insert-single-row)
+- [Example 4: Insert Multiple Rows](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-4-insert-multiple-rows)
+- [Example 5: Select All Columns](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-5-select-all-columns)
+- [Example 6: Select Projection](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-6-select-projection)
+- [Example 7: Where Equality](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-7-where-equality)
+- [Example 8: Where Comparison](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-8-where-comparison)
+- [Example 9: Where And Or](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-9-where-and-or)
+- [Example 10: Where Like Prefix](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-10-where-like-prefix)
+- [Example 11: Where In Set](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-11-where-in-set)
+- [Example 12: Order By Ascending](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-12-order-by-ascending)
+- [Example 13: Order By Descending](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-13-order-by-descending)
+- [Example 14: Limit Rows](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-14-limit-rows)
+- [Example 15: Limit Offset Paging](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-15-limit-offset-paging)
+- [Example 16: Select Distinct](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-16-select-distinct)
+- [Example 17: Type Affinity](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-17-type-affinity)
+- [Example 18: Not Null Constraint](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-18-not-null-constraint)
+- [Example 19: Unique Constraint](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-19-unique-constraint)
+- [Example 20: Default Value](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-20-default-value)
+- [Example 21: Check Constraint](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-21-check-constraint)
+- [Example 22: Autoincrement Rowid](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-22-autoincrement-rowid)
+- [Example 23: Update One Row](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-23-update-one-row)
+- [Example 24: Update All Rows](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-24-update-all-rows)
+- [Example 25: Delete Row](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-25-delete-row)
+- [Example 26: Declare Foreign Key](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-26-declare-foreign-key)
+- [Example 27: Enforce Foreign Key](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-27-enforce-foreign-key)
+- [Example 28: Inner Join Two Tables](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-28-inner-join-two-tables)
+- [Example 29: Python Connect And Query](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-29-python-connect-and-query)
+- [Example 30: Python Parameterized Insert](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/beginner#example-30-python-parameterized-insert)
+
+### Intermediate (Examples 31–58)
+
+- [Example 31: Left Join Unmatched](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-31-left-join-unmatched)
+- [Example 32: Join with Aliases](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-32-join-with-aliases)
+- [Example 33: Three-Table Join](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-33-three-table-join)
+- [Example 34: Group By Count](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-34-group-by-count)
+- [Example 35: Group By Sum](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-35-group-by-sum)
+- [Example 36: Group By Avg](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-36-group-by-avg)
+- [Example 37: Min-Max Aggregate](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-37-min-max-aggregate)
+- [Example 38: Having Filter Groups](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-38-having-filter-groups)
+- [Example 39: Where Plus Having](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-39-where-plus-having)
+- [Example 40: Count Star vs Column](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-40-count-star-vs-column)
+- [Example 41: Null Is Null](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-41-null-is-null)
+- [Example 42: Null Coalesce](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-42-null-coalesce)
+- [Example 43: Null Three-Valued](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-43-null-three-valued)
+- [Example 44: Aggregate Over Join](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-44-aggregate-over-join)
+- [Example 45: Normalize Repeating Group (1NF)](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-45-normalize-repeating-group-1nf)
+- [Example 46: Normalize Transitive Dependency (3NF)](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-46-normalize-transitive-dependency-3nf)
+- [Example 47: Python Named Params](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-47-python-named-params)
+- [Example 48: Python Executemany](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-48-python-executemany)
+- [Example 49: Python Fetchone Loop](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-49-python-fetchone-loop)
+- [Example 50: Python Row Factory](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-50-python-row-factory)
+- [Example 51: Transaction Commit](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-51-transaction-commit)
+- [Example 52: Transaction Rollback](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-52-transaction-rollback)
+- [Example 53: Transaction Context Manager](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-53-transaction-context-manager)
+- [Example 54: Injection Safe vs Unsafe](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-54-injection-safe-vs-unsafe)
+- [Example 55: Upsert On Conflict](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-55-upsert-on-conflict)
+- [Example 56: Subquery in Where](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-56-subquery-in-where)
+- [Example 57: Self Join](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-57-self-join)
+- [Example 58: Case Expression](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/intermediate#example-58-case-expression)
+
+### Advanced (Examples 59–80)
+
+- [Example 59: Migration Add Column](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-59-migration-add-column)
+- [Example 60: Migration Backfill](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-60-migration-backfill)
+- [Example 61: Migration Version Tracking](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-61-migration-version-tracking)
+- [Example 62: N+1 Query Problem Demonstrated](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-62-n1-query-problem-demonstrated)
+- [Example 63: N+1 Fixed with a Single Join](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-63-n1-fixed-with-a-single-join)
+- [Example 64: N+1 Fixed with a Batched Fetch](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-64-n1-fixed-with-a-batched-fetch)
+- [Example 65: Composite Primary Key](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-65-composite-primary-key)
+- [Example 66: Cascade Delete](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-66-cascade-delete)
+- [Example 67: Restrict Delete](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-67-restrict-delete)
+- [Example 68: Savepoint Partial Rollback](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-68-savepoint-partial-rollback)
+- [Example 69: Python Report Function](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-69-python-report-function)
+- [Example 70: Group Concat](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-70-group-concat)
+- [Example 71: Anti-Join Missing Rows](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-71-anti-join-missing-rows)
+- [Example 72: Atomic Transfer](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-72-atomic-transfer)
+- [Example 73: Python DAL Module](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-73-python-dal-module)
+- [Example 74: Seed from SQL File](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-74-seed-from-sql-file)
+- [Example 75: Export Query to CSV](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-75-export-query-to-csv)
+- [Example 76: Integrity Checks](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-76-integrity-checks)
+- [Example 77: Design a 3NF Schema](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-77-design-a-3nf-schema)
+- [Example 78: Correlated Subquery](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-78-correlated-subquery)
+- [Example 79: Join, Group, and Having Report](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-79-join-group-and-having-report)
+- [Example 80: pytest Rollback Integration](/en/c/learn/fundamentally-strong/software-engineer/sql-essentials/learning/advanced#example-80-pytest-rollback-integration)
+
+---
+
+← Previous: [9 · Project Management](../../../overview.md) · Next: [Beginner Examples](./beginner.md) →

--- a/plans/in-progress/fundamentally-strong-software-engineer/delivery.md
+++ b/plans/in-progress/fundamentally-strong-software-engineer/delivery.md
@@ -2073,126 +2073,126 @@ fundamentally-strong-software-engineer/<phase-slug>`), do this phase's work, the
 Row: By Example · SQL + Python † (SQLite) · topic wt 200 · Learn 110 / Drill 210 · **subject**. Template →
 [`syllabus/10-sql-essentials.md`](./syllabus/10-sql-essentials.md).
 
-- [ ] **[AI] V** — `web-researcher` for `sql-essentials`; resolve every Accuracy-notes "to verify" line in
+- [x] **[AI] V** — `web-researcher` for `sql-essentials`; resolve every Accuracy-notes "to verify" line in
       [`syllabus/10-sql-essentials.md`](./syllabus/10-sql-essentials.md) and fold dated findings back into that file.
       **Acceptance**: no unresolved "verify" line remains.
-- [ ] **[AI] A1-concepts** — Author `CONTENT/sql-essentials/learning/` teaching **every** concept in `syllabus/10-sql-essentials.md` §Concepts (DD-34 1:1 mirror; concepts before examples). One checkbox per `co-NN`:
-  - [ ] co-01 · relational-model
-  - [ ] co-02 · primary-keys
-  - [ ] co-03 · foreign-keys
-  - [ ] co-04 · constraints
-  - [ ] co-05 · normalization
-  - [ ] co-06 · column-types
-  - [ ] co-07 · ddl-create-table
-  - [ ] co-08 · select-projection-filtering
-  - [ ] co-09 · ordering-and-limiting
-  - [ ] co-10 · insert
-  - [ ] co-11 · update
-  - [ ] co-12 · delete
-  - [ ] co-13 · inner-join
-  - [ ] co-14 · outer-join
-  - [ ] co-15 · aggregation
-  - [ ] co-16 · having-filter
-  - [ ] co-17 · null-semantics
-  - [ ] co-18 · transactions
-  - [ ] co-19 · python-sqlite3-connection
-  - [ ] co-20 · parameterized-queries
-  - [ ] co-21 · cursor-and-results
-  - [ ] co-22 · schema-migration
-  - [ ] co-23 · n-plus-1-avoidance
-  - [ ] co-24 · cli-usage
-- [ ] **[AI] A1-examples** — Author `CONTENT/sql-essentials/learning/code/` — one runnable `.sql`/`python3` example per worked example in `syllabus/10-sql-essentials.md` §Worked examples (DD-20/DD-30/DD-34/DD-39). One checkbox per `ex-NN` (1:1 mirror):
-  - [ ] ex-01 · create-author-table — verify `.schema` lists column + PK
-  - [ ] ex-02 · open-database-cli — verify prompt opens, no tables yet
-  - [ ] ex-03 · insert-single-row — verify exactly one row returns
-  - [ ] ex-04 · insert-multiple-rows — verify `count(*)` returns 3
-  - [ ] ex-05 · select-all-columns — verify every column and row returned
-  - [ ] ex-06 · select-projection — verify only `title` appears
-  - [ ] ex-07 · where-equality — verify single matching row
-  - [ ] ex-08 · where-comparison — verify only rows above threshold
-  - [ ] ex-09 · where-and-or — verify combined boolean filtering
-  - [ ] ex-10 · where-like-prefix — verify prefix pattern matches
-  - [ ] ex-11 · where-in-set — verify set-membership filtering
-  - [ ] ex-12 · order-by-ascending — verify alphabetical ordering
-  - [ ] ex-13 · order-by-descending — verify most-expensive-first
-  - [ ] ex-14 · limit-rows — verify at most two rows
-  - [ ] ex-15 · limit-offset-paging — verify second page of two rows
-  - [ ] ex-16 · select-distinct — verify duplicate values collapse
-  - [ ] ex-17 · type-affinity — verify `'42'` stored as integer
-  - [ ] ex-18 · not-null-constraint — verify NOT NULL error
-  - [ ] ex-19 · unique-constraint — verify UNIQUE error
-  - [ ] ex-20 · default-value — verify default applied
-  - [ ] ex-21 · check-constraint — verify negative price rejected
-  - [ ] ex-22 · autoincrement-rowid — verify ids auto-assign 1, 2
-  - [ ] ex-23 · update-one-row — verify only that row changed
-  - [ ] ex-24 · update-all-rows — verify every row changed
-  - [ ] ex-25 · delete-row — verify row gone, count drops by one
-  - [ ] ex-26 · declare-foreign-key — verify FK clause in `.schema`
-  - [ ] ex-27 · enforce-foreign-key — verify orphan rejected
-  - [ ] ex-28 · inner-join-two-tables — verify each book pairs with author
-  - [ ] ex-29 · python-connect-and-query — verify script prints rows
-  - [ ] ex-30 · python-parameterized-insert — verify inserts without interpolation
-  - [ ] ex-31 · left-join-unmatched — verify authors with no books show NULL title
-  - [ ] ex-32 · join-with-aliases — verify same result more readably
-  - [ ] ex-33 · three-table-join — verify combined columns across three relations
-  - [ ] ex-34 · group-by-count — verify per-author book counts
-  - [ ] ex-35 · group-by-sum — verify per-group totals
-  - [ ] ex-36 · group-by-avg — verify per-group averages
-  - [ ] ex-37 · min-max-aggregate — verify cheapest and dearest
-  - [ ] ex-38 · having-filter-groups — verify only authors with >1 book
-  - [ ] ex-39 · where-plus-having — verify row filter before, group filter after
-  - [ ] ex-40 · count-star-vs-column — verify column count excludes NULLs
-  - [ ] ex-41 · null-is-null — verify rows with unknown year match
-  - [ ] ex-42 · null-coalesce — verify NULLs substituted with 0
-  - [ ] ex-43 · null-three-valued — verify `= NULL` returns no rows
-  - [ ] ex-44 · aggregate-over-join — verify per-author total across join
-  - [ ] ex-45 · normalize-repeating-group — verify 1NF/2NF removes repeating group
-  - [ ] ex-46 · normalize-transitive-dep — verify 3NF holds one fact per place
-  - [ ] ex-47 · python-named-params — verify named binding
-  - [ ] ex-48 · python-executemany — verify bulk insert of all rows
-  - [ ] ex-49 · python-fetchone-loop — verify streamed row-by-row consumption
-  - [ ] ex-50 · python-row-factory — verify column-name access
-  - [ ] ex-51 · transaction-commit — verify write persists in new connection
-  - [ ] ex-52 · transaction-rollback — verify DB unchanged
-  - [ ] ex-53 · transaction-context-manager — verify auto-rollback on raise
-  - [ ] ex-54 · injection-safe-vs-unsafe — verify only parameterized form safe
-  - [ ] ex-55 · upsert-on-conflict — verify second insert updates
-  - [ ] ex-56 · subquery-in-where — verify filtering by subquery result
-  - [ ] ex-57 · self-join — verify each employee pairs with manager
-  - [ ] ex-58 · case-expression — verify conditional derived column
-  - [ ] ex-59 · migration-add-column — verify existing rows gain default
-  - [ ] ex-60 · migration-backfill — verify all rows populated
-  - [ ] ex-61 · migration-version-tracking — verify `user_version` bumps
-  - [ ] ex-62 · n-plus-1-demonstrated — verify N+1 round-trips occur
-  - [ ] ex-63 · n-plus-1-fixed-join — verify one query returns same data
-  - [ ] ex-64 · n-plus-1-fixed-in — verify single round-trip
-  - [ ] ex-65 · composite-primary-key — verify duplicate pair rejected
-  - [ ] ex-66 · cascade-delete — verify author's books removed too
-  - [ ] ex-67 · restrict-delete — verify delete blocked
-  - [ ] ex-68 · savepoint-partial-rollback — verify only inner work undone
-  - [ ] ex-69 · python-report-function — verify returned rows match expected
-  - [ ] ex-70 · group-concat — verify titles concatenate per group
-  - [ ] ex-71 · anti-join-missing — verify authors with zero books isolated
-  - [ ] ex-72 · atomic-transfer — verify all-or-nothing transfer
-  - [ ] ex-73 · python-dal-module — verify pytest suite green
-  - [ ] ex-74 · seed-from-sql-file — verify seeded row count
-  - [ ] ex-75 · export-query-to-csv — verify CSV contains result rows
-  - [ ] ex-76 · integrity-checks — verify both PRAGMA checks report no problems
-  - [ ] ex-77 · design-3nf-schema — verify no transitive dependency remains
-  - [ ] ex-78 · correlated-subquery — verify per-row computed count
-  - [ ] ex-79 · report-join-group-having — verify matches expected values
-  - [ ] ex-80 · pytest-rollback-integration — verify green (row count unchanged)
-- [ ] **[AI] A2 (capstone)** — Author `CONTENT/sql-essentials/learning/capstone/` (`_index.md` weight 900) per the
+- [x] **[AI] A1-concepts** — Author `CONTENT/sql-essentials/learning/` teaching **every** concept in `syllabus/10-sql-essentials.md` §Concepts (DD-34 1:1 mirror; concepts before examples). One checkbox per `co-NN`:
+  - [x] co-01 · relational-model
+  - [x] co-02 · primary-keys
+  - [x] co-03 · foreign-keys
+  - [x] co-04 · constraints
+  - [x] co-05 · normalization
+  - [x] co-06 · column-types
+  - [x] co-07 · ddl-create-table
+  - [x] co-08 · select-projection-filtering
+  - [x] co-09 · ordering-and-limiting
+  - [x] co-10 · insert
+  - [x] co-11 · update
+  - [x] co-12 · delete
+  - [x] co-13 · inner-join
+  - [x] co-14 · outer-join
+  - [x] co-15 · aggregation
+  - [x] co-16 · having-filter
+  - [x] co-17 · null-semantics
+  - [x] co-18 · transactions
+  - [x] co-19 · python-sqlite3-connection
+  - [x] co-20 · parameterized-queries
+  - [x] co-21 · cursor-and-results
+  - [x] co-22 · schema-migration
+  - [x] co-23 · n-plus-1-avoidance
+  - [x] co-24 · cli-usage
+- [x] **[AI] A1-examples** — Author `CONTENT/sql-essentials/learning/code/` — one runnable `.sql`/`python3` example per worked example in `syllabus/10-sql-essentials.md` §Worked examples (DD-20/DD-30/DD-34/DD-39). One checkbox per `ex-NN` (1:1 mirror):
+  - [x] ex-01 · create-author-table — verify `.schema` lists column + PK
+  - [x] ex-02 · open-database-cli — verify prompt opens, no tables yet
+  - [x] ex-03 · insert-single-row — verify exactly one row returns
+  - [x] ex-04 · insert-multiple-rows — verify `count(*)` returns 3
+  - [x] ex-05 · select-all-columns — verify every column and row returned
+  - [x] ex-06 · select-projection — verify only `title` appears
+  - [x] ex-07 · where-equality — verify single matching row
+  - [x] ex-08 · where-comparison — verify only rows above threshold
+  - [x] ex-09 · where-and-or — verify combined boolean filtering
+  - [x] ex-10 · where-like-prefix — verify prefix pattern matches
+  - [x] ex-11 · where-in-set — verify set-membership filtering
+  - [x] ex-12 · order-by-ascending — verify alphabetical ordering
+  - [x] ex-13 · order-by-descending — verify most-expensive-first
+  - [x] ex-14 · limit-rows — verify at most two rows
+  - [x] ex-15 · limit-offset-paging — verify second page of two rows
+  - [x] ex-16 · select-distinct — verify duplicate values collapse
+  - [x] ex-17 · type-affinity — verify `'42'` stored as integer
+  - [x] ex-18 · not-null-constraint — verify NOT NULL error
+  - [x] ex-19 · unique-constraint — verify UNIQUE error
+  - [x] ex-20 · default-value — verify default applied
+  - [x] ex-21 · check-constraint — verify negative price rejected
+  - [x] ex-22 · autoincrement-rowid — verify ids auto-assign 1, 2
+  - [x] ex-23 · update-one-row — verify only that row changed
+  - [x] ex-24 · update-all-rows — verify every row changed
+  - [x] ex-25 · delete-row — verify row gone, count drops by one
+  - [x] ex-26 · declare-foreign-key — verify FK clause in `.schema`
+  - [x] ex-27 · enforce-foreign-key — verify orphan rejected
+  - [x] ex-28 · inner-join-two-tables — verify each book pairs with author
+  - [x] ex-29 · python-connect-and-query — verify script prints rows
+  - [x] ex-30 · python-parameterized-insert — verify inserts without interpolation
+  - [x] ex-31 · left-join-unmatched — verify authors with no books show NULL title
+  - [x] ex-32 · join-with-aliases — verify same result more readably
+  - [x] ex-33 · three-table-join — verify combined columns across three relations
+  - [x] ex-34 · group-by-count — verify per-author book counts
+  - [x] ex-35 · group-by-sum — verify per-group totals
+  - [x] ex-36 · group-by-avg — verify per-group averages
+  - [x] ex-37 · min-max-aggregate — verify cheapest and dearest
+  - [x] ex-38 · having-filter-groups — verify only authors with >1 book
+  - [x] ex-39 · where-plus-having — verify row filter before, group filter after
+  - [x] ex-40 · count-star-vs-column — verify column count excludes NULLs
+  - [x] ex-41 · null-is-null — verify rows with unknown year match
+  - [x] ex-42 · null-coalesce — verify NULLs substituted with 0
+  - [x] ex-43 · null-three-valued — verify `= NULL` returns no rows
+  - [x] ex-44 · aggregate-over-join — verify per-author total across join
+  - [x] ex-45 · normalize-repeating-group — verify 1NF/2NF removes repeating group
+  - [x] ex-46 · normalize-transitive-dep — verify 3NF holds one fact per place
+  - [x] ex-47 · python-named-params — verify named binding
+  - [x] ex-48 · python-executemany — verify bulk insert of all rows
+  - [x] ex-49 · python-fetchone-loop — verify streamed row-by-row consumption
+  - [x] ex-50 · python-row-factory — verify column-name access
+  - [x] ex-51 · transaction-commit — verify write persists in new connection
+  - [x] ex-52 · transaction-rollback — verify DB unchanged
+  - [x] ex-53 · transaction-context-manager — verify auto-rollback on raise
+  - [x] ex-54 · injection-safe-vs-unsafe — verify only parameterized form safe
+  - [x] ex-55 · upsert-on-conflict — verify second insert updates
+  - [x] ex-56 · subquery-in-where — verify filtering by subquery result
+  - [x] ex-57 · self-join — verify each employee pairs with manager
+  - [x] ex-58 · case-expression — verify conditional derived column
+  - [x] ex-59 · migration-add-column — verify existing rows gain default
+  - [x] ex-60 · migration-backfill — verify all rows populated
+  - [x] ex-61 · migration-version-tracking — verify `user_version` bumps
+  - [x] ex-62 · n-plus-1-demonstrated — verify N+1 round-trips occur
+  - [x] ex-63 · n-plus-1-fixed-join — verify one query returns same data
+  - [x] ex-64 · n-plus-1-fixed-in — verify single round-trip
+  - [x] ex-65 · composite-primary-key — verify duplicate pair rejected
+  - [x] ex-66 · cascade-delete — verify author's books removed too
+  - [x] ex-67 · restrict-delete — verify delete blocked
+  - [x] ex-68 · savepoint-partial-rollback — verify only inner work undone
+  - [x] ex-69 · python-report-function — verify returned rows match expected
+  - [x] ex-70 · group-concat — verify titles concatenate per group
+  - [x] ex-71 · anti-join-missing — verify authors with zero books isolated
+  - [x] ex-72 · atomic-transfer — verify all-or-nothing transfer
+  - [x] ex-73 · python-dal-module — verify pytest suite green
+  - [x] ex-74 · seed-from-sql-file — verify seeded row count
+  - [x] ex-75 · export-query-to-csv — verify CSV contains result rows
+  - [x] ex-76 · integrity-checks — verify both PRAGMA checks report no problems
+  - [x] ex-77 · design-3nf-schema — verify no transitive dependency remains
+  - [x] ex-78 · correlated-subquery — verify per-row computed count
+  - [x] ex-79 · report-join-group-having — verify matches expected values
+  - [x] ex-80 · pytest-rollback-integration — verify green (row count unchanged)
+- [x] **[AI] A2 (capstone)** — Author `CONTENT/sql-essentials/learning/capstone/` (`_index.md` weight 900) per the
       syllabus `## Capstone spec`. **Acceptance**: the done bar is met and the concepts-exercised checklist
       is fully hit.
-- [ ] **[AI] A3/D/F/G** — `apps-ayokoding-www-by-example-checker` + `apps-ayokoding-www-link-checker` +
+- [x] **[AI] A3/D/F/G** — `apps-ayokoding-www-by-example-checker` + `apps-ayokoding-www-link-checker` +
       `apps-ayokoding-www-facts-checker` clean (resolve via matching fixer); author
       `CONTENT/sql-essentials/drilling/_index.md` (wt 210) covering the same Items with mocked/self-contained
       inputs; `npx nx run ayokoding-www:build` + `npm run lint:md` exit 0.
 
 ### Phase 11 Gate
 
-- [ ] [AI] `sql-essentials/` complete: `_index.md` wt 200, `learning/_index.md` wt 110,
+- [x] [AI] `sql-essentials/` complete: `_index.md` wt 200, `learning/_index.md` wt 110,
       `drilling/_index.md` wt 210, capstone wt 900; all 24 concepts + 80 worked examples + capstone present;
       checkers + facts-checker clean; build + `lint:md` exit 0.
 

--- a/plans/in-progress/fundamentally-strong-software-engineer/syllabus/10-sql-essentials.md
+++ b/plans/in-progress/fundamentally-strong-software-engineer/syllabus/10-sql-essentials.md
@@ -34,6 +34,13 @@ public-domain (Tier-1, DD-21).
   param) — both current. Note the SQLite version bundled with a given Python build varies; phrase the
   topic to read `sqlite3.sqlite_version` at runtime rather than asserting a fixed bundled version.
   (sqlite.org / docs.python.org)
+- 2026-07-14 — re-verified: no drift since 2026-07-12. SQLite remains **3.53.3** (2026-06-26, still
+  latest per sqlite.org/changes.html) and public-domain (sqlite.org/copyright.html). Python `sqlite3`
+  API surface (`connect`/`cursor`/`execute`/`commit`/`close`, `?`/`:name` placeholders, `with conn:`
+  auto-commit/rollback, `sqlite3.Row`, `executemany`, `sqlite3.sqlite_version`) unchanged, no
+  deprecations (docs.python.org/3/library/sqlite3.html). UPSERT, foreign-key pragma/CASCADE/RESTRICT,
+  SAVEPOINT/ROLLBACK TO, PRAGMA user_version/integrity_check/foreign_key_check, and CLI dot-commands
+  (`.tables`/`.schema`/`.mode`/`.output`) all confirmed unchanged against sqlite.org primary docs.
 
 ### DD-35 primary-source citations (fetched-and-read)
 


### PR DESCRIPTION
## Summary

- Adds the `sql-essentials` By-Example topic (SQL + Python via SQLite) under
  `fundamentally-strong/software-engineer`: 24 concepts, 80 worked examples
  (30 beginner / 28 intermediate / 22 advanced), an intra-topic capstone, and
  a drilling section (24 recall Q&A, 12 applied problems, 8 code katas,
  self-check checklist, elaborative interrogation prompts).
- Web-verified the syllabus's Accuracy notes (SQLite 3.53.3, Python `sqlite3`
  stdlib API) and folded dated findings back into `syllabus/10-sql-essentials.md`.
- Wires the topic into the `fundamentally-strong` nav.
- Exempts ayokoding-www example-code `.sql` files from `prettier-plugin-sql`
  (they are sqlite3 CLI REPL scripts that legitimately embed dot-commands
  like `.headers`/`.mode`, which the formatter cannot parse).

Ticks every checkbox in `plans/in-progress/fundamentally-strong-software-engineer/delivery.md`
Phase 11 (all 24 `co-NN` concepts, all 80 `ex-NN` examples, capstone, quality
gates).

## Test plan

- [x] `apps-ayokoding-www-by-example-checker` clean (initial run found
      CRITICAL annotation-density and HIGH diagram-count gaps; fixed by
      `apps-ayokoding-www-by-example-fixer`; independently re-verified clean)
- [x] `apps-ayokoding-www-link-checker` clean
- [x] `apps-ayokoding-www-facts-checker` clean
- [x] Independently ran `pyright` (strict) and executed every `.sql`/`python3`
      example directly (not just trusting sub-agent self-reports)
- [x] `npx nx run ayokoding-www:build` exits 0
- [x] `npm run lint:md` exits 0
- [x] `rhino-cli md mermaid/heading-hierarchy/naming/frontmatter validate` all clean
- [x] Pre-push hooks green (typecheck, lint, test:quick, specs:coverage —
      224 scenarios / 834 steps all covered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)