### PR TITLE
feat(ayokoding-www): scroll the docs sidebar vertically on overflow

### DIFF
--- a/apps/ayokoding-www-fe-e2e/src/steps/resizable-sidebar.steps.ts
+++ b/apps/ayokoding-www-fe-e2e/src/steps/resizable-sidebar.steps.ts
@@ -364,6 +364,33 @@ Then("the label is not clipped or wrapped", async ({ page }) => {
   await expect(noWrapLinks.first()).toBeAttached();
 });
 
+/**
+ * The div `resizable-sidebar.tsx` renders as `ResizablePanel`'s sole child — the immediate
+ * child of the primitive's `resizable-panel-content` slot — which owns the rail's vertical
+ * scroll (see that file's docstring for why it, not `<aside>`, is the real scroll owner).
+ */
+const VERTICAL_SCROLL_CONTAINER_SELECTOR = `aside:has(${PANEL_SELECTOR}) [data-slot="resizable-panel-content"] > div`;
+
+Given("a docs sidebar whose nav tree is taller than the visible rail height", async ({ page }) => {
+  // Rather than fabricating tall content, shrink the viewport height enough that the docs
+  // page's real nav tree exceeds the rail's `h-[calc(100vh-4rem)]` height — mirroring the
+  // "narrowed to N pixels" technique above, which shrinks width instead for the horizontal
+  // scenario.
+  await page.setViewportSize({ width: 1280, height: 300 });
+  await page.goto(DOCS_PAGE);
+});
+
+Then("the sidebar content area is vertically scrollable", async ({ page }) => {
+  const scrollContainer = page.locator(VERTICAL_SCROLL_CONTAINER_SELECTOR);
+  await expect(scrollContainer).toHaveCount(1);
+  await expect.poll(async () => scrollContainer.evaluate((el) => el.scrollHeight > el.clientHeight)).toBe(true);
+});
+
+Then("the horizontal scroll behavior is unaffected", async ({ page }) => {
+  const scrollContainer = page.locator(SCROLL_CONTAINER_SELECTOR);
+  await expect(scrollContainer).toHaveCount(1);
+});
+
 /** Selector for `mobile-nav.tsx`'s `SheetContent` root (see its `data-slot`). */
 const MOBILE_DRAWER_SELECTOR = '[data-slot="sheet-content"]';
 

--- a/apps/ayokoding-www-fe-e2e/src/steps/resizable-sidebar.steps.ts
+++ b/apps/ayokoding-www-fe-e2e/src/steps/resizable-sidebar.steps.ts
@@ -387,8 +387,15 @@ Then("the sidebar content area is vertically scrollable", async ({ page }) => {
 });
 
 Then("the horizontal scroll behavior is unaffected", async ({ page }) => {
+  // This scenario's 1280px-wide viewport (see the Given step above, which only shrinks height)
+  // means a real docs label is unlikely to overflow horizontally here, so asserting live
+  // `scrollWidth > clientWidth` overflow (as the dedicated horizontal scenario at line 356-360
+  // does) would be flaky at this viewport. Instead assert the container still carries the
+  // `overflow-x: auto` computed style — proving the horizontal-scroll *capability* the vertical
+  // fix must not remove, without depending on this viewport happening to trigger overflow.
   const scrollContainer = page.locator(SCROLL_CONTAINER_SELECTOR);
   await expect(scrollContainer).toHaveCount(1);
+  await expect(scrollContainer).toHaveCSS("overflow-x", "auto");
 });
 
 /** Selector for `mobile-nav.tsx`'s `SheetContent` root (see its `data-slot`). */

--- a/apps/ayokoding-www/src/features/navigation/shell/resizable-sidebar.test.tsx
+++ b/apps/ayokoding-www/src/features/navigation/shell/resizable-sidebar.test.tsx
@@ -200,6 +200,51 @@ describeFeature(feature, ({ Scenario, Background }) => {
     });
   });
 
