### PR TITLE
fix(rhino-cli): add --exclude-source-dir for app_dir step-scan exclusions

### DIFF
--- a/apps/ayokoding-www/project.json
+++ b/apps/ayokoding-www/project.json
@@ -114,7 +114,7 @@
     "specs:behavior:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/ayokoding/behavior/ayokoding-www/gherkin specs/apps/ayokoding/behavior/ayokoding-be/gherkin specs/apps/ayokoding/behavior/ayokoding-build-tools/gherkin apps/ayokoding-www"
+        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps --exclude-source-dir content specs/apps/ayokoding/behavior/ayokoding-www/gherkin specs/apps/ayokoding/behavior/ayokoding-be/gherkin specs/apps/ayokoding/behavior/ayokoding-build-tools/gherkin apps/ayokoding-www"
       },
       "cache": true,
       "inputs": [

--- a/apps/rhino-cli/src/application/speccoverage/checker.rs
+++ b/apps/rhino-cli/src/application/speccoverage/checker.rs
@@ -105,6 +105,26 @@ fn skip_dirs() -> &'static HashSet<&'static str> {
     })
 }
 
+/// Returns `true` if `name` should be skipped when walking an `app_dir`
+/// source tree: either a universal skip-dir (see [`skip_dirs`]) or one of
+/// the caller-supplied `exclude_dirs` (fed from `ScanOptions::exclude_source_dirs`,
+/// i.e. the `--exclude-source-dir` CLI flag).
+///
+/// Deliberately a *separate* exclusion list from `--exclude-dir` (which only
+/// filters the `.feature`-file walk, see [`walk_feature_files`]): a directory
+/// name can be a legitimate spec-organization folder in the spec tree while
+/// also being a legitimate app-source folder name in the app tree (e.g. a
+/// Next.js content-layer `content/` directory holding step-decorator-shaped
+/// teaching examples, coexisting with a Gherkin `content/` folder grouping
+/// content-API scenarios). Sharing one exclusion list between both walks
+/// would let excluding one tree silently exclude the other. This lets a
+/// project declare the app-tree exclusion explicitly in its own Nx target
+/// rather than rhino-cli hardcoding that project's directory-naming
+/// convention for every repo that links this binary.
+fn is_excluded_source_dir(name: &str, exclude_dirs: &[String]) -> bool {
+    skip_dirs().contains(name) || exclude_dirs.iter().any(|d| d == name)
+}
+
 // ============================================================
 // Public entry point
 // ============================================================