+  Scenario(
+    "Scroll the sidebar vertically when the nav tree is taller than the viewport",
+    ({ Given, When, Then, And }) => {
+      let container: HTMLElement;
+
+      Given("a docs sidebar whose nav tree is taller than the visible rail height", () => {
+        // jsdom has no real layout engine (no scrollHeight/clientHeight measurement), so exact
+        // overflow measurement is verified at E2E level; here the tree is rendered with enough
+        // nodes that it would overflow a real, fixed-height rail.
+      });
+
+      When("the reader views the sidebar", () => {
+        // Clean up any previous renders to isolate this scenario.
+        cleanup();
+        const manyNodes = Array.from({ length: 40 }, (_, i) => ({
+          slug: `topic-${i}`,
+          title: `Topic ${i}`,
+          weight: i,
+          isSection: true,
+          children: [],
+        }));
+        const result = render(
+          <ResizableSidebar locale="en">
+            <SidebarTree nodes={manyNodes} locale="en" />
+          </ResizableSidebar>,
+        );
+        container = result.container;
+      });
+
+      Then("the sidebar content area is vertically scrollable", () => {
+        // The wrapper is the immediate child of ResizablePanel's content slot — the element
+        // resizable-sidebar.tsx renders directly inside `<ResizablePanel>`, matching the "new
+        // wrapper" this scenario exercises regardless of its exact className contents.
+        const wrapper = container.querySelector('[data-slot="resizable-panel-content"] > div') as HTMLElement;
+        expect(wrapper).toBeInstanceOf(HTMLElement);
+        expect(wrapper.className).toContain("overflow-y-auto");
+      });
+
+      // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/resizable-sidebar.feature:Scroll the sidebar vertically when the nav tree is taller than the viewport
+      And("the horizontal scroll behavior is unaffected", () => {
+        expect(container.querySelector(".overflow-x-auto")).toBeTruthy();
+      });
+    },
+  );
+
   Scenario("Apply a preset width to the mobile nav drawer", ({ Given, When, Then }) => {
     Given("the mobile nav drawer is open at a 375 pixel viewport", () => {
       // jsdom does not evaluate @media rules, so the 375px viewport itself is not

--- a/apps/ayokoding-www/src/features/navigation/shell/resizable-sidebar.test.tsx
+++ b/apps/ayokoding-www/src/features/navigation/shell/resizable-sidebar.test.tsx
@@ -236,6 +236,10 @@ describeFeature(feature, ({ Scenario, Background }) => {
         const wrapper = container.querySelector('[data-slot="resizable-panel-content"] > div') as HTMLElement;
         expect(wrapper).toBeInstanceOf(HTMLElement);
         expect(wrapper.className).toContain("overflow-y-auto");
+        // `overflow-x-hidden` is the crux of this fix: it stops the CSS overflow spec from
+        // computing `overflow-x: auto` and duplicating sidebar-tree.tsx's horizontal scroll one
+        // level deeper. Pin it explicitly, not just `overflow-y-auto`.
+        expect(wrapper.className).toContain("overflow-x-hidden");
       });
 
       // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/resizable-sidebar.feature:Scroll the sidebar vertically when the nav tree is taller than the viewport

--- a/apps/ayokoding-www/src/features/navigation/shell/resizable-sidebar.tsx
+++ b/apps/ayokoding-www/src/features/navigation/shell/resizable-sidebar.tsx
@@ -24,20 +24,26 @@ interface ResizableSidebarProps {
  * Renders the docs sidebar's `<aside>` shell itself — hidden below `md`, a
  * sticky rail from `md` up — with `ResizablePanel` nested inside it
  * (providing width + the drag/keyboard handle), rather than the reverse.
- * `ResizablePanel`'s content wrapper is `overflow-hidden` by design (see
- * `resizable-panel.tsx`), and `overflow: hidden` on any ancestor of a
- * `position: sticky` element breaks its stickiness — so `sticky`,
- * `overflow-y-auto`, and the fixed height live on `<aside>` itself (which has
- * no such ancestor above it), never on a div nested inside `ResizablePanel`'s
- * children. `<aside>` deliberately has no `border-r` of its own — the
- * `ResizablePanel` handle already renders the sidebar/content boundary, and a
- * second static border on the same edge produced an unintentional compound
- * double-border with no visible seam between the two (see DWT-003 in this
- * plan's rule-15 retest).
+ * `<aside>` itself owns no overflow: its only child (`ResizablePanel`, given
+ * `className="h-full"`) is stretched to exactly `<aside>`'s fixed height by
+ * flexbox, so it never exceeds `<aside>`'s own box. `ResizablePanel`'s content
+ * wrapper (`resizable-panel-content`) stays `overflow-hidden` by design (see
+ * `resizable-panel.tsx`) as a width-bleed guard. Vertical scroll instead lives
+ * on the div immediately inside it below — stretched to that same fixed
+ * height via `h-full`, so it scrolls its own (potentially tall) content
+ * without ever needing `resizable-panel-content` itself to overflow.
+ * `overflow-x-hidden` is required alongside `overflow-y-auto` there: per the
+ * CSS overflow spec, setting only `overflow-y` to non-`visible` makes
+ * `overflow-x` compute to `auto` too, which would silently duplicate
+ * `sidebar-tree.tsx`'s own horizontal scroll one level deeper. `<aside>`
+ * deliberately has no `border-r` of its own — the `ResizablePanel` handle
+ * already renders the sidebar/content boundary, and a second static border on
+ * the same edge produced an unintentional compound double-border with no
+ * visible seam between the two (see DWT-003 in this plan's rule-15 retest).
  */
 export function ResizableSidebar({ locale, children }: ResizableSidebarProps) {
   return (
-    <aside className="sticky top-16 hidden h-[calc(100vh-4rem)] shrink-0 overflow-y-auto md:block">
+    <aside className="sticky top-16 hidden h-[calc(100vh-4rem)] shrink-0 md:block">
       <ResizablePanel
         storageKey={SIDEBAR_STORAGE_KEY}
         minPct={MIN_WIDTH_PCT}
@@ -45,7 +51,7 @@ export function ResizableSidebar({ locale, children }: ResizableSidebarProps) {
         className="h-full"
         handleAriaLabel={t(locale, "resizableSidebarHandleLabel")}
       >
-        <div className="p-4">{children}</div>
+        <div className="h-full overflow-x-hidden overflow-y-auto p-4">{children}</div>
       </ResizablePanel>
     </aside>
   );

--- a/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/resizable-sidebar.feature
+++ b/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/resizable-sidebar.feature
@@ -35,6 +35,13 @@ Feature: Resizable Docs Sidebar
     And the item's expand-or-collapse chevron remains visible
 
   @unit @e2e
+  Scenario: Scroll the sidebar vertically when the nav tree is taller than the viewport
+    Given a docs sidebar whose nav tree is taller than the visible rail height
+    When the reader views the sidebar
+    Then the sidebar content area is vertically scrollable
+    And the horizontal scroll behavior is unaffected
+
+  @unit @e2e
   Scenario: Apply a preset width to the mobile nav drawer
     Given the mobile nav drawer is open at a 375 pixel viewport
     When the reader selects the wider preset


### PR DESCRIPTION
## Summary

The desktop docs sidebar already scrolled **horizontally** per-row (long nav labels) but silently **clipped** a nav tree taller than the viewport. This adds vertical scroll, with the same constraint the horizontal path already follows: a scrollbar appears **only** on real overflow, never always-on.

### Root cause

`<aside>` carried `overflow-y-auto` + a fixed height, but its only child (`ResizablePanel`, `h-full`) is stretched by flexbox to exactly the aside's height and never exceeds it — so that scroll never engaged (dead code). The actual clip happened one level deeper at `resizable-panel-content`, which is `overflow-hidden` by design (a width-bleed guard, and an intentional avoidance of an extra overflow context above the sticky rail / sticky chevron).

### Fix (`resizable-sidebar.tsx`, app-local — the shared `ResizablePanel` primitive is untouched)

- Move vertical scroll onto the div immediately inside `resizable-panel-content`: `h-full overflow-y-auto overflow-x-hidden p-4`. It's stretched to the same fixed height, so it scrolls its own tall content.
- `overflow-x-hidden` is required: per the CSS overflow spec, a non-`visible` `overflow-y` forces `overflow-x` to compute to `auto`, which would duplicate `sidebar-tree.tsx`'s existing horizontal scroll one level deeper.
- Remove the now-provably-dead `overflow-y-auto` from `<aside>`; update the docstring to describe the corrected overflow ownership.

## Test plan

- **Gherkin**: new `@unit @e2e` scenario "Scroll the sidebar vertically when the nav tree is taller than the viewport" in `resizable-sidebar.feature`.
- **Unit** (vitest-cucumber): asserts the wrapper carries `overflow-y-auto`; RED confirmed against pre-fix code (`p-4` only), GREEN after. Full existing 9-scenario suite stays green.
- **E2E** (Playwright-BDD): `scrollHeight > clientHeight` at a short viewport; horizontal scroll re-asserted unaffected.
- **Pre-push gate** (`build`, `test:quick`, `lint` for `ayokoding-www` + `ayokoding-www-fe-e2e`): green.
- **Manual** (prod build, Playwright): at a 300px-tall viewport the rail is vertically scrollable (368 > 236) and scrolls independently of the page; at a tall viewport no scrollbar appears (1136 === 1136); horizontal scroll container intact; `<aside>` sticky behavior and the sticky chevron unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