@@ -162,7 +182,7 @@ fn collect_feature_files(opts: &ScanOptions) -> std::result::Result<Vec<PathBuf>
 fn check_shared_steps(opts: &ScanOptions) -> std::result::Result<CheckResult, Error> {
     let start = Instant::now();
     let spec_files = collect_feature_files(opts)?;
-    let all_step_texts = extract_all_step_texts(&opts.app_dir)?;
+    let all_step_texts = extract_all_step_texts(&opts.app_dir, &opts.exclude_source_dirs)?;
     let mut step_gaps: Vec<StepGap> = Vec::new();
     let mut all_gherkin_steps: Vec<String> = Vec::new();
     let mut total_scenarios = 0usize;
@@ -212,7 +232,7 @@ fn check_shared_steps(opts: &ScanOptions) -> std::result::Result<CheckResult, Er
 fn check_one_to_one(opts: &ScanOptions) -> std::result::Result<CheckResult, Error> {
     let start = Instant::now();
     let spec_files = collect_feature_files(opts)?;
-    let all_step_texts = extract_all_step_texts(&opts.app_dir)?;
+    let all_step_texts = extract_all_step_texts(&opts.app_dir, &opts.exclude_source_dirs)?;
     let mut gaps: Vec<CoverageGap> = Vec::new();
     let mut scenario_gaps: Vec<ScenarioGap> = Vec::new();
     let mut step_gaps: Vec<StepGap> = Vec::new();
@@ -227,7 +247,8 @@ fn check_one_to_one(opts: &ScanOptions) -> std::result::Result<CheckResult, Erro
             .map(|s| s.trim_end_matches(".feature").to_string())
             .unwrap_or_default();
 
-        let test_file_paths = find_all_matching_test_files(&opts.app_dir, &stem)?;
+        let test_file_paths =
+            find_all_matching_test_files(&opts.app_dir, &stem, &opts.exclude_source_dirs)?;
 
         if test_file_paths.is_empty() {
             let rel_path = rel_to(&opts.repo_root, spec_file);
@@ -519,7 +540,7 @@ fn is_in_test_dir(path: &Path) -> bool {
 }
 
 /// Recursively walks `app_dir` and returns all test/step files whose base name
-/// matches `stem`, skipping directories listed in [`skip_dirs`].
+/// matches `stem`, skipping directories per [`is_excluded_source_dir`].
 ///
 /// Returns an empty `Vec` if `app_dir` does not exist.
 ///
@@ -529,6 +550,7 @@ fn is_in_test_dir(path: &Path) -> bool {
 fn find_all_matching_test_files(
     app_dir: &Path,
     stem: &str,
+    exclude_dirs: &[String],
 ) -> std::result::Result<Vec<PathBuf>, Error> {
     if !app_dir.exists() {
         return Ok(Vec::new());
@@ -537,7 +559,7 @@ fn find_all_matching_test_files(
     let walker = WalkDir::new(app_dir).into_iter().filter_entry(|e| {
         if e.file_type().is_dir() {
             let name = e.file_name().to_string_lossy();
-            !skip_dirs().contains(name.as_ref())
+            !is_excluded_source_dir(name.as_ref(), exclude_dirs)
         } else {
             true
         }
@@ -629,13 +651,17 @@ fn extract_go_scenario_titles(p: &Path) -> std::result::Result<HashSet<String>, 
 /// Walks `app_dir` recursively and extracts all step definitions from every
 /// recognised source file, aggregating them into a single [`StepMatcher`].
 ///
-/// Skips directories in `skip_dirs`. Returns an empty matcher if `app_dir`
-/// does not exist.
+/// Skips directories per [`is_excluded_source_dir`] — the universal
+/// `skip_dirs` set plus any caller-supplied `exclude_dirs`. Returns an empty
+/// matcher if `app_dir` does not exist.
 ///
 /// # Errors
 ///
 /// Returns an error if the directory walk encounters an I/O error.
-pub fn extract_all_step_texts(app_dir: &Path) -> std::result::Result<StepMatcher, Error> {
+pub fn extract_all_step_texts(
+    app_dir: &Path,
+    exclude_dirs: &[String],
+) -> std::result::Result<StepMatcher, Error> {
     let mut sm = StepMatcher::new();
     if !app_dir.exists() {
         return Ok(sm);
@@ -644,7 +670,7 @@ pub fn extract_all_step_texts(app_dir: &Path) -> std::result::Result<StepMatcher
     let walker = WalkDir::new(app_dir).into_iter().filter_entry(|e| {
         if e.file_type().is_dir() {
             let name = e.file_name().to_string_lossy();
-            !skip_dirs().contains(name.as_ref())
+            !is_excluded_source_dir(name.as_ref(), exclude_dirs)
         } else {
             true
         }
@@ -922,9 +948,39 @@ mod tests {
             "@Given(\"a user\")\nvoid step() {}\n",
         )
         .unwrap();
-        let sm = extract_all_step_texts(tmp.path()).unwrap();
+        let sm = extract_all_step_texts(tmp.path(), &[]).unwrap();
         assert!(sm.matches("user logs in"));
         assert!(sm.matches("a user"));
+    }
+
+    #[test]
+    fn extract_all_step_texts_honors_exclude_dirs_in_source_walk() {
+        // `--exclude-dir` was originally wired only into the `.feature`-file walk
+        // (see `walk_feature_files_skips_excluded_dirs` above); it must also apply to the
+        // app_dir *source* walk so a project with a directory-naming convention `skip_dirs`
+        // doesn't know about (e.g. a content-layer directory holding step-decorator-shaped
+        // teaching examples) can declare the exclusion explicitly via its own Nx target
+        // rather than rhino-cli hardcoding that project's convention for every repo.
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("content/learning/code")).unwrap();
+        std::fs::write(
+            tmp.path().join("content/learning/code/test_bdd_example.py"),
+            "@given(\"a taught condition\")\ndef given_taught():\n    pass\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        std::fs::write(
+            tmp.path().join("src/real_steps.rs"),
+            "#[given(\"a real step\")]\nfn given_real() {}\n",
+        )
+        .unwrap();
+
+        let unfiltered = extract_all_step_texts(tmp.path(), &[]).unwrap();
+        assert!(unfiltered.matches("a taught condition"));
+
+        let filtered = extract_all_step_texts(tmp.path(), &["content".to_string()]).unwrap();
+        assert!(filtered.matches("a real step"));
+        assert!(!filtered.matches("a taught condition"));
     }
 
     #[test]
@@ -951,7 +1007,7 @@ mod tests {
             "#[given(\"a real step\")]\nfn given_real() {}\n",
         )
         .unwrap();
-        let sm = extract_all_step_texts(tmp.path()).unwrap();
+        let sm = extract_all_step_texts(tmp.path(), &[]).unwrap();
         assert!(sm.matches("a real step"));
         assert!(!sm.matches("a condition"));
     }
@@ -978,10 +1034,61 @@ mod tests {
             quiet: false,
             shared_steps: false,
             exclude_dirs: vec![],
+            exclude_source_dirs: vec![],
         };
         let r = check_all(&opts).unwrap();
         assert_eq!(r.gaps.len(), 1);
         assert_eq!(r.gaps[0].stem, "user-login");
+    }
+
+    #[test]
+    fn exclude_dirs_and_exclude_source_dirs_are_independent() {
+        // A directory name can be legitimate in BOTH trees at once for different
+        // reasons — e.g. `content/` grouping content-API Gherkin scenarios in the
+        // spec tree while also being a Next.js content-layer directory in the app
+        // tree. Excluding it from one walk must never silently exclude it from the
+        // other: `exclude_dirs` (feature-file walk) and `exclude_source_dirs`
+        // (app_dir source walk) are deliberately separate CLI flags/fields for
+        // exactly this reason.
+        let tmp = TempDir::new().unwrap();
+        let specs = tmp.path().join("specs");
+        let app = tmp.path().join("app");
+        std::fs::create_dir_all(specs.join("content")).unwrap();
+        std::fs::create_dir_all(app.join("content")).unwrap();
+        std::fs::write(
+            specs.join("content/content-api.feature"),
+            "Feature: x\nScenario: T\n  Given a taught condition\n",
+        )
+        .unwrap();
+        std::fs::write(
+            app.join("content/steps.py"),
+            "@given(\"a taught condition\")\ndef given_taught():\n    pass\n",
+        )
+        .unwrap();
+
+        // Excluding "content" only via exclude_source_dirs must still pick up the
+        // real spec scenario in specs/content/ — no false step gap.
+        let opts = ScanOptions {
+            repo_root: tmp.path().to_path_buf(),
+            specs_dir: specs.clone(),
+            specs_dirs: vec![],
+            app_dir: app.clone(),
+            verbose: false,
+            quiet: false,
+            shared_steps: true,
+            exclude_dirs: vec![],
+            exclude_source_dirs: vec!["content".to_string()],
+        };
+        let r = check_all(&opts).unwrap();
+        assert_eq!(
+            r.total_scenarios, 1,
+            "spec scenario must still be collected"
+        );
+        assert_eq!(
+            r.step_gaps.len(),
+            1,
+            "step impl was excluded from the source walk, so the step is uncovered"
+        );
     }
 
     #[test]
@@ -1088,14 +1195,14 @@ mod tests {
         std::fs::create_dir_all(tmp.path().join("src")).unwrap();
         std::fs::write(tmp.path().join("node_modules/x.test.ts"), "").unwrap();
         std::fs::write(tmp.path().join("src/x.test.ts"), "").unwrap();
-        let matches = find_all_matching_test_files(tmp.path(), "x").unwrap();
+        let matches = find_all_matching_test_files(tmp.path(), "x", &[]).unwrap();
         assert_eq!(matches.len(), 1);
         assert!(matches[0].to_string_lossy().contains("src"));
     }
 
     #[test]
     fn find_all_matching_test_files_returns_empty_for_missing_dir() {
-        let matches = find_all_matching_test_files(Path::new("/nonexistent"), "x").unwrap();
+        let matches = find_all_matching_test_files(Path::new("/nonexistent"), "x", &[]).unwrap();
         assert!(matches.is_empty());
     }
 
@@ -1114,6 +1221,7 @@ mod tests {
             quiet: false,
             shared_steps: false,
             exclude_dirs: vec![],
+            exclude_source_dirs: vec![],
         };
         let files = collect_feature_files(&opts).unwrap();
         assert_eq!(files.len(), 1);
@@ -1145,6 +1253,7 @@ mod tests {
             quiet: false,
             shared_steps: true,
             exclude_dirs: vec![],
+            exclude_source_dirs: vec![],
         };
         let r = check_all(&opts).unwrap();
         assert_eq!(r.gaps.len(), 0); // shared_steps skips file matching

--- a/apps/rhino-cli/src/application/speccoverage/checker.rs
+++ b/apps/rhino-cli/src/application/speccoverage/checker.rs
@@ -107,8 +107,9 @@ fn skip_dirs() -> &'static HashSet<&'static str> {
 
 /// Returns `true` if `name` should be skipped when walking an `app_dir`
 /// source tree: either a universal skip-dir (see [`skip_dirs`]) or one of
-/// the caller-supplied `exclude_dirs` (fed from `ScanOptions::exclude_source_dirs`,
-/// i.e. the `--exclude-source-dir` CLI flag).
+/// the caller-supplied `exclude_source_dirs` (fed from
+/// `ScanOptions::exclude_source_dirs`, i.e. the `--exclude-source-dir` CLI
+/// flag).
 ///
 /// Deliberately a *separate* exclusion list from `--exclude-dir` (which only
 /// filters the `.feature`-file walk, see [`walk_feature_files`]): a directory
@@ -121,8 +122,8 @@ fn skip_dirs() -> &'static HashSet<&'static str> {
 /// project declare the app-tree exclusion explicitly in its own Nx target
 /// rather than rhino-cli hardcoding that project's directory-naming
 /// convention for every repo that links this binary.
-fn is_excluded_source_dir(name: &str, exclude_dirs: &[String]) -> bool {
-    skip_dirs().contains(name) || exclude_dirs.iter().any(|d| d == name)
+fn is_excluded_source_dir(name: &str, exclude_source_dirs: &[String]) -> bool {
+    skip_dirs().contains(name) || exclude_source_dirs.iter().any(|d| d == name)
 }
 
 // ============================================================
@@ -550,7 +551,7 @@ fn is_in_test_dir(path: &Path) -> bool {
 fn find_all_matching_test_files(
     app_dir: &Path,
     stem: &str,
-    exclude_dirs: &[String],
+    exclude_source_dirs: &[String],
 ) -> std::result::Result<Vec<PathBuf>, Error> {
     if !app_dir.exists() {
         return Ok(Vec::new());
@@ -559,7 +560,7 @@ fn find_all_matching_test_files(
     let walker = WalkDir::new(app_dir).into_iter().filter_entry(|e| {
         if e.file_type().is_dir() {
             let name = e.file_name().to_string_lossy();
-            !is_excluded_source_dir(name.as_ref(), exclude_dirs)
+            !is_excluded_source_dir(name.as_ref(), exclude_source_dirs)
         } else {
             true
         }
@@ -652,15 +653,15 @@ fn extract_go_scenario_titles(p: &Path) -> std::result::Result<HashSet<String>, 
 /// recognised source file, aggregating them into a single [`StepMatcher`].
 ///
 /// Skips directories per [`is_excluded_source_dir`] — the universal
-/// `skip_dirs` set plus any caller-supplied `exclude_dirs`. Returns an empty
-/// matcher if `app_dir` does not exist.
+/// `skip_dirs` set plus any caller-supplied `exclude_source_dirs`. Returns an
+/// empty matcher if `app_dir` does not exist.
 ///
 /// # Errors
 ///
 /// Returns an error if the directory walk encounters an I/O error.
 pub fn extract_all_step_texts(
     app_dir: &Path,
-    exclude_dirs: &[String],
+    exclude_source_dirs: &[String],
 ) -> std::result::Result<StepMatcher, Error> {
     let mut sm = StepMatcher::new();
     if !app_dir.exists() {
@@ -670,7 +671,7 @@ pub fn extract_all_step_texts(
     let walker = WalkDir::new(app_dir).into_iter().filter_entry(|e| {
         if e.file_type().is_dir() {
             let name = e.file_name().to_string_lossy();
-            !is_excluded_source_dir(name.as_ref(), exclude_dirs)
+            !is_excluded_source_dir(name.as_ref(), exclude_source_dirs)
         } else {
             true
         }

--- a/apps/rhino-cli/src/application/speccoverage/types.rs
+++ b/apps/rhino-cli/src/application/speccoverage/types.rs
@@ -35,6 +35,19 @@ pub struct ScanOptions {
     pub shared_steps: bool,
     /// Directory names to skip during the feature-file walk.
     pub exclude_dirs: Vec<String>,
+    /// Directory names to skip during the `app_dir` source walk (step-definition
+    /// extraction and 1-to-1 test-file matching), in addition to the built-in
+    /// universal skip set.
+    ///
+    /// Kept separate from `exclude_dirs`: the two walks scan different trees
+    /// (spec files vs. application source) and a directory name can be a
+    /// legitimate spec-organization folder in one tree while also being a
+    /// legitimate app-source folder name in the other (e.g. a Gherkin
+    /// directory named `content/` grouping content-API scenarios coexisting
+    /// with a Next.js `content/` content-layer directory) — collapsing them
+    /// into one flag would make excluding one tree silently exclude the
+    /// other.
+    pub exclude_source_dirs: Vec<String>,
 }
 
 /// A feature file that has no corresponding test/step file in the app directory.

--- a/apps/rhino-cli/src/commands/specs_coverage.rs
+++ b/apps/rhino-cli/src/commands/specs_coverage.rs
@@ -559,6 +559,128 @@ pub fn run_domain(
 mod tests {
     use super::*;
     use crate::test_support::CwdLock;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    /// Initializes a bare-minimum git repo at `root` (no commit required —
+    /// `git rev-parse --show-toplevel` only needs a `.git` directory).
+    fn init_git_repo(root: &Path) {
+        let status = Command::new("git")
+            .args(["init"])
+            .current_dir(root)
+            .status()
+            .expect("git init");
+        assert!(status.success(), "git init must succeed");
+    }
+
+    /// Writes a spec dir with one scenario ("a real step") and an app dir
+    /// containing both a matching step implementation (`src/real_steps.rs`)
+    /// and an orphan step implementation under a directory named `content`
+    /// (`content/legacy_steps.py`, matching no Gherkin step) — the same
+    /// content-vs-spec-tree name collision the `--exclude-source-dir` flag
+    /// exists to resolve.
+    ///
+    /// Returns `(specs_dir_rel, app_dir_rel)`, the two path args callers pass
+    /// as [`ValidateArgs::paths`] (relative to `root`, which becomes the repo
+    /// root once `init_git_repo` + `set_current_dir` have run).
+    fn write_exclude_source_dir_fixture(root: &Path) -> (String, String) {
+        let specs_dir = root.join("specs");
+        std::fs::create_dir_all(&specs_dir).unwrap();
+        std::fs::write(
+            specs_dir.join("example.feature"),
+            "Feature: Example\n  Scenario: A scenario\n    Given a real step\n",
+        )
+        .unwrap();
+
+        let app_dir = root.join("app");
+        std::fs::create_dir_all(app_dir.join("content")).unwrap();
+        std::fs::write(
+            app_dir.join("content/legacy_steps.py"),
+            "@given(\"a taught condition\")\ndef given_taught():\n    pass\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(app_dir.join("src")).unwrap();
+        std::fs::write(
+            app_dir.join("src/real_steps.rs"),
+            "#[given(\"a real step\")]\nfn given_real() {}\n",
+        )
+        .unwrap();
+
+        ("specs".to_string(), "app".to_string())
+    }
+
+    #[test]
+    fn run_honors_exclude_source_dir_end_to_end() {
+        let _cwd = CwdLock::acquire();
+        let repo = TempDir::new().unwrap();
+        let root = repo.path();
+        init_git_repo(root);
+        let (specs_dir, app_dir) = write_exclude_source_dir_fixture(root);
+        std::env::set_current_dir(root).expect("chdir to temp repo root");
+
+        let mut args = base_args(vec![specs_dir, app_dir]);
+        args.shared_steps = true;
+
+        // Without --exclude-source-dir, the app-tree walk picks up the Python
+        // step decorator under `content/`. It matches no Gherkin step, so it
+        // surfaces as an orphan step impl and run() fails.
+        let err = run(&args, OutputFormat::Text).unwrap_err();
+        assert!(
+            err.to_string().contains("1 orphan step impl"),
+            "expected an orphan-step-impl gap from the unexcluded content/ dir, got: {err}"
+        );
+
+        // With --exclude-source-dir content, args.exclude_source_dir must be
+        // threaded into opts.exclude_source_dirs (specs_coverage.rs's run()),
+        // excluding content/ from the app-tree walk so only the matching
+        // `real_steps.rs` step implementation remains.
+        args.exclude_source_dir = vec!["content".to_string()];
+        assert!(
+            run(&args, OutputFormat::Text).is_ok(),
+            "expected --exclude-source-dir content to exclude the app-tree content/ dir end-to-end"
+        );
+    }
+
+    #[test]
+    fn run_level_check_honors_exclude_source_dir_end_to_end() {
+        let _cwd = CwdLock::acquire();
+        let repo = TempDir::new().unwrap();
+        let root = repo.path();
+        init_git_repo(root);
+        let (specs_dir, level_dir) = write_exclude_source_dir_fixture(root);
+        std::env::set_current_dir(root).expect("chdir to temp repo root");
+
+        let mut args = ValidateArgs {
+            paths: vec![specs_dir, level_dir.clone()],
+            shared_steps: true,
+            exclude_dir: vec![],
+            exclude_source_dir: vec![],
+            unit_dir: Some(level_dir.clone()),
+            integration_dir: Some(level_dir.clone()),
+            e2e_dir: Some(level_dir),
+            unit_report: None,
+            integration_report: None,
+            e2e_report: None,
+        };
+
+        // Without --exclude-source-dir, every level's scan sees the same
+        // orphan step impl under content/, so run_level_check (invoked once
+        // per level by run_three_level) reports every level as failing.
+        let err = run(&args, OutputFormat::Text).unwrap_err();
+        assert!(
+            err.to_string().contains("level(s)"),
+            "expected all three levels to fail from the unexcluded content/ dir, got: {err}"
+        );
+
+        // With --exclude-source-dir content, args.exclude_source_dir must be
+        // threaded into opts.exclude_source_dirs inside run_level_check too,
+        // so every level's scan excludes content/ and passes.
+        args.exclude_source_dir = vec!["content".to_string()];
+        assert!(
+            run(&args, OutputFormat::Text).is_ok(),
+            "expected --exclude-source-dir content to exclude the app-tree content/ dir in three-level mode"
+        );
+    }
 
     fn base_args(paths: Vec<String>) -> ValidateArgs {
         ValidateArgs {

--- a/apps/rhino-cli/src/commands/specs_coverage.rs
+++ b/apps/rhino-cli/src/commands/specs_coverage.rs
@@ -30,9 +30,16 @@ pub struct ValidateArgs {
     /// Skip file matching; validate steps across ALL source files.
     #[arg(long = "shared-steps")]
     pub shared_steps: bool,
-    /// Spec directory names to exclude (repeatable).
+    /// Spec directory names to exclude from the `.feature`-file walk (repeatable).
     #[arg(long = "exclude-dir", value_name = "DIR")]
     pub exclude_dir: Vec<String>,
+    /// App-dir directory names to exclude from the step-implementation source
+    /// walk (repeatable). Separate from `--exclude-dir`: a name can be a
+    /// legitimate spec-organization folder in the spec tree while also being
+    /// a legitimate app-source folder name (e.g. a Next.js content-layer
+    /// `content/` directory holding step-decorator-shaped teaching examples).
+    #[arg(long = "exclude-source-dir", value_name = "DIR")]
+    pub exclude_source_dir: Vec<String>,
     /// Directory containing unit test implementations (three-level mode).
     #[arg(long = "unit-dir", value_name = "DIR")]
     pub unit_dir: Option<String>,
@@ -145,6 +152,7 @@ fn run_level_check(
         quiet: false,
         shared_steps: args.shared_steps,
         exclude_dirs: args.exclude_dir.clone(),
+        exclude_source_dirs: args.exclude_source_dir.clone(),
     };
 
     let result = checker::check_all(&opts)
@@ -442,6 +450,7 @@ pub fn run(args: &ValidateArgs, output_format: OutputFormat) -> std::result::Res
         quiet: false,
         shared_steps: args.shared_steps,
         exclude_dirs: args.exclude_dir.clone(),
+        exclude_source_dirs: args.exclude_source_dir.clone(),
     };
 
     let result = checker::check_all(&opts).context("spec coverage check failed")?;
@@ -556,6 +565,7 @@ mod tests {
             paths,
             shared_steps: false,
             exclude_dir: vec![],
+            exclude_source_dir: vec![],
             unit_dir: None,
             integration_dir: None,
             e2e_dir: None,
@@ -646,6 +656,7 @@ mod tests {
             ],
             shared_steps: true,
             exclude_dir: vec![],
+            exclude_source_dir: vec![],
             unit_dir: Some("apps/rhino-cli/tests/fixtures/three-level/unit".to_string()),
             integration_dir: Some(
                 "apps/rhino-cli/tests/fixtures/three-level/integration".to_string(),
@@ -677,6 +688,7 @@ mod tests {
             ],
             shared_steps: true,
             exclude_dir: vec![],
+            exclude_source_dir: vec![],
             unit_dir: Some("apps/rhino-cli/tests/fixtures/three-level/unit".to_string()),
             integration_dir: Some("apps/rhino-cli/tests/fixtures/three-level/unit".to_string()),
             e2e_dir: Some("apps/rhino-cli/tests/fixtures/three-level/unit".to_string()),
@@ -700,6 +712,7 @@ mod tests {
             ],
             shared_steps: true,
             exclude_dir: vec![],
+            exclude_source_dir: vec![],
             unit_dir: Some("apps/rhino-cli/tests/fixtures/three-level/unit".to_string()),
             integration_dir: None,
             e2e_dir: None,
@@ -731,6 +744,7 @@ mod tests {
             ],
             shared_steps: true,
             exclude_dir: vec![],
+            exclude_source_dir: vec![],
             unit_dir: None,
             integration_dir: None,
             e2e_dir: None,

--- a/repo-governance/development/infra/nx-targets.md
+++ b/repo-governance/development/infra/nx-targets.md
@@ -514,22 +514,24 @@ exercised at the correct test level. It is enforced by the pre-push hook alongsi
 
 **Command flags used across project types**:
 
-| Flag                         | Purpose                                                                                                               |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `--shared-steps`             | Validates steps across ALL source files rather than requiring 1:1 file-to-feature matching; used by all projects      |
-| `--exclude-dir test-support` | Excludes E2E-only `test-support` API spec files from non-E2E projects; used by demo-be backends and demo-fe frontends |
+| Flag                         | Purpose                                                                                                                                                                                                                                                                                    |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--shared-steps`             | Validates steps across ALL source files rather than requiring 1:1 file-to-feature matching; used by all projects                                                                                                                                                                           |
+| `--exclude-dir test-support` | Excludes E2E-only `test-support` API spec files from non-E2E projects; used by demo-be backends and demo-fe frontends                                                                                                                                                                      |
+| `--exclude-source-dir <dir>` | Excludes a directory name from the **app-tree source walk only** (never the `.feature`-file walk); for a directory name legitimate in both trees but that must not be scanned as source, e.g. ayokoding-www's Next.js `content/` directory colliding with a Gherkin `content/` spec folder |
 
 **Project coverage status**:
 
-| Project group                                                   | Status   | Notes                                                                                                 |
-| --------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
-| Rust CLI apps (`rhino-cli`, `ayokoding-cli`, `ose-cli`)         | Enforced | `--shared-steps` only; no `--exclude-dir` needed (no test-support specs)                              |
-| API backends (`organiclever-be`)                                | Enforced | `--shared-steps --exclude-dir test-support`                                                           |
-| E2E runners (`organiclever-be-e2e`, `organiclever-app-web-e2e`) | Enforced | `--shared-steps` only; test-support steps are implemented here                                        |
-| Content platforms (`ayokoding-www`, `ose-www`)                  | Enforced | `--shared-steps`                                                                                      |
-| Web UI apps (`organiclever-app-web`)                            | Enforced | `--shared-steps`                                                                                      |
-| Libraries (`rust-commons`)                                      | Enforced | `--shared-steps`                                                                                      |
-| Projects with genuine step gaps                                 | Deferred | `specs:behavior:coverage` target exists but validation deferred until step implementation is complete |
+| Project group                                                   | Status   | Notes                                                                                                                   |
+| --------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Rust CLI apps (`rhino-cli`, `ayokoding-cli`, `ose-cli`)         | Enforced | `--shared-steps` only; no `--exclude-dir` needed (no test-support specs)                                                |
+| API backends (`organiclever-be`)                                | Enforced | `--shared-steps --exclude-dir test-support`                                                                             |
+| E2E runners (`organiclever-be-e2e`, `organiclever-app-web-e2e`) | Enforced | `--shared-steps` only; test-support steps are implemented here                                                          |
+| Content platforms (`ose-www`)                                   | Enforced | `--shared-steps`                                                                                                        |
+| Content platforms (`ayokoding-www`)                             | Enforced | `--shared-steps --exclude-source-dir content` (excludes the Next.js `content/` directory from the app-tree source walk) |
+| Web UI apps (`organiclever-app-web`)                            | Enforced | `--shared-steps`                                                                                                        |
+| Libraries (`rust-commons`)                                      | Enforced | `--shared-steps`                                                                                                        |
+| Projects with genuine step gaps                                 | Deferred | `specs:behavior:coverage` target exists but validation deferred until step implementation is complete                   |
 
 All apps and E2E runners are required to have a `specs:behavior:coverage` target. Projects with
 genuine step gaps have the target deferred temporarily until step implementations are complete.


### PR DESCRIPTION
## Summary

`specs:behavior:coverage`'s `app_dir` source walk (step-implementation extraction) had no exclusion mechanism separate from the universal `skip_dirs()` set, so a project with a naming convention rhino-cli didn't know about had no way to opt out short of rhino-cli hardcoding that project's convention into the byte-identical shared binary.

Concretely: Phase 16 of the `fundamentally-strong-software-engineer` educational-content plan added self-contained BDD teaching examples (pytest-bdd/behave step-decorator syntax) under `apps/ayokoding-www/content/.../learning/code/`. Per DD-24, colocated example code under `content/` is content, excluded from build/test gates — but rhino-cli's scanner walked it anyway and flagged 11 of these as false "orphan step implementation" findings, failing the pre-push hook.

## Design

Considered and rejected: hardcoding `"content"` into rhino-cli's `skip_dirs()`. Two problems:
1. It bakes one app's directory-naming convention into a binary that's byte-identical across 3 repos (ose-public/ose-primer/ose-infra), for a convention that may not even apply to the other two.
2. Testing revealed a real collision: `content` is *also* a legitimate Gherkin spec-organization folder name (this repo already groups content-API scenarios under `specs/.../content/`). A single shared exclusion value applied to both the feature-file walk and the source walk would silently drop real spec coverage in one tree while fixing the other.

Instead: a new `--exclude-source-dir` CLI flag, kept deliberately separate from the existing `--exclude-dir` (which only ever filtered the `.feature`-file walk). Each project now declares its own app-source exclusions explicitly in its own Nx target — `apps/ayokoding-www/project.json`'s `specs:behavior:coverage` target gains `--exclude-source-dir content`. No hardcoded assumption in the shared binary.

## Testing

- New unit test `extract_all_step_texts_honors_exclude_dirs_in_source_walk` — RED before the fix (proves the walk ignored `exclude_dirs` for source scanning), GREEN after.
- New regression test `exclude_dirs_and_exclude_source_dirs_are_independent` — directly encodes the collision found during manual testing (a `content/` dir that's legitimate in both trees at once); proves excluding one tree never silently excludes the other.
- All 1155 existing unit tests still pass; `cargo clippy`/`cargo fmt --check` clean.
- Manually reproduced the original failure against Phase 16's real worktree content (11 orphan step impls without the flag), then verified `--exclude-source-dir content` resolves it cleanly (`Spec coverage valid! 18 specs, 224 scenarios, 834 steps — all covered.`) with no side effects on the legitimate `content/`-named spec folder.
- rhino-cli's own self-check (`specs:behavior:coverage` against `apps/rhino-cli`) still passes cleanly post-change: 57 specs, 316 scenarios, 1313 steps — all covered (no regression).

## Test plan

- [x] `cargo test` — 1155 passed
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] Manual repro against Phase 16's real content — confirmed fix resolves the original failure
- [x] Manual regression check — confirmed the `content`-as-spec-folder collision is avoided
- [ ] CI green on this PR
- [ ] Sync to `ose-primer` and `ose-infra` per the rhino-cli byte-identity constraint (follow-up, this PR is ose-public only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)