### PR TITLE
feat(ayokoding-www): add Functional Programming topic (Phase 26)

### DIFF
--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/_index.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/_index.md
@@ -32,3 +32,4 @@ weight: 107
   - [20 · Computer Architecture](/en/c/learn/fundamentally-strong/software-engineer/computer-architecture)
   - [21 · Object-Oriented Design & Patterns](/en/c/learn/fundamentally-strong/software-engineer/object-oriented-design-and-patterns)
   - [22 · Programming Paradigms](/en/c/learn/fundamentally-strong/software-engineer/programming-paradigms)
+  - [23 · Functional Programming](/en/c/learn/fundamentally-strong/software-engineer/functional-programming)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/_index.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/_index.md
@@ -86,3 +86,6 @@ weight: 1750
 - [22 · Programming Paradigms](/en/c/learn/fundamentally-strong/software-engineer/programming-paradigms)
   - [Learning](/en/c/learn/fundamentally-strong/software-engineer/programming-paradigms/learning)
   - [Drilling](/en/c/learn/fundamentally-strong/software-engineer/programming-paradigms/drilling)
+- [23 · Functional Programming](/en/c/learn/fundamentally-strong/software-engineer/functional-programming)
+  - [Learning](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning)
+  - [Drilling](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/drilling)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/_index.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/_index.md
@@ -1,0 +1,15 @@
+---
+title: "23 · Functional Programming"
+date: 2026-07-17T00:00:00+07:00
+draft: false
+weight: 330
+---
+
+- [Learning](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning)
+  - [Overview](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/overview)
+  - [Beginner Examples](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner)
+  - [Intermediate Examples](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate)
+  - [Advanced Examples](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced)
+  - [Capstone](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone)
+- [Drilling](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/drilling)
+  - [Overview](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/drilling/overview)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/_index.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Drilling"
+date: 2026-07-17T00:00:00+07:00
+draft: false
+weight: 223
+---
+
+- [Overview](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/drilling/overview)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-01-hidden-mutation-breaks-purity/after/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-01-hidden-mutation-breaks-purity/after/kata.py
@@ -1,0 +1,26 @@
+"""Kata 1 (after): purity fix -- builds and returns NEW records, the caller's input is never touched."""
+
+from dataclasses import dataclass, replace
+
+
+@dataclass  # => still a plain mutable record -- the FIX is in apply_discount, not the type
+class CartItem:
+    name: str
+    price: float
+
+
+def apply_discount(cart: list[CartItem], rate: float) -> list[CartItem]:
+    return [
+        replace(item, price=item.price * rate) for item in cart
+    ]  # => new CartItem per element
+
+
+cart = [CartItem("pen", 10.0), CartItem("mug", 20.0)]
+first_pass = apply_discount(cart, 0.9)
+second_pass = apply_discount(
+    cart, 0.9
+)  # cart itself was never mutated, so this is a FRESH discount
+print([item.price for item in second_pass])
+print(
+    first_pass is second_pass
+)  # different objects, and cart's own prices are untouched

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-01-hidden-mutation-breaks-purity/before/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-01-hidden-mutation-breaks-purity/before/kata.py
@@ -1,0 +1,26 @@
+"""Kata 1 (before): purity violation -- a function that looks pure secretly mutates its input."""
+
+from dataclasses import dataclass
+
+
+@dataclass  # => NOT frozen -- a mutable record, which is exactly what makes the bug below possible
+class CartItem:
+    name: str
+    price: float
+
+
+def apply_discount(cart: list[CartItem], rate: float) -> list[CartItem]:
+    for item in cart:
+        item.price *= rate  # SMELL: mutates each CartItem IN PLACE -- the caller's own data changes
+    return cart
+
+
+cart = [CartItem("pen", 10.0), CartItem("mug", 20.0)]
+first_pass = apply_discount(cart, 0.9)
+second_pass = apply_discount(
+    cart, 0.9
+)  # meant to apply a FRESH 0.9 discount a second time
+print([item.price for item in second_pass])
+print(
+    first_pass is second_pass
+)  # BUG: same object -- the discount compounded onto itself

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-02-frozen-dataclass-replace/after/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-02-frozen-dataclass-replace/after/kata.py
@@ -1,0 +1,17 @@
+"""Kata 2 (after): immutability fix -- dataclasses.replace() builds a NEW record, never mutates."""
+
+from dataclasses import dataclass, replace
+
+
+@dataclass(frozen=True)
+class RetryConfig:
+    retries: int
+    timeout_seconds: float
+
+
+config = RetryConfig(retries=1, timeout_seconds=5.0)
+updated_config = replace(
+    config, retries=5
+)  # => a NEW RetryConfig, config itself is untouched
+print(config)
+print(updated_config)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-02-frozen-dataclass-replace/before/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-02-frozen-dataclass-replace/before/kata.py
@@ -1,0 +1,14 @@
+"""Kata 2 (before): immutability violation -- direct attribute assignment on a frozen dataclass."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RetryConfig:
+    retries: int
+    timeout_seconds: float
+
+
+config = RetryConfig(retries=1, timeout_seconds=5.0)
+config.retries = 5  # type: ignore[misc]  # BUG: frozen dataclasses reject assignment -- raises at runtime
+print(config)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-03-closure-late-binding/after/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-03-closure-late-binding/after/kata.py
@@ -1,0 +1,12 @@
+"""Kata 3 (after): closure fix -- a default argument binds EACH closure's own value at creation time."""
+
+from typing import Callable
+
+thresholds = [10, 20, 30]
+validators: list[Callable[[int], bool]] = []
+for t in thresholds:
+    validators.append(
+        lambda x, t=t: x > t
+    )  # => t=t binds THIS iteration's value, not the variable
+
+print([v(15) for v in validators])  # each validator now uses its own captured threshold

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-03-closure-late-binding/before/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-03-closure-late-binding/before/kata.py
@@ -1,0 +1,14 @@
+"""Kata 3 (before): closure violation -- every closure in the list captures the SAME loop variable."""
+
+from typing import Callable
+
+thresholds = [10, 20, 30]
+validators: list[Callable[[int], bool]] = []
+for t in thresholds:
+    validators.append(
+        lambda x: x > t
+    )  # SMELL: captures the VARIABLE t, not its value at this point
+
+print(
+    [v(15) for v in validators]
+)  # every validator should differ; watch what actually happens

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-04-compose-vs-pipe-order/after/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-04-compose-vs-pipe-order/after/kata.py
@@ -1,0 +1,23 @@
+"""Kata 4 (after): composition-order fix -- pipe() runs left-to-right, matching the reading order."""
+
+from functools import reduce
+from typing import Callable
+
+
+def pipe(x: int, *fns: Callable[[int], int]) -> int:
+    return reduce(
+        lambda acc, fn: fn(acc), fns, x
+    )  # => applies fns in ORDER, left to right
+
+
+def add_one(x: int) -> int:
+    return x + 1
+
+
+def double(x: int) -> int:
+    return x * 2
+
+
+# INTENT: "add one, THEN double" -- pipe(5, add_one, double) reads AND runs left to right.
+result = pipe(5, add_one, double)  # => add_one(5)=6 runs first, then double(6)=12
+print(result)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-04-compose-vs-pipe-order/before/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-04-compose-vs-pipe-order/before/kata.py
@@ -1,0 +1,27 @@
+"""Kata 4 (before): composition-order bug -- compose() runs right-to-left, not the intended order."""
+
+from typing import Callable
+
+
+def compose(f: Callable[[int], int], g: Callable[[int], int]) -> Callable[[int], int]:
+    return lambda x: f(
+        g(x)
+    )  # => g runs FIRST, then f -- right-to-left, mathematical convention
+
+
+def add_one(x: int) -> int:
+    return x + 1
+
+
+def double(x: int) -> int:
+    return x * 2
+
+
+# INTENT: "add one, THEN double" -- reading compose(add_one, double) left to right like a pipe call.
+transform = compose(
+    add_one, double
+)  # SMELL: reads left-to-right but compose runs right-to-left
+result = transform(
+    5
+)  # BUG: double(5) runs FIRST giving 10, then add_one gives 11 -- not (5+1)*2=12
+print(result)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-05-mutable-default-accumulator/after/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-05-mutable-default-accumulator/after/kata.py
@@ -1,0 +1,20 @@
+"""Kata 5 (after): fix -- a None sentinel builds a FRESH dict on every call, reduce folds over it."""
+
+from functools import reduce
+
+
+def histogram(words: list[str], counts: dict[str, int] | None = None) -> dict[str, int]:
+    start: dict[str, int] = (
+        counts if counts is not None else {}
+    )  # => fresh dict every call
+    return reduce(
+        lambda acc, w: {**acc, w: acc.get(w, 0) + 1}, words, start
+    )  # => builds NEW dicts
+
+
+first_doc = histogram(["a", "b", "a"])
+print(first_doc)
+second_doc = histogram(
+    ["c"]
+)  # a fresh, empty accumulator every time the default is used
+print(second_doc)  # correctly isolated from the first, unrelated call

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-05-mutable-default-accumulator/before/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-05-mutable-default-accumulator/before/kata.py
@@ -1,0 +1,21 @@
+"""Kata 5 (before): a mutable default argument silently shares ONE accumulator across every call."""
+
+
+def histogram(
+    words: list[str], counts: dict[str, int] = {}
+) -> dict[str, int]:  # SMELL: mutable default
+    for w in words:
+        counts[w] = (
+            counts.get(w, 0) + 1
+        )  # BUG: mutates the SHARED default dict object in place
+    return counts
+
+
+first_doc = histogram(["a", "b", "a"])
+print(first_doc)
+second_doc = histogram(
+    ["c"]
+)  # an UNRELATED document -- should start from a fresh, empty count
+print(
+    second_doc
+)  # BUG: "c" is mixed in with leftover counts from the first, unrelated call

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-06-generator-exhaustion/after/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-06-generator-exhaustion/after/kata.py
@@ -1,0 +1,19 @@
+"""Kata 6 (after): fix -- materialize a list when the SAME data is genuinely needed more than once."""
+
+from typing import Iterator
+
+
+def squared(nums: list[int]) -> Iterator[int]:
+    for n in nums:
+        yield n * n
+
+
+values = list(
+    squared([1, 2, 3])
+)  # => a list, not a generator -- safe to iterate as many times as needed
+total = sum(values)  # first pass over the materialized list
+print(total)
+remaining = list(
+    values
+)  # second pass -- the list still has every element, nothing was consumed
+print(remaining)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-06-generator-exhaustion/before/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-06-generator-exhaustion/before/kata.py
@@ -1,0 +1,21 @@
+"""Kata 6 (before): a generator is iterated once, exhausted, then silently yields nothing again."""
+
+from typing import Iterator
+
+
+def squared(nums: list[int]) -> Iterator[int]:
+    for n in nums:
+        yield (
+            n * n
+        )  # => a lazy, single-use generator -- each value produced only on demand
+
+
+values = squared(
+    [1, 2, 3]
+)  # SMELL: ONE generator object, about to be consumed twice below
+total = sum(values)  # first pass -- fully consumes/exhausts the generator
+print(total)
+remaining = list(
+    values
+)  # BUG: the SAME exhausted generator -- nothing left to yield, no error raised
+print(remaining)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-07-match-case-no-exhaustiveness/after/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-07-match-case-no-exhaustiveness/after/kata.py
@@ -1,0 +1,38 @@
+"""Kata 7 (after): fix -- an explicit wildcard case raises instead of silently falling through."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Circle:
+    radius: float
+
+
+@dataclass(frozen=True)
+class Square:
+    side: float
+
+
+@dataclass(frozen=True)
+class Triangle:
+    base: float
+    height: float
+
+
+Shape = Circle | Square | Triangle
+
+
+def area(shape: Shape) -> float:
+    match shape:
+        case Circle(radius=r):
+            return 3.14159 * r * r
+        case Square(side=s):
+            return s * s
+        case Triangle(base=b, height=h):  # => the new variant now has its OWN branch
+            return 0.5 * b * h
+        case _:  # => a manual safety net for any FUTURE variant this evaluator hasn't been taught yet
+            raise ValueError(f"unhandled shape variant: {shape!r}")
+
+
+result = area(Triangle(base=4.0, height=3.0))
+print(result)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-07-match-case-no-exhaustiveness/before/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-07-match-case-no-exhaustiveness/before/kata.py
@@ -1,0 +1,37 @@
+"""Kata 7 (before): a new ADT variant falls through match/case silently -- no compile-time warning."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Circle:
+    radius: float
+
+
+@dataclass(frozen=True)
+class Square:
+    side: float
+
+
+@dataclass(frozen=True)
+class Triangle:  # => a NEW variant added to the shape family after the evaluator below was written
+    base: float
+    height: float
+
+
+Shape = Circle | Square | Triangle  # => the ADT now has THREE variants
+
+
+def area(shape: Shape) -> float:  # type: ignore[misc]  # pyright statically flags what CPython won't
+    match shape:  # type: ignore[misc]  # SMELL: no Triangle case, no wildcard -- pyright catches it, CPython doesn't
+        case Circle(radius=r):
+            return 3.14159 * r * r
+        case Square(side=s):
+            return s * s
+    # BUG: falls through here for Triangle -- Python raises NOTHING, the function returns None
+
+
+result = area(
+    Triangle(base=4.0, height=3.0)
+)  # a legitimate Shape value the evaluator never handles
+print(result)  # BUG: prints None instead of raising or computing an area

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-08-memoize-impure-function/after/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-08-memoize-impure-function/after/kata.py
@@ -1,0 +1,18 @@
+"""Kata 8 (after): fix -- no memoization on an impure lookup; the function always reads the current state."""
+
+prices: dict[str, float] = {"widget": 9.99}
+
+
+def get_price(
+    sku: str,
+) -> float:  # => no @lru_cache -- this function depends on prices, not just sku
+    return prices[sku]
+
+
+first_lookup = get_price("widget")
+print(first_lookup)
+prices["widget"] = 14.99  # the underlying price table changes at runtime
+second_lookup = get_price("widget")
+print(
+    second_lookup
+)  # correctly reflects the updated price -- nothing was cached to go stale

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-08-memoize-impure-function/before/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-08-memoize-impure-function/before/kata.py
@@ -1,0 +1,23 @@
+"""Kata 8 (before): @lru_cache applied to an IMPURE function -- the cache freezes a stale value."""
+
+from functools import lru_cache
+
+prices: dict[str, float] = {"widget": 9.99}
+
+
+@lru_cache  # SMELL: memoization is only safe on a PURE function -- this one reads mutable module state
+def get_price(sku: str) -> float:
+    return prices[
+        sku
+    ]  # BUG: depends on `prices`, not just on `sku` -- not actually pure
+
+
+first_lookup = get_price("widget")
+print(first_lookup)
+prices["widget"] = (
+    14.99  # the underlying price table changes at runtime, as real price tables do
+)
+second_lookup = get_price("widget")
+print(
+    second_lookup
+)  # BUG: still 9.99 -- the cache never learns the price actually changed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-09-railway-skips-err-check/after/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-09-railway-skips-err-check/after/kata.py
@@ -1,0 +1,49 @@
+"""Kata 9 (after): fix -- and_then checks the variant BEFORE calling the next step, short-circuiting on Err."""
+
+from dataclasses import dataclass
+from typing import Callable, Generic, TypeVar
+
+T = TypeVar("T")
+E = TypeVar("E")
+U = TypeVar("U")
+
+
+@dataclass(frozen=True)
+class Ok(Generic[T]):
+    value: T
+
+
+@dataclass(frozen=True)
+class Err(Generic[E]):
+    error: E
+
+
+Result = Ok[T] | Err[E]
+
+
+def and_then(
+    result: Result[T, str], step: Callable[[T], Result[U, str]]
+) -> Result[U, str]:
+    match (
+        result
+    ):  # => checks the variant FIRST, exactly once, before ever calling step()
+        case Ok(value=v):
+            return step(v)  # => only reachable when result actually succeeded
+        case Err(error=e):
+            return Err(e)  # => short-circuits -- step() is never called on a failure
+
+
+def parse_positive(raw: str) -> Result[int, str]:
+    n = int(raw)
+    return Ok(n) if n > 0 else Err(f"{raw} is not positive")
+
+
+def double_it(n: int) -> Result[int, str]:
+    return Ok(n * 2)
+
+
+first_step = parse_positive("-5")
+final = and_then(
+    first_step, double_it
+)  # correctly short-circuits, double_it is never called
+print(final)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-09-railway-skips-err-check/before/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-09-railway-skips-err-check/before/kata.py
@@ -1,0 +1,46 @@
+"""Kata 9 (before): a hand-written and_then forgets to check for Err before calling the next step."""
+
+from dataclasses import dataclass
+from typing import Callable, Generic, TypeVar
+
+T = TypeVar("T")
+E = TypeVar("E")
+U = TypeVar("U")
+
+
+@dataclass(frozen=True)
+class Ok(Generic[T]):
+    value: T
+
+
+@dataclass(frozen=True)
+class Err(Generic[E]):
+    error: E
+
+
+Result = Ok[T] | Err[E]
+
+
+def and_then(
+    result: Result[T, str], step: Callable[[T], Result[U, str]]
+) -> Result[U, str]:
+    # SMELL: calls step() on result.value UNCONDITIONALLY -- never checks whether result is an Err first
+    return step(result.value)  # type: ignore[union-attr]  # BUG: Err has no .value -- crashes on failure
+
+
+def parse_positive(raw: str) -> Result[int, str]:
+    n = int(raw)
+    return Ok(n) if n > 0 else Err(f"{raw} is not positive")
+
+
+def double_it(n: int) -> Result[int, str]:
+    return Ok(n * 2)
+
+
+first_step = parse_positive(
+    "-5"
+)  # this is a legitimate FAILURE, not a bug in parse_positive itself
+final = and_then(
+    first_step, double_it
+)  # BUG: crashes with AttributeError instead of propagating Err
+print(final)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-10-print-leaks-into-core/after/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-10-print-leaks-into-core/after/kata.py
@@ -1,0 +1,33 @@
+"""Kata 10 (after): fix -- the core stays pure; only the shell performs I/O, and only around the core."""
+
+import io
+from contextlib import redirect_stdout
+
+
+def parse_and_total(
+    rows: list[str],
+) -> int:  # => the pure core -- no print, no I/O of any kind
+    return sum(int(row) for row in rows)
+
+
+def run_shell(
+    rows: list[str],
+) -> None:  # => the imperative shell -- the ONLY place logging happens
+    print(f"parsing {len(rows)} rows")
+    total = parse_and_total(rows)
+    print(total)
+
+
+rows = ["10", "20", "30"]
+captured = io.StringIO()
+with redirect_stdout(captured):
+    total = parse_and_total(
+        rows
+    )  # calling the core directly needs NO stdout redirection to test
+print(total)
+print(
+    repr(captured.getvalue())
+)  # empty -- the core performed no I/O, confirming it stayed pure
+run_shell(
+    rows
+)  # the shell is where logging + the final print belong -- the core stays silent

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-10-print-leaks-into-core/before/kata.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/code/kata-10-print-leaks-into-core/before/kata.py
@@ -1,0 +1,25 @@
+"""Kata 10 (before): a debug print() leaks I/O into what is supposed to be the pure core."""
+
+import io
+from contextlib import redirect_stdout
+
+
+def parse_and_total(
+    rows: list[str],
+) -> int:  # meant to be the PURE core -- no I/O anywhere
+    print(
+        f"parsing {len(rows)} rows"
+    )  # SMELL: a debug print buried inside the "pure" core
+    return sum(int(row) for row in rows)
+
+
+rows = ["10", "20", "30"]
+captured = io.StringIO()
+with redirect_stdout(
+    captured
+):  # BUG: a "pure" function should never need its stdout redirected
+    total = parse_and_total(rows)
+print(total)
+print(
+    repr(captured.getvalue())
+)  # BUG: proves the core actually performed I/O -- it isn't pure

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/overview.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/overview.md
@@ -1675,4 +1675,4 @@ topic's whole budget on formalism before a reader has even seen the patterns pay
 
 ---
 
-← Previous: [Capstone](../learning/capstone/overview.md)
+← Previous: [Capstone](../learning/capstone/overview.md) &middot; Next: [24 · Concurrency & Parallelism](../../concurrency-and-parallelism/learning/overview.md) →

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/overview.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/drilling/overview.md
@@ -1,0 +1,1678 @@
+---
+title: "Overview"
+date: 2026-07-17T00:00:00+07:00
+draft: false
+weight: 1
+---
+
+This page is the spaced-repetition companion to the Functional Programming topic: five fixed drills
+that force active recall instead of passive re-reading. Work through them in order -- short-answer
+recall first, then scenario judgment, then hands-on repetition, then a checklist to confirm real
+automaticity, and finally why/why-not prompts that test whether you can explain the reasoning, not
+just execute the syntax. Every answer is hidden in a `<details>` block; try each item yourself before
+opening it. Together, the five drills below touch every one of this topic's 28 concepts and cite
+specific examples spanning all 80 worked examples in the Beginner, Intermediate, and Advanced tiers,
+plus the capstone.
+
+## Recall Q&A
+
+Twenty-eight short-answer questions, one per concept. Answer from memory before opening each answer.
+
+**Q1 (co-01 -- Pure Functions).** What does it mean for a function to be pure, and what does that
+buy the caller?
+
+<details>
+<summary>Answer</summary>
+
+A pure function's output depends ONLY on its arguments, and it produces no observable side effect --
+no mutating an argument, no writing to a global, no printing, no touching a file or the network. Call
+it twice with the same arguments and it always gives the same result, which makes it trivially safe to
+call twice, safe to call from multiple threads, and easy to test with nothing but its arguments and its
+return value (Example 1 contrasts `add_pure` against `add_impure`; Example 58 property-tests purity
+itself across 200 generated inputs).
+
+</details>
+
+**Q2 (co-02 -- Side Effects and the Purity Boundary).** What exactly counts as a side effect, and why
+does naming the purity boundary matter?
+
+<details>
+<summary>Answer</summary>
+
+A side effect is anything a function does besides computing and returning a value -- printing, mutating
+an argument the caller can see, writing a file, incrementing state outside the function's own scope.
+Naming exactly where that boundary sits is a design decision, not an accident: a codebase that never
+draws it lets side effects creep in anywhere, which is precisely what makes large imperative code hard
+to test (Example 1's impure twin mutates a global as its side effect; Example 3 classifies three
+functions and confirms only the pure one is flagged pure).
+
+</details>
+
+**Q3 (co-03 -- Referential Transparency).** What does "referentially transparent" mean concretely, and
+what does it let a reader do?
+
+<details>
+<summary>Answer</summary>
+
+A call is referentially transparent if it can be replaced by its own return value anywhere in the
+program without changing what the program does -- `add(2, 3)` can always be replaced by `5`. This is
+what makes equational reasoning possible: a reader can simplify an expression by substituting a call for
+its value the same way they simplify algebra, without tracing side effects to check the substitution is
+safe (Example 2 replaces a call with its literal value inside a larger expression and confirms the
+output is unchanged).
+
+</details>
+
+**Q4 (co-04 -- Immutability).** Name two of this topic's stdlib tools for immutable data, and state
+why "an object nobody can mutate" is valuable.
+
+<details>
+<summary>Answer</summary>
+
+`tuple` and `frozenset` are built-in immutable containers; `@dataclass(frozen=True)` makes a custom
+record immutable, raising `FrozenInstanceError` on an attempted attribute set; `types.MappingProxyType`
+wraps a `dict` in a read-only view. An object nobody can mutate is always safe to hand to another
+function, another thread, or another part of the codebase -- there is no way for that code to corrupt
+what the caller still holds a reference to (Example 4 catches a `TypeError` on tuple mutation; Example 5
+shows a frozen dataclass rejecting an attribute set).
+
+</details>
+
+**Q5 (co-05 -- Persistent Data and Structural Sharing).** What makes a data structure "persistent," and
+why does structural sharing matter for its cost?
+
+<details>
+<summary>Answer</summary>
+
+A persistent data structure keeps every old version reachable after an "update," because the update
+never mutates anything -- it builds a new version that shares whatever structure didn't change with the
+old one. Structural sharing is what makes immutability affordable: without it, every update would have
+to deep-copy the entire structure, which is both slow and memory-hungry; sharing the unchanged parts can
+keep an update as cheap as O(1) (Example 7's cons-list prepend; Example 59's persistent binary tree
+update confirms the old root stays intact).
+
+</details>
+
+**Q6 (co-06 -- First-Class Functions).** What does it mean for functions to be "ordinary values" in
+Python, and what does that make possible?
+
+<details>
+<summary>Answer</summary>
+
+Functions in Python can be assigned to a variable, stored in a list or dict, passed as an argument, and
+returned from another function, all without special syntax. Once functions are values, behavior itself
+becomes something you can pass around, store, and compose -- the seed that higher-order functions,
+closures, currying, composition, and decorators all grow from (Example 8 assigns a function to a
+variable and calls through it; Example 9 stores several functions in a list and calls each in turn).
+
+</details>
+
+**Q7 (co-07 -- Higher-Order Functions).** What is a higher-order function, and what does it let you
+factor apart from what?
+
+<details>
+<summary>Answer</summary>
+
+A higher-order function takes another function as an argument, returns one, or both -- `apply(fn, x)`
+returning `fn(x)` works identically whether `fn` doubles, squares, or does something else entirely,
+because `apply` never needs to know what `fn` actually does. This factors "the shape of the computation"
+apart from "what specifically happens at each step," the mechanism underneath decorators and
+`map`/`filter`/`reduce` (Example 10's `apply(fn, x)` verified against two different functions).
+
+</details>
+
+**Q8 (co-08 -- Closures for Configuration).** What does a closure capture, and how is that different
+from a parameter passed in fresh on every call?
+
+<details>
+<summary>Answer</summary>
+
+A closure captures a variable from its enclosing scope and keeps using that captured value even after
+the enclosing function has returned -- `multiplier(3)` returns a function that remembers `3` forever, so
+`multiplier(3)(4)` multiplies by the captured `3`, not by something threaded through fresh each call.
+This lets you "bake in" configuration once and get back a specialized function (Example 12's closure
+captures a threshold; Example 32 contrasts a stateful closure counter against a pure fold, naming
+exactly where each one's state lives).
+
+</details>
+
+**Q9 (co-09 -- Currying).** What does currying do to an n-argument function, and how is it distinct
+from partial application (co-10)?
+
+<details>
+<summary>Answer</summary>
+
+Currying turns an n-argument function into a chain of one-argument functions -- `add(a, b)` becomes
+`add(a)(b)`, where `add(a)` returns a new one-argument function waiting for `b`. Currying is ALWAYS one
+argument at a time by construction, while `functools.partial` can fix any number of arguments at once
+in a single call (Example 17 hand-curries a 2-argument function; Example 62's `@curry` decorator
+auto-curries by counting a function's arity).
+
+</details>
+
+**Q10 (co-10 -- Partial Application).** What does `functools.partial` do, and why reach for it over a
+hand-written wrapping lambda?
+
+<details>
+<summary>Answer</summary>
+
+Partial application fixes some of a function's arguments right now and returns a smaller function
+waiting for the rest -- `functools.partial(pow, 2)` fixes the base at `2` and returns a one-argument
+function computing `2**n`, no lambda or manual closure required. It is more discoverable to a reviewer
+and composes cleanly with `functools.reduce` and decorator pipelines elsewhere in this topic (Example 18
+verified to compute `2**n`; Example 33 chains several `partial` calls into a composed transform).
+
+</details>
+
+**Q11 (co-11 -- Function Composition).** What does `compose(f, g)` actually compute, and in what
+order do `f` and `g` run?
+
+<details>
+<summary>Answer</summary>
+
+`compose(f, g)` builds a new function so that calling it on `x` runs `g(x)` FIRST and feeds its result
+into `f` -- it computes exactly `f(g(x))`, right-to-left relative to how the call is written. This is how
+small, single-purpose functions become a pipeline without being fused into one large function body, each
+piece staying independently testable (Example 19 verified to compute `f(g(x))`; Example 34's
+`compose(*fns)` folds a whole list of functions with the application order verified).
+
+</details>
+
+**Q12 (co-12 -- Pipe Utilities).** How does `pipe(x, f, g)` differ from `compose(f, g)` in what it
+reads like, given that both can compute the same thing?
+
+<details>
+<summary>Answer</summary>
+
+`pipe(x, f, g)` reads left-to-right in the order it actually executes -- "start with `x`, apply `f`,
+then apply `g`" -- instead of the inside-out reading order nested calls (or `compose`) require. `pipe`
+and `compose` can compute the identical thing; the difference is purely a readability trade for a chain
+of more than two or three steps (Example 20's `pipe(x, f, g)` verified equal to the nested-call
+equivalent; Example 74 directly contrasts a deep `pipe` chain against nested calls on real data).
+
+</details>
+
+**Q13 (co-13 -- Map, Filter, Reduce).** Which loop pattern does each of `map`, `filter`, and `reduce`
+replace, and why does recognizing that matter?
+
+<details>
+<summary>Answer</summary>
+
+`map` applies a function to every element (replacing a "transform each item" loop), `filter` keeps only
+the elements a predicate accepts (replacing a "collect matching items" loop), and `reduce` folds a
+sequence to one accumulated value (replacing an "initialize then mutate a running total" loop). Together
+they cover the overwhelming majority of "loop over a collection and do something" code without a single
+mutable accumulator variable exposed to the caller (Example 13's `map`; Example 14's `filter`; Example
+15's `reduce`; Example 37 chains all three for a data summary).
+
+</details>
+
+**Q14 (co-14 -- Recursion and Python's Missing TCO).** What specific limit does CPython's lack of
+tail-call optimization put on deep recursion, and what are the two standard workarounds?
+
+<details>
+<summary>Answer</summary>
+
+CPython, by explicit design choice, performs NO tail-call optimization -- a deeply recursive call still
+grows the call stack one frame per call and eventually raises `RecursionError`, unlike languages that
+optimize a self-tail-call into a loop automatically. The two standard workarounds are an explicit stack
+or a trampoline (Example 44 converts a deep recursion into an explicit stack; Example 66 builds a
+trampoline and verifies a deep recursion completes without ever raising `RecursionError`).
+
+</details>
+
+**Q15 (co-15 -- Lazy Evaluation and Generators).** What does "lazy" mean concretely for a Python
+generator, and what does that make possible that an eager list cannot do?
+
+<details>
+<summary>Answer</summary>
+
+A generator computes a value only when it is actually needed -- a generator expression builds no list
+at all, and each value is produced on demand, one `next()` call at a time. That is what makes an
+infinite sequence (like `itertools.count()`) usable in the first place, and it lets a pipeline over a
+sequence of unknown or infinite size run without ever materializing that sequence in memory (Example 21
+shows only pulled values are computed; Example 63 builds a lazy, infinite prime sieve).
+
+</details>
+
+**Q16 (co-16 -- The itertools Toolkit).** Name three `itertools` functions this topic uses, and what
+do they all have in common?
+
+<details>
+<summary>Answer</summary>
+
+`islice` takes a slice of any iterable (including an infinite one) without materializing it, `chain`
+concatenates iterables, `accumulate` produces running totals, `groupby` groups consecutive equal keys,
+`tee` splits one iterator into several independent ones, and `pairwise` yields consecutive element
+pairs. Every one of them is itself lazy -- none build an intermediate list (Example 23 uses `islice`
+over an infinite `count()`; Example 39 verifies prefix sums via `accumulate`).
+
+</details>
+
+**Q17 (co-17 -- Memoization).** Why is memoization only safe to apply to a PURE function, specifically?
+
+<details>
+<summary>Answer</summary>
+
+Memoization caches a function's results keyed by its arguments, so a repeated call with the same
+arguments returns the cached result instead of recomputing it -- which is only safe because the function
+being cached is pure (co-01). Caching an impure function's result would silently return a stale value
+(and any stale side effect) forever after the first call, even after whatever the function actually
+depends on has changed (Example 25 puts `@lru_cache` on a recursive `fib` and confirms `cache_info()`
+shows hits; Kata 8 reproduces the stale-cache bug directly by memoizing an impure lookup).
+
+</details>
+
+**Q18 (co-18 -- Decorators as Higher-Order Functions).** What is `@log_calls` on `def greet(): ...`
+exactly equivalent to, spelled without the `@` syntax?
+
+<details>
+<summary>Answer</summary>
+
+`@log_calls` on `def greet(): ...` is exactly `greet = log_calls(greet)` -- a decorator is a
+higher-order function that takes a function and returns a wrapped replacement. Decorators let you attach
+cross-cutting behavior (logging, caching, retrying, timing) to a function without touching that
+function's own body, and `functools.wraps` preserves the wrapped function's `__name__` and metadata so
+introspection still sees the original identity (Example 26 wraps a function with a logging decorator;
+Example 43 confirms `functools.wraps` preserves `__name__`).
+
+</details>
+
+**Q19 (co-19 -- Point-Free Style).** What does "point-free" refer to, and what is the topic's stance
+on how far to take it?
+
+<details>
+<summary>Answer</summary>
+
+Point-free style expresses a transformation by composing functions together without ever naming the
+argument the data flows through -- a pipeline built entirely from `compose`/`pipe` calls has no
+`lambda x: ...` anywhere, because the "point" (the argument) is never explicitly written. This topic
+treats it as one more tool, not a stylistic mandate -- taken too far it can obscure what's actually
+happening (Example 35 rewrites a lambda pipeline point-free and confirms identical output; Example 73
+builds a small point-free combinator library).
+
+</details>
+
+**Q20 (co-20 -- Algebraic Data Types in Python).** How does an ADT built from a union of frozen
+dataclasses make illegal states unrepresentable?
+
+<details>
+<summary>Answer</summary>
+
+`Circle | Square` (PEP 604 union syntax) says a `Shape` is EITHER a `Circle` or a `Square`, each
+carrying only the fields relevant to that variant -- there is no way to construct a `Circle` with a
+`side_length` field, because that field doesn't exist on `Circle` at all. This is a stronger guarantee
+than one class with nullable fields, where nothing stops a `Circle` instance from also carrying a stray
+field that means nothing (Example 45 models a shape as a union of frozen dataclasses and verifies each
+variant).
+
+</details>
+
+**Q21 (co-21 -- Structural Pattern Matching).** What is the ONE fact to hold onto about Python's
+`match`/`case` exhaustiveness, and how do you defend against it yourself?
+
+<details>
+<summary>Answer</summary>
+
+Python's `match`/`case` (PEP 634) has NO compile-time exhaustiveness checking at the language level --
+an unmatched value simply falls through with no error unless the developer adds an explicit wildcard
+`case _` and raises there themselves. (A static type checker like pyright CAN flag a non-exhaustive
+match over a fully-known closed union as a best-effort heuristic, but CPython itself enforces nothing at
+runtime.) (Example 46 matches over the `Circle | Square` ADT with an explicit note on this gap; Kata 7
+reproduces the silent fall-through directly by omitting both the new variant's case and the wildcard.)
+
+</details>
+
+**Q22 (co-22 -- The Option/Maybe Type).** What does a hand-rolled `Option` force the caller to do that
+a bare `Optional[int]` return type does not?
+
+<details>
+<summary>Answer</summary>
+
+A function returning `Optional[int]` still lets a caller forget the `None` check and crash later with a
+"`NoneType` has no attribute" error, far from where the `None` actually originated. An `Option`-returning
+function (`Some`/`Nothing`, hand-rolled and stdlib-only) forces the caller to unwrap the result
+explicitly (or `map` through it), turning a possible runtime crash into a type-level obligation the
+caller cannot silently skip (Example 48 builds `Some`/`Nothing` with `map`; Example 49 chains
+`Option`-returning lookups and confirms short-circuit on the first miss).
+
+</details>
+
+**Q23 (co-23 -- The Result/Either Type).** What does a `Result` return type make visible to a caller
+that an exception-raising function's signature does not?
+
+<details>
+<summary>Answer</summary>
+
+`def parse(s: str) -> int` tells a caller nothing about whether it can raise; `def parse(s: str) ->
+Result[int, str]` states the failure mode directly in the type the caller sees at the call site, without
+reading the implementation. This makes failure an ordinary value you can `map` over, compose, and
+inspect, instead of a special control-flow mechanism that unwinds the stack (Example 50 carries an error
+as a value through a hand-rolled `Ok`/`Err`; Example 51 confirms a `Result` chain stops at the first
+`Err`).
+
+</details>
+
+**Q24 (co-24 -- Railway-Oriented Error Handling).** What does railway-oriented programming replace,
+and what handles the short-circuiting behavior instead?
+
+<details>
+<summary>Answer</summary>
+
+Railway-oriented programming threads a `Result` through a pipeline of steps, replacing a pyramid of
+nested `if err != nil` checks (or scattered `try`/`except` blocks) with a single linear chain that reads
+top-to-bottom. The short-circuiting is handled once, by the `Result` type's own `and_then`/`map`
+machinery, instead of being re-implemented by hand at every step (Example 52's validation pipeline
+confirms one bad field short-circuits the rest; Kata 9 reproduces the crash that results when a
+hand-written `and_then` skips checking for `Err` before calling the next step).
+
+</details>
+
+**Q25 (co-25 -- Functor Intuition).** What is the functor identity law, and what does it state
+concretely about `map`?
+
+<details>
+<summary>Answer</summary>
+
+The functor identity law states `container.map(identity) == container` -- mapping the identity function
+over a container changes nothing but confirms `map` genuinely just "applies this function to whatever's
+inside, however many things that is" (zero, one, or many), the exact same idea whether the container is
+a `list`, `Some`, or `Nothing`. Recognizing the functor pattern lets you transfer intuition about list
+`map` directly onto `Option`, `Result`, and any wrapped-value type you build (Example 53 shows the
+identity law by example; Example 70 property-tests the identity and composition laws together).
+
+</details>
+
+**Q26 (co-26 -- Applicative Intuition).** What can an applicative combine that a plain `map`/functor
+cannot, on its own?
+
+<details>
+<summary>Answer</summary>
+
+`map`/functor only handles a function of ONE wrapped argument; an applicative is the natural next step
+for combining SEVERAL independently-wrapped values with a multi-argument function --
+`map2(add, Some(2), Some(3))` unwraps both `Option`s, calls `add(2, 3)`, and wraps the result back up as
+`Some(5)`, short-circuiting to `Nothing` if either input is absent (Example 55's `map2` combines two
+`Option`s; Example 71 builds an applicative that accumulates every validation error instead of stopping
+at the first one).
+
+</details>
+
+**Q27 (co-27 -- Monad Intuition).** Why can't `map` alone chain functions that each return an
+already-wrapped value, and what does `bind`/`and_then` add?
+
+<details>
+<summary>Answer</summary>
+
+`map` applied to a function that itself returns a wrapped value produces a nested wrapper --
+`Ok(5).map(lambda x: Ok(x + 1))` would give `Ok(Ok(6))`, not `Ok(6)`. `bind` (also called `and_then` or
+`flat_map`) is the extra piece that flattens the result instead: `Ok(5).and_then(lambda x: Ok(x + 1))`
+correctly returns `Ok(6)` (Example 51's `and_then` on `Result`; Example 72 shows left-identity,
+right-identity, and associativity by example, the three monad laws made concrete).
+
+</details>
+
+**Q28 (co-28 -- Functional Core, Imperative Shell).** What does a functional-core/imperative-shell
+split quarantine, and why does the core need no mocking to test?
+
+<details>
+<summary>Answer</summary>
+
+A functional-core/imperative-shell design splits a program into a pure transformation core (parse,
+transform, aggregate -- no I/O anywhere) surrounded by a thin imperative shell that holds every effect
+(reading a file, writing output, talking to a network). The core is tested directly with no mocking,
+because it has nothing to mock -- it is the same purity-boundary idea from co-02, made into a concrete
+architectural pattern (Example 57 splits a CSV analyzer into a pure core and an I/O shell; Kata 10
+reproduces a debug `print()` that leaks I/O into what was meant to be the pure core).
+
+</details>
+
+## Applied problems
+
+Ten scenarios. Each describes a symptom without naming the concept -- decide which one applies, then
+check.
+
+**AP1.** A function has no `print` statements, mutates no arguments, and returns a value -- yet calling
+it twice with the exact same arguments produces two different results, because internally it reads
+`random.random()` to decide part of its output.
+
+<details>
+<summary>Answer</summary>
+
+This is a purity violation (co-01, co-02) -- purity requires the OUTPUT to depend only on the
+arguments, and reading ANY external, non-deterministic, or mutable state (not just writing to it) breaks
+that guarantee just as thoroughly as printing or mutating an argument would (Example 1; Example 3; Kata
+1's mutation-based variant of the same "hidden dependency" family).
+
+</details>
+
+**AP2.** A caller passes a `tuple` of settings into a function that reuses the SAME tuple safely across
+three different threads, but a code reviewer objects that a `list` was used for the exact same purpose
+in a sibling module and later blamed for a hard-to-reproduce bug.
+
+<details>
+<summary>Answer</summary>
+
+This is an immutability question (co-04) -- a `tuple` cannot be mutated after construction, so handing
+it to three threads is safe by construction; a `list` handed the same way is an accident waiting to
+happen, because ANY of the three threads (or any other code holding the reference) can mutate it out
+from under the others (Example 4; Kata 2's `dataclasses.replace` shows the safe way to "update" an
+immutable record instead of mutating it in place).
+
+</details>
+
+**AP3.** Three UI validators are built inside a loop, one per configured threshold, and stored in a list
+to call later -- but when they are all called afterward, EVERY one of them enforces the SAME threshold:
+the last one in the loop.
+
+<details>
+<summary>Answer</summary>
+
+This is closure late binding (co-08) -- a closure captures the VARIABLE, not a frozen snapshot of its
+value at closure-creation time. By the time any of the three lambdas is called, the loop variable has
+already reached its final value, and all three see that same final value; binding it as a default
+argument at each iteration is the fix (Example 11; Example 12; Kata 3).
+
+</details>
+
+**AP4.** A three-step transform pipeline is built by composing three small functions, and the pipeline
+PASSES its own unit tests (each step function tested in isolation), but the end-to-end output is wrong
+-- inspection shows the steps ran in the opposite order the developer intended.
+
+<details>
+<summary>Answer</summary>
+
+This is a composition-ordering mistake (co-11, co-12) -- `compose(f, g)` applies `g` FIRST then `f`
+(right-to-left, mathematical convention), while `pipe(x, f, g)` applies `f` first then `g` (left-to-right,
+reading order). Reaching for the wrong helper silently reverses execution order even though every
+individual step is correct in isolation (Example 19; Example 20; Kata 4).
+
+</details>
+
+**AP5.** A `reduce`-based helper that tallies word frequency across a document works correctly on the
+FIRST document ever passed to it in a test run, but on a SECOND, unrelated document it returns totals
+that are visibly too high, as if it remembered the previous document's counts.
+
+<details>
+<summary>Answer</summary>
+
+This is a mutable-default-argument leak (co-04, co-13) -- a mutable default argument (`counts={}`) is
+created ONCE, at function-definition time, and every call that omits the argument shares that SAME dict
+object. The `reduce` logic itself is correct; it is the accumulator it folds into that leaks across
+calls (Example 15; Example 36; Kata 5).
+
+</details>
+
+**AP6.** A generator built to stream values from a large computed sequence is passed to one function
+that sums the values, and then passed AGAIN to a second function that expects to also print each value
+-- but the second function silently receives nothing at all, and no exception is ever raised.
+
+<details>
+<summary>Answer</summary>
+
+This is generator exhaustion (co-15) -- a generator is a single-use, statefully-exhausted iterator; once
+fully consumed by the sum, there is nothing left to yield on a second pass, and Python raises nothing to
+flag the mistake, it simply produces an empty iteration (Example 21; Example 22; Kata 6).
+
+</details>
+
+**AP7.** A new variant is added to an existing closed set of dataclasses that form an ADT, and the
+`match`/`case` evaluator that walks it keeps running without any error -- but silently returns `None`
+for every value of the new variant, instead of the value the codebase actually expects.
+
+<details>
+<summary>Answer</summary>
+
+This is `match`/`case`'s missing runtime exhaustiveness check (co-20, co-21) -- Python does not warn or
+error at the LANGUAGE level when a `match` block fails to cover every variant of a closed union; an
+unmatched value simply falls through, and with no explicit `case _:` raising an error, that fall-through
+looks like a legitimate result instead of a caught bug (Example 45; Example 46; Example 67; Kata 7).
+
+</details>
+
+**AP8.** A price-lookup function is decorated with `@lru_cache` to "make it faster," and the very first
+call after deployment returns the right price -- but every call for the rest of the process's lifetime
+keeps returning that SAME first price, even after the underlying price table is updated at runtime.
+
+<details>
+<summary>Answer</summary>
+
+This is memoization applied to an impure function (co-17, co-01) -- `lru_cache` is only safe on a
+function whose result depends ONLY on its arguments; this function secretly reads a mutable,
+externally-updated dict, so caching its result the first time freezes a value that was only ever correct
+at that one instant (Example 25; Example 41; Kata 8).
+
+</details>
+
+**AP9.** A validation pipeline threading a hand-rolled `Result` type is supposed to stop at the FIRST
+failing step and report only that one error, but a bug report shows it instead crashes with an unrelated
+`AttributeError` deep inside a LATER step, on a value that was never a legitimate success in the first
+place.
+
+<details>
+<summary>Answer</summary>
+
+This is railway-oriented error handling done incorrectly (co-22, co-23, co-24) -- a correct
+`and_then`/`bind` chain checks whether the PREVIOUS step returned `Ok`/`Some` before ever calling the
+next step's function. Skip that check, and the next step receives the raw `Err`/`Nothing` wrapper as if
+it were a success value; calling success-shaped code on it crashes instead of cleanly short-circuiting
+(Example 51; Example 52; Kata 9).
+
+</details>
+
+**AP10.** A function named `analyze_report` is described in code review as "the pure core" of a small
+tool, but the reviewer notices it cannot be unit-tested without redirecting `sys.stdout`, because it has
+a debug `print()` statement buried three lines into its body.
+
+<details>
+<summary>Answer</summary>
+
+This is a functional-core/imperative-shell boundary violation (co-28, co-02) -- a function that performs
+I/O (even just a diagnostic `print`) is, by definition, no longer part of the pure core. The moment a
+test needs to capture or redirect output to verify behavior, that is the signal the boundary has been
+drawn in the wrong place, and the print call belongs in the imperative shell instead (Example 57;
+Example 76; Kata 10).
+
+</details>
+
+## Code katas
+
+Ten hands-on repetition drills. Each is a before/after `.py` file colocated under `drilling/code/`.
+Every "before" script is a real, runnable Python program that misapplies the concept being drilled --
+run it yourself, diagnose the bug from the observed behavior, fix it from memory, then compare your fix
+against the "after" script and the model solution before checking your work against the
+actually-executed output shown. Every kata script, both before and after, is fully type-annotated and
+`pyright --strict` clean.
+
+### Kata 1 -- purity: a function that looks pure secretly mutates its input
+
+_relates to co-01, co-02, Example 1_
+
+**Task.** `apply_discount(cart, rate)` should return a discounted cart WITHOUT changing the caller's
+own list. The version below is broken: it mutates each `CartItem` in place, so calling it twice
+compounds the discount onto itself instead of applying a fresh one each time.
+
+**Before** (`drilling/code/kata-01-hidden-mutation-breaks-purity/before/kata.py`)
+
+```python
+"""Kata 1 (before): purity violation -- a function that looks pure secretly mutates its input."""
+
+from dataclasses import dataclass
+
+
+@dataclass  # => NOT frozen -- a mutable record, which is exactly what makes the bug below possible
+class CartItem:
+    name: str
+    price: float
+
+
+def apply_discount(cart: list[CartItem], rate: float) -> list[CartItem]:
+    for item in cart:
+        item.price *= rate  # SMELL: mutates each CartItem IN PLACE -- the caller's own data changes
+    return cart
+
+
+cart = [CartItem("pen", 10.0), CartItem("mug", 20.0)]
+first_pass = apply_discount(cart, 0.9)
+second_pass = apply_discount(cart, 0.9)  # meant to apply a FRESH 0.9 discount a second time
+print([item.price for item in second_pass])
+print(first_pass is second_pass)  # BUG: same object -- the discount compounded onto itself
+```
+
+**Observed (buggy) output** (captured by actually running the script above):
+
+```text
+[8.1, 16.2]
+True
+```
+
+**After** (`drilling/code/kata-01-hidden-mutation-breaks-purity/after/kata.py`)
+
+```python
+"""Kata 1 (after): purity fix -- builds and returns NEW records, the caller's input is never touched."""
+
+from dataclasses import dataclass, replace
+
+
+@dataclass  # => still a plain mutable record -- the FIX is in apply_discount, not the type
+class CartItem:
+    name: str
+    price: float
+
+
+def apply_discount(cart: list[CartItem], rate: float) -> list[CartItem]:
+    return [replace(item, price=item.price * rate) for item in cart]  # => new CartItem per element
+
+
+cart = [CartItem("pen", 10.0), CartItem("mug", 20.0)]
+first_pass = apply_discount(cart, 0.9)
+second_pass = apply_discount(cart, 0.9)  # cart itself was never mutated, so this is a FRESH discount
+print([item.price for item in second_pass])
+print(first_pass is second_pass)  # different objects, and cart's own prices are untouched
+```
+
+<details>
+<summary>Model solution</summary>
+
+**Root cause**: `item.price *= rate` mutates the SAME `CartItem` objects the caller's `cart` list
+holds references to. Two calls to `apply_discount` therefore compound: the second call discounts the
+ALREADY-discounted prices, not the originals. Building a brand-new `CartItem` per element (via
+`dataclasses.replace`) means the function only ever reads the input, never writes to it.
+
+**Run**: `python3 kata.py`
+
+**Output**:
+
+```text
+[9.0, 18.0]
+False
+```
+
+</details>
+
+### Kata 2 -- immutability: direct attribute assignment on a frozen dataclass
+
+_relates to co-04, co-05, Example 5_
+
+**Task.** `RetryConfig` is a frozen dataclass, so "updating" `retries` by direct assignment should be
+impossible. The version below is broken: it tries anyway, and the program crashes instead of producing
+an updated config.
+
+**Before** (`drilling/code/kata-02-frozen-dataclass-replace/before/kata.py`)
+
+```python
+"""Kata 2 (before): immutability violation -- direct attribute assignment on a frozen dataclass."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RetryConfig:
+    retries: int
+    timeout_seconds: float
+
+
+config = RetryConfig(retries=1, timeout_seconds=5.0)
+config.retries = 5  # type: ignore[misc]  # BUG: frozen dataclasses reject assignment -- raises at runtime
+print(config)
+```
+
+**Observed (buggy) output** (captured by actually running the script above -- an uncaught crash):
+
+```text
+Traceback (most recent call last):
+  ...
+dataclasses.FrozenInstanceError: cannot assign to field 'retries'
+```
+
+**After** (`drilling/code/kata-02-frozen-dataclass-replace/after/kata.py`)
+
+```python
+"""Kata 2 (after): immutability fix -- dataclasses.replace() builds a NEW record, never mutates."""
+
+from dataclasses import dataclass, replace
+
+
+@dataclass(frozen=True)
+class RetryConfig:
+    retries: int
+    timeout_seconds: float
+
+
+config = RetryConfig(retries=1, timeout_seconds=5.0)
+updated_config = replace(config, retries=5)  # => a NEW RetryConfig, config itself is untouched
+print(config)
+print(updated_config)
+```
+
+<details>
+<summary>Model solution</summary>
+
+**Root cause**: a frozen dataclass overrides `__setattr__` to reject any assignment after
+`__init__`, at RUNTIME -- `# type: ignore[misc]` only silences pyright's static warning, it does not
+change what the program does when actually run. `dataclasses.replace(config, retries=5)` is the correct
+"update": it builds a NEW instance with the named fields overridden, leaving `config` itself completely
+untouched.
+
+**Run**: `python3 kata.py`
+
+**Output**:
+
+```text
+RetryConfig(retries=1, timeout_seconds=5.0)
+RetryConfig(retries=5, timeout_seconds=5.0)
+```
+
+</details>
+
+### Kata 3 -- closures: every closure in the list captures the SAME loop variable
+
+_relates to co-08, Example 11, Example 12_
+
+**Task.** Three validators, one per threshold in `[10, 20, 30]`, should each enforce a DIFFERENT
+threshold. The version below is broken: all three closures capture the SAME loop variable `t`, so by
+the time any of them is called, `t` has already reached its final value.
+
+**Before** (`drilling/code/kata-03-closure-late-binding/before/kata.py`)
+
+```python
+"""Kata 3 (before): closure violation -- every closure in the list captures the SAME loop variable."""
+
+from typing import Callable
+
+thresholds = [10, 20, 30]
+validators: list[Callable[[int], bool]] = []
+for t in thresholds:
+    validators.append(lambda x: x > t)  # SMELL: captures the VARIABLE t, not its value at this point
+
+print([v(15) for v in validators])  # every validator should differ; watch what actually happens
+```
+
+**Observed (buggy) output** (captured by actually running the script above):
+
+```text
+[False, False, False]
+```
+
+**After** (`drilling/code/kata-03-closure-late-binding/after/kata.py`)
+
+```python
+"""Kata 3 (after): closure fix -- a default argument binds EACH closure's own value at creation time."""
+
+from typing import Callable
+
+thresholds = [10, 20, 30]
+validators: list[Callable[[int], bool]] = []
+for t in thresholds:
+    validators.append(lambda x, t=t: x > t)  # => t=t binds THIS iteration's value, not the variable
+
+print([v(15) for v in validators])  # each validator now uses its own captured threshold
+```
+
+<details>
+<summary>Model solution</summary>
+
+**Root cause**: a closure captures the ENCLOSING VARIABLE, not a snapshot of its value at the moment
+the lambda is defined. By the time `validators` is actually called (after the loop finishes), `t` holds
+its LAST value (`30`) for all three lambdas equally. `lambda x, t=t: x > t` works because Python
+evaluates a default-argument expression exactly ONCE, at the moment THAT lambda is created -- binding
+each closure's own `t=t` default to that iteration's value permanently.
+
+**Run**: `python3 kata.py`
+
+**Output**:
+
+```text
+[True, False, False]
+```
+
+</details>
+
+### Kata 4 -- composition: compose() runs right-to-left, not the intended reading order
+
+_relates to co-11, co-12, Example 19, Example 20_
+
+**Task.** `transform(5)` should compute "add one, THEN double" -- `(5 + 1) * 2 = 12`. The version
+below is broken: `compose(add_one, double)` reads left-to-right like a `pipe` call, but `compose` itself
+runs its SECOND argument first.
+
+**Before** (`drilling/code/kata-04-compose-vs-pipe-order/before/kata.py`)
+
+```python
+"""Kata 4 (before): composition-order bug -- compose() runs right-to-left, not the intended order."""
+
+from typing import Callable
+
+
+def compose(f: Callable[[int], int], g: Callable[[int], int]) -> Callable[[int], int]:
+    return lambda x: f(g(x))  # => g runs FIRST, then f -- right-to-left, mathematical convention
+
+
+def add_one(x: int) -> int:
+    return x + 1
+
+
+def double(x: int) -> int:
+    return x * 2
+
+
+# INTENT: "add one, THEN double" -- reading compose(add_one, double) left to right like a pipe call.
+transform = compose(add_one, double)  # SMELL: reads left-to-right but compose runs right-to-left
+result = transform(5)  # BUG: double(5) runs FIRST giving 10, then add_one gives 11 -- not (5+1)*2=12
+print(result)
+```
+
+**Observed (buggy) output** (captured by actually running the script above):
+
+```text
+11
+```
+
+**After** (`drilling/code/kata-04-compose-vs-pipe-order/after/kata.py`)
+
+```python
+"""Kata 4 (after): composition-order fix -- pipe() runs left-to-right, matching the reading order."""
+
+from functools import reduce
+from typing import Callable
+
+
+def pipe(x: int, *fns: Callable[[int], int]) -> int:
+    return reduce(lambda acc, fn: fn(acc), fns, x)  # => applies fns in ORDER, left to right
+
+
+def add_one(x: int) -> int:
+    return x + 1
+
+
+def double(x: int) -> int:
+    return x * 2
+
+
+# INTENT: "add one, THEN double" -- pipe(5, add_one, double) reads AND runs left to right.
+result = pipe(5, add_one, double)  # => add_one(5)=6 runs first, then double(6)=12
+print(result)
+```
+
+<details>
+<summary>Model solution</summary>
+
+**Root cause**: `compose(f, g)` computes `f(g(x))` -- `g` ALWAYS runs first, regardless of how
+natural the call `compose(add_one, double)` looks to read left to right. `pipe(x, *fns)` sidesteps the
+whole ambiguity by reading AND executing in the same order: the first function argument after `x` is
+the first one applied.
+
+**Run**: `python3 kata.py`
+
+**Output**:
+
+```text
+12
+```
+
+</details>
+
+### Kata 5 -- map/filter/reduce: a mutable default argument silently shares ONE accumulator
+
+_relates to co-04, co-13, Example 15, Example 36_
+
+**Task.** `histogram(words)` should start counting from a fresh, empty dict every time the `counts`
+argument is omitted. The version below is broken: two DIFFERENT, unrelated calls end up sharing the
+SAME accumulator dict.
+
+**Before** (`drilling/code/kata-05-mutable-default-accumulator/before/kata.py`)
+
+```python
+"""Kata 5 (before): a mutable default argument silently shares ONE accumulator across every call."""
+
+
+def histogram(words: list[str], counts: dict[str, int] = {}) -> dict[str, int]:  # SMELL: mutable default
+    for w in words:
+        counts[w] = counts.get(w, 0) + 1  # BUG: mutates the SHARED default dict object in place
+    return counts
+
+
+first_doc = histogram(["a", "b", "a"])
+print(first_doc)
+second_doc = histogram(["c"])  # an UNRELATED document -- should start from a fresh, empty count
+print(second_doc)  # BUG: "c" is mixed in with leftover counts from the first, unrelated call
+```
+
+**Observed (buggy) output** (captured by actually running the script above):
+
+```text
+{'a': 2, 'b': 1}
+{'a': 2, 'b': 1, 'c': 1}
+```
+
+**After** (`drilling/code/kata-05-mutable-default-accumulator/after/kata.py`)
+
+```python
+"""Kata 5 (after): fix -- a None sentinel builds a FRESH dict on every call, reduce folds over it."""
+
+from functools import reduce
+
+
+def histogram(words: list[str], counts: dict[str, int] | None = None) -> dict[str, int]:
+    start: dict[str, int] = counts if counts is not None else {}  # => fresh dict every call
+    return reduce(lambda acc, w: {**acc, w: acc.get(w, 0) + 1}, words, start)  # => builds NEW dicts
+
+
+first_doc = histogram(["a", "b", "a"])
+print(first_doc)
+second_doc = histogram(["c"])  # a fresh, empty accumulator every time the default is used
+print(second_doc)  # correctly isolated from the first, unrelated call
+```
+
+<details>
+<summary>Model solution</summary>
+
+**Root cause**: Python evaluates a default argument expression exactly ONCE, at function-definition
+time -- `{}` is created a single time, and the `before` version's loop MUTATES that single shared dict
+in place on every call that omits `counts`. Using `None` as a sentinel and building a fresh `{}` inside
+the body (or, as shown, folding with `functools.reduce` into a NEW dict each step) removes the shared
+mutable target entirely.
+
+**Run**: `python3 kata.py`
+
+**Output**:
+
+```text
+{'a': 2, 'b': 1}
+{'c': 1}
+```
+
+</details>
+
+### Kata 6 -- laziness: a generator is iterated once, exhausted, then silently yields nothing again
+
+_relates to co-15, Example 21, Example 22_
+
+**Task.** `values` should be usable for a second pass after `sum()` consumes it once. The version
+below is broken: `squared(...)` returns a single-use generator, and the second pass over the SAME
+object silently produces nothing.
+
+**Before** (`drilling/code/kata-06-generator-exhaustion/before/kata.py`)
+
+```python
+"""Kata 6 (before): a generator is iterated once, exhausted, then silently yields nothing again."""
+
+from typing import Iterator
+
+
+def squared(nums: list[int]) -> Iterator[int]:
+    for n in nums:
+        yield n * n  # => a lazy, single-use generator -- each value produced only on demand
+
+
+values = squared([1, 2, 3])  # SMELL: ONE generator object, about to be consumed twice below
+total = sum(values)  # first pass -- fully consumes/exhausts the generator
+print(total)
+remaining = list(values)  # BUG: the SAME exhausted generator -- nothing left to yield, no error raised
+print(remaining)
+```
+
+**Observed (buggy) output** (captured by actually running the script above):
+
+```text
+14
+[]
+```
+
+**After** (`drilling/code/kata-06-generator-exhaustion/after/kata.py`)
+
+```python
+"""Kata 6 (after): fix -- materialize a list when the SAME data is genuinely needed more than once."""
+
+from typing import Iterator
+
+
+def squared(nums: list[int]) -> Iterator[int]:
+    for n in nums:
+        yield n * n
+
+
+values = list(squared([1, 2, 3]))  # => a list, not a generator -- safe to iterate as many times as needed
+total = sum(values)  # first pass over the materialized list
+print(total)
+remaining = list(values)  # second pass -- the list still has every element, nothing was consumed
+print(remaining)
+```
+
+<details>
+<summary>Model solution</summary>
+
+**Root cause**: a generator object tracks its own position and raises `StopIteration` once exhausted --
+`sum(values)` fully drains it, so `list(values)` afterward has nothing left to pull and produces an
+empty list with NO error to flag the mistake. Wrapping the generator in `list(...)` once, up front,
+trades away the laziness (the whole sequence is now materialized in memory) in exchange for being safely
+re-iterable as many times as needed -- the right trade whenever a value is genuinely consumed more than
+once.
+
+**Run**: `python3 kata.py`
+
+**Output**:
+
+```text
+14
+[1, 4, 9]
+```
+
+</details>
+
+### Kata 7 -- pattern matching: a new ADT variant falls through match/case silently
+
+_relates to co-20, co-21, Example 46, Example 67_
+
+**Task.** `area(shape)` should compute an area for every `Shape` variant, including the newly-added
+`Triangle`. The version below is broken: the `match` block has no `case` for `Triangle` and no
+wildcard `case _`, so the function falls through and returns `None` instead of an area or an error.
+
+**Before** (`drilling/code/kata-07-match-case-no-exhaustiveness/before/kata.py`)
+
+```python
+"""Kata 7 (before): a new ADT variant falls through match/case silently -- no compile-time warning."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Circle:
+    radius: float
+
+
+@dataclass(frozen=True)
+class Square:
+    side: float
+
+
+@dataclass(frozen=True)
+class Triangle:  # => a NEW variant added to the shape family after the evaluator below was written
+    base: float
+    height: float
+
+
+Shape = Circle | Square | Triangle  # => the ADT now has THREE variants
+
+
+def area(shape: Shape) -> float:  # type: ignore[misc]  # pyright statically flags what CPython won't
+    match shape:  # type: ignore[misc]  # SMELL: no Triangle case, no wildcard -- pyright catches it, CPython doesn't
+        case Circle(radius=r):
+            return 3.14159 * r * r
+        case Square(side=s):
+            return s * s
+    # BUG: falls through here for Triangle -- Python raises NOTHING, the function returns None
+
+
+result = area(Triangle(base=4.0, height=3.0))  # a legitimate Shape value the evaluator never handles
+print(result)  # BUG: prints None instead of raising or computing an area
+```
+
+**Observed (buggy) output** (captured by actually running the script above):
+
+```text
+None
+```
+
+**After** (`drilling/code/kata-07-match-case-no-exhaustiveness/after/kata.py`)
+
+```python
+"""Kata 7 (after): fix -- an explicit wildcard case raises instead of silently falling through."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Circle:
+    radius: float
+
+
+@dataclass(frozen=True)
+class Square:
+    side: float
+
+
+@dataclass(frozen=True)
+class Triangle:
+    base: float
+    height: float
+
+
+Shape = Circle | Square | Triangle
+
+
+def area(shape: Shape) -> float:
+    match shape:
+        case Circle(radius=r):
+            return 3.14159 * r * r
+        case Square(side=s):
+            return s * s
+        case Triangle(base=b, height=h):  # => the new variant now has its OWN branch
+            return 0.5 * b * h
+        case _:  # => a manual safety net for any FUTURE variant this evaluator hasn't been taught yet
+            raise ValueError(f"unhandled shape variant: {shape!r}")
+
+
+result = area(Triangle(base=4.0, height=3.0))
+print(result)
+```
+
+<details>
+<summary>Model solution</summary>
+
+**Root cause**: Python's `match`/`case` has no LANGUAGE-level exhaustiveness check -- a `match` block
+that doesn't cover every variant simply falls through with no error, and a function with no explicit
+`return` on that path implicitly returns `None`. (Note: this specific example IS statically catchable --
+pyright's `reportMatchNotExhaustive` correctly flags the `before` version, which is why it needs a
+`# type: ignore` to demonstrate the runtime behavior at all; the underlying CPython runtime still
+enforces nothing.) Adding both the missing `case Triangle(...)` branch AND a `case _:` wildcard that
+raises makes any FUTURE unhandled variant a loud, immediate crash instead of a silent `None`.
+
+**Run**: `python3 kata.py`
+
+**Output**:
+
+```text
+6.0
+```
+
+</details>
+
+### Kata 8 -- memoization: @lru_cache applied to an impure function freezes a stale value
+
+_relates to co-17, co-01, Example 25, Example 41_
+
+**Task.** `get_price("widget")` should always reflect the CURRENT contents of `prices`. The version
+below is broken: `@lru_cache` treats `get_price` as if it were pure, so it caches the first result and
+never notices `prices` changed.
+
+**Before** (`drilling/code/kata-08-memoize-impure-function/before/kata.py`)
+
+```python
+"""Kata 8 (before): @lru_cache applied to an IMPURE function -- the cache freezes a stale value."""
+
+from functools import lru_cache
+
+prices: dict[str, float] = {"widget": 9.99}
+
+
+@lru_cache  # SMELL: memoization is only safe on a PURE function -- this one reads mutable module state
+def get_price(sku: str) -> float:
+    return prices[sku]  # BUG: depends on `prices`, not just on `sku` -- not actually pure
+
+
+first_lookup = get_price("widget")
+print(first_lookup)
+prices["widget"] = 14.99  # the underlying price table changes at runtime, as real price tables do
+second_lookup = get_price("widget")
+print(second_lookup)  # BUG: still 9.99 -- the cache never learns the price actually changed
+```
+
+**Observed (buggy) output** (captured by actually running the script above):
+
+```text
+9.99
+9.99
+```
+
+**After** (`drilling/code/kata-08-memoize-impure-function/after/kata.py`)
+
+```python
+"""Kata 8 (after): fix -- no memoization on an impure lookup; the function always reads the current state."""
+
+prices: dict[str, float] = {"widget": 9.99}
+
+
+def get_price(sku: str) -> float:  # => no @lru_cache -- this function depends on prices, not just sku
+    return prices[sku]
+
+
+first_lookup = get_price("widget")
+print(first_lookup)
+prices["widget"] = 14.99  # the underlying price table changes at runtime
+second_lookup = get_price("widget")
+print(second_lookup)  # correctly reflects the updated price -- nothing was cached to go stale
+```
+
+<details>
+<summary>Model solution</summary>
+
+**Root cause**: `get_price`'s result depends on the MODULE-LEVEL `prices` dict, not just on its own
+`sku` argument -- it is not actually pure, even though its signature looks like a simple lookup.
+`@lru_cache` assumes purity and caches by argument alone, so once `get_price("widget")` is called once,
+every LATER call with `"widget"` returns the frozen first result forever, regardless of what `prices`
+does afterward. The fix is not a smarter cache; it's recognizing this function was never safe to
+memoize in the first place.
+
+**Run**: `python3 kata.py`
+
+**Output**:
+
+```text
+9.99
+14.99
+```
+
+</details>
+
+### Kata 9 -- railway errors: a hand-written and_then skips the Err check before calling the next step
+
+_relates to co-22, co-23, co-24, Example 51, Example 52_
+
+**Task.** `and_then(first_step, double_it)` should propagate `first_step`'s `Err` untouched when
+`first_step` already failed, never calling `double_it` at all. The version below is broken: it calls
+`step(result.value)` unconditionally, even when `result` is an `Err` with no `.value` field.
+
+**Before** (`drilling/code/kata-09-railway-skips-err-check/before/kata.py`)
+
+```python
+"""Kata 9 (before): a hand-written and_then forgets to check for Err before calling the next step."""
+
+from dataclasses import dataclass
+from typing import Callable, Generic, TypeVar
+
+T = TypeVar("T")
+E = TypeVar("E")
+U = TypeVar("U")
+
+
+@dataclass(frozen=True)
+class Ok(Generic[T]):
+    value: T
+
+
+@dataclass(frozen=True)
+class Err(Generic[E]):
+    error: E
+
+
+Result = Ok[T] | Err[E]
+
+
+def and_then(result: Result[T, str], step: Callable[[T], Result[U, str]]) -> Result[U, str]:
+    # SMELL: calls step() on result.value UNCONDITIONALLY -- never checks whether result is an Err first
+    return step(result.value)  # type: ignore[union-attr]  # BUG: Err has no .value -- crashes on failure
+
+
+def parse_positive(raw: str) -> Result[int, str]:
+    n = int(raw)
+    return Ok(n) if n > 0 else Err(f"{raw} is not positive")
+
+
+def double_it(n: int) -> Result[int, str]:
+    return Ok(n * 2)
+
+
+first_step = parse_positive("-5")  # this is a legitimate FAILURE, not a bug in parse_positive itself
+final = and_then(first_step, double_it)  # BUG: crashes with AttributeError instead of propagating Err
+print(final)
+```
+
+**Observed (buggy) output** (captured by actually running the script above -- an uncaught crash):
+
+```text
+Traceback (most recent call last):
+  ...
+AttributeError: 'Err' object has no attribute 'value'
+```
+
+**After** (`drilling/code/kata-09-railway-skips-err-check/after/kata.py`)
+
+```python
+"""Kata 9 (after): fix -- and_then checks the variant BEFORE calling the next step, short-circuiting on Err."""
+
+from dataclasses import dataclass
+from typing import Callable, Generic, TypeVar
+
+T = TypeVar("T")
+E = TypeVar("E")
+U = TypeVar("U")
+
+
+@dataclass(frozen=True)
+class Ok(Generic[T]):
+    value: T
+
+
+@dataclass(frozen=True)
+class Err(Generic[E]):
+    error: E
+
+
+Result = Ok[T] | Err[E]
+
+
+def and_then(result: Result[T, str], step: Callable[[T], Result[U, str]]) -> Result[U, str]:
+    match result:  # => checks the variant FIRST, exactly once, before ever calling step()
+        case Ok(value=v):
+            return step(v)  # => only reachable when result actually succeeded
+        case Err(error=e):
+            return Err(e)  # => short-circuits -- step() is never called on a failure
+
+
+def parse_positive(raw: str) -> Result[int, str]:
+    n = int(raw)
+    return Ok(n) if n > 0 else Err(f"{raw} is not positive")
+
+
+def double_it(n: int) -> Result[int, str]:
+    return Ok(n * 2)
+
+
+first_step = parse_positive("-5")
+final = and_then(first_step, double_it)  # correctly short-circuits, double_it is never called
+print(final)
+```
+
+<details>
+<summary>Model solution</summary>
+
+**Root cause**: the broken `and_then` reaches for `result.value` before confirming `result` is
+actually an `Ok` -- `Err` has an `.error` field, not `.value`, so the attribute access crashes the
+instant a legitimate failure reaches it. Pattern-matching on `result`'s variant FIRST (`case Ok(value=v)`
+vs. `case Err(error=e)`) makes the check impossible to skip: `step` is only ever called inside the `Ok`
+branch, and an `Err` is returned untouched from the `Err` branch, exactly the short-circuit railway
+semantics are supposed to guarantee.
+
+**Run**: `python3 kata.py`
+
+**Output**:
+
+```text
+Err(error='-5 is not positive')
+```
+
+</details>
+
+### Kata 10 -- functional core: a debug print() leaks I/O into what should be the pure core
+
+_relates to co-28, co-02, Example 57, Example 76_
+
+**Task.** `parse_and_total(rows)` is meant to be the pure core of a small tool -- callable and
+testable with zero I/O. The version below is broken: it has a debug `print()` buried inside it, so a
+test that wants to verify its return value ALSO has to capture stdout to avoid noisy test output.
+
+**Before** (`drilling/code/kata-10-print-leaks-into-core/before/kata.py`)
+
+```python
+"""Kata 10 (before): a debug print() leaks I/O into what is supposed to be the pure core."""
+
+import io
+from contextlib import redirect_stdout
+
+
+def parse_and_total(rows: list[str]) -> int:  # meant to be the PURE core -- no I/O anywhere
+    print(f"parsing {len(rows)} rows")  # SMELL: a debug print buried inside the "pure" core
+    return sum(int(row) for row in rows)
+
+
+rows = ["10", "20", "30"]
+captured = io.StringIO()
+with redirect_stdout(captured):  # BUG: a "pure" function should never need its stdout redirected
+    total = parse_and_total(rows)
+print(total)
+print(repr(captured.getvalue()))  # BUG: proves the core actually performed I/O -- it isn't pure
+```
+
+**Observed (buggy) output** (captured by actually running the script above):
+
+```text
+60
+'parsing 3 rows\n'
+```
+
+**After** (`drilling/code/kata-10-print-leaks-into-core/after/kata.py`)
+
+```python
+"""Kata 10 (after): fix -- the core stays pure; only the shell performs I/O, and only around the core."""
+
+import io
+from contextlib import redirect_stdout
+
+
+def parse_and_total(rows: list[str]) -> int:  # => the pure core -- no print, no I/O of any kind
+    return sum(int(row) for row in rows)
+
+
+def run_shell(rows: list[str]) -> None:  # => the imperative shell -- the ONLY place logging happens
+    print(f"parsing {len(rows)} rows")
+    total = parse_and_total(rows)
+    print(total)
+
+
+rows = ["10", "20", "30"]
+captured = io.StringIO()
+with redirect_stdout(captured):
+    total = parse_and_total(rows)  # calling the core directly needs NO stdout redirection to test
+print(total)
+print(repr(captured.getvalue()))  # empty -- the core performed no I/O, confirming it stayed pure
+run_shell(rows)  # the shell is where logging + the final print belong -- the core stays silent
+```
+
+<details>
+<summary>Model solution</summary>
+
+**Root cause**: a `print()` call, even a "harmless" diagnostic one, is I/O -- the moment `parse_and_total`
+performs it, the function is no longer pure, and any test of its RETURN VALUE also has to manage its
+side effect (here, by redirecting stdout) to avoid polluting test output. Moving the print into a
+separate `run_shell` function draws the functional-core/imperative-shell boundary explicitly: the core
+is called directly with no redirection needed at all, and the shell is the ONLY place any output happens.
+
+**Run**: `python3 kata.py`
+
+**Output**:
+
+```text
+60
+''
+parsing 3 rows
+60
+```
+
+</details>
+
+## Self-check checklist
+
+Work through this list without looking anything up. Every item should be something you can do from
+memory, not something you'd need to search for.
+
+**Purity, side effects, referential transparency, immutability, persistence**
+
+- [ ] I can call a function twice with identical arguments and explain why a PURE function must give
+      the same result both times, while an impure one might not (co-01).
+- [ ] I can name the specific hidden effect that turns a pure-looking function into an impure one --
+      printing, mutating an argument, reading external mutable state (co-02).
+- [ ] I can replace a call with its own return value inside a larger expression and explain why that
+      substitution is always safe for a referentially transparent function (co-03).
+- [ ] I can reach for `tuple`, `frozenset`, `@dataclass(frozen=True)`, or `MappingProxyType` when data
+      needs to be safe to hand to another thread or function (co-04).
+- [ ] I can explain why structural sharing keeps a persistent update cheap, instead of requiring a full
+      deep copy on every change (co-05).
+
+**Functions as values: first-class, higher-order, closures, currying, composition, pipe**
+
+- [ ] I can assign a function to a variable, store several in a list, and pass one as an argument,
+      without any special syntax (co-06).
+- [ ] I can write a higher-order function (like `apply(fn, x)`) that works identically regardless of
+      what `fn` itself does (co-07).
+- [ ] I can write a closure that captures a configuration value once and reuses it on every later call,
+      and name exactly where that captured state lives (co-08).
+- [ ] I can hand-curry a two-argument function into `f(a)(b)`, and explain how currying differs from
+      partial application (co-09).
+- [ ] I can reach for `functools.partial` instead of a hand-written wrapping lambda to fix some of a
+      function's arguments (co-10).
+- [ ] I can write `compose(f, g)` and correctly state that `g` runs FIRST, computing `f(g(x))` (co-11).
+- [ ] I can write a `pipe(x, f, g)` helper that reads AND executes left to right, and explain when that
+      readability trade is worth it over `compose` (co-12).
+
+**Sequence transforms, recursion, laziness, itertools, memoization**
+
+- [ ] I can recognize a hand-written accumulation loop as secretly a `map`, a `filter`, or a `reduce`,
+      and rewrite it as one (co-13).
+- [ ] I can state CPython's specific limit on deep recursion (no tail-call optimization,
+      `RecursionError`) and name the two standard workarounds (co-14).
+- [ ] I can write a generator that produces values on demand, and explain why that makes an infinite
+      sequence usable at all (co-15).
+- [ ] I can reach for `itertools.islice`, `chain`, `accumulate`, `groupby`, `tee`, or `pairwise` instead
+      of hand-rolling the equivalent loop (co-16).
+- [ ] I can explain why memoization is only safe on a function that is genuinely PURE, and reproduce
+      what goes wrong when it's applied to one that isn't (co-17).
+
+**Decorators, point-free style, ADTs, pattern matching**
+
+- [ ] I can write a decorator, explain it as `greet = log_calls(greet)` spelled with `@`, and use
+      `functools.wraps` to preserve the wrapped function's identity (co-18).
+- [ ] I can rewrite a lambda-based pipeline in point-free style, and explain when doing so helps
+      readability versus when it obscures it (co-19).
+- [ ] I can model a "one of several shapes" value as a union of frozen dataclasses (an ADT), and
+      explain what illegal state that construction makes unrepresentable (co-20).
+- [ ] I can dispatch over an ADT's variants with `match`/`case`, and state precisely what Python's
+      `match`/`case` does NOT check for me at the language level (co-21).
+
+**Option/Result, railway errors, functor/applicative/monad**
+
+- [ ] I can build and use a hand-rolled `Some`/`Nothing`, and explain what it forces a caller to do
+      that a bare `Optional[int]` does not (co-22).
+- [ ] I can build and use a hand-rolled `Ok`/`Err`, and explain what it makes visible in a function's
+      signature that an exception does not (co-23).
+- [ ] I can thread a `Result` through a multi-step pipeline so the FIRST failure short-circuits every
+      remaining step (co-24).
+- [ ] I can state the functor identity law (`container.map(identity) == container`) and explain what it
+      confirms about `map`'s behavior (co-25).
+- [ ] I can combine two independently-wrapped values with a multi-argument function (an applicative
+      `map2`), and explain how that differs from chaining two `map` calls (co-26).
+- [ ] I can chain functions that each return an already-wrapped value with `bind`/`and_then`, and
+      explain why `map` alone would produce a nested wrapper instead (co-27).
+
+**Functional core, imperative shell**
+
+- [ ] I can split a small tool into a pure core (parse/transform/aggregate, zero I/O) and a thin
+      imperative shell that holds every effect, and explain why the core needs no mocking to test
+      (co-28).
+
+## Elaborative interrogation & self-explanation
+
+Nine why/why-not prompts. Answer in your own words before checking -- the goal is explaining the
+reasoning, not reciting a definition.
+
+**W1.** Why does this topic insist "push side effects to the edges and keep a pure core" instead of
+"eliminate side effects entirely" -- given that a real program unavoidably has to read a file or print
+something eventually?
+
+<details>
+<summary>Answer</summary>
+
+Eliminating I/O is not actually an option for a program that has to do anything observable in the real
+world -- the honest goal is `taming-state`: quarantining WHERE effects live instead of pretending they
+don't exist. The functional-core/imperative-shell split (co-28) is the concrete architectural answer:
+the core stays testable with zero mocking precisely because it holds none of the effects, and the shell
+is small and thin precisely because it holds ALL of them, in one place a reviewer can scrutinize
+directly.
+
+</details>
+
+**W2.** Why is `determinism-vs-emergence` -- purity buying deterministic, replayable behavior -- named
+as one of this topic's cross-cutting big ideas, rather than treated as a property specific to co-01
+alone?
+
+<details>
+<summary>Answer</summary>
+
+Determinism shows up wherever purity does, under different names: memoization (co-17) is only safe
+because a pure function's result is deterministic by argument; a persistent data structure's old version
+(co-05) stays trustworthy because nothing about it can have silently changed; property-testing purity
+itself (Example 58) is really testing determinism directly. Recognizing "this is the same
+determinism-vs-emergence trade again" is what lets a developer transfer intuition from one FP feature to
+an unfamiliar one.
+
+</details>
+
+**W3.** Why does the Tensions & trade-offs section of this topic's overview call insisting on purity
+inside a tight numeric loop "dogma, not engineering," rather than treating purity as an unconditional
+good?
+
+<details>
+<summary>Answer</summary>
+
+`abstraction-and-its-cost` is the honest counterweight this topic names explicitly: immutability
+allocates, and a persistent update that shares structure is still not free -- Example 75 measures this
+cost numerically rather than asserting it. A tight numeric loop or a huge in-place buffer is a place an
+imperative core is honestly faster, and pretending otherwise trades a real performance cost for a
+principle that buys nothing concrete in that specific spot.
+
+</details>
+
+**W4.** Why does Kata 9's `and_then` crash with an `AttributeError` instead of just returning the wrong
+value quietly, the way several of this topic's other katas do?
+
+<details>
+<summary>Answer</summary>
+
+`Err` genuinely has no `.value` field -- it has `.error` instead -- so `step(result.value)` is not
+merely logically wrong, it is a type-shape mismatch the moment `result` is actually an `Err`. Contrast
+Kata 7, where the bug (a missing `match` case) produces a plausible-looking `None` instead of a crash:
+some correctness bugs fail loudly by construction (a crash you cannot miss), and others fail silently by
+construction (a wrong value indistinguishable from a right one) -- recognizing which failure MODE a bug
+class produces is itself a useful skill.
+
+</details>
+
+**W5.** Why does Kata 7's note explicitly point out that pyright's `reportMatchNotExhaustive` DOES catch
+the missing `Triangle` case statically, when co-21's own concept description says `match`/`case` has "no
+compile-time exhaustiveness checking"?
+
+<details>
+<summary>Answer</summary>
+
+Both statements are true at different levels: the Python LANGUAGE itself (CPython, at runtime) enforces
+nothing about `match`/`case` exhaustiveness -- an unmatched value simply falls through. A separate,
+optional STATIC TYPE CHECKER (pyright) can layer a best-effort exhaustiveness heuristic on top, but only
+when it can see the union's FULL set of variants statically; anything that defeats that visibility (a
+dynamically-constructed type, a variant defined in another module pyright isn't shown) removes the
+safety net entirely. The topic's own maxim -- always add a `case _:` that raises -- is what makes the
+guarantee hold regardless of which type checker (if any) a project runs.
+
+</details>
+
+**W6.** Why does co-24 (railway-oriented error handling) matter as its own named concept, when it is
+"just" `and_then`/`bind` (co-27) applied in a sequence?
+
+<details>
+<summary>Answer</summary>
+
+Railway-oriented programming names the SHAPE of the resulting code, not a new mechanism: a chain of
+`and_then` calls reads top-to-bottom as one linear success path, with every failure mode handled ONCE by
+the `Result` type's own machinery instead of re-implemented as a nested `if err != nil` pyramid at every
+step. Naming the pattern is what lets a developer recognize "this messy nested-conditional code is
+secretly a railway that hasn't been written as one yet" the next time they see it.
+
+</details>
+
+**W7.** Why does this topic's capstone (and Example 80) combine a functional core, `Result`-based
+errors, AND an applicative combine into ONE tool, rather than demonstrating each pattern in a separate,
+smaller example?
+
+<details>
+<summary>Answer</summary>
+
+Each pattern in isolation (Examples 1-56) proves the mechanism works; the capstone proves the mechanisms
+COMPOSE -- a real tool needs a pure core (co-28) that produces `Result`-typed rows (co-23), some of
+which fail independently and need combining via an applicative that accumulates every error instead of
+stopping at the first (co-26), all while the imperative shell stays the ONLY place touching a file. That
+composition is the actual skill a production codebase demands, not any one pattern recited alone.
+
+</details>
+
+**W8.** Why does co-17 (memoization) explicitly require co-01 (purity) as a PRECONDITION, rather than
+being a general-purpose "make any function faster" technique?
+
+<details>
+<summary>Answer</summary>
+
+Memoization's entire correctness argument is "the same arguments always produce the same result, so
+caching by argument is safe" -- which is EXACTLY the purity guarantee (co-01) and nothing else. Kata 8
+demonstrates the failure directly: `@lru_cache` on a function reading mutable external state doesn't
+just fail to speed anything up correctly, it actively returns WRONG, stale answers forever after the
+first call, which is worse than not caching at all.
+
+</details>
+
+**W9.** Why does this topic teach functors, applicatives, and monads (co-25 to co-27) as "patterns you
+recognize and use" rather than with the rigorous, law-checking treatment a category-theory course would
+give them?
+
+<details>
+<summary>Answer</summary>
+
+The topic's own scope note names this trade-off directly: a gentle, practical first exposure lets a
+developer recognize the SAME shape (`map` on a list, `map` on an `Option`, `and_then` chaining
+`Result`-returning steps) across libraries and languages immediately, which is the day-to-day payoff.
+The deeper, law-checking rigor (why the functor laws must hold, what associativity actually guarantees)
+is deliberately deferred to a later Type Systems topic -- teaching both at once here would spend this
+topic's whole budget on formalism before a reader has even seen the patterns pay off in working code.
+
+</details>
+
+---
+
+← Previous: [Capstone](../learning/capstone/overview.md)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/_index.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Learning"
+date: 2026-07-17T00:00:00+07:00
+draft: false
+weight: 123
+---
+
+- [Overview](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/overview)
+- [Beginner Examples](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner)
+- [Intermediate Examples](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate)
+- [Advanced Examples](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced)
+- [Capstone](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone)
+  - [Overview](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/overview)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced.md
@@ -1,0 +1,2635 @@
+---
+title: "Advanced Examples"
+date: 2026-07-17T00:00:00+07:00
+draft: false
+weight: 30
+---
+
+Examples 57-80 close out this topic at real-tool scale: a CSV analyzer split into a pure core and an
+I/O shell (co-28, co-01), purity and the functor laws checked as properties across hundreds of
+generated inputs using nothing but stdlib `random` (co-01, co-03, co-25), a persistent binary tree and
+a Redux-style reducer (co-05, co-01, co-04), Kleisli composition and a `@curry` decorator (co-11,
+co-27, co-23, co-09, co-18), a lazy infinite prime sieve and a three-stage `yield` pull pipeline
+(co-15, co-16), a bounded LRU memoizer and a trampoline standing in for CPython's missing tail-call
+optimization (co-17, co-18, co-14), an expression-AST interpreter dispatched with `match`/`case`
+(co-20, co-21), `Option` and `Result` chained do-style with both a short-circuiting and an
+error-accumulating validation pipeline (co-22, co-27, co-24, co-23, co-26), a point-free combinator
+library and a deep `pipe` vs. nested-calls comparison (co-19, co-12, co-11), the honest performance
+cost of immutability measured directly, a refactor away from shared mutable state, decorator-stack
+ordering, a laziness trade-off shown from both sides, `Option` vs. `Result` on the identical pipeline,
+and a capstone-preview log analyzer combining every pattern from this topic into one tool (co-04,
+co-05, co-28, co-18, co-11, co-15, co-22, co-23, co-27, co-26). Every example below is a complete,
+self-contained `example.py` colocated under `learning/code/ex-NN-slug/`, run with `python3 example.py`
+to capture the **Output** block shown, and verified a second way with a colocated `test_example.py`
+under `pytest -q`.
+
+---
+
+### Example 57: A CSV Analyzer Split into a Pure Core and an I/O Shell
+
+_ex-57 &middot; exercises co-28, co-01_
+
+This topic's earlier functional-core/imperative-shell splits (Example 29, Example 76) worked on tiny
+routines; this example applies the same split to a small but realistic tool. `parse_sales`,
+`total_by_product`, and `format_report` are pure functions a test can call directly with a string
+literal, while `run_shell` is the one function that touches `print`.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Gray #808080
+flowchart LR
+    T["csv_text"]:::blue --> P["parse_sales#40;#41;<br/>PURE"]:::blue
+    P --> A["total_by_product#40;#41;<br/>PURE"]:::blue
+    A --> R["format_report#40;#41;<br/>PURE"]:::blue
+    R --> S["run_shell#40;#41;<br/>print only"]:::gray
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef gray fill:#808080,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 57: A CSV Analyzer Split into a Pure Core and an I/O Shell."""
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds the immutable Sale record
+
+
+@dataclass(frozen=True)  # => an immutable value object -- no sale record mutates after parsing
+class Sale:  # => one parsed CSV row
+    product: str  # => the product name column
+    amount: float  # => the sale amount column
+
+
+def parse_sales(csv_text: str) -> list[Sale]:  # => PURE CORE: text in, data out, zero I/O
+    rows = csv_text.strip().splitlines()[1:]  # => strips the header row, keeps only data rows
+    sales: list[Sale] = []  # => the accumulator this pure function builds and returns
+    for row in rows:  # => walks every data row exactly once
+        product, amount = row.split(",")  # => splits "apple,10.0" into two fields
+        sales.append(Sale(product=product, amount=float(amount)))  # => builds one immutable Sale
+    return sales  # => a plain list -- testable with a string literal, no file needed
+
+
+def total_by_product(sales: list[Sale]) -> dict[str, float]:  # => PURE CORE: aggregate step
+    totals: dict[str, float] = {}  # => the running per-product total, local to this call
+    for sale in sales:  # => folds every sale into the totals dict
+        totals[sale.product] = totals.get(sale.product, 0.0) + sale.amount  # => accumulates per product
+    return totals  # => a fresh dict -- the input list itself is never mutated
+
+
+def format_report(totals: dict[str, float]) -> str:  # => PURE CORE: data -> text, still no I/O
+    lines = [f"{product}: {amount:.2f}" for product, amount in sorted(totals.items())]  # => one line per product
+    return "\n".join(lines)  # => a plain string -- the shell decides how to display it
+
+
+def run_shell(csv_text: str) -> None:  # => the IMPERATIVE SHELL -- the ONLY function that prints
+    sales = parse_sales(csv_text)  # => delegates to the pure core
+    totals = total_by_product(sales)  # => delegates to the pure core
+    report = format_report(totals)  # => delegates to the pure core
+    print(report)  # => the topic's single I/O side effect, isolated to this one line
+
+
+csv_text = "product,amount\napple,10.0\nbanana,5.0\napple,3.0\n"  # => stands in for a real file's contents
+# => this is the functional-core/imperative-shell pattern (co-28) at real-tool scale
+run_shell(csv_text)  # => Output: apple: 13.00 then banana: 5.00
+```
+
+**Output**:
+
+```text
+apple: 13.00
+banana: 5.00
+```
+
+```python
+"""Example 57: pytest verification for A CSV Analyzer Split into a Pure Core and an I/O Shell."""
+
+from example import format_report, parse_sales, total_by_product
+
+
+def test_pure_core_needs_no_file_and_no_mocking() -> None:
+    csv_text = "product,amount\nx,1.0\nx,2.0\n"
+    sales = parse_sales(csv_text)
+    totals = total_by_product(sales)
+    assert totals == {"x": 3.0}
+    assert format_report(totals) == "x: 3.00"
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: A tool built as pure functions plus one thin I/O shell is testable with plain string
+literals -- no file fixtures, no mocking, no capturing stdout.
+
+**Why it matters**: Real tools read files, hit databases, or call APIs, which is exactly what makes
+naive implementations hard to test. Isolating every side effect into one shell function while keeping
+`parse_sales`, `total_by_product`, and `format_report` pure means the bulk of the logic -- the part
+most likely to have bugs -- is tested with ordinary function calls, not integration fixtures.
+
+---
+
+### Example 58: Property-Testing Purity Without a Third-Party Library
+
+_ex-58 &middot; exercises co-01, co-03_
+
+The syllabus for this example names Hypothesis, but this repository's Python examples are stdlib-only,
+so this example builds the same idea -- checking a property across many generated inputs -- with
+`random.seed` plus a list comprehension. `normalize_score` is called twice on the same 200
+pseudo-random inputs, and the two runs must match exactly for purity to hold.
+
+```python
+"""Example 58: Property-Testing Purity Without a Third-Party Library."""
+
+import random  # => stdlib source of pseudo-random test inputs -- no third-party library needed
+
+
+def normalize_score(raw: int) -> int:  # => the function under test: clamps a raw score into 0..100
+    return max(0, min(100, raw))  # => pure: same raw always clamps to the same result
+
+
+random.seed(1234)  # => a FIXED seed makes this "random" test fully reproducible on every run
+generated_inputs = [random.randint(-500, 500) for _ in range(200)]  # => 200 pseudo-random raw scores
+
+first_pass = [normalize_score(x) for x in generated_inputs]  # => calls the function ONCE per input
+second_pass = [normalize_score(x) for x in generated_inputs]  # => calls it AGAIN, same inputs, later
+
+purity_property_holds = first_pass == second_pass  # => THE property: two independent runs agree exactly
+
+# => property-based testing checks an invariant across MANY generated inputs, not one
+print(purity_property_holds)  # => Output: True -- purity verified across all 200 generated inputs, not one
+print(len(generated_inputs))  # => Output: 200 -- a property test checks MANY cases, not a single example
+```
+
+**Output**:
+
+```text
+True
+200
+```
+
+```python
+"""Example 58: pytest verification for Property-Testing Purity Without a Third-Party Library."""
+
+import random
+
+from example import normalize_score
+
+
+def test_purity_holds_across_many_generated_inputs() -> None:
+    random.seed(99)  # => a different fixed seed than example.py, still fully reproducible
+    inputs = [random.randint(-1000, 1000) for _ in range(500)]
+    first_pass = [normalize_score(x) for x in inputs]
+    second_pass = [normalize_score(x) for x in inputs]
+    assert first_pass == second_pass
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: A property test replaces "does this one example work" with "does this invariant hold
+across hundreds of generated examples," and a fixed `random.seed` keeps that check fully reproducible
+without needing a third-party library.
+
+**Why it matters**: A single hand-picked example can pass by coincidence; testing the same invariant
+across 200-500 pseudo-random inputs makes that far less likely. Hypothesis automates input generation
+and shrinking beyond what this stdlib version offers, but the core idea -- generate many inputs, assert
+one property holds for all of them -- is available in plain Python with zero dependencies.
+
+---
+
+### Example 59: A Persistent Binary Tree With a Structural-Sharing Update
+
+_ex-59 &middot; exercises co-05_
+
+Example 30 showed O(1) structural sharing on a linked list; this example generalizes the same idea to
+a branching structure. Inserting into a binary search tree rebuilds only the nodes on the path to the
+new leaf -- every untouched sibling subtree is the exact same object as before the insert.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05
+flowchart TD
+    R1["5"]:::blue --> L1["3"]:::blue
+    R1 --> RR1["8"]:::blue
+
+    R2["5 #40;new#41;"]:::orange --> L2["3 #40;new#41;"]:::orange
+    R2 --> RR2["8 #40;SAME node#41;"]:::blue
+    L2 --> LL2["1 #40;new leaf#41;"]:::orange
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 59: A Persistent Binary Tree With a Structural-Sharing Update."""
+
+from __future__ import annotations  # => enables the quoted 'Tree | None' forward references below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds the immutable Tree node
+
+
+@dataclass(frozen=True)  # => an immutable binary search tree node
+class Tree:  # => the node type itself
+    value: int  # => this node's own value
+    left: "Tree | None"  # => the left subtree, or None
+    right: "Tree | None"  # => the right subtree, or None
+
+
+def insert(tree: "Tree | None", value: int) -> Tree:  # => builds a NEW path, reuses the rest
+    if tree is None:  # => base case: an empty spot becomes a new leaf
+        return Tree(value=value, left=None, right=None)  # => the freshly-created leaf
+    if value < tree.value:  # => goes left -- only the LEFT spine gets rebuilt
+        return Tree(value=tree.value, left=insert(tree.left, value), right=tree.right)  # => right subtree REUSED
+    if value > tree.value:  # => goes right -- only the RIGHT spine gets rebuilt
+        return Tree(value=tree.value, left=tree.left, right=insert(tree.right, value))  # => left subtree REUSED
+    return tree  # => value already present -- no change needed, return the SAME node
+
+
+def to_sorted_list(tree: "Tree | None") -> list[int]:  # => in-order walk, for verification only
+    if tree is None:  # => base case: an empty subtree contributes nothing
+        return []  # => an empty list, the recursion's base result
+    return to_sorted_list(tree.left) + [tree.value] + to_sorted_list(tree.right)  # => left, self, right
+
+
+root_a = insert(insert(insert(None, 5), 3), 8)  # => builds {5: left=3, right=8}
+root_b = insert(root_a, 1)  # => inserts 1, which goes LEFT of 3
+
+# => persistent trees generalize the persistent list's O(1)-sharing idea to branching structures
+print(to_sorted_list(root_a))  # => Output: [3, 5, 8]
+print(to_sorted_list(root_b))  # => Output: [1, 3, 5, 8]
+print(root_b.right is root_a.right)  # => Output: True -- the untouched right subtree (8) is REUSED
+```
+
+**Output**:
+
+```text
+[3, 5, 8]
+[1, 3, 5, 8]
+True
+```
+
+```python
+"""Example 59: pytest verification for A Persistent Binary Tree With a Structural-Sharing Update."""
+
+from example import insert, to_sorted_list
+
+
+def test_insert_shares_the_untouched_subtree() -> None:
+    root_a = insert(insert(None, 10), 20)
+    root_b = insert(root_a, 5)
+    assert to_sorted_list(root_a) == [10, 20]
+    assert to_sorted_list(root_b) == [5, 10, 20]
+    assert root_b.right is root_a.right  # => the untouched right subtree is reused, not rebuilt
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Insert on a persistent tree only rebuilds nodes on the path from the root to the
+change; every subtree off that path is reused by reference, not copied.
+
+**Why it matters**: A naive "immutable" tree that deep-copies the whole structure on every insert would
+be O(n) per update regardless of tree shape. Structural sharing keeps a balanced tree's insert at
+O(log n) -- the same asymptotic cost as a mutable tree -- while still giving every prior version of the
+tree a permanently valid, unaffected snapshot.
+
+---
+
+### Example 60: A Redux-Style Pure `(state, action) -> state` Reducer
+
+_ex-60 &middot; exercises co-01, co-04_
+
+This example models an entire application's state transitions as one pure function: given the current
+`CartState` and an `Action`, `reducer` returns a brand-new state, never mutating the one it was given.
+Replaying the same action list from the same starting state twice produces two states that compare
+equal, proving the reducer has no hidden dependency on anything but its own two arguments.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart LR
+    S0["CartState<br/>items=#40;#41;, total=0"]:::blue -->|AddItem apple| S1["items=#40;apple#41;<br/>total=2.0"]:::orange
+    S1 -->|AddItem bread| S2["items=#40;apple,bread#41;<br/>total=5.5"]:::orange
+    S2 -->|ClearCart| S3["items=#40;#41;<br/>total=0"]:::teal
+    S3 -->|AddItem milk| S4["items=#40;milk#41;<br/>total=4.0"]:::orange
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 60: A Redux-Style Pure (state, action) -> state Reducer."""
+
+from __future__ import annotations  # => enables the quoted forward references used below
+
+from dataclasses import dataclass, replace  # => replace builds a NEW state from an OLD one
+
+
+@dataclass(frozen=True)  # => the entire application state, immutable
+class CartState:  # => the class body begins here
+    items: tuple[str, ...]  # => an immutable tuple of item names, never mutated in place
+    total: float  # => the running total, replaced wholesale on every action
+
+
+@dataclass(frozen=True)  # => an action: describes WHAT happened, carries no behavior
+class AddItem:  # => the class body begins here
+    name: str  # => the item being added
+    price: float  # => the item's price
+
+
+@dataclass(frozen=True)  # => a second action variant, carrying no data at all
+class ClearCart:  # => the class body begins here
+    pass  # => no fields -- this action needs no data to be meaningful
+
+
+Action = AddItem | ClearCart  # => the ADT of every possible action this reducer accepts
+
+
+def reducer(state: CartState, action: Action) -> CartState:  # => PURE: (state, action) -> NEW state
+    if isinstance(action, AddItem):  # => narrows action to AddItem inside this branch
+        return replace(state, items=state.items + (action.name,), total=state.total + action.price)  # => the AddItem branch's new state
+    return replace(state, items=(), total=0.0)  # => ClearCart resets everything, still a NEW CartState
+
+
+initial_state = CartState(items=(), total=0.0)  # => the starting state before any actions
+actions: list[Action] = [  # => the sequence of actions this example replays
+    AddItem("apple", 2.0),  # => action 1: adds an item
+    AddItem("bread", 3.5),  # => action 2: adds a second item
+    ClearCart(),  # => action 3: resets the cart entirely
+    AddItem("milk", 4.0),  # => action 4: adds an item AFTER the reset
+]  # => closes the actions list literal
+
+final_state = initial_state  # => the accumulator this replay loop rebinds, never mutates
+for action in actions:  # => REPLAYS every action, one reducer call each
+    final_state = reducer(final_state, action)  # => each call returns a BRAND NEW state, never mutates
+
+replayed_state = initial_state  # => a SECOND independent replay, from the SAME starting state
+for action in actions:  # => replays the SAME action list a SECOND time
+    replayed_state = reducer(replayed_state, action)  # => identical steps, identical inputs
+
+# => this is the Redux/Elm reducer pattern: state transitions as pure function calls
+print(final_state)  # => Output: CartState(items=('milk',), total=4.0)
+print(final_state == replayed_state)  # => Output: True -- replaying identical actions reproduces the SAME state
+```
+
+**Output**:
+
+```text
+CartState(items=('milk',), total=4.0)
+True
+```
+
+```python
+"""Example 60: pytest verification for A Redux-Style Pure Reducer."""
+
+from example import Action, AddItem, CartState, reducer
+
+
+def test_replaying_actions_reproduces_the_state() -> None:
+    actions: list[Action] = [AddItem("a", 1.0), AddItem("b", 2.0)]
+    state_1 = CartState(items=(), total=0.0)
+    for action in actions:
+        state_1 = reducer(state_1, action)
+
+    state_2 = CartState(items=(), total=0.0)
+    for action in actions:
+        state_2 = reducer(state_2, action)
+
+    assert state_1 == state_2 == CartState(items=("a", "b"), total=3.0)
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: A pure `(state, action) -> state` reducer makes state transitions replayable and
+deterministic -- the same action sequence from the same starting state always reaches the same result.
+
+**Why it matters**: This is the design behind Redux and Elm's state management, and the reason it works
+is entirely this topic's core idea: purity plus immutability. Because `reducer` never mutates its
+input and depends on nothing but its two arguments, tools built on this pattern can replay action
+histories, implement undo/redo by keeping old states around, and time-travel debug by re-running a
+recorded action log against a fresh state.
+
+---
+
+### Example 61: Composing `Result`-Returning Functions (Kleisli Composition)
+
+_ex-61 &middot; exercises co-11, co-27, co-23_
+
+Example 19's `compose` chains ordinary functions; this example chains functions that each return a
+`Result`, short-circuiting the moment one of them fails. `kleisli_compose` looks like `compose` but
+checks `isinstance(first, Err)` between steps instead of calling the next function unconditionally.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Gray #808080
+flowchart LR
+    T["'1'"]:::blue --> P["parse_int"]:::blue --> R1["Ok#40;1#41;"]:::blue --> Re["reciprocal"]:::blue --> O1["Ok#40;1#41;"]:::blue
+    T2["'0'"]:::blue --> P2["parse_int"]:::blue --> R2["Ok#40;0#41;"]:::blue --> Re2["reciprocal"]:::blue --> O2["Err: zero"]:::gray
+    T3["'x'"]:::blue --> P3["parse_int"]:::blue --> R3["Err: not an int"]:::gray -.->|Re never runs| O3["Err propagates"]:::gray
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef gray fill:#808080,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 61: Composing Result-Returning Functions (Kleisli Composition)."""
+
+from __future__ import annotations  # => enables the quoted 'Result[U, str]' forward references below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds both Result variants
+from typing import Callable, Generic, TypeVar  # => Generic/TypeVar/Callable type kleisli_compose below
+
+T = TypeVar("T")  # => the type kleisli_compose's INPUT function consumes
+U = TypeVar("U")  # => the type kleisli_compose's OUTPUT function produces
+E = TypeVar("E")  # => the type of the error an Err wraps
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the success variant's body
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(Generic[E]):  # => the failure variant's body
+    error: E  # => the single field this variant carries
+
+
+Result = Ok[T] | Err[E]  # => the ADT itself: a Result is EITHER variant
+
+
+def kleisli_compose(  # => composes TWO Result-returning functions into ONE, like compose but Result-aware
+    f: Callable[[T], "Result[U, str]"], g: Callable[[U], "Result[U, str]"]  # => the two steps kleisli_compose chains
+) -> Callable[[T], "Result[U, str]"]:  # => closes the multi-line signature above
+    def composed(x: T) -> "Result[U, str]":  # => the returned, composed pipeline function
+        first = f(x)  # => runs the FIRST step
+        if isinstance(first, Err):  # => short-circuits: g never runs if f already failed
+            return first  # => propagates f's failure untouched
+        return g(first.value)  # => chains g onto f's unwrapped success value
+
+    return composed  # => kleisli_compose itself returns the composed pipeline function
+
+
+def parse_int(text: str) -> "Result[int, str]":  # => step 1: str -> Result[int, str]
+    try:  # => attempts the conversion
+        return Ok(int(text))  # => success: wraps the parsed int
+    except ValueError:  # => text was not a valid integer
+        return Err(f"'{text}' is not an integer")  # => the error travels as an ordinary VALUE
+
+
+def reciprocal(n: int) -> "Result[int, str]":  # => step 2: int -> Result[int, str]
+    if n == 0:  # => the ONLY failure condition this step checks
+        return Err("cannot take the reciprocal of zero")  # => switches to the failure track
+    return Ok(1 // n if n == 1 else 0)  # => simplified integer reciprocal, just for this example
+
+
+pipeline = kleisli_compose(parse_int, reciprocal)  # => ONE composed function: str -> Result[int, str]
+
+# => Kleisli composition is compose specialized to Result-returning functions
+print(pipeline("1"))  # => Output: Ok(value=1)
+print(pipeline("0"))  # => Output: Err(error='cannot take the reciprocal of zero')
+print(pipeline("x"))  # => Output: Err(error="'x' is not an integer")
+```
+
+**Output**:
+
+```text
+Ok(value=1)
+Err(error='cannot take the reciprocal of zero')
+Err(error="'x' is not an integer")
+```
+
+```python
+"""Example 61: pytest verification for Composing Result-Returning Functions."""
+
+from example import Err, Ok, kleisli_compose, parse_int, reciprocal
+
+
+def test_composed_pipeline_propagates_the_first_failure() -> None:
+    pipeline = kleisli_compose(parse_int, reciprocal)
+    assert pipeline("1") == Ok(1)
+    assert pipeline("bad") == Err("'bad' is not an integer")
+    assert pipeline("0") == Err("cannot take the reciprocal of zero")
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Kleisli composition chains `Result`-returning functions the same way ordinary
+`compose` chains plain functions, except each step checks for failure before calling the next one.
+
+**Why it matters**: Without Kleisli composition, chaining several fallible steps means either nested
+`if isinstance(..., Err)` checks at every call site or a bespoke pipeline function per combination of
+steps. Wrapping that check inside a reusable `kleisli_compose` keeps the call sites as simple as
+composing ordinary functions, while the failure-propagation logic lives in exactly one place.
+
+---
+
+### Example 62: A `@curry` Decorator Auto-Currying by Arity
+
+_ex-62 &middot; exercises co-09, co-18_
+
+Example 18's `partial` fixed arguments manually, one `functools.partial` call at a time; this example
+builds a decorator that inspects a function's own signature and automatically returns a new
+partially-applied function until enough arguments have accumulated. `add3(1)(2)(3)`, `add3(1, 2)(3)`,
+and `add3(1, 2, 3)` all reach the identical result.
+
+```python
+"""Example 62: A @curry Decorator Auto-Currying by Arity."""
+
+import inspect  # => inspects fn's own signature to learn how many arguments it needs
+from functools import wraps  # => preserves add3's identity through the decorator
+from typing import Any, Callable  # => Any/Callable type this deliberately dynamic decorator
+
+
+def curry(fn: Callable[..., Any]) -> Callable[..., Any]:  # => a decorator that auto-curries fn
+    arity = len(inspect.signature(fn).parameters)  # => how many arguments fn ultimately needs
+
+    @wraps(fn)  # => preserves fn's __name__/__doc__ on the curried wrapper
+    def curried(*args: Any) -> Any:  # => accumulates arguments across MULTIPLE calls
+        if len(args) >= arity:  # => enough arguments collected -- call the real function NOW
+            return fn(*args)  # => the real call, with every argument finally in hand
+
+        def more_needed(*more: Any) -> Any:  # => named + fully typed -- an untyped lambda can't carry annotations
+            return curried(*args, *more)  # => not enough yet -- keeps accumulating arguments
+
+        return more_needed  # => returns the function wanting more arguments
+
+    return curried  # => curry itself returns the auto-currying wrapper
+
+
+@curry  # => wraps add3 so it can be called one argument at a time, or all at once
+def add3(a: int, b: int, c: int) -> int:  # => an ordinary 3-argument function
+    return a + b + c  # => the actual sum
+
+
+all_at_once = add3(1, 2, 3)  # => calling with all 3 arguments works like the undecorated function
+one_at_a_time = add3(1)(2)(3)  # => calling one argument per call ALSO reaches the same result
+mixed = add3(1, 2)(3)  # => and any grouping in between works too
+
+# => auto-currying via inspect.signature makes ANY function callable one argument at a time
+print(all_at_once)  # => Output: 6
+print(one_at_a_time)  # => Output: 6
+print(mixed)  # => Output: 6
+```
+
+**Output**:
+
+```text
+6
+6
+6
+```
+
+```python
+"""Example 62: pytest verification for A @curry Decorator Auto-Currying by Arity."""
+
+from example import add3
+
+
+def test_partial_calls_accumulate_arguments_until_full_arity() -> None:
+    assert add3(1, 2, 3) == 6
+    assert add3(1)(2)(3) == 6
+    assert add3(1, 2)(3) == 6
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `@curry` reads a function's own arity via `inspect.signature` and returns partial
+applications until enough arguments have accumulated -- one decorator handles any 1-to-N-arity
+function without per-function boilerplate.
+
+**Why it matters**: Manual currying with `functools.partial` at every call site works but scatters the
+same pattern across a codebase. A generic `@curry` decorator centralizes the "call with fewer
+arguments than needed, get back a function wanting the rest" behavior once, letting call sites read
+naturally whether they supply one argument or all of them at once.
+
+---
+
+### Example 63: A Lazy Prime Sieve Over an Infinite Generator
+
+_ex-63 &middot; exercises co-15, co-16_
+
+This is the classic functional demonstration of laziness: `natural_numbers_from` never terminates, and
+`sieve` recursively wraps ever-narrower filtered views of it, yet nothing is actually computed until
+`islice` pulls a bounded number of primes out. The recursion in `sieve` only runs as deep as the
+consumer actually pulls.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart LR
+    N["count#40;2#41;<br/>2, 3, 4, 5, ..."]:::blue --> S2["sieve: first=2<br/>filter n % 2 != 0"]:::orange
+    S2 --> S3["sieve: first=3<br/>filter n % 3 != 0"]:::orange
+    S3 --> S5["sieve: first=5<br/>..."]:::teal
+    S5 -.->|islice pulls 10| Out["2, 3, 5, 7, 11, ..."]:::blue
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 63: A Lazy Prime Sieve Over an Infinite Generator."""
+
+from itertools import count, islice  # => count: infinite lazy range; islice: pulls a bounded slice
+from typing import Iterator  # => Iterator types both generators below
+
+
+def natural_numbers_from(start: int) -> Iterator[int]:  # => an INFINITE generator -- never runs out
+    yield from count(start)  # => delegates to itertools.count, lazily, forever
+
+
+def sieve(numbers: Iterator[int]) -> Iterator[int]:  # => a lazy, recursive Eratosthenes-style sieve
+    first = next(numbers)  # => the next number is prime by construction (nothing smaller divided it)
+    yield first  # => yields it immediately -- consumer can use it before the rest is computed
+    yield from sieve(n for n in numbers if n % first != 0)  # => filters multiples, sieves the REST lazily
+
+
+primes = sieve(natural_numbers_from(2))  # => an infinite lazy stream of primes -- nothing computed yet
+first_ten = list(islice(primes, 10))  # => pulls EXACTLY 10 primes, the ONLY work this line forces
+
+# => the classic functional demonstration that laziness makes infinite structures usable
+print(first_ten)  # => Output: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+```
+
+**Output**:
+
+```text
+[2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+```
+
+```python
+"""Example 63: pytest verification for A Lazy Prime Sieve Over an Infinite Generator."""
+
+from itertools import islice
+
+from example import natural_numbers_from, sieve
+
+
+def test_sieve_produces_the_correct_first_primes() -> None:
+    primes = sieve(natural_numbers_from(2))
+    assert list(islice(primes, 5)) == [2, 3, 5, 7, 11]
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: An infinite generator combined with lazy, recursive filtering lets `sieve` describe
+"the prime sieve algorithm over all natural numbers" without ever running forever -- `islice` decides
+how much of that infinite description actually gets computed.
+
+**Why it matters**: An eager implementation of the same sieve would need an upper bound chosen in
+advance, wasting work if the bound is too high or failing if it is too low. The lazy version separates
+"what is a prime sieve" from "how many primes do I need right now," letting the exact same `sieve`
+function serve a caller who wants 10 primes and one who wants 10,000.
+
+---
+
+### Example 64: A Pull Pipeline of `yield` Stages
+
+_ex-64 &middot; exercises co-15_
+
+Three generator functions -- `read_lines`, `strip_blank`, `uppercase` -- are chained so each one pulls
+from the stage before it exactly as needed. Nothing runs until `list(pipeline)` forces the final pull,
+at which point every stage runs interleaved, one line at a time, rather than one stage fully finishing
+before the next starts.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart LR
+    R["read_lines#40;text#41;"]:::blue -->|pulled one line at a time| Sb["strip_blank"]:::orange
+    Sb -->|pulled one line at a time| U["uppercase"]:::teal
+    U -->|pulled by list#40;#41;| Out["['HELLO', 'WORLD', 'FP']"]:::blue
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 64: A Pull Pipeline of yield Stages."""
+
+from typing import Iterator  # => Iterator types every stage in this pipeline
+
+
+def read_lines(text: str) -> Iterator[str]:  # => stage 1: text -> a lazy stream of lines
+    for line in text.splitlines():  # => walks the raw text one line at a time
+        yield line  # => suspends after EACH line, waiting for the next pull
+
+
+def strip_blank(lines: Iterator[str]) -> Iterator[str]:  # => stage 2: filters out blank lines, lazily
+    for line in lines:  # => pulls from stage 1 ONE line at a time
+        if line.strip():  # => only forwards lines with real content
+            yield line  # => only forwards non-blank lines downstream
+
+
+def uppercase(lines: Iterator[str]) -> Iterator[str]:  # => stage 3: transforms each surviving line
+    for line in lines:  # => pulls from stage 2 ONE line at a time
+        yield line.upper()  # => the actual transformation this stage performs
+
+
+text = "hello\n\nworld\n   \nfp"  # => a raw multi-line string, including blank/whitespace-only lines
+pipeline = uppercase(strip_blank(read_lines(text)))  # => THREE stages chained, nothing runs yet
+
+result = list(pipeline)  # => pulling into a list is what finally forces every stage to run
+
+# => each stage suspends independently -- no stage ever buffers its whole output
+print(result)  # => Output: ['HELLO', 'WORLD', 'FP']
+```
+
+**Output**:
+
+```text
+['HELLO', 'WORLD', 'FP']
+```
+
+```python
+"""Example 64: pytest verification for A Pull Pipeline of yield Stages."""
+
+from example import read_lines, strip_blank, uppercase
+
+
+def test_pipeline_streams_through_all_three_stages() -> None:
+    text = "a\n\nb"
+    pipeline = uppercase(strip_blank(read_lines(text)))
+    assert list(pipeline) == ["A", "B"]
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Chaining generator functions builds a pull-based pipeline where each stage suspends
+independently -- no stage buffers its entire output before the next stage starts consuming it.
+
+**Why it matters**: An eager pipeline (each stage returning a full list) would fully materialize the
+output of `read_lines`, then all of `strip_blank`'s output, then all of `uppercase`'s output, using
+memory proportional to the input three times over. The pull pipeline processes one line through all
+three stages before moving to the next line, which is why the same pattern scales to files far larger
+than available memory.
+
+---
+
+### Example 65: A Memoization Decorator With a Bounded `maxsize`
+
+_ex-65 &middot; exercises co-17, co-18_
+
+Example 17's memoize dictionary cached every result forever; this example bounds the cache using
+`collections.OrderedDict` as an LRU (least-recently-used) store. `bounded_memoize(maxsize=2)` evicts
+the least-recently-used entry once a third distinct key arrives, so previously cached results can
+become cache misses again.
+
+```python
+"""Example 65: A Memoization Decorator With a Bounded maxsize."""
+
+from collections import OrderedDict  # => insertion-ordered dict -- the basis of this LRU cache
+from typing import Callable  # => Callable types every layer of this decorator factory
+
+
+def bounded_memoize(maxsize: int) -> Callable[[Callable[[int], int]], Callable[[int], int]]:  # => a decorator FACTORY
+    def decorator(fn: Callable[[int], int]) -> Callable[[int], int]:  # => the actual decorator
+        cache: OrderedDict[int, int] = OrderedDict()  # => insertion order tracks recency
+
+        def wrapper(n: int) -> int:  # => the cache-checking, eviction-aware wrapper
+            if n in cache:  # => cache HIT: refresh its recency, return the stored value
+                cache.move_to_end(n)  # => marks n as the MOST recently used entry
+                return cache[n]  # => the stored value, no recomputation
+            result = fn(n)  # => cache MISS: run the real computation
+            cache[n] = result  # => stores the fresh result as the newest entry
+            if len(cache) > maxsize:  # => over budget -- evict the LEAST recently used entry
+                cache.popitem(last=False)  # => last=False pops the OLDEST inserted/touched key
+            return result  # => the freshly computed value
+
+        return wrapper  # => decorator itself returns the cache-checking wrapper
+
+    return decorator  # => bounded_memoize itself returns the decorator
+
+
+calls: list[int] = []  # => records every argument that actually triggered a real computation
+
+
+@bounded_memoize(maxsize=2)  # => keeps at most 2 cached results -- the THIRD distinct key evicts one
+def track(n: int) -> int:  # => the function being memoized
+    calls.append(n)  # => only runs on a cache MISS
+    return n * n  # => the actual (slow, pure) computation being cached
+
+
+track(1)  # => miss: cache holds {1}
+track(2)  # => miss: cache holds {1, 2}
+track(1)  # => HIT: 1 becomes the most recently used entry, no new call recorded
+track(3)  # => miss, over budget: evicts 2 (least recently used); cache holds {1, 3}
+track(2)  # => 2 was evicted -- this is a MISS again, not a hit
+track(1)  # => 1 was ALSO evicted by the previous miss -- another MISS
+
+# => bounding a cache trades perfect memoization for a fixed memory budget
+print(calls)  # => Output: [1, 2, 3, 2, 1] -- five real computations out of six calls
+```
+
+**Output**:
+
+```text
+[1, 2, 3, 2, 1]
+```
+
+```python
+"""Example 65: pytest verification for A Memoization Decorator With a Bounded maxsize."""
+
+from example import bounded_memoize
+
+
+def test_lru_eviction_forces_a_recompute_for_the_oldest_key() -> None:
+    calls: list[int] = []
+
+    @bounded_memoize(maxsize=1)
+    def track(n: int) -> int:
+        calls.append(n)
+        return n
+
+    track(1)  # => miss
+    track(2)  # => miss, evicts 1 (maxsize=1)
+    track(1)  # => 1 was evicted -- miss again
+    assert calls == [1, 2, 1]
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Bounding a memoization cache with an LRU eviction policy trades perfect memoization
+(cache everything forever) for a fixed, predictable memory budget -- at the cost of occasionally
+recomputing a result that was cached before.
+
+**Why it matters**: An unbounded memoization dictionary is fine for a small, known input space but
+becomes an unbounded memory leak for functions called with many distinct arguments over a long-running
+process's lifetime. `functools.lru_cache` provides this exact behavior in the standard library;
+building it by hand here shows what that decorator is actually doing underneath its `maxsize`
+parameter.
+
+---
+
+### Example 66: A Trampoline Simulating Tail-Call Optimization
+
+_ex-66 &middot; exercises co-14_
+
+Example 26 converted recursion into an explicit stack to survive CPython's missing tail-call
+optimization; this example uses a different technique for the same problem. `sum_to_n_trampolined`
+never actually recurses -- it returns a `Bounce` wrapping the next step, and `trampoline`'s `while`
+loop repeatedly calls that step in a single stack frame, however many "recursive" steps it represents.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05
+flowchart LR
+    T["trampoline#40;#41;<br/>ONE stack frame"]:::blue -->|calls thunk| B1["Bounce n=50000"]:::orange
+    B1 -->|result.thunk#40;#41;| B2["Bounce n=49999"]:::orange
+    B2 -.->|... 50,000 bounces ...| B3["Bounce n=1"]:::orange
+    B3 -->|returns plain int| Done["1250025000"]:::blue
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 66: A Trampoline Simulating Tail-Call Optimization."""
+
+from typing import Callable  # => Callable types the zero-arg thunk; "Bounce | int" uses PEP 604 union syntax
+
+
+class Bounce:  # => a marker: "not done yet, call this thunk next" -- NOT the final answer
+    def __init__(self, thunk: Callable[[], "Bounce | int"]) -> None:  # => wraps a zero-arg step function
+        self.thunk = thunk  # => stored for the trampoline loop to call on its NEXT iteration
+
+
+def trampoline(result: "Bounce | int") -> int:  # => drives the loop -- ONE stack frame, however deep
+    while isinstance(result, Bounce):  # => keeps bouncing as long as we get another Bounce back
+        result = result.thunk()  # => calls the next step -- reuses THIS loop's frame, not a new one
+    return result  # => once it's a plain int, the computation is actually done
+
+
+def sum_to_n_trampolined(n: int, acc: int = 0) -> "Bounce | int":  # => "recursive-looking" but returns a Bounce
+    if n == 0:  # => base case: nothing left to add
+        return acc  # => a plain int, stops the trampoline
+    return Bounce(lambda: sum_to_n_trampolined(n - 1, acc + n))  # => NOT a real recursive call -- returns immediately
+
+
+deep_n = 50_000  # => far past CPython's default recursion limit if called naively
+
+result = trampoline(sum_to_n_trampolined(deep_n))  # => the WHILE LOOP does the "recursion," not the call stack
+
+# => the trampoline pattern is Python's manual workaround for missing tail-call optimization
+print(result)  # => Output: 1250025000
+print(result == deep_n * (deep_n + 1) // 2)  # => Output: True -- correct despite the extreme depth
+```
+
+**Output**:
+
+```text
+1250025000
+True
+```
+
+```python
+"""Example 66: pytest verification for A Trampoline Simulating Tail-Call Optimization."""
+
+from example import sum_to_n_trampolined, trampoline
+
+
+def test_trampoline_handles_depth_that_would_break_plain_recursion() -> None:
+    deep_n = 50_000
+    result = trampoline(sum_to_n_trampolined(deep_n))
+    assert result == deep_n * (deep_n + 1) // 2
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: A trampoline replaces genuine recursive calls with a loop that repeatedly invokes
+zero-argument "next step" thunks, so a computation that looks recursive can run to depths that would
+otherwise raise `RecursionError`, all in one stack frame.
+
+**Why it matters**: Languages with tail-call optimization turn a tail-recursive function into a loop
+automatically; CPython never does this, capping recursion depth by default. The trampoline pattern
+gives Python code the same practical outcome by hand -- useful for interpreters, deep tree walks, or
+any naturally recursive algorithm whose input size cannot be bounded in advance.
+
+---
+
+### Example 67: An Expression AST as an ADT With a `match` Evaluator
+
+_ex-67 &middot; exercises co-20, co-21_
+
+Example 24's `Shape` ADT modeled data; this example models a small language. `Num`, `Add`, and `Mul`
+form the ADT for an arithmetic expression tree, and `evaluate` walks it recursively with a `match`
+statement, one `case` per node type -- the canonical shape of a tree-walking interpreter.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart TD
+    Add1["Add"]:::blue --> Num1["Num#40;2#41;"]:::orange
+    Add1 --> Mul1["Mul"]:::teal
+    Mul1 --> Num2["Num#40;3#41;"]:::orange
+    Mul1 --> Num3["Num#40;4#41;"]:::orange
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 67: An Expression AST as an ADT With a match Evaluator."""
+
+from __future__ import annotations  # => enables the quoted 'Expr' forward references below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds each AST node variant
+
+
+@dataclass(frozen=True)  # => a leaf node: a literal number
+class Num:  # => the class body begins here
+    value: float  # => the literal's own value
+
+
+@dataclass(frozen=True)  # => a branch node: left + right
+class Add:  # => the class body begins here
+    left: "Expr"  # => the left operand, itself an Expr
+    right: "Expr"  # => the right operand, itself an Expr
+
+
+@dataclass(frozen=True)  # => a branch node: left * right
+class Mul:  # => the class body begins here
+    left: "Expr"  # => the left operand, itself an Expr
+    right: "Expr"  # => the right operand, itself an Expr
+
+
+Expr = Num | Add | Mul  # => the ADT: any expression is EXACTLY one of these three shapes
+
+
+def evaluate(expr: Expr) -> float:  # => match/case walks the AST, one branch per variant
+    match expr:  # => opens the match/case block over expr
+        case Num(value=v):  # => a leaf -- just return its value
+            return v  # => the leaf's own value
+        case Add(left=l, right=r):  # => recurse into both children, then add
+            return evaluate(l) + evaluate(r)  # => the actual addition Add represents
+        case Mul(left=l, right=r):  # => recurse into both children, then multiply
+            return evaluate(l) * evaluate(r)  # => the actual multiplication Mul represents
+
+
+expression = Add(Num(2.0), Mul(Num(3.0), Num(4.0)))  # => represents "2.0 + (3.0 * 4.0)"
+
+# => an interpreter is the canonical use case for ADTs plus match/case together
+print(evaluate(expression))  # => Output: 14.0
+```
+
+**Output**:
+
+```text
+14.0
+```
+
+```python
+"""Example 67: pytest verification for An Expression AST as an ADT With a match Evaluator."""
+
+from example import Add, Mul, Num, evaluate
+
+
+def test_evaluator_respects_precedence_baked_into_the_tree_shape() -> None:
+    expr = Add(Num(2), Mul(Num(3), Num(4)))
+    assert evaluate(expr) == 14.0
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: An ADT of expression node types plus a `match`-based `evaluate` function is a
+complete, minimal tree-walking interpreter -- precedence lives entirely in how the tree is shaped, not
+in any parsing logic evaluate itself has to reason about.
+
+**Why it matters**: This same shape -- an ADT for the AST, `match`/`case` for the evaluator -- scales
+from a four-node arithmetic example to real interpreters, compilers, and query planners. Because the
+ADT is a closed set of variants, `match` can (with the right static checker) verify every case is
+handled, catching a missing node type at review time instead of as a runtime crash on unusual input.
+
+---
+
+### Example 68: Sequencing `Option` Computations, Do-Style
+
+_ex-68 &middot; exercises co-22, co-27_
+
+Example 25 introduced `Option`; this example chains three `Option`-returning steps with `and_then` so
+the pipeline reads top-to-bottom like a sequence of statements rather than as nested callbacks.
+`compute` short-circuits to `Nothing` the instant any step fails, and every later step is simply never
+called.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Gray #808080
+flowchart LR
+    A["safe_div#40;100, 4#41;"]:::blue -->|Some 25.0| B["safe_sqrt"]:::blue -->|Some 5.0| C["x100"]:::blue -->|Some 500.0| Ok["Some#40;500.0#41;"]:::blue
+    A2["safe_div#40;100, 0#41;"]:::blue -->|Nothing| Skip1["and_then skipped"]:::gray
+    A3["safe_div#40;-100, 4#41;"]:::blue -->|Some -25.0| B3["safe_sqrt"]:::blue -->|Nothing: negative| Skip2["and_then skipped"]:::gray
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef gray fill:#808080,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 68: Sequencing Option Computations, Do-Style."""
+
+from __future__ import annotations  # => enables the quoted 'Option[U]' forward reference below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds both Option variants
+from typing import Callable, Generic, TypeVar  # => Generic/TypeVar/Callable type and_then below
+
+T = TypeVar("T")  # => the type of the value a Some wraps
+U = TypeVar("U")  # => the type and_then's step function returns
+
+
+@dataclass(frozen=True)  # => marks Some immutable, matching the FP style
+class Some(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this variant carries
+
+    def and_then(self, fn: Callable[[T], "Option[U]"]) -> "Option[U]":  # => the sequencing operation
+        return fn(self.value)  # => runs fn on the unwrapped value; fn itself returns an Option
+
+
+@dataclass(frozen=True)  # => marks Nothing immutable too
+class Nothing:  # => the class body begins here
+    def and_then(self, fn: Callable[[T], U]) -> "Nothing":  # => short-circuits, generic so union calls stay typed
+        return self  # => Nothing stays Nothing, regardless of fn
+
+
+Option = Some[T] | Nothing  # => the ADT itself: an Option is EITHER variant
+
+
+def safe_div(a: float, b: float) -> "Option[float]":  # => a step that may be absent (division by zero)
+    return Nothing() if b == 0 else Some(a / b)  # => success wraps, failure returns Nothing
+
+
+def safe_sqrt(x: float) -> "Option[float]":  # => a step that may be absent (negative input)
+    return Nothing() if x < 0 else Some(x**0.5)  # => success wraps, failure returns Nothing
+
+
+def sqrt_step(ratio: float) -> "Option[float]":  # => named + typed and_then step -- a bare lambda can't carry annotations
+    return safe_sqrt(ratio)  # => same behavior as the inline version, now with a concrete float param
+
+
+def scale_step(root: float) -> "Option[float]":  # => named + typed and_then step, same reasoning
+    return Some(root * 100)  # => wraps the scaled result back into Some
+
+
+def compute(a: float, b: float) -> "Option[float]":  # => "do-style": each step reads like a statement
+    return (  # => opens the do-style chain of and_then calls
+        safe_div(a, b)  # => step 1
+        .and_then(sqrt_step)  # => step 2, only runs if step 1 succeeded
+        .and_then(scale_step)  # => step 3, only runs if step 2 succeeded
+    )  # => closes the do-style chain of and_then calls
+
+
+# => chained and_then calls read like a sequence of statements, not nested callbacks
+print(compute(100, 4))  # => Output: Some(value=500.0)
+print(compute(100, 0))  # => Output: Nothing() -- short-circuits at the FIRST step
+print(compute(-100, 4))  # => Output: Nothing() -- short-circuits at the SECOND step
+```
+
+**Output**:
+
+```text
+Some(value=500.0)
+Nothing()
+Nothing()
+```
+
+```python
+"""Example 68: pytest verification for Sequencing Option Computations, Do-Style."""
+
+from example import Nothing, Some, compute
+
+
+def test_do_style_chain_short_circuits_on_absence() -> None:
+    assert compute(100, 4) == Some(500.0)
+    assert compute(100, 0) == Nothing()
+    assert compute(-100, 4) == Nothing()
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Chaining `and_then` calls turns a sequence of fallible steps into code that reads
+top-to-bottom, one step per line, without the pyramid of nested `if`/`else` checks a manual
+implementation of the same short-circuiting would require.
+
+**Why it matters**: "Do notation" in languages with built-in monad support compiles to exactly this
+`and_then` chaining. Writing it out explicitly in Python shows what that sugar actually does: each
+step commits to running only if every step before it succeeded, and the chain's final shape (`Some` or
+`Nothing`) tells the caller everything it needs to know without inspecting any step in between.
+
+---
+
+### Example 69: Validating a Form, Short-Circuiting on the First Failing Rule
+
+_ex-69 &middot; exercises co-24, co-23_
+
+Example 26's error-track pipeline used two rules; this example scales the same railway-oriented
+pattern to three independent checks -- username length, password length, and a minimum age.
+`validate_signup` returns the first `Err` it encounters and never runs the checks after it, so the
+caller always learns about exactly one problem at a time.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Gray #808080
+flowchart LR
+    U["check_username"]:::blue -->|Ok| P["check_password"]:::blue -->|Ok| A["check_age"]:::blue -->|Ok| W["welcome message"]:::blue
+    U -.->|Err| Stop1["STOP: rules 2,3 skipped"]:::gray
+    P -.->|Err| Stop2["STOP: rule 3 skipped"]:::gray
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef gray fill:#808080,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 69: Validating a Form, Short-Circuiting on the First Failing Rule."""
+
+from __future__ import annotations  # => enables the quoted 'Result[str, str]' forward references below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds both Result variants
+from typing import Generic, TypeVar  # => Generic/TypeVar make Ok[T] and Err[E] proper generic containers
+
+T = TypeVar("T")  # => the type of the value an Ok wraps
+E = TypeVar("E")  # => the type of the error an Err wraps
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(Generic[E]):  # => the class body begins here
+    error: E  # => the single field this variant carries
+
+
+Result = Ok[T] | Err[E]  # => the ADT itself: a Result is EITHER variant
+
+
+def check_username(username: str) -> "Result[str, str]":  # => rule 1
+    return Ok(username) if len(username) >= 3 else Err("username too short")  # => the ONLY check this rule makes
+
+
+def check_password(password: str) -> "Result[str, str]":  # => rule 2
+    return Ok(password) if len(password) >= 8 else Err("password too short")  # => the ONLY check this rule makes
+
+
+def check_age(age: int) -> "Result[int, str]":  # => rule 3
+    return Ok(age) if age >= 13 else Err("must be at least 13")  # => the ONLY check this rule makes
+
+
+def validate_signup(username: str, password: str, age: int) -> "Result[str, str]":  # => threads all 3 rules
+    username_result = check_username(username)  # => rule 1's switch point
+    if isinstance(username_result, Err):  # => STOP: rules 2 and 3 never run
+        return username_result  # => reports THIS rule as the failing one
+    password_result = check_password(password)  # => rule 2's switch point
+    if isinstance(password_result, Err):  # => STOP: rule 3 never runs
+        return password_result  # => reports THIS rule as the failing one
+    age_result = check_age(age)  # => rule 3's switch point
+    if isinstance(age_result, Err):  # => the last possible failure point
+        return age_result  # => reports THIS rule as the failing one
+    return Ok(f"welcome, {username_result.value}")  # => all three rules passed
+
+
+# => real forms usually have more than two fields -- this scales the railway pattern to three
+print(validate_signup("ana", "longenough", 20))  # => Output: Ok(value='welcome, ana')
+print(validate_signup("an", "longenough", 20))  # => Output: Err(error='username too short')
+print(validate_signup("ana", "short", 20))  # => Output: Err(error='password too short')
+print(validate_signup("ana", "longenough", 10))  # => Output: Err(error='must be at least 13')
+```
+
+**Output**:
+
+```text
+Ok(value='welcome, ana')
+Err(error='username too short')
+Err(error='password too short')
+Err(error='must be at least 13')
+```
+
+```python
+"""Example 69: pytest verification for Validating a Form, Short-Circuiting on the First Failing Rule."""
+
+from example import Err, Ok, validate_signup
+
+
+def test_the_failing_rule_is_the_one_reported() -> None:
+    assert validate_signup("ana", "longenough", 20) == Ok("welcome, ana")
+    assert validate_signup("an", "longenough", 20) == Err("username too short")
+    assert validate_signup("ana", "short", 20) == Err("password too short")
+    assert validate_signup("ana", "longenough", 10) == Err("must be at least 13")
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Railway-oriented validation with three chained rules still reports exactly one
+failure at a time -- the first one encountered -- which is simple to reason about but tells the caller
+nothing about the other two rules until the first one is fixed.
+
+**Why it matters**: Short-circuiting validation is the right choice when a later check genuinely
+depends on an earlier one succeeding, or when showing one error at a time keeps a form simpler. Example
+71 shows the opposite choice -- collecting every error at once -- and the two examples together make
+the trade-off between them concrete rather than abstract.
+
+---
+
+### Example 70: Property-Checking the Functor Identity and Composition Laws
+
+_ex-70 &middot; exercises co-25_
+
+Example 25's functor identity law was checked once, by hand, on one `Some` value; this example checks
+both the identity law and the composition law across 300 pseudo-random `Box` values using the same
+stdlib `random`-based technique as Example 58. A functor implementation that violates either law will
+show up here as `False` for at least one of the 300 checks.
+
+```python
+"""Example 70: Property-Checking the Functor Identity and Composition Laws."""
+
+import random  # => stdlib source of pseudo-random Box values -- no third-party library needed
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds the immutable Box
+from typing import Callable, Generic, TypeVar  # => Generic/TypeVar/Callable type the functor below
+
+T = TypeVar("T")  # => the type of the value a Box wraps
+U = TypeVar("U")  # => the type map's function returns
+
+
+@dataclass(frozen=True)  # => the functor under test
+class Box(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this container carries
+
+    def map(self, fn: Callable[[T], U]) -> "Box[U]":  # => applies fn inside, stays wrapped
+        return Box(fn(self.value))  # => applies fn inside, re-wraps as Box
+
+
+def identity(x: int) -> int:  # => the identity function, used by the identity law
+    return x  # => returns its argument unchanged
+
+
+def add_one(x: int) -> int:  # => one of the two functions used by the composition law
+    return x + 1  # => the actual +1
+
+
+def double(x: int) -> int:  # => the second function used by the composition law
+    return x * 2  # => the actual *2
+
+
+def check_identity_law(box: "Box[int]") -> bool:  # => box.map(identity) == box
+    return box.map(identity) == box  # => the identity law's own definition
+
+
+def check_composition_law(box: "Box[int]") -> bool:  # => box.map(f).map(g) == box.map(compose(g, f))
+    mapped_twice = box.map(add_one).map(double)  # => two SEPARATE map calls, one after another
+    mapped_once = box.map(lambda x: double(add_one(x)))  # => ONE map call with the composed function
+    return mapped_twice == mapped_once  # => the composition law's own definition
+
+
+random.seed(42)  # => fixed seed -- this property check is fully reproducible
+generated_boxes = [Box(random.randint(-1000, 1000)) for _ in range(300)]  # => 300 random Box values
+
+identity_law_holds = all(check_identity_law(b) for b in generated_boxes)  # => checks ALL 300, not one
+composition_law_holds = all(check_composition_law(b) for b in generated_boxes)  # => checks ALL 300, not one
+
+# => checking BOTH functor laws together is what makes a map implementation trustworthy
+print(identity_law_holds)  # => Output: True
+print(composition_law_holds)  # => Output: True
+```
+
+**Output**:
+
+```text
+True
+True
+```
+
+```python
+"""Example 70: pytest verification for Property-Checking the Functor Identity and Composition Laws."""
+
+import random
+
+from example import Box, check_composition_law, check_identity_law
+
+
+def test_both_functor_laws_hold_across_many_generated_boxes() -> None:
+    random.seed(7)
+    boxes = [Box(random.randint(-500, 500)) for _ in range(100)]
+    assert all(check_identity_law(b) for b in boxes)
+    assert all(check_composition_law(b) for b in boxes)
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Checking the functor identity and composition laws across 300 generated values,
+rather than one hand-picked value, is what makes "this `map` implementation is a lawful functor" a
+statement backed by evidence rather than a single example.
+
+**Why it matters**: A `map` implementation that happens to satisfy the laws for one convenient test
+value can still violate them for others -- a bug that a single-example test would never catch.
+Property-checking both laws together across many generated boxes is exactly the confidence a
+third-party library like Hypothesis would provide automatically; here it costs nothing but a
+`random.seed` and a list comprehension.
+
+---
+
+### Example 71: An Applicative Validation That Accumulates All Errors
+
+_ex-71 &middot; exercises co-26, co-24_
+
+Example 69 short-circuits on the first failing rule; this example deliberately does the opposite.
+`combine3` runs `validate_username`, `validate_password`, and `validate_age` unconditionally, then
+merges every `Invalid`'s errors into one combined `Invalid` -- the caller sees all three problems at
+once instead of fixing them one at a time.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart TD
+    U["validate_username#40;'an'#41;<br/>Invalid"]:::orange --> C["combine3"]:::blue
+    P["validate_password#40;'short'#41;<br/>Invalid"]:::orange --> C
+    A["validate_age#40;10#41;<br/>Invalid"]:::orange --> C
+    C --> R["Invalid: ALL 3 errors merged"]:::teal
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 71: An Applicative Validation That Accumulates All Errors."""
+
+from __future__ import annotations  # => enables the quoted 'Validated[T]' forward references below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds both Validated variants
+from typing import Generic, TypeVar  # => Generic/TypeVar make Valid[T] a proper generic container
+
+T = TypeVar("T")  # => the type of the value a Valid wraps
+
+
+@dataclass(frozen=True)  # => success, carrying the validated value
+class Valid(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => failure, carrying EVERY error found, not just the first
+class Invalid:  # => the class body begins here
+    errors: tuple[str, ...]  # => one entry per failing rule, accumulated across all checks
+
+
+Validated = Valid[T] | Invalid  # => this topic's SECOND Result-shaped type -- accumulates instead of short-circuits
+
+
+def validate_username(username: str) -> "Validated[str]":  # => rule 1, independent of the others
+    return Valid(username) if len(username) >= 3 else Invalid(("username too short",))  # => the ONLY check this rule makes
+
+
+def validate_password(password: str) -> "Validated[str]":  # => rule 2, independent of the others
+    return Valid(password) if len(password) >= 8 else Invalid(("password too short",))  # => the ONLY check this rule makes
+
+
+def validate_age(age: int) -> "Validated[int]":  # => rule 3, independent of the others
+    return Valid(age) if age >= 13 else Invalid(("must be at least 13",))  # => the ONLY check this rule makes
+
+
+def combine3(  # => the applicative combinator: runs ALL THREE checks, merges ALL failures
+    a: "Validated[str]", b: "Validated[str]", c: "Validated[int]"  # => the three independent checks to combine
+) -> "Validated[str]":  # => closes the multi-line signature above
+    errors: list[str] = []  # => collects failures from EVERY input, not just the first
+    for result in (a, b, c):  # => visits all three, regardless of whether earlier ones already failed
+        if isinstance(result, Invalid):  # => this particular check failed
+            errors.extend(result.errors)  # => appends THIS check's errors onto the running list
+    if errors:  # => at least one check failed
+        return Invalid(tuple(errors))  # => reports EVERY failing rule, not just the first
+    return Valid(f"welcome, {a.value}")  # type: ignore[union-attr]  # => all three checks passed
+
+
+all_valid = combine3(validate_username("ana"), validate_password("longenough"), validate_age(20))  # => every check passes
+all_invalid = combine3(validate_username("an"), validate_password("short"), validate_age(10))  # => every check fails
+
+# => this is railway-oriented programming's opposite: gather everything, stop for nothing
+print(all_valid)  # => Output: Valid(value='welcome, ana')
+print(all_invalid)  # => Output: Invalid(errors=('username too short', 'password too short', 'must be at least 13'))
+```
+
+**Output**:
+
+```text
+Valid(value='welcome, ana')
+Invalid(errors=('username too short', 'password too short', 'must be at least 13'))
+```
+
+```python
+"""Example 71: pytest verification for An Applicative Validation That Accumulates All Errors."""
+
+from example import Invalid, combine3, validate_age, validate_password, validate_username
+
+
+def test_every_failing_rule_is_collected_not_just_the_first() -> None:
+    result = combine3(validate_username("a"), validate_password("x"), validate_age(5))
+    assert result == Invalid(("username too short", "password too short", "must be at least 13"))
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: An applicative combinator runs every independent check regardless of earlier
+failures and merges all their errors into one result, which is the opposite trade-off from monadic
+short-circuiting.
+
+**Why it matters**: A monadic `bind` chain (Example 61, Example 69) cannot accumulate errors across
+independent checks because each step depends on the previous one succeeding -- that dependency is
+exactly what short-circuits it. Applicatives sidestep that by treating the checks as independent from
+the start, which is why real-world form validation libraries are typically built on an applicative
+structure rather than a monadic one.
+
+---
+
+### Example 72: Left-Identity, Right-Identity, and Associativity for `Result`
+
+_ex-72 &middot; exercises co-27_
+
+This example makes concrete why "monad" is a precise term rather than a vague design pattern: `Result`
+qualifies specifically because its `bind` satisfies three laws. `unit(8).bind(half) == half(8)` is
+left identity, `Ok(8).bind(unit) == Ok(8)` is right identity, and the two ways of grouping a
+three-step `bind` chain agree, which is associativity.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart TD
+    L["Left identity<br/>unit#40;x#41;.bind#40;f#41; == f#40;x#41;"]:::blue
+    R["Right identity<br/>m.bind#40;unit#41; == m"]:::orange
+    A["Associativity<br/>#40;m.bind#40;f#41;#41;.bind#40;g#41; == m.bind#40;x -> f#40;x#41;.bind#40;g#41;#41;"]:::teal
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 72: Left-Identity, Right-Identity, and Associativity for Result."""
+
+from __future__ import annotations  # => enables the quoted 'Result[U, object]' forward references below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds both Result variants
+from typing import Callable, Generic, TypeVar  # => Generic/TypeVar/Callable type bind and unit below
+
+T = TypeVar("T")  # => the type of the value an Ok wraps
+U = TypeVar("U")  # => the type bind's step function returns
+E = TypeVar("E")  # => the type of the error an Err wraps
+F = TypeVar("F")  # => the error type threaded through bind's step function, not hardcoded to object
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this variant carries
+
+    def bind(self, fn: Callable[[T], "Result[U, F]"]) -> "Result[U, F]":  # => F comes from fn's OWN error type
+        return fn(self.value)  # => unwraps, runs fn (which itself returns a Result), no double-wrap
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(Generic[E]):  # => the class body begins here
+    error: E  # => the single field this variant carries
+
+    def bind(self, fn: Callable[[T], U]) -> "Err[E]":  # => NO-OP, generic so a typed fn still passes the check
+        return self  # => fn never runs once the chain has already failed
+
+
+Result = Ok[T] | Err[E]  # => the ADT itself: a Result is EITHER variant
+
+
+def unit(x: T) -> "Result[T, object]":  # => the monad's "wrap a plain value" operation, a.k.a. return/pure
+    return Ok(x)  # => the simplest possible success
+
+
+def half(n: int) -> "Result[float, str]":  # => an arbitrary bind step, reused by all three law checks
+    return Ok(n / 2) if n % 2 == 0 else Err(f"{n} is odd")  # => succeeds on even n, fails on odd n
+
+
+def add_ten(x: float) -> "Result[float, str]":  # => a SECOND arbitrary bind step, for associativity
+    return Ok(x + 10)  # => always succeeds
+
+
+left_identity_holds = unit(8).bind(half) == half(8)  # => unit(x).bind(f) == f(x)
+right_identity_holds = Ok(8).bind(unit) == Ok(8)  # => m.bind(unit) == m
+associativity_holds = Ok(8).bind(half).bind(add_ten) == Ok(8).bind(  # => m.bind(f).bind(g)
+    lambda x: half(x).bind(add_ten)  # => == m.bind(lambda x: f(x).bind(g))
+)  # => closes the associativity check's multi-line expression
+
+# => these three laws are what makes 'monad' a precise term, not just a vague design pattern
+print(left_identity_holds)  # => Output: True
+print(right_identity_holds)  # => Output: True
+print(associativity_holds)  # => Output: True
+```
+
+**Output**:
+
+```text
+True
+True
+True
+```
+
+```python
+"""Example 72: pytest verification for the three monad laws on Result."""
+
+from example import Ok, add_ten, half, unit
+
+
+def test_all_three_monad_laws_hold() -> None:
+    assert unit(8).bind(half) == half(8)  # => left identity
+    assert Ok(8).bind(unit) == Ok(8)  # => right identity
+    assert Ok(8).bind(half).bind(add_ten) == Ok(8).bind(lambda x: half(x).bind(add_ten))  # => associativity
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `Result`'s `bind` satisfies left identity, right identity, and associativity
+simultaneously, which is the actual mathematical definition of a monad -- not just "a container with a
+`bind` method."
+
+**Why it matters**: These three laws guarantee that `bind` chains can be refactored, split, or combined
+without changing behavior -- exactly the kind of reasoning this topic has relied on informally across
+Examples 61, 68, and 69. Verifying the laws hold for this hand-rolled `Result` confirms those earlier
+examples were not just convenient special cases but instances of a structure with real, checkable
+guarantees.
+
+---
+
+### Example 73: A Small Point-Free Combinator Library
+
+_ex-73 &middot; exercises co-19, co-12_
+
+Example 22 wrote one point-free `compose(triple, add_one)` by hand; this example builds three reusable
+combinators -- `pipe`, `const`, and `flip` -- that generalize the technique. `transform = pipe(add_one,
+double, str)` builds a pipeline entirely from function values, without ever naming the value flowing
+between them.
+
+```python
+"""Example 73: A Small Point-Free Combinator Library."""
+
+from functools import reduce  # => reduce powers pipe's left-to-right fold
+from typing import Any, Callable, TypeVar  # => Callable/TypeVar type this small combinator library; Any types pipe's dynamic arity
+
+A = TypeVar("A")  # => a generic type parameter shared by const
+B = TypeVar("B")  # => a second generic type parameter shared by flip
+
+
+def pipe(*fns: Callable[..., Any]) -> Callable[..., Any]:  # => LEFT-to-right composition -- the first fn runs FIRST
+    def apply_step(acc: Any, fn: Callable[..., Any]) -> Any:  # => named + typed -- one fold step, calls fn on acc
+        return fn(acc)  # => applies ONE fn to the running accumulator, returns the next accumulator
+
+    def piped(x: Any) -> Any:  # => named + typed -- an untyped lambda can't carry these annotations
+        return reduce(apply_step, fns, x)  # => folds fns in ORDER, unlike compose
+
+    return piped  # => pipe itself returns the composed pipeline function
+
+
+def const(value: A) -> Callable[..., A]:  # => a combinator: ignores its argument(s), always returns value
+    return lambda *_ignored: value  # => the returned function discards WHATEVER it's called with
+
+
+def flip(fn: Callable[[A, B], A]) -> Callable[[B, A], A]:  # => a combinator: swaps a 2-arg function's order
+    return lambda b, a: fn(a, b)  # => calls fn with its two arguments REVERSED
+
+
+def subtract(a: int, b: int) -> int:  # => an ordinary 2-argument function, order matters
+    return a - b  # => the actual subtraction
+
+
+always_zero = const(0)  # => a function of ANY arguments that always returns 0
+flipped_subtract = flip(subtract)  # => subtract with its arguments swapped
+
+def add_one(x: int) -> int:  # => named + typed -- pipe's Callable[..., Any] gives lambdas no param context
+    return x + 1  # => adds 1 to x -- one plain step for pipe/flip to compose over
+
+
+def double(x: int) -> int:  # => named + typed, same reasoning
+    return x * 2  # => doubles x -- the second plain step in the transform pipeline
+
+
+transform = pipe(add_one, double, str)  # => a combined "add 1, double, stringify" pipeline
+
+# => a tiny combinator library is how point-free style scales beyond one-off rewrites
+print(transform(3))  # => Output: 8  (str of (3+1)*2)
+print(always_zero(1, 2, 3))  # => Output: 0 -- ignores every argument it was given
+print(subtract(10, 3))  # => Output: 7
+print(flipped_subtract(10, 3))  # => Output: -7 -- same two arguments, swapped order changes the answer
+```
+
+**Output**:
+
+```text
+8
+0
+7
+-7
+```
+
+```python
+"""Example 73: pytest verification for A Small Point-Free Combinator Library."""
+
+from example import const, flip, pipe, subtract
+
+
+def _add_one(x: int) -> int:
+    return x + 1
+
+
+def _double(x: int) -> int:
+    return x * 2
+
+
+def test_pipe_const_and_flip_compose_correctly() -> None:
+    transform = pipe(_add_one, _double)
+    assert transform(3) == 8
+
+    always_five = const(5)
+    assert always_five(1, 2, 3) == 5
+
+    flipped_subtract = flip(subtract)
+    assert flipped_subtract(10, 3) == -7
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: A handful of small, generic combinators -- `pipe`, `const`, `flip` -- cover most of
+what point-free rewrites need, without hand-writing a fresh composition for each new pipeline.
+
+**Why it matters**: One-off point-free rewrites (Example 22) show the technique works, but real code
+needs it repeatedly across many pipelines with different shapes. A tiny reusable combinator library is
+the difference between "point-free style as a curiosity" and "point-free style as a practical everyday
+tool" -- the same handful of combinators cover most pipeline-building needs a codebase runs into.
+
+---
+
+### Example 74: A Deep `pipe` vs. Nested Calls on Real Data
+
+_ex-74 &middot; exercises co-12, co-11_
+
+This example runs the identical four-step computation -- strip, lowercase, split, count -- two ways on
+the same messy input string, and prints proof the two versions agree. The comparison argues for `pipe`
+purely on readability grounds: `nested_result` must be read from the innermost call outward, while
+`piped_result` reads top-to-bottom in the order the steps actually run.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05
+flowchart TD
+    subgraph Nested["Nested calls -- read INSIDE-OUT"]
+        N4["count_words#40;<br/>split_words#40;<br/>to_lowercase#40;<br/>strip_whitespace#40;raw#41;#41;#41;#41;"]:::orange
+    end
+    subgraph Piped["pipe -- read TOP-TO-BOTTOM"]
+        P1["strip_whitespace"]:::blue --> P2["to_lowercase"]:::blue --> P3["split_words"]:::blue --> P4["count_words"]:::blue
+    end
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 74: A Deep pipe vs. Nested Calls on Real Data."""
+
+from functools import reduce  # => reduce powers pipe's left-to-right fold
+from typing import Any, Callable  # => Callable types the pipe helper below; Any types its dynamic arity
+
+
+def pipe(*fns: Callable[..., Any]) -> Callable[..., Any]:  # => reads TOP-TO-BOTTOM / LEFT-TO-RIGHT: first fn runs first
+    def apply_step(acc: Any, fn: Callable[..., Any]) -> Any:  # => named + typed -- one fold step, calls fn on acc
+        return fn(acc)
+
+    def piped(x: Any) -> Any:  # => named + typed -- an untyped lambda can't carry these annotations
+        return reduce(apply_step, fns, x)  # => folds fns in ORDER, not reversed
+
+    return piped  # => pipe itself returns the composed pipeline function
+
+
+def strip_whitespace(text: str) -> str:  # => step 1
+    return text.strip()  # => removes leading/trailing whitespace
+
+
+def to_lowercase(text: str) -> str:  # => step 2
+    return text.lower()  # => normalizes case
+
+
+def split_words(text: str) -> list[str]:  # => step 3
+    return text.split()  # => splits on any run of whitespace
+
+
+def count_words(words: list[str]) -> int:  # => step 4
+    return len(words)  # => the final count
+
+
+raw = "  Hello  World  from   FUNCTIONAL Python  "  # => messy real-world input
+
+nested_result = count_words(split_words(to_lowercase(strip_whitespace(raw))))  # => reads INSIDE-OUT
+piped_result = pipe(strip_whitespace, to_lowercase, split_words, count_words)(raw)  # => reads TOP-TO-BOTTOM
+
+# => the exact same computation, argued for on READABILITY grounds alone
+print(nested_result)  # => Output: 5
+print(piped_result)  # => Output: 5
+print(nested_result == piped_result)  # => Output: True -- IDENTICAL computation, two different reading orders
+```
+
+**Output**:
+
+```text
+5
+5
+True
+```
+
+```python
+"""Example 74: pytest verification for A Deep pipe vs. Nested Calls on Real Data."""
+
+from example import count_words, pipe, split_words, strip_whitespace, to_lowercase
+
+
+def test_pipe_and_nested_calls_compute_the_identical_answer() -> None:
+    raw = "  A  B  C  "
+    nested = count_words(split_words(to_lowercase(strip_whitespace(raw))))
+    piped = pipe(strip_whitespace, to_lowercase, split_words, count_words)(raw)
+    assert nested == piped == 3
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `pipe` and deeply nested calls compute the exact same result -- the only difference
+is which order a reader has to scan the code to understand what runs first.
+
+**Why it matters**: A four-step nested call is still readable; a ten-step one is not, because a reader
+has to mentally invert the entire expression to find the innermost, first-running call. `pipe` keeps
+the reading order and the execution order identical regardless of how many steps a pipeline grows to,
+which is why deep transformation chains in real codebases favor it over nesting.
+
+---
+
+### Example 75: Measuring Persistent-Update Cost vs. In-Place Mutation
+
+_ex-75 &middot; exercises co-04, co-05_
+
+Every earlier example in this topic showed immutability's benefits; this one measures its honest cost.
+`bump_immutable` allocates a brand-new `ImmutablePoint` on every one of 200,000 updates via
+`dataclasses.replace`, while `bump_mutable` writes into the same object's attribute in place -- both
+reach the identical final value, but only one of them allocates.
+
+```python
+"""Example 75: Measuring Persistent-Update Cost vs. In-Place Mutation."""
+
+import time  # => times both code paths for a rough, qualitative comparison
+from dataclasses import dataclass, replace  # => replace builds a NEW ImmutablePoint from an OLD one
+
+
+@dataclass(frozen=True)  # => the IMMUTABLE version: every "update" allocates a new object
+class ImmutablePoint:  # => the class body begins here
+    x: int  # => the coordinate this example bumps repeatedly
+    y: int  # => unused by this example, kept for a realistic shape
+
+
+class MutablePoint:  # => the MUTABLE version: "update" writes in place, no allocation
+    def __init__(self, x: int, y: int) -> None:  # => an ordinary, non-frozen class
+        self.x = x  # => a plain, mutable attribute
+        self.y = y  # => a plain, mutable attribute
+
+
+def bump_immutable(p: ImmutablePoint, n: int) -> ImmutablePoint:  # => allocates a NEW object each call
+    for _ in range(n):  # => repeats the "update" n times
+        p = replace(p, x=p.x + 1)  # => n allocations total -- one frozen dataclass per step
+    return p  # => the final, newest ImmutablePoint
+
+
+def bump_mutable(p: MutablePoint, n: int) -> MutablePoint:  # => mutates the SAME object each call
+    for _ in range(n):  # => repeats the "update" n times
+        p.x += 1  # => zero extra allocations -- writes directly into existing memory
+    return p  # => the SAME object, just with x changed n times
+
+
+iterations = 200_000  # => enough repetitions to make the cost difference measurable
+
+start = time.perf_counter()  # => marks the start of the immutable-path timing
+result_immutable = bump_immutable(ImmutablePoint(0, 0), iterations)  # => n allocations happen here
+immutable_seconds = time.perf_counter() - start  # => elapsed time for n allocations
+
+start = time.perf_counter()  # => marks the start of the mutable-path timing
+result_mutable = bump_mutable(MutablePoint(0, 0), iterations)  # => n in-place writes happen here
+mutable_seconds = time.perf_counter() - start  # => elapsed time for n in-place writes
+
+# => this is the honest cost side of the immutability trade-off this topic advocates
+print(result_immutable.x == result_mutable.x == iterations)  # => Output: True -- BOTH reach the correct answer
+print(immutable_seconds > 0 and mutable_seconds > 0)  # => Output: True -- both measured a nonzero duration
+```
+
+**Output**:
+
+```text
+True
+True
+```
+
+```python
+"""Example 75: pytest verification for Measuring Persistent-Update Cost vs. In-Place Mutation."""
+
+from example import ImmutablePoint, MutablePoint, bump_immutable, bump_mutable
+
+
+def test_both_versions_reach_the_correct_final_value() -> None:
+    n = 100
+    assert bump_immutable(ImmutablePoint(0, 0), n).x == n
+    assert bump_mutable(MutablePoint(0, 0), n).x == n
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Both the immutable and mutable versions reach the identical final value, but the
+immutable version allocates a new object on every single update while the mutable version allocates
+zero -- immutability's safety comes at a real, measurable allocation cost.
+
+**Why it matters**: This topic has advocated immutability throughout, and that advocacy is only honest
+if the cost side is acknowledged too. In a hot loop touching the same value millions of times, that
+per-update allocation can matter; in most application code it does not, because the safety and
+reasoning benefits (no aliasing bugs, no defensive copying) outweigh an allocation cost that modern
+allocators handle cheaply.
+
+---
+
+### Example 76: Refactoring Shared-Mutable Code to Pass State Explicitly
+
+_ex-76 &middot; exercises co-28, co-04_
+
+`deposit_impure` reads and writes a module-level global, so testing it in isolation requires resetting
+that global between tests. `deposit_pure` does the same job by taking the current balance as an
+explicit argument and returning the new one -- the refactor this example performs is functional-core/
+imperative-shell applied to a single function pair.
+
+```python
+"""Example 76: Refactoring Shared-Mutable Code to Pass State Explicitly."""
+
+_shared_balance = 0  # => the BEFORE state: a module-level global every function silently depends on
+
+
+def deposit_impure(amount: int) -> int:  # => reads AND writes the hidden global -- a shared-state trap
+    global _shared_balance  # => declares intent to mutate the MODULE-level balance
+    _shared_balance += amount  # => any other function could ALSO be mutating this concurrently
+    return _shared_balance  # => the new, globally-visible balance
+
+
+def deposit_pure(balance: int, amount: int) -> int:  # => the AFTER state: balance passed explicitly
+    return balance + amount  # => no globals, no hidden dependency -- callers control the state directly
+
+
+_shared_balance = 0  # => resets the impure global before demonstrating it
+impure_result_1 = deposit_impure(100)  # => mutates _shared_balance to 100
+impure_result_2 = deposit_impure(50)  # => mutates _shared_balance to 150 -- depends on the call BEFORE it
+
+pure_result_1 = deposit_pure(0, 100)  # => explicit starting balance, explicit result
+pure_result_2 = deposit_pure(pure_result_1, 50)  # => explicit threading -- no hidden state anywhere
+
+# => this refactor is functional-core/imperative-shell applied to a single function pair
+print(impure_result_2 == pure_result_2)  # => Output: True -- same final answer, radically different design
+print(_shared_balance)  # => Output: 150 -- the global STILL exists in the impure version
+```
+
+**Output**:
+
+```text
+True
+150
+```
+
+```python
+"""Example 76: pytest verification for Refactoring Shared-Mutable Code to Pass State Explicitly."""
+
+from example import deposit_pure
+
+
+def test_explicit_state_threading_needs_no_global_reset_between_tests() -> None:
+    balance = deposit_pure(0, 100)
+    balance = deposit_pure(balance, 50)
+    assert balance == 150  # => reproducible without resetting any module-level global first
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Passing state explicitly as an argument, instead of mutating a module-level global,
+removes the hidden dependency between calls -- `deposit_pure`'s test needs no setup or teardown to
+reset shared state, while a correct test of `deposit_impure` would.
+
+**Why it matters**: `deposit_impure`'s bug class -- forgetting to reset `_shared_balance` between test
+runs, or two concurrent callers stepping on each other's updates -- disappears entirely once state is
+threaded explicitly. This is the same functional-core/imperative-shell idea from Example 29 and Example
+57, applied here to the smallest possible unit: a single stateful function refactored into a pure one.
+
+---
+
+### Example 77: Stacking Multiple Decorators and Reasoning About Order
+
+_ex-77 &middot; exercises co-18, co-11_
+
+`double` is wrapped by two `logged` decorators, and this example proves decorator stacking is function
+composition wearing different syntax: `@logged("outer")` above `@logged("inner")` means outer's
+`enter` logs first, but inner's `enter` logs before outer's own function call actually completes --
+the same nesting order `compose(outer, inner)` would produce.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart TD
+    O1["outer enter"]:::blue --> I1["inner enter"]:::orange --> D["double#40;5#41; = 10"]:::teal --> I2["inner exit"]:::orange --> O2["outer exit"]:::blue
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 77: Stacking Multiple Decorators and Reasoning About Order."""
+
+from functools import wraps  # => preserves double's identity through both decorator layers
+from typing import Callable  # => Callable types the logged decorator factory below
+
+call_order: list[str] = []  # => records the ACTUAL order decorators run in, top-to-bottom vs inside-out
+
+
+def logged(label: str) -> Callable[[Callable[[int], int]], Callable[[int], int]]:  # => a decorator factory
+    def decorator(fn: Callable[[int], int]) -> Callable[[int], int]:  # => the actual decorator
+        @wraps(fn)  # => preserves fn's identity through this layer
+        def wrapper(x: int) -> int:  # => logs entry/exit around whatever fn this layer wraps
+            call_order.append(f"{label} enter")  # => runs BEFORE the wrapped function
+            result = fn(x)  # => calls the NEXT layer in (or the real function, if innermost)
+            call_order.append(f"{label} exit")  # => runs AFTER the wrapped function
+            return result  # => forwards the inner result unchanged
+
+        return wrapper  # => decorator itself returns the logging wrapper
+
+    return decorator  # => logged(label) itself returns the decorator
+
+
+@logged("outer")  # => applied SECOND -- wraps whatever @logged("inner") already produced
+@logged("inner")  # => applied FIRST -- wraps the raw function directly
+def double(x: int) -> int:  # => the innermost function, wrapped twice
+    return x * 2  # => the actual computation, untouched by either decorator
+
+
+result = double(5)  # => triggers BOTH wrapper layers, in a specific nesting order
+
+# => decorator stacking is function composition wearing different syntax
+print(result)  # => Output: 10
+print(call_order)  # => Output: ['outer enter', 'inner enter', 'inner exit', 'outer exit']
+```
+
+**Output**:
+
+```text
+10
+['outer enter', 'inner enter', 'inner exit', 'outer exit']
+```
+
+```python
+"""Example 77: pytest verification for Stacking Multiple Decorators and Reasoning About Order."""
+
+from example import call_order, double
+
+
+def test_decorators_nest_outermost_first_innermost_last() -> None:
+    call_order.clear()
+    double(5)
+    assert call_order == ["outer enter", "inner enter", "inner exit", "outer exit"]
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Stacked decorators nest like function composition: the topmost `@decorator` wraps
+everything below it, so its `enter` logic runs first and its `exit` logic runs last, with every layer
+in between nested symmetrically around the innermost function call.
+
+**Why it matters**: Decorator order bugs are common precisely because the visual top-to-bottom order of
+`@decorator` lines does not immediately read as "outermost wraps everything below it." Seeing the
+explicit `call_order` list -- outer enters, inner enters, the real function runs, inner exits, outer
+exits -- turns an easy-to-misremember rule into something verified by running the code.
+
+---
+
+### Example 78: A Case Where Laziness Saves Work, and One Where It Hides a Cost
+
+_ex-78 &middot; exercises co-15_
+
+This example shows laziness from both sides in one file. Case 1 proves a lazy generator can stop after
+finding the first value over 50 without computing the other roughly 950 values in the range -- clear
+savings. Case 2 shows the hidden cost: re-iterating an already-exhausted generator silently yields
+nothing at all, with no error to signal the mistake.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Gray #808080
+flowchart LR
+    subgraph Case1["Case 1: laziness SAVES work"]
+        L1["lazy_squares#40;1..999#41;"]:::blue -->|stops at first #62; 50| Done1["~8 computed, not 999"]:::orange
+    end
+    subgraph Case2["Case 2: laziness HIDES a cost"]
+        L2["lazy_squares#40;1..3#41;"]:::blue -->|first pass: 3 computed| P1["[1, 4, 9]"]:::orange
+        L2 -.->|second pass: EXHAUSTED| P2["[] -- silently empty"]:::gray
+    end
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef gray fill:#808080,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 78: A Case Where Laziness Saves Work, and One Where It Hides a Cost."""
+
+from typing import Iterator  # => Iterator types the lazy generator below
+
+work_done: list[str] = []  # => records every "expensive" step actually performed
+
+
+def expensive_step(n: int) -> int:  # => stands in for a slow computation
+    work_done.append(f"computed {n}")  # => only runs when this step is ACTUALLY reached
+    return n * n  # => the "expensive" result
+
+
+def lazy_squares(numbers: range) -> Iterator[int]:  # => LAZY: nothing runs until pulled
+    for n in numbers:  # => walks the range one value at a time, on demand
+        yield expensive_step(n)  # => suspends here between pulls
+
+
+def eager_squares(numbers: range) -> list[int]:  # => EAGER: computes EVERY value immediately
+    return [expensive_step(n) for n in numbers]  # => materializes the WHOLE list before returning
+
+
+work_done.clear()  # => resets the log before Case 1
+lazy_stream = lazy_squares(range(1, 1000))  # => nothing computed yet
+first_over_50 = next(n for n in lazy_stream if n > 50)  # => stops pulling the instant it finds one
+lazy_work_count = len(work_done)  # => far fewer than 999
+
+work_done.clear()  # => resets the log before Case 2
+lazy_stream_2 = lazy_squares(range(1, 4))  # => a FRESH lazy generator
+first_pass = list(lazy_stream_2)  # => first pass: 3 values computed
+second_pass = list(lazy_stream_2)  # => generator already EXHAUSTED -- silently yields nothing
+hidden_cost_count = len(work_done)  # => still 3, NOT 6 -- the second pass did nothing at all, silently
+
+# => laziness is a trade-off, not a free win -- both sides of it matter
+print(first_over_50)  # => Output: 64
+print(lazy_work_count < 10)  # => Output: True -- laziness saved most of the 999 possible computations
+print(second_pass)  # => Output: [] -- the SILENT trap: re-iterating an exhausted generator gives nothing
+print(hidden_cost_count)  # => Output: 3 -- proves the second pass computed NOTHING, not that it recomputed
+```
+
+**Output**:
+
+```text
+64
+True
+[]
+3
+```
+
+```python
+"""Example 78: pytest verification for A Case Where Laziness Saves Work, and One Where It Hides a Cost."""
+
+from example import lazy_squares, work_done
+
+
+def test_reiterating_an_exhausted_generator_yields_nothing_silently() -> None:
+    work_done.clear()
+    stream = lazy_squares(range(1, 4))
+    first_pass = list(stream)  # => consumes the generator fully
+    assert first_pass == [1, 4, 9]
+    assert len(work_done) == 3
+
+    second_pass = list(stream)  # => the SAME (now exhausted) generator object
+    assert second_pass == []  # => silently empty -- no error, no recomputation
+    assert len(work_done) == 3  # => confirms NOTHING extra was computed
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Laziness saves real work when a consumer stops pulling early, but a generator is a
+one-shot, statefully-exhausted object -- iterating it a second time silently produces nothing, with no
+exception to flag the mistake.
+
+**Why it matters**: The "laziness is free" framing this topic has implicitly used up to now is
+incomplete. A generator that gets accidentally iterated twice (passed to two different consumers, or
+reused across a retry loop) fails silently rather than loudly, which is a real production bug class.
+Knowing both sides -- the savings and the exhaustion trap -- is what lets a developer choose a
+generator versus a list deliberately rather than by habit.
+
+---
+
+### Example 79: The Same Pipeline in `Option` vs. `Result`
+
+_ex-79 &middot; exercises co-22, co-23, co-27_
+
+`parse_option` and `parse_result` run the identical parsing logic and chain the identical `and_then`
+step, differing only in their error type. `Option`'s `Nothing()` carries no information about why
+parsing "bad" failed, while `Result`'s `Err("'bad' is not a digit string")` carries the reason --
+otherwise the two pipelines are structurally identical.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Gray #808080
+flowchart LR
+    O["parse_option#40;'bad'#41;"]:::blue --> N["Nothing#40;#41;<br/>NO reason attached"]:::gray
+    R["parse_result#40;'bad'#41;"]:::orange --> E["Err#40;'bad' is not a digit string'#41;<br/>reason attached"]:::gray
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef gray fill:#808080,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 79: The Same Pipeline in Option vs. Result."""
+
+from __future__ import annotations  # => enables the quoted forward references used below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds all four variants below
+from typing import Callable, Generic, TypeVar  # => Generic/TypeVar/Callable type both and_then methods
+
+T = TypeVar("T")  # => the type of the value a Some or Ok wraps
+U = TypeVar("U")  # => the type each and_then's step function returns
+
+
+@dataclass(frozen=True)  # => marks Some immutable, matching the FP style
+class Some(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this variant carries
+
+    def and_then(self, fn: Callable[[T], "Option[U]"]) -> "Option[U]":  # => Option's chaining operation
+        return fn(self.value)  # => runs fn on the unwrapped value
+
+
+@dataclass(frozen=True)  # => marks Nothing immutable too
+class Nothing:  # => the class body begins here
+    def and_then(self, fn: Callable[[T], U]) -> "Nothing":  # => short-circuits, generic so union calls stay typed
+        return self  # => Nothing carries NO explanation for why
+
+
+Option = Some[T] | Nothing  # => the Option ADT: EITHER variant
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this variant carries
+
+    def and_then(self, fn: Callable[[T], "Res[U]"]) -> "Res[U]":  # => Result's chaining operation
+        return fn(self.value)  # => runs fn on the unwrapped value
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err:  # => the class body begins here
+    error: str  # => Result CARRIES a reason -- Option's Nothing cannot
+
+    def and_then(self, fn: Callable[[T], U]) -> "Err":  # => short-circuits, generic so union calls stay typed
+        return self  # => the REASON rides through untouched
+
+
+Res = Ok[T] | Err  # => the Result ADT: EITHER variant
+
+
+def parse_option(text: str) -> "Option[int]":  # => same parsing logic, Option's error model: just absence
+    return Some(int(text)) if text.isdigit() else Nothing()  # => success wraps, failure loses all context
+
+
+def parse_result(text: str) -> "Res[int]":  # => same parsing logic, Result's error model: WHY it failed
+    return Ok(int(text)) if text.isdigit() else Err(f"'{text}' is not a digit string")  # => failure keeps context
+
+
+def double_option(n: int) -> "Option[int]":  # => named + typed -- a bare lambda loses its param type on the union call
+    return Some(n * 2)  # => same "double" step as double_result, wrapped in Option's variant
+
+
+def double_result(n: int) -> "Res[int]":  # => named + typed, same reasoning as double_option
+    return Ok(n * 2)  # => same "double" step as double_option, wrapped in Result's variant
+
+
+option_pipeline = parse_option("42").and_then(double_option)  # => Option pipeline
+result_pipeline = parse_result("42").and_then(double_result)  # => Result pipeline, same shape
+
+option_failure = parse_option("bad")  # => Nothing -- no explanation attached
+result_failure = parse_result("bad")  # => Err carrying a human-readable reason
+
+# => the SAME chain, two error models -- pick based on whether the reason matters
+print(option_pipeline)  # => Output: Some(value=84)
+print(result_pipeline)  # => Output: Ok(value=84)
+print(option_failure)  # => Output: Nothing() -- WHY it failed is not represented at all
+print(result_failure)  # => Output: Err(error="'bad' is not a digit string") -- the reason IS represented
+```
+
+**Output**:
+
+```text
+Some(value=84)
+Ok(value=84)
+Nothing()
+Err(error="'bad' is not a digit string")
+```
+
+```python
+"""Example 79: pytest verification for The Same Pipeline in Option vs. Result."""
+
+from example import Err, Nothing, Ok, Option, Res, Some, parse_option, parse_result
+
+
+def _increment_option(n: int) -> Option[int]:
+    return Some(n + 1)
+
+
+def _increment_result(n: int) -> Res[int]:
+    return Ok(n + 1)
+
+
+def test_option_discards_the_reason_result_keeps_it() -> None:
+    assert parse_option("bad") == Nothing()
+    assert parse_result("bad") == Err("'bad' is not a digit string")
+    assert parse_option("5").and_then(_increment_option) == Some(6)
+    assert parse_result("5").and_then(_increment_result) == Ok(6)
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `Option` and `Result` support the identical `and_then` chaining API; the only real
+difference is whether the failure case carries a reason -- `Nothing()` cannot, `Err(reason)` always
+does.
+
+**Why it matters**: Reaching for `Option` when a caller will eventually need to know why something
+failed forces awkward workarounds later (an out-of-band log message, a second lookup to explain the
+absence). Choosing `Result` from the start whenever failure needs an explanation -- and `Option` only
+when "present or absent" is the complete story -- avoids that retrofit entirely.
+
+---
+
+### Example 80: A Functional-Core Log Analyzer With `Result` Errors and an Applicative Combine
+
+_ex-80 &middot; exercises co-28, co-23, co-26_
+
+The capstone preview: `parse_all` combines this topic's error-accumulating applicative style (Example 71) with the functional-core/imperative-shell split (Example 29, Example 57) at the scale of a small
+real tool. Every line of a simulated log file is parsed independently, every parse failure is collected
+rather than stopping at the first one, and `run_shell` is still the only function that prints.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Gray #808080
+flowchart TD
+    T["raw_text lines"]:::blue --> P["parse_all#40;#41;<br/>PURE, accumulates ALL errors"]:::blue
+    P -->|Ok| C["count_by_level#40;#41;<br/>PURE"]:::teal
+    P -->|Err: all bad lines| Report["run_shell prints every error"]:::orange
+    C --> Shell["run_shell prints counts"]:::gray
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef gray fill:#808080,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 80: A Functional-Core Log Analyzer With Result Errors and an Applicative Combine."""
+
+from __future__ import annotations  # => enables the quoted 'Result[T]'/'Result[list[LogEntry]]' references below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds every immutable record here
+from typing import Generic, TypeVar  # => Generic/TypeVar make Ok[T] a proper generic container
+
+T = TypeVar("T")  # => the type of the value an Ok wraps
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err:  # => the class body begins here
+    errors: tuple[str, ...]  # => accumulates every malformed line, not just the first
+
+
+Result = Ok[T] | Err  # => the ADT itself: a Result is EITHER variant
+
+
+@dataclass(frozen=True)  # => one PARSED, immutable log line
+class LogEntry:  # => the class body begins here
+    level: str  # => INFO, WARN, or ERROR
+    message: str  # => the rest of the line, trimmed
+
+
+def parse_line(line: str, line_number: int) -> "Result[LogEntry]":  # => PURE CORE: one line -> Result
+    parts = line.split(":", 1)  # => splits "ERROR:disk full" into ["ERROR", "disk full"]
+    if len(parts) != 2 or parts[0] not in ("INFO", "WARN", "ERROR"):  # => the ONLY validity rule
+        return Err((f"line {line_number}: malformed entry '{line}'",))  # => a single-error Err, keyed to this line
+    return Ok(LogEntry(level=parts[0], message=parts[1].strip()))  # => success wraps the parsed entry
+
+
+def parse_all(lines: list[str]) -> "Result[list[LogEntry]]":  # => applicative combine: ALL lines, ALL errors
+    entries: list[LogEntry] = []  # => collects every SUCCESSFULLY parsed entry
+    errors: list[str] = []  # => collects every FAILURE, across every line, not just the first
+    for i, line in enumerate(lines, start=1):  # => visits EVERY line regardless of earlier failures
+        result = parse_line(line, i)  # => delegates to the pure per-line parser
+        if isinstance(result, Ok):  # => this particular line parsed cleanly
+            entries.append(result.value)  # => a good line contributes an entry
+        else:  # => this particular line was malformed
+            errors.extend(result.errors)  # => a bad line contributes its error, parsing CONTINUES
+    if errors:  # => at least one line was malformed
+        return Err(tuple(errors))  # => reports EVERY malformed line at once
+    return Ok(entries)  # => every line parsed cleanly
+
+
+def count_by_level(entries: list[LogEntry]) -> dict[str, int]:  # => PURE CORE: aggregation step
+    counts: dict[str, int] = {}  # => the running per-level total
+    for entry in entries:  # => folds every entry into the counts dict
+        counts[entry.level] = counts.get(entry.level, 0) + 1  # => accumulates per level
+    return counts  # => a fresh dict -- the input list itself is never mutated
+
+
+def run_shell(raw_text: str) -> None:  # => IMPERATIVE SHELL: the only function that prints
+    lines = raw_text.strip().splitlines()  # => splits the "file contents" into lines
+    parsed = parse_all(lines)  # => delegates to the pure, error-accumulating core
+    if isinstance(parsed, Err):  # => reports every problem found, still just ONE code path
+        print(f"{len(parsed.errors)} error(s) found:")  # => the shell's own summary line
+        for error in parsed.errors:  # => walks EVERY accumulated error, not just the first
+            print(f"  {error}")  # => one printed line per malformed input line
+        return  # => stops here -- no report is generated from partially-bad input
+    counts = count_by_level(parsed.value)  # => delegates to the pure aggregation core
+    for level in sorted(counts):  # => alphabetical report, deterministic output
+        print(f"{level}: {counts[level]}")  # => one printed line per log level
+
+
+good_log = "INFO:started\nWARN:low disk\nERROR:crashed\nINFO:restarted"  # => stands in for a real log file
+# => this preview is a smaller version of what the capstone builds end to end
+run_shell(good_log)  # => Output: ERROR: 1, then INFO: 2, then WARN: 1
+
+bad_log = "INFO:ok\nnonsense line\nERROR:bad\nanother bad one"  # => two malformed lines mixed in
+run_shell(bad_log)  # => Output: 2 error(s) found, both listed
+```
+
+**Output**:
+
+```text
+ERROR: 1
+INFO: 2
+WARN: 1
+2 error(s) found:
+  line 2: malformed entry 'nonsense line'
+  line 4: malformed entry 'another bad one'
+```
+
+```python
+"""Example 80: pytest verification for A Functional-Core Log Analyzer With Result Errors and an Applicative Combine."""
+
+from example import Err, Ok, count_by_level, parse_all
+
+
+def test_core_accumulates_every_malformed_line_and_counts_the_rest() -> None:
+    good = ["INFO:a", "WARN:b", "INFO:c"]
+    result = parse_all(good)
+    assert isinstance(result, Ok)
+    assert count_by_level(result.value) == {"INFO": 2, "WARN": 1}
+
+    bad = ["INFO:a", "nonsense", "also nonsense"]
+    bad_result = parse_all(bad)
+    assert isinstance(bad_result, Err)
+    assert len(bad_result.errors) == 2  # => BOTH malformed lines reported, not just the first
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `parse_all` combines the functional-core/imperative-shell split with applicative,
+error-accumulating validation at the scale of a small real tool -- every line is parsed independently,
+every failure is collected, and exactly one function touches `print`.
+
+**Why it matters**: This example previews the capstone at a smaller scale: a functional core
+(`parse_line`, `parse_all`, `count_by_level`) that a test calls directly with string literals, wrapped
+by one thin shell (`run_shell`) that handles the only I/O. Every pattern this topic built up --
+immutable records, ADTs, `Result`-based error handling, applicative accumulation, pure/impure
+separation -- comes together here in one working tool.
+
+---
+
+← Previous: [Intermediate Examples](./intermediate.md) &middot; Next: [Capstone](./capstone/overview.md) →

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner.md
@@ -1,0 +1,2185 @@
+---
+title: "Beginner Examples"
+date: 2026-07-17T00:00:00+07:00
+draft: false
+weight: 10
+---
+
+Examples 1-28 build the vocabulary every later example assumes: telling a pure function from an
+impure one and naming exactly what a side effect is (co-01, co-02, co-03), the immutable data types
+Python ships with -- `tuple`, `frozen` dataclasses, and `dataclasses.replace` -- plus a first taste of
+structural sharing on a persistent cons-list (co-04, co-05), functions as ordinary first-class values
+stored, passed, and returned (co-06 through co-09), `functools.partial` and hand-written `compose`/
+`pipe` helpers (co-10, co-11, co-12), the `map`/`filter`/`reduce` trio (co-13), generators and a first
+look at `itertools` (co-15, co-16), `functools.lru_cache` memoization and a logging decorator
+(co-17, co-18), recursion under CPython's missing tail-call optimization (co-14), and guarding a
+`None`-returning lookup as this topic's first brush with "absence as a value" (co-22). Every example
+below is a complete, self-contained `example.py` colocated under `learning/code/ex-NN-slug/`, run with
+`python3 example.py` to capture the **Output** block shown, and verified a second way with a colocated
+`test_example.py` under `pytest -q`.
+
+---
+
+### Example 1: Pure vs. Impure -- Same Result Every Time
+
+_ex-01 &middot; exercises co-01, co-02_
+
+A pure function's result depends only on its arguments; an impure twin with the identical signature can
+answer differently on the second call because it also reads or writes state the caller never sees. This
+example places `add_pure` beside `add_impure`, an otherwise-identical function that mutates a
+module-level counter, and confirms only the pure one gives the same result twice.
+
+```python
+"""Example 1: Pure vs. Impure -- Same Result Every Time."""
+
+counter_total = 0  # => module-level global state -- the impure twin's playground
+
+
+def add_pure(a: int, b: int) -> int:  # => pure: output depends ONLY on a and b
+    return a + b  # => no write to anything outside this function -- no side effect
+
+
+def add_impure(a: int, b: int) -> int:  # => same signature, very different behavior
+    global counter_total  # => declares intent to MUTATE module-level state
+    counter_total += a + b  # => side effect: writes state outside this function's scope
+    # => the return value now depends on how many times this ran BEFORE, not just a, b
+    return counter_total
+
+
+first_pure = add_pure(2, 3)  # => first_pure is 5
+second_pure = add_pure(2, 3)  # => second_pure is 5 -- SAME args, SAME result
+print(first_pure == second_pure)  # => True: repeat calls with identical args always agree
+# => Output: True
+
+first_impure = add_impure(2, 3)  # => first_impure is 5 (counter_total was 0 before this)
+second_impure = add_impure(2, 3)  # => second_impure is 10 -- SAME args, DIFFERENT result!
+print(first_impure == second_impure)  # => False: hidden global state changed the answer
+# => Output: False
+```
+
+**Output**:
+
+```text
+True
+False
+```
+
+```python
+"""Example 1: pytest verification for Pure vs. Impure -- Same Result Every Time."""
+
+from example import add_impure, add_pure  # => imports both functions under test
+
+
+def test_pure_add_is_repeatable() -> None:
+    first = add_pure(2, 3)  # => first call
+    second = add_pure(2, 3)  # => identical args, called again
+    assert first == second == 5  # => pure function: always the same result
+
+
+def test_impure_add_is_not_repeatable() -> None:
+    first = add_impure(10, 10)  # => mutates the module-level counter as a side effect
+    second = add_impure(10, 10)  # => SAME args, but counter_total has already grown
+    assert first != second  # => impure function: repeat calls disagree
+
+
+# => Run: pytest -- Output: 2 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+2 passed
+```
+
+**Key takeaway**: A pure function's output is a function of its arguments alone; an impure twin with an
+identical signature can silently disagree with itself the moment hidden state changes underneath it.
+
+**Why it matters**: Bugs that "only happen sometimes" are usually a pure-looking call secretly reading
+or writing state outside its own arguments and return value. Recognizing the pure/impure boundary at a
+glance is the single skill every later concept in this topic -- immutability, referential transparency,
+the functional-core/imperative-shell split -- builds directly on top of.
+
+---
+
+### Example 2: Referential Transparency by Substitution
+
+_ex-02 &middot; exercises co-03_
+
+A call is referentially transparent when it can be replaced by its own return value anywhere in the
+program without changing what the program computes. This example builds the same result two ways --
+once by calling `add(2, 3)` inside a larger expression, once by substituting its value `5` directly --
+and confirms both give the identical answer.
+
+```python
+"""Example 2: Referential Transparency by Substitution."""
+
+
+def add(a: int, b: int) -> int:  # => a pure function -- referentially transparent
+    return a + b  # => always returns the same value for the same a, b
+
+
+def price_with_call() -> int:  # => uses the CALL add(2, 3) inside a larger expression
+    return add(2, 3) * 10  # => add(2, 3) is evaluated, then multiplied by 10
+
+
+def price_with_value() -> int:  # => the call REPLACED by its own return value, 5
+    return 5 * 10  # => substituting add(2, 3) -> 5 changes nothing about the result
+
+
+call_result = price_with_call()  # => call_result is 50
+value_result = price_with_value()  # => value_result is 50 -- IDENTICAL to call_result
+print(call_result == value_result)  # => True: the call was safely replaceable by its value
+# => Output: True
+```
+
+**Output**:
+
+```text
+True
+```
+
+```python
+"""Example 2: pytest verification for Referential Transparency by Substitution."""
+
+from example import price_with_call, price_with_value
+
+
+def test_call_and_value_agree() -> None:
+    # => substituting add(2, 3) with its value 5 changes nothing about the result
+    assert price_with_call() == price_with_value() == 50
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: If a call can always be swapped for its return value without changing the program's
+behavior, it is referentially transparent -- and pure functions are exactly the ones with this property.
+
+**Why it matters**: Referential transparency is what makes equational reasoning possible: simplifying an
+expression by substituting a call for its value, the same way algebra simplifies `2 + 3` to `5`.
+Compilers rely on the identical property for constant folding and memoization, and so does every human
+reader trying to predict what a function call does without tracing hidden side effects first.
+
+---
+
+### Example 3: Classify Pure vs. Impure Functions
+
+_ex-03 &middot; exercises co-02_
+
+Naming exactly where the purity boundary sits is a design decision, not an accident -- a function that
+prints, one that mutates its argument, and one that only computes and returns are three different
+contracts wearing the same syntax. This example defines all three and a tiny classifier, and confirms
+only the side-effect-free one is flagged pure.
+
+```python
+"""Example 3: Classify Pure vs. Impure Functions."""
+
+log: list[str] = []  # => module-level list -- a target for one function's side effect
+
+
+def loud_double(x: int) -> int:  # => impure: prints, an observable side effect
+    print(f"doubling {x}")  # => I/O is a side effect -- output visible OUTSIDE the return value
+    return x * 2  # => the return value itself is fine; the PRINT above is the side effect
+
+
+def mutate_double(items: list[int]) -> None:  # => impure: mutates the CALLER's own list
+    items.append(items[-1] * 2)  # => appends in place -- the caller's list object changes
+    # => returns None on purpose: the "result" is the mutation itself, not a return value
+
+
+def pure_double(x: int) -> int:  # => pure: only reads x, only returns a new value
+    return x * 2  # => no print, no mutation of any argument, no global touched
+
+
+def is_pure(fn_name: str) -> bool:  # => a tiny classifier keyed by name for this example
+    return fn_name == "pure_double"  # => only pure_double is flagged pure by this check
+
+
+nums = [1, 2]  # => a list the impure mutate_double will mutate below
+mutate_double(nums)  # => side effect: nums is mutated to [1, 2, 4]
+classifications = {  # => a dict recording each function's purity classification
+    "loud_double": is_pure("loud_double"),  # => False -- prints, so it is impure
+    "mutate_double": is_pure("mutate_double"),  # => False -- mutates its argument
+    "pure_double": is_pure("pure_double"),  # => True -- the only one flagged pure
+}  # => three functions, three independent purity verdicts
+print(classifications["pure_double"])  # => Output: True
+print(  # => reads both remaining classifications out of the same dict
+    classifications["loud_double"], classifications["mutate_double"]
+)
+# => Output: False False
+```
+
+**Output**:
+
+```text
+True
+False False
+```
+
+```python
+"""Example 3: pytest verification for Classify Pure vs. Impure Functions."""
+
+from example import is_pure, mutate_double, pure_double
+
+
+def test_only_pure_double_is_flagged_pure() -> None:
+    assert is_pure("pure_double") is True  # => the only function with zero side effects
+    assert is_pure("loud_double") is False  # => prints -- a side effect
+    assert is_pure("mutate_double") is False  # => mutates its argument -- a side effect
+
+
+def test_mutate_double_changes_caller_list() -> None:
+    items = [1, 2]
+    mutate_double(items)  # => appends items[-1] * 2 in place
+    assert items == [1, 2, 4]  # => the CALLER's own list object was mutated
+    assert pure_double(3) == 6  # => pure_double never touches items at all
+
+
+# => Run: pytest -- Output: 2 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+2 passed
+```
+
+**Key takeaway**: Printing, mutating an argument, and touching a global are all side effects, even
+though every one of these functions has an ordinary-looking signature -- purity has to be verified by
+reading the body, not guessed from the call site.
+
+**Why it matters**: Codebases where nothing declares its own purity leave every function's contract
+implicit, so any call might secretly mutate state a reviewer never sees. Explicitly classifying
+functions this way is the first concrete step toward the functional-core/imperative-shell split this
+whole topic builds toward.
+
+---
+
+### Example 4: Tuple Immutability vs. List Mutability
+
+_ex-04 &middot; exercises co-04_
+
+Python ships two sequence types with opposite mutability contracts: `list` allows item assignment,
+`tuple` does not. This example mutates a list in place, then attempts the identical operation on a
+tuple and catches the `TypeError` that immutability guarantees.
+
+```python
+"""Example 4: Tuple Immutability vs. List Mutability."""
+
+mutable_list: list[int] = [1, 2, 3]  # => a list -- mutable, in-place assignment is legal
+mutable_list[0] = 99  # => legal: lists allow item assignment
+print(mutable_list)  # => Output: [99, 2, 3]
+
+immutable_tuple: tuple[int, int, int] = (1, 2, 3)  # => a tuple -- immutable, fixed after creation
+try:  # => opens a block that expects the next line to raise
+    immutable_tuple[0] = 99  # type: ignore[index]  # => attempts item assignment on a tuple
+    raised = False  # => unreachable if TypeError fires, kept for completeness
+except TypeError as exc:  # => tuples have no __setitem__ -- this is EXPECTED, not a bug
+    raised = True  # => confirms the immutability guarantee was actually enforced
+    print(f"raised: {type(exc).__name__}")  # => Output: raised: TypeError
+
+print(raised)  # => Output: True
+print(immutable_tuple)  # => Output: (1, 2, 3) -- unchanged, the assignment never happened
+```
+
+**Output**:
+
+```text
+[99, 2, 3]
+raised: TypeError
+True
+(1, 2, 3)
+```
+
+```python
+"""Example 4: pytest verification for Tuple Immutability vs. List Mutability."""
+
+
+def test_list_allows_item_assignment() -> None:
+    items = [1, 2, 3]
+    items[0] = 99  # => legal for a list
+    assert items == [99, 2, 3]
+
+
+def test_tuple_rejects_item_assignment() -> None:
+    values = (1, 2, 3)
+    try:
+        values[0] = 99  # type: ignore[index]  # => tuples have no __setitem__
+        raised = False
+    except TypeError:
+        raised = True
+    assert raised is True  # => confirms immutability is actually enforced
+    assert values == (1, 2, 3)  # => unchanged
+
+
+# => Run: pytest -- Output: 2 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+2 passed
+```
+
+**Key takeaway**: A `tuple` is a `list` with item assignment removed -- reach for it whenever a
+sequence's contents should never change after construction.
+
+**Why it matters**: Choosing `tuple` over `list` for fixed data is a free, zero-cost guarantee: any code
+path that tries to mutate it fails loudly with `TypeError` instead of silently corrupting shared state.
+That loud failure is exactly the safety property every later immutability example in this topic --
+frozen dataclasses, persistent structures -- builds on.
+
+---
+
+### Example 5: A Frozen Dataclass Rejects Mutation
+
+_ex-05 &middot; exercises co-04_
+
+`@dataclass(frozen=True)` generates `__init__`, `__repr__`, and `__eq__` the same way a plain dataclass
+does, but also blocks every attribute assignment after construction. This example builds a `Point`,
+prints it, then confirms a later assignment raises `FrozenInstanceError` instead of silently succeeding.
+
+```python
+"""Example 5: A Frozen Dataclass Rejects Mutation."""
+
+from dataclasses import FrozenInstanceError, dataclass  # => frozen=True raises this on assignment
+
+
+@dataclass(frozen=True)  # => generates __init__/__repr__/__eq__ AND blocks attribute assignment
+class Point:  # => an immutable value object -- once built, it cannot change
+    x: int  # => a regular field, just frozen at the class level
+    y: int  # => a second field -- @dataclass generates __init__(self, x, y) from both
+
+
+p = Point(1, 2)  # => __init__ is allowed to set fields ONCE, during construction
+print(p)  # => Output: Point(x=1, y=2)
+
+try:  # => opens a block that expects the assignment below to raise
+    p.x = 99  # type: ignore[misc]  # => any LATER assignment is rejected, not just during init
+    raised = False  # => unreachable if FrozenInstanceError fires first, kept for completeness
+except FrozenInstanceError:  # => the frozen dataclass's own guard fired
+    raised = True  # => confirms mutation was actually blocked, not silently ignored
+print(raised)  # => Output: True
+print(p)  # => Output: Point(x=1, y=2) -- still the original values
+```
+
+**Output**:
+
+```text
+Point(x=1, y=2)
+True
+Point(x=1, y=2)
+```
+
+```python
+"""Example 5: pytest verification for A Frozen Dataclass Rejects Mutation."""
+
+from dataclasses import FrozenInstanceError
+
+from example import Point
+
+
+def test_frozen_dataclass_rejects_assignment() -> None:
+    p = Point(1, 2)
+    try:
+        p.x = 99  # type: ignore[misc]  # => frozen dataclasses block ALL later assignment
+        raised = False
+    except FrozenInstanceError:
+        raised = True
+    assert raised is True
+    assert p == Point(1, 2)  # => unchanged -- the assignment never took effect
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `frozen=True` upgrades a dataclass from "boilerplate-free record" to "boilerplate-free
+immutable value object" -- construction is the only moment its fields can ever be set.
+
+**Why it matters**: Immutable value objects are safe to hand to any other function, thread, or part of
+the codebase without defensive copying, because nothing downstream can corrupt what you still hold a
+reference to. `frozen=True` gets this guarantee for the cost of one keyword argument, no hand-written
+`__setattr__` override required.
+
+---
+
+### Example 6: dataclasses.replace Produces a New Record
+
+_ex-06 &middot; exercises co-04, co-05_
+
+Since a frozen dataclass cannot be mutated, "updating" one means building a new instance instead --
+`dataclasses.replace` does exactly that, copying every field except the ones explicitly overridden.
+This example moves a `Point`'s `x` field and confirms the original is completely untouched.
+
+```python
+"""Example 6: dataclasses.replace Produces a New Record."""
+
+from dataclasses import dataclass, replace  # => replace: a shallow copy with fields overridden
+
+
+@dataclass(frozen=True)  # => frozen so "updating" MUST go through replace, not assignment
+class Point:  # => the value object replace() will copy-with-overrides below
+    x: int  # => first field -- the one this example overrides via replace
+    y: int  # => second field -- left untouched, copied straight through by replace
+
+
+original = Point(1, 2)  # => the record we will "update" without mutating
+moved = replace(original, x=99)  # => builds a NEW Point: x overridden, y copied unchanged
+# => original itself is never touched by replace -- it only READS original's fields
+
+print(original)  # => Output: Point(x=1, y=2) -- untouched
+print(moved)  # => Output: Point(x=99, y=2) -- a distinct object with the new x
+print(original == moved)  # => Output: False -- two different values now
+print(original is moved)  # => Output: False -- two different objects, not aliases
+```
+
+**Output**:
+
+```text
+Point(x=1, y=2)
+Point(x=99, y=2)
+False
+False
+```
+
+```python
+"""Example 6: pytest verification for dataclasses.replace Produces a New Record."""
+
+from dataclasses import replace
+
+from example import Point
+
+
+def test_replace_leaves_original_untouched() -> None:
+    original = Point(1, 2)
+    moved = replace(original, x=99)  # => a NEW record, y copied unchanged
+    assert original == Point(1, 2)  # => original never mutated
+    assert moved == Point(99, 2)  # => new record has the overridden field
+    assert original is not moved  # => two distinct objects
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `dataclasses.replace(obj, field=new_value)` is the idiomatic "update" for a frozen
+dataclass -- a shallow copy with named fields overridden, never a mutation of `obj` itself.
+
+**Why it matters**: This topic uses `dataclasses.replace`, not the newer `copy.replace` (Python 3.13+),
+specifically to stay compatible with Python 3.10 -- a concrete example of choosing the stdlib API with
+the widest supported floor rather than the newest one. The pattern itself is the same shape every later
+persistent-update example in this topic reuses at larger scale.
+
+---
+
+### Example 7: A Persistent Cons-List Prepend
+
+_ex-07 &middot; exercises co-05_
+
+A persistent data structure keeps every old version reachable after an "update," because the update
+never mutates anything -- it builds a new version that shares whatever structure did not change with the
+old one. This example prepends onto a cons-list built from frozen dataclass nodes and confirms the
+older version is still completely intact.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05
+flowchart LR
+    B["version_b<br/>head=2"]:::orange -->|tail| A["version_a<br/>head=1"]:::blue
+    A -->|tail| N["None<br/>empty list"]:::blue
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 7: A Persistent Cons-List Prepend."""
+
+from __future__ import annotations  # => lets ConsList reference itself in its own field type
+
+from dataclasses import dataclass  # => @dataclass generates __init__/__repr__/__eq__ for the node
+
+
+@dataclass(frozen=True)  # => frozen: once linked, a node's head/tail never change
+class ConsList:  # => the classic persistent linked list: a head value plus a tail list
+    head: int  # => this node's own value
+    tail: "ConsList | None"  # => None marks the empty tail -- the end of the list
+
+
+def prepend(value: int, lst: "ConsList | None") -> ConsList:  # => builds a NEW node
+    return ConsList(head=value, tail=lst)  # => tail is the OLD list, reused, never copied
+
+
+def to_list(lst: "ConsList | None") -> list[int]:  # => walks nodes into a plain list, for printing
+    result: list[int] = []  # => the plain list this walk accumulates into
+    while lst is not None:  # => walking SHARED structure -- no mutation happens here
+        result.append(lst.head)  # => reads this node's value
+        lst = lst.tail  # => advances to the next shared node, never rewriting it
+    return result  # => a fresh plain list -- the ConsList nodes themselves stay untouched
+
+
+empty: ConsList | None = None  # => the empty list -- the shared base every version points to
+version_a = prepend(1, empty)  # => version_a is [1]
+version_b = prepend(2, version_a)  # => version_b is [2, 1] -- REUSES version_a as its tail
+
+print(to_list(version_a))  # => Output: [1]
+print(to_list(version_b))  # => Output: [2, 1]
+print(version_b.tail is version_a)  # => Output: True -- structural sharing, not a copy
+```
+
+**Output**:
+
+```text
+[1]
+[2, 1]
+True
+```
+
+```python
+"""Example 7: pytest verification for A Persistent Cons-List Prepend."""
+
+from example import ConsList, prepend, to_list
+
+
+def test_prepend_shares_the_old_tail() -> None:
+    version_a: ConsList | None = prepend(1, None)  # => [1]
+    version_b = prepend(2, version_a)  # => [2, 1], reusing version_a as tail
+
+    assert to_list(version_a) == [1]  # => version_a unaffected by building version_b
+    assert to_list(version_b) == [2, 1]
+    assert version_b.tail is version_a  # => structural sharing, not a copy
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Prepending onto a persistent linked list is `O(1)` and never touches the existing
+nodes -- the new head simply points at the unchanged old list as its tail.
+
+**Why it matters**: Structural sharing is what makes immutability affordable at scale: without it, every
+"update" to a large structure would require a full deep copy. A cons-list prepend is the simplest
+possible demonstration of the same sharing principle that makes persistent trees, immutable state
+reducers, and functional data structures in general practical rather than wasteful.
+
+---
+
+### Example 8: A Function Assigned to a Variable
+
+_ex-08 &middot; exercises co-06_
+
+Functions in Python are ordinary values -- assigning one to a new name copies no code, it just gives the
+same underlying function object a second name. This example assigns `shout` to `greeter` and confirms
+calling through either name produces identical behavior.
+
+```python
+"""Example 8: A Function Assigned to a Variable."""
+
+
+def shout(text: str) -> str:  # => an ordinary function, defined once
+    return text.upper() + "!"  # => uppercases and appends an exclamation mark
+
+
+greeter = shout  # => assigns the FUNCTION OBJECT itself to a new name -- no call, no ()
+# => greeter and shout now both refer to the SAME underlying function object
+
+direct_result = shout("hello")  # => calling through the original name
+aliased_result = greeter("hello")  # => calling through the alias -- identical behavior
+
+print(direct_result)  # => Output: HELLO!
+print(aliased_result)  # => Output: HELLO!
+print(direct_result == aliased_result)  # => Output: True -- same function, same result
+print(greeter is shout)  # => Output: True -- greeter is not a copy, it IS shout
+```
+
+**Output**:
+
+```text
+HELLO!
+HELLO!
+True
+True
+```
+
+```python
+"""Example 8: pytest verification for A Function Assigned to a Variable."""
+
+from example import shout
+
+
+def test_alias_behaves_identically() -> None:
+    greeter = shout  # => same function object, new name
+    assert greeter is shout  # => not a copy
+    assert greeter("hi") == shout("hi") == "HI!"
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `greeter = shout` binds a second name to the same function object -- `greeter is shout`
+is `True`, not merely `greeter == shout`.
+
+**Why it matters**: Treating functions as ordinary values -- assignable, storable, passable -- is the
+foundation every other concept in this section builds on. Without first-class functions, higher-order
+functions, closures, currying, composition, and decorators would all be inexpressible: every one of
+those later ideas is, underneath, just another way of storing, combining, or transforming a function
+value. Languages that lack this property (early Java, for instance) had to bolt on interfaces and
+anonymous classes just to approximate what Python gets for free from day one.
+
+---
+
+### Example 9: Functions Stored in a List
+
+_ex-09 &middot; exercises co-06_
+
+Because functions are ordinary values, a `list` can hold several of them exactly like it holds
+integers or strings. This example stores three unrelated functions in a list and calls each one with
+the same input.
+
+```python
+"""Example 9: Functions Stored in a List."""
+
+
+def double(x: int) -> int:  # => three ordinary, unrelated single-purpose functions
+    return x * 2  # => doubles its argument
+
+
+def square(x: int) -> int:
+    return x * x  # => squares its argument
+
+
+def negate(x: int) -> int:
+    return -x  # => flips the sign of its argument
+
+
+operations = [double, square, negate]  # => a list of FUNCTION OBJECTS, not their results
+# => nothing has been called yet -- the list just holds three callables
+
+results = [op(5) for op in operations]  # => calls each stored function with the same input
+# => results is [10, 25, -5]: double(5), square(5), negate(5) in that order
+
+print(results)  # => Output: [10, 25, -5]
+print(all(callable(op) for op in operations))  # => Output: True -- every element is callable
+```
+
+**Output**:
+
+```text
+[10, 25, -5]
+True
+```
+
+```python
+"""Example 9: pytest verification for Functions Stored in a List."""
+
+from example import double, negate, square
+
+
+def test_stored_functions_are_called_correctly() -> None:
+    operations = [double, square, negate]
+    results = [op(5) for op in operations]
+    assert results == [10, 25, -5]
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: A list of functions is a list of callables like any other -- building `operations`
+does not call anything; the comprehension `op(5)` is the only place any of the three ever run.
+
+**Why it matters**: Storing behavior in an ordinary collection is the building block behind dispatch
+tables, pipeline stages, and plugin-style registries -- adding a new operation is as simple as appending
+one more function to the list, with zero changes to the code that iterates over it.
+
+---
+
+### Example 10: A Higher-Order apply Function
+
+_ex-10 &middot; exercises co-07_
+
+A higher-order function takes another function as an argument, returns one, or both -- `apply(fn, x)`
+is the smallest possible example, forwarding `x` to whichever function it was handed. This example
+calls `apply` with two entirely different functions and confirms it forwards correctly to both.
+
+```python
+"""Example 10: A Higher-Order apply Function."""
+
+from typing import Callable  # => the type of "a function taking int, returning int"
+
+
+def apply(fn: Callable[[int], int], x: int) -> int:  # => HOF: takes a FUNCTION as an argument
+    return fn(x)  # => apply never needs to know what fn actually does
+
+
+def increment(n: int) -> int:  # => one candidate to pass into apply
+    return n + 1  # => adds exactly one
+
+
+def triple(n: int) -> int:  # => a second, unrelated candidate to pass into apply
+    return n * 3  # => multiplies by three
+
+
+result_increment = apply(increment, 10)  # => apply calls increment(10) internally
+result_triple = apply(triple, 10)  # => same apply, DIFFERENT function passed in
+
+print(result_increment)  # => Output: 11
+print(result_triple)  # => Output: 30
+print(apply(increment, 10) == increment(10))  # => Output: True -- apply just forwards the call
+```
+
+**Output**:
+
+```text
+11
+30
+True
+```
+
+```python
+"""Example 10: pytest verification for A Higher-Order apply Function."""
+
+from example import apply, increment, triple
+
+
+def test_apply_forwards_to_whichever_function_is_passed() -> None:
+    assert apply(increment, 10) == 11
+    assert apply(triple, 10) == 30
+    assert apply(increment, 10) == increment(10)  # => apply changes nothing about the call
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `apply` never inspects what `fn` does -- it only forwards the call -- which is exactly
+what makes it reusable across any function matching its signature.
+
+**Why it matters**: This is the smallest possible higher-order function, and the same shape underlies
+`map`/`filter`/`reduce` (co-13), decorators (co-18), and every callback-based API in the standard
+library. Recognizing "a function taking a function" as an ordinary, unremarkable pattern is a
+prerequisite for everything that follows in this topic.
+
+---
+
+### Example 11: A Function Returning a Closure
+
+_ex-11 &middot; exercises co-07, co-08_
+
+A higher-order function can also return a function -- and when the returned function references a
+variable from its enclosing scope, that variable is captured in a closure, remembered even after the
+outer function has returned. This example builds `multiplier(n)`, confirming each call produces an
+independent closure remembering its own `n`.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart LR
+    M["multiplier#40;3#41;"]:::blue -->|returns| C["closure<br/>remembers n=3"]:::orange
+    C -->|"call#40;4#41;"| R["12"]:::teal
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 11: A Function Returning a Closure."""
+
+from typing import Callable  # => the return type of multiplier -- "a function int -> int"
+
+
+def multiplier(n: int) -> Callable[[int], int]:  # => HOF: RETURNS a function, doesn't just take one
+    def multiply_by_n(x: int) -> int:  # => a closure -- captures n from the enclosing scope
+        return x * n  # => n is remembered even after multiplier() has already returned
+
+    return multiply_by_n  # => the inner function itself is the return value
+
+
+times_three = multiplier(3)  # => times_three is now a function that always multiplies by 3
+times_five = multiplier(5)  # => a SEPARATE closure, capturing a different n (5)
+
+print(times_three(4))  # => Output: 12  (4 * 3, using the captured n=3)
+print(times_five(4))  # => Output: 20  (4 * 5, using the captured n=5)
+print(multiplier(3)(4) == 12)  # => Output: True -- calling the returned function immediately
+```
+
+**Output**:
+
+```text
+12
+20
+True
+```
+
+```python
+"""Example 11: pytest verification for A Function Returning a Closure."""
+
+from example import multiplier
+
+
+def test_returned_closures_remember_their_own_n() -> None:
+    times_three = multiplier(3)
+    times_five = multiplier(5)
+    assert times_three(4) == 12
+    assert times_five(4) == 20
+    assert multiplier(3)(4) == 12  # => calling the returned function immediately
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Each call to `multiplier(n)` produces an independent closure -- `times_three` and
+`times_five` remember two different `n` values simultaneously, with no shared state between them.
+
+**Why it matters**: Returning a closure is how a function "bakes in" configuration once and hands back a
+specialized version, rather than threading a parameter through every future call site. This is the
+direct ancestor of `functools.partial` (co-10) and every parameterized decorator (co-18) that follows
+later in this topic.
+
+---
+
+### Example 12: A Closure Capturing a Threshold
+
+_ex-12 &middot; exercises co-08_
+
+Closures are useful for more than multiplication -- any value baked in at closure-creation time changes
+the closure's behavior on every future call. This example builds two validators with different captured
+thresholds and confirms they disagree on the identical input.
+
+```python
+"""Example 12: A Closure Capturing a Threshold."""
+
+from typing import Callable  # => the return type of make_validator -- "a function int -> bool"
+
+
+def make_validator(threshold: int) -> Callable[[int], bool]:  # => bakes threshold into a closure
+    def is_above_threshold(value: int) -> bool:  # => captures threshold, no parameter for it
+        return value > threshold  # => reads the ENCLOSING threshold, not a fresh argument
+
+    return is_above_threshold  # => this closure, not a plain value, is what gets returned
+
+
+passes_ten = make_validator(10)  # => remembers threshold=10 forever
+passes_hundred = make_validator(100)  # => a DIFFERENT closure, remembers threshold=100
+
+print(passes_ten(15))  # => Output: True   (15 > 10)
+print(passes_hundred(15))  # => Output: False  (15 is NOT > 100)
+print(passes_ten(15) != passes_hundred(15))  # => Output: True -- same input, different config
+```
+
+**Output**:
+
+```text
+True
+False
+True
+```
+
+```python
+"""Example 12: pytest verification for A Closure Capturing a Threshold."""
+
+from example import make_validator
+
+
+def test_closures_vary_with_their_captured_threshold() -> None:
+    passes_ten = make_validator(10)
+    passes_hundred = make_validator(100)
+    assert passes_ten(15) is True
+    assert passes_hundred(15) is False
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: The captured `threshold` lives inside the closure, not in a parameter the caller
+supplies each time -- two closures built from the same factory can disagree forever on the same input.
+
+**Why it matters**: Baking configuration into a closure at creation time avoids re-passing the same
+argument on every call, which is exactly the shape validators, comparators, and event handlers take in
+production code. It is also the same mechanism, in miniature, that a parameterized decorator like
+`@retry(3)` (Example 42) relies on later in this topic.
+
+---
+
+### Example 13: map() Uppercases Every Word
+
+_ex-13 &middot; exercises co-13_
+
+`map(fn, iterable)` lazily applies `fn` to every element, producing an iterator rather than a list --
+nothing runs until the iterator is consumed. This example maps `str.upper` over a list of words and
+confirms every element was transformed, none dropped.
+
+```python
+"""Example 13: map() Uppercases Every Word."""
+
+words = ["functional", "programming", "in", "python"]  # => the source sequence
+
+uppercased = map(str.upper, words)  # => LAZY: map builds an iterator, nothing runs yet
+# => str.upper is an unbound method -- map calls it as str.upper(word) for each word
+
+uppercased_list = list(uppercased)  # => forces evaluation -- NOW every word is uppercased
+print(uppercased_list)  # => Output: ['FUNCTIONAL', 'PROGRAMMING', 'IN', 'PYTHON']
+print(len(uppercased_list) == len(words))  # => Output: True -- map is 1:1, never drops elements
+print(all(w.isupper() for w in uppercased_list))  # => Output: True -- every word transformed
+```
+
+**Output**:
+
+```text
+['FUNCTIONAL', 'PROGRAMMING', 'IN', 'PYTHON']
+True
+True
+```
+
+```python
+"""Example 13: pytest verification for map() Uppercases Every Word."""
+
+
+def test_map_uppercases_every_element() -> None:
+    words = ["a", "bee", "sea"]
+    result = list(map(str.upper, words))
+    assert result == ["A", "BEE", "SEA"]
+    assert len(result) == len(words)  # => map never drops elements
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `map` is always 1:1 -- the output has exactly as many elements as the input, each one
+transformed, none dropped and none added.
+
+**Why it matters**: `map` replaces a hand-written accumulation loop (`for w in words: result.append(...)`)
+with a single declarative expression, and being lazy means a `map` over a huge or infinite source never
+materializes more than the caller actually consumes -- the same laziness this topic revisits with
+generators and `itertools` later.
+
+---
+
+### Example 14: filter() Keeps Only Evens
+
+_ex-14 &middot; exercises co-13_
+
+`filter(predicate, iterable)` keeps only the elements the predicate accepts, lazily -- the complement of
+`map`'s "transform every element." This example filters a list down to its even numbers and confirms
+exactly half survive.
+
+```python
+"""Example 14: filter() Keeps Only Evens."""
+
+
+def is_even(n: int) -> bool:  # => the predicate filter will apply to each element
+    return n % 2 == 0  # => True keeps the element, False drops it
+
+
+nums = [1, 2, 3, 4, 5, 6, 7, 8]  # => the source sequence
+
+evens = filter(is_even, nums)  # => LAZY: builds an iterator, no filtering has happened yet
+evens_list = list(evens)  # => forces evaluation -- runs is_even on every element
+
+print(evens_list)  # => Output: [2, 4, 6, 8]
+print(len(evens_list))  # => Output: 4 -- exactly half of the original 8 elements
+print(all(n % 2 == 0 for n in evens_list))  # => Output: True -- odds were dropped, not zeroed
+```
+
+**Output**:
+
+```text
+[2, 4, 6, 8]
+4
+True
+```
+
+```python
+"""Example 14: pytest verification for filter() Keeps Only Evens."""
+
+from example import is_even
+
+
+def test_filter_keeps_only_predicate_matches() -> None:
+    nums = [1, 2, 3, 4, 5, 6]
+    result = list(filter(is_even, nums))
+    assert result == [2, 4, 6]
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `filter` shrinks a sequence; it never transforms the surviving elements -- combine it
+with `map` (Example 16) when both shrinking and transforming are needed.
+
+**Why it matters**: `filter` states "keep only elements matching this predicate" directly, without a
+mutable accumulator variable exposed to the caller -- recognizing a hand-written "loop, if-check,
+append" pattern as secretly a `filter` is one of the most immediately useful skills in this topic.
+
+---
+
+### Example 15: reduce() Sums a List
+
+_ex-15 &middot; exercises co-13_
+
+`functools.reduce(fn, iterable, seed)` folds a whole sequence down to a single accumulated value, one
+element at a time, with no explicit accumulator variable in the caller's own code. This example folds a
+list of integers into their sum and confirms it matches the built-in `sum`.
+
+```python
+"""Example 15: reduce() Sums a List."""
+
+from functools import reduce  # => reduce lives in functools, not the builtins
+
+
+def add(a: int, b: int) -> int:  # => the "how to combine two values" step reduce repeats
+    return a + b  # => the two-argument combiner reduce calls at every step
+
+
+nums = [1, 2, 3, 4, 5]  # => the source sequence
+
+total = reduce(add, nums, 0)  # => folds nums into ONE value, starting from the seed 0
+# => reduce computes add(add(add(add(add(0,1),2),3),4),5) -- one running accumulator, no loop written
+
+print(total)  # => Output: 15
+print(total == sum(nums))  # => Output: True -- reduce(add, ..., 0) IS how sum() works internally
+```
+
+**Output**:
+
+```text
+15
+True
+```
+
+```python
+"""Example 15: pytest verification for reduce() Sums a List."""
+
+from functools import reduce
+
+from example import add
+
+
+def test_reduce_sums_the_sequence() -> None:
+    nums = [1, 2, 3, 4, 5]
+    assert reduce(add, nums, 0) == 15 == sum(nums)
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `reduce(fn, iterable, seed)` states "combine every element into one value using fn,
+starting from seed" as a single expression -- no explicit running-total variable in the caller.
+
+**Why it matters**: `map`, `filter`, and `reduce` together cover the overwhelming majority of "loop over
+a collection and do something" code, without a single mutable accumulator variable exposed to the
+caller. `reduce` specifically is the general case that `sum`, `max`, and `any`/`all` are all specialized
+shortcuts for -- once a developer can build an arbitrary reduction by hand, reaching for the stdlib
+shortcut where one exists becomes a readability choice, not a capability gap. Example 37 later chains
+all three into one data-summary pipeline.
+
+---
+
+### Example 16: A Comprehension Matching map() and filter()
+
+_ex-16 &middot; exercises co-13_
+
+A list comprehension with a condition expresses `map` plus `filter` together in one expression -- the
+`if` clause is the filter step, the leading expression is the map step. This example builds the same
+squared-evens list two ways and confirms they are identical.
+
+```python
+"""Example 16: A Comprehension Matching map() and filter()."""
+
+nums = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]  # => the shared source sequence for both approaches
+
+via_map_filter = list(  # => map(square, filter(is_even, nums)), spelled out with a lambda
+    map(lambda n: n * n, filter(lambda n: n % 2 == 0, nums))  # => two nested lazy iterators
+)  # => filter runs first (keeps evens), THEN map squares what survived
+
+via_comprehension = [n * n for n in nums if n % 2 == 0]  # => same two steps, ONE expression
+# => "if n % 2 == 0" is the filter step; "n * n" is the map step -- read left to right
+
+print(via_map_filter)  # => Output: [4, 16, 36, 64, 100]
+print(via_comprehension)  # => Output: [4, 16, 36, 64, 100]
+print(via_map_filter == via_comprehension)  # => Output: True -- two spellings, identical result
+```
+
+**Output**:
+
+```text
+[4, 16, 36, 64, 100]
+[4, 16, 36, 64, 100]
+True
+```
+
+```python
+"""Example 16: pytest verification for A Comprehension Matching map() and filter()."""
+
+
+def test_comprehension_matches_map_filter() -> None:
+    nums = list(range(1, 11))
+    via_map_filter = list(map(lambda n: n * n, filter(lambda n: n % 2 == 0, nums)))
+    via_comprehension = [n * n for n in nums if n % 2 == 0]
+    assert via_map_filter == via_comprehension
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: A comprehension's `if` clause is a `filter`; its leading expression is a `map` -- the
+two spellings compute identically, and Python code usually favors the comprehension for readability.
+
+**Why it matters**: Recognizing that a comprehension and a `map`/`filter` chain are the same computation
+means reaching for whichever reads more clearly in context, rather than treating them as competing
+paradigms. Both remain fully declarative -- neither exposes a mutable loop variable to the caller.
+
+---
+
+### Example 17: Hand-Curry a Two-Argument Function
+
+_ex-17 &middot; exercises co-09_
+
+Currying turns an `n`-argument function into a chain of one-argument functions, each application
+peeling off exactly one argument. This example hand-curries a 2-argument `add` into `add_curried(a)(b)`
+and confirms it matches the uncurried call.
+
+```python
+"""Example 17: Hand-Curry a Two-Argument Function."""
+
+from typing import Callable  # => the return type of add_curried -- "a function int -> int"
+
+
+def add(a: int, b: int) -> int:  # => the ordinary, uncurried, 2-argument function
+    return a + b  # => both arguments supplied in a SINGLE call
+
+
+def add_curried(a: int) -> Callable[[int], int]:  # => takes ONE argument, returns a function
+    def inner(b: int) -> int:  # => the function waiting for the SECOND argument
+        return a + b  # => a is captured from the enclosing scope, b arrives here
+
+    return inner  # => add_curried(a) is itself a usable, partially-applied function
+
+
+uncurried_result = add(2, 3)  # => the ordinary call -- both arguments at once
+curried_result = add_curried(2)(3)  # => two separate calls: add_curried(2) THEN (3)
+
+print(uncurried_result)  # => Output: 5
+print(curried_result)  # => Output: 5
+print(uncurried_result == curried_result)  # => Output: True -- same computation, different shape
+
+add_two = add_curried(2)  # => a reusable, specialized function: "add 2 to whatever comes next"
+print(add_two(10))  # => Output: 12
+```
+
+**Output**:
+
+```text
+5
+5
+True
+12
+```
+
+```python
+"""Example 17: pytest verification for Hand-Curry a Two-Argument Function."""
+
+from example import add, add_curried
+
+
+def test_curried_call_matches_uncurried_call() -> None:
+    assert add_curried(2)(3) == add(2, 3) == 5
+
+
+def test_partially_applied_curry_is_reusable() -> None:
+    add_two = add_curried(2)
+    assert add_two(10) == 12
+    assert add_two(20) == 22
+
+
+# => Run: pytest -- Output: 2 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+2 passed
+```
+
+**Key takeaway**: `add_curried(2)` is itself a usable, reusable function -- currying lets each partial
+application produce a new, smaller function rather than requiring every argument at once.
+
+**Why it matters**: Currying and partial application (co-10, Example 18) are closely related but
+distinct: currying is always one argument at a time by construction, while `functools.partial` can fix
+any number of arguments in a single call. Example 62 later automates this hand-written pattern with a
+`@curry` decorator.
+
+---
+
+### Example 18: functools.partial Fixes an Argument
+
+_ex-18 &middot; exercises co-10_
+
+`functools.partial(fn, *args)` fixes some arguments right now and returns a smaller function waiting
+for the rest -- the stdlib's built-in answer to "I want this function, but with an argument already
+decided." This example fixes `power`'s base and confirms the result matches calling `power` directly.
+
+```python
+"""Example 18: functools.partial Fixes an Argument."""
+
+from functools import partial  # => stdlib's built-in way to pre-fill arguments
+
+
+def power(base: int, exponent: int) -> int:  # => the general 2-argument function
+    return base**exponent  # => base to the exponent power
+
+
+square_of = partial(power, 2)  # => fixes base=2, returns a 1-argument function of exponent
+# => no lambda, no hand-written closure -- functools builds the wrapper for us
+
+print(square_of(3))  # => Output: 8  (power(2, 3) == 2**3)
+print(square_of(10))  # => Output: 1024  (power(2, 10) == 2**10)
+print(power(2, 10) == square_of(10))  # => Output: True -- partial just pre-supplies base
+```
+
+**Output**:
+
+```text
+8
+1024
+True
+```
+
+```python
+"""Example 18: pytest verification for functools.partial Fixes an Argument."""
+
+from functools import partial
+
+from example import power
+
+
+def test_partial_fixes_the_first_argument() -> None:
+    square_of = partial(power, 2)
+    assert square_of(10) == power(2, 10) == 1024
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `functools.partial(fn, arg)` is more discoverable and less error-prone than a
+hand-written wrapping lambda for the identical purpose -- reach for it whenever a function needs "the
+same fn, with an argument already decided."
+
+**Why it matters**: `partial` composes cleanly with `functools.reduce` (Example 33 chains several
+`partial` calls into a pipeline) and with decorator pipelines elsewhere in this topic, and it is the
+stdlib-blessed alternative every code reviewer will recognize instantly over an equivalent
+hand-written closure. Reaching for `partial` instead of writing `lambda n: pow(2, n)` by hand also
+signals intent directly -- "this is a fixed-argument specialization of an existing function" -- rather
+than making a reader reverse-engineer that same fact from an ad hoc closure body.
+
+---
+
+### Example 19: A compose(f, g) Helper
+
+_ex-19 &middot; exercises co-11_
+
+Composition builds a new function `f ∘ g` out of two existing ones, so calling the composed function on
+`x` runs `g(x)` first and feeds its result into `f`. This example hand-writes `compose` and confirms it
+computes exactly `f(g(x))`.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart LR
+    X["x = 3"]:::blue -->|"g = add_one"| G["4"]:::orange
+    G -->|"f = double"| F["8"]:::teal
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 19: A compose(f, g) Helper."""
+
+from typing import Callable  # => the type of every function this example composes
+
+
+def compose(  # => a HOF: takes two functions, RETURNS a new function
+    f: Callable[[int], int], g: Callable[[int], int]  # => the two functions being combined
+) -> Callable[[int], int]:  # => the return type -- itself a function int -> int
+    def composed(x: int) -> int:  # => the returned function -- runs g FIRST, then f
+        return f(g(x))  # => g(x) computed first; its result feeds into f
+
+    return composed  # => composed itself, not a value, is compose's return value
+
+
+def add_one(x: int) -> int:  # => one of the two small functions being composed together
+    return x + 1  # => adds exactly one
+
+
+def double(x: int) -> int:  # => the other small function being composed together
+    return x * 2  # => doubles its argument
+
+
+add_then_double = compose(double, add_one)  # => reads right-to-left: double(add_one(x))
+result = add_then_double(3)  # => add_one(3) is 4, then double(4) is 8
+
+print(result)  # => Output: 8
+print(add_then_double(3) == double(add_one(3)))  # => Output: True -- compose just names f(g(x))
+```
+
+**Output**:
+
+```text
+8
+True
+```
+
+```python
+"""Example 19: pytest verification for A compose(f, g) Helper."""
+
+from example import add_one, compose, double
+
+
+def test_compose_runs_g_then_f() -> None:
+    add_then_double = compose(double, add_one)
+    assert add_then_double(3) == double(add_one(3)) == 8
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `compose(f, g)` names the shape "run `g` first, feed its result into `f`" as a single
+reusable function, instead of writing `f(g(x))` fresh at every call site.
+
+**Why it matters**: Composition is how small, single-purpose functions become a pipeline without being
+fused into one large function body -- each piece stays independently readable and independently
+testable. A codebase built from composed small functions can also be tested at each stage in isolation,
+rather than only end to end, which makes it far easier to pinpoint exactly which step introduced a
+regression. Example 34 later generalizes this to `compose(*fns)` over an arbitrary list of functions.
+
+---
+
+### Example 20: A Left-to-Right pipe Helper
+
+_ex-20 &middot; exercises co-12, co-11_
+
+Where `compose` reads right-to-left (`f(g(x))`), a `pipe` utility reads left-to-right in the order
+values actually flow -- `pipe(x, f, g)` means "start with `x`, apply `f`, then apply `g`." This example
+confirms `pipe` and the equivalent nested call compute the identical result.
+
+```python
+"""Example 20: A Left-to-Right pipe Helper."""
+
+from functools import reduce  # => reduce folds *fns into x one step at a time
+from typing import Callable  # => the type of each step function pipe accepts
+
+
+def pipe(x: int, *fns: Callable[[int], int]) -> int:  # => *fns: any number of step functions
+    return reduce(lambda acc, fn: fn(acc), fns, x)  # => applies each fn IN ORDER, left to right
+
+
+def add_one(x: int) -> int:  # => the first step in the pipeline below
+    return x + 1  # => adds exactly one
+
+
+def double(x: int) -> int:  # => the second step in the pipeline below
+    return x * 2  # => doubles its argument
+
+
+piped_result = pipe(3, add_one, double)  # => reads top-to-bottom: start at 3, add_one, THEN double
+nested_result = double(add_one(3))  # => the equivalent nested call -- reads inside-out instead
+
+print(piped_result)  # => Output: 8
+print(nested_result)  # => Output: 8
+print(piped_result == nested_result)  # => Output: True -- pipe and nesting compute the same thing
+```
+
+**Output**:
+
+```text
+8
+8
+True
+```
+
+```python
+"""Example 20: pytest verification for A Left-to-Right pipe Helper."""
+
+from example import add_one, double, pipe
+
+
+def test_pipe_matches_nested_calls() -> None:
+    assert pipe(3, add_one, double) == double(add_one(3)) == 8
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `pipe` and nested calls compute the identical thing; the only difference is reading
+direction -- `pipe` reads in execution order, nested calls read inside-out.
+
+**Why it matters**: For a chain of more than two or three steps, reading left-to-right in execution
+order is measurably easier to follow than unwinding nested parentheses. Example 74 later contrasts a
+much deeper `pipe` chain against the equivalent nesting on real data, where this readability gap
+becomes concrete.
+
+---
+
+### Example 21: A Generator Yields on Demand
+
+_ex-21 &middot; exercises co-15_
+
+A generator function runs no code at all when called -- it returns a generator object, and the body
+only advances up to the next `yield` each time `next()` is called. This example builds an infinite
+counter and confirms only the values actually pulled are ever computed.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+sequenceDiagram
+    participant Caller
+    participant Gen as counter#40;10#41;
+    Caller->>Gen: next#40;gen#41;
+    Gen-->>Caller: 10
+    Caller->>Gen: next#40;gen#41;
+    Gen-->>Caller: 11
+    Caller->>Gen: next#40;gen#41;
+    Gen-->>Caller: 12
+```
+
+```python
+"""Example 21: A Generator Yields on Demand."""
+
+from typing import Iterator  # => the return type of a generator function
+
+
+def counter(start: int) -> Iterator[int]:  # => a generator FUNCTION -- calling it runs NO code yet
+    n = start  # => the running value, remembered ACROSS yields
+    while True:  # => an INFINITE loop -- safe only because yield pauses execution each time
+        yield n  # => pauses here, handing n back to the caller, resuming on the NEXT next()
+        n += 1  # => only runs AFTER the caller pulls again
+
+
+pulled: list[int] = []  # => tracks exactly which values were actually computed
+gen = counter(10)  # => creates the generator OBJECT -- the while loop has not run at all yet
+
+pulled.append(next(gen))  # => resumes the generator until the first yield -- pulled: [10]
+pulled.append(next(gen))  # => resumes again from where it paused -- pulled: [10, 11]
+pulled.append(next(gen))  # => a third pull -- pulled: [10, 11, 12]
+
+print(pulled)  # => Output: [10, 11, 12]
+print(len(pulled))  # => Output: 3 -- only 3 values ever computed, despite counter() being infinite
+```
+
+**Output**:
+
+```text
+[10, 11, 12]
+3
+```
+
+```python
+"""Example 21: pytest verification for A Generator Yields on Demand."""
+
+from example import counter
+
+
+def test_only_pulled_values_are_computed() -> None:
+    gen = counter(10)
+    pulled = [next(gen), next(gen), next(gen)]
+    assert pulled == [10, 11, 12]
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Calling a generator function builds a paused generator object; the body only advances
+between `yield` points, one `next()` call at a time -- an infinite `while True` loop is safe precisely
+because of this pause.
+
+**Why it matters**: Laziness lets a pipeline operate over a sequence of unknown or infinite size without
+ever materializing it in memory -- the caller only pays for values it actually pulls. Every later
+generator and `itertools` example in this topic (Examples 22-24, 38, 63-64) builds directly on this
+pull-based execution model.
+
+---
+
+### Example 22: Generator Expression vs. List
+
+_ex-22 &middot; exercises co-15_
+
+A list comprehension computes and stores every element immediately; a generator expression with
+identical syntax computes nothing until pulled. This example measures the memory footprint of both over
+one million elements and confirms the generator's footprint stays essentially flat.
+
+```python
+"""Example 22: Generator Expression vs. List."""
+
+import sys  # => sys.getsizeof measures the actual object footprint, in bytes
+
+n = 1_000_000  # => a large N -- big enough to make the memory difference obvious
+
+eager_list = [i * i for i in range(n)]  # => EAGER: every single square computed and stored NOW
+lazy_generator = (i * i for i in range(n))  # => LAZY: builds a generator object, computes NOTHING yet
+# => same source expression, two entirely different memory strategies
+
+list_bytes = sys.getsizeof(eager_list)  # => size of N already-materialized integers' container
+generator_bytes = sys.getsizeof(lazy_generator)  # => size of the generator machinery only
+
+print(list_bytes > generator_bytes)  # => Output: True -- the list is dramatically larger
+print(generator_bytes < 300)  # => Output: True -- a generator's footprint stays tiny regardless of n
+print(next(lazy_generator))  # => Output: 0 -- the FIRST square is only computed on this pull
+```
+
+**Output**:
+
+```text
+True
+True
+0
+```
+
+```python
+"""Example 22: pytest verification for Generator Expression vs. List."""
+
+import sys
+
+
+def test_generator_footprint_stays_small() -> None:
+    n = 1_000_000
+    eager_list = [i * i for i in range(n)]
+    lazy_generator = (i * i for i in range(n))
+    assert sys.getsizeof(eager_list) > sys.getsizeof(lazy_generator)
+    assert sys.getsizeof(lazy_generator) < 300
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: The list comprehension and generator expression compute the identical values; only
+the moment and location of computation differ -- upfront and in memory versus on-demand and streamed.
+
+**Why it matters**: Swapping `[...]` for `(...)` is a one-character change with a dramatic memory
+consequence for large or infinite sequences. Choosing eagerly when every value is needed anyway, and
+lazily when only a prefix or a filtered subset is needed, is a concrete, measurable design decision --
+not a stylistic preference.
+
+---
+
+### Example 23: islice Over an Infinite count()
+
+_ex-23 &middot; exercises co-16, co-15_
+
+`itertools.islice` takes a slice of any iterable, including an infinite one, without ever trying to
+exhaust it. This example takes the first five values from an infinite generator of even numbers and
+confirms the underlying source resumes right where `islice` stopped.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05
+flowchart LR
+    S["count#40;0, 2#41;<br/>infinite: 0, 2, 4, ..."]:::blue -->|"islice#40;..., 5#41;"| F["[0, 2, 4, 6, 8]"]:::orange
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 23: islice Over an Infinite count()."""
+
+from itertools import count, islice  # => count(): an infinite counter; islice: a lazy slice
+
+infinite_evens = (n for n in count(0, 2))  # => LAZY, infinite: 0, 2, 4, 6, ... forever
+first_five = list(islice(infinite_evens, 5))  # => islice pulls exactly 5 values, then STOPS
+# => the underlying infinite generator is NEVER exhausted -- islice just stops pulling
+
+print(first_five)  # => Output: [0, 2, 4, 6, 8]
+print(len(first_five))  # => Output: 5 -- islice never tries to exhaust the infinite source
+next_value = next(infinite_evens)  # => the underlying generator resumes right where islice left it
+print(next_value)  # => Output: 10 -- confirms islice consumed exactly the first 5, no more
+```
+
+**Output**:
+
+```text
+[0, 2, 4, 6, 8]
+5
+10
+```
+
+```python
+"""Example 23: pytest verification for islice Over an Infinite count()."""
+
+from itertools import count, islice
+
+
+def test_islice_takes_exactly_n_from_an_infinite_source() -> None:
+    infinite_evens = (n for n in count(0, 2))
+    first_five = list(islice(infinite_evens, 5))
+    assert first_five == [0, 2, 4, 6, 8]
+    assert next(infinite_evens) == 10  # => confirms the source resumes right where islice stopped
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `islice(iterable, n)` pulls exactly `n` values and stops -- it never tries to exhaust
+its source, which is what makes it safe to use directly on an infinite generator.
+
+**Why it matters**: `itertools.islice` is the idiomatic way to bound an otherwise-unbounded stream
+without wrapping it in manual counting logic. Hand-writing the equivalent bound with an index-tracking
+loop is a common place off-by-one bugs creep in; `islice` centralizes that bookkeeping in a single,
+well-tested stdlib call. Example 63's lazy prime sieve later composes `islice` with several other
+`itertools` building blocks to stay entirely lazy end to end.
+
+---
+
+### Example 24: chain and groupby Over Data
+
+_ex-24 &middot; exercises co-16_
+
+`itertools.chain` concatenates several iterables into one flat sequence; `itertools.groupby` groups
+only _consecutive_ equal keys, which means its input must already be sorted by that key. This example
+combines two lists, sorts, and groups them by first letter.
+
+```python
+"""Example 24: chain and groupby Over Data."""
+
+from itertools import chain, groupby  # => chain: concatenate iterables; groupby: group consecutive keys
+
+morning = ["apple", "apricot", "banana"]  # => two separately-sourced lists to combine
+evening = ["blueberry", "cherry", "avocado"]  # => notice: NOT globally sorted by first letter
+
+combined = list(chain(morning, evening))  # => one flat sequence, morning's items THEN evening's
+print(combined)  # => shows the raw, unsorted concatenation before grouping
+# => Output: ['apple', 'apricot', 'banana', 'blueberry', 'cherry', 'avocado']
+
+grouped = {  # => groupby only groups CONSECUTIVE equal keys -- input must be pre-sorted by key
+    letter: list(items)  # => materialize each lazy group before it is invalidated
+    for letter, items in groupby(  # => sorted() first, so equal first-letters become consecutive
+        sorted(combined), key=lambda w: w[0]  # => the grouping key: each word's first letter
+    )  # => groupby itself is lazy -- list(items) above is what forces each group
+}  # => a plain dict, one entry per distinct first letter seen
+print(grouped["a"])  # => Output: ['apple', 'apricot', 'avocado']
+print(grouped["b"])  # => Output: ['banana', 'blueberry']
+```
+
+**Output**:
+
+```text
+['apple', 'apricot', 'banana', 'blueberry', 'cherry', 'avocado']
+['apple', 'apricot', 'avocado']
+['banana', 'blueberry']
+```
+
+```python
+"""Example 24: pytest verification for chain and groupby Over Data."""
+
+from itertools import chain, groupby
+
+
+def test_chain_then_groupby() -> None:
+    morning = ["apple", "apricot", "banana"]
+    evening = ["blueberry", "cherry", "avocado"]
+    combined = list(chain(morning, evening))
+    grouped = {k: list(v) for k, v in groupby(sorted(combined), key=lambda w: w[0])}
+    assert grouped["a"] == ["apple", "apricot", "avocado"]
+    assert grouped["b"] == ["banana", "blueberry"]
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `groupby` groups only _consecutive_ matching keys -- forgetting to `sorted()` the
+input first is the single most common `groupby` mistake, silently producing more, smaller groups than
+expected.
+
+**Why it matters**: `chain` and `groupby` are two of `itertools`'s most-used composable building blocks
+-- reaching for them instead of a hand-rolled concatenation loop or grouping dict keeps the code both
+shorter and lazy end to end, right up until the point something forces materialization.
+
+---
+
+### Example 25: @lru_cache on a Recursive fib
+
+_ex-25 &middot; exercises co-17_
+
+`functools.lru_cache` memoizes a pure function's results keyed by its arguments -- a repeated call with
+the same argument is served from the cache instead of recomputed. This example decorates a naive
+recursive Fibonacci and confirms `cache_info()` shows a hit on the second identical call.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart LR
+    A["fib#40;30#41;<br/>first call"]:::blue -->|"cache MISS<br/>full recursion"| B["832040<br/>cached"]:::orange
+    C["fib#40;30#41;<br/>second call"]:::blue -->|"cache HIT<br/>no recursion"| B
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 25: @lru_cache on a Recursive fib."""
+
+from functools import lru_cache  # => decorator-based memoization, keyed by call arguments
+
+
+@lru_cache(maxsize=None)  # => unbounded cache -- every unique n is computed at most once
+def fib(n: int) -> int:  # => the classic exponential-without-caching recursive definition
+    if n < 2:  # => base case: fib(0) = 0, fib(1) = 1
+        return n  # => no further recursion needed below n=2
+    return fib(n - 1) + fib(n - 2)  # => WITHOUT caching this branches exponentially
+
+
+result = fib(30)  # => triggers a burst of recursive calls, each cached the FIRST time it runs
+info_after_first = fib.cache_info()  # => snapshot: hits so far, misses so far
+
+fib(30)  # => calling AGAIN with the same n=30 -- served entirely from cache, no recursion
+info_after_second = fib.cache_info()  # => hits increased, misses did NOT
+
+print(result)  # => Output: 832040
+print(info_after_second.hits > info_after_first.hits)  # => Output: True -- repeat call hit the cache
+print(info_after_second.misses == info_after_first.misses)  # => Output: True -- no NEW work happened
+```
+
+**Output**:
+
+```text
+832040
+True
+True
+```
+
+```python
+"""Example 25: pytest verification for @lru_cache on a Recursive fib."""
+
+from example import fib
+
+
+def test_repeat_call_hits_the_cache() -> None:
+    fib.cache_clear()  # => start from a known, empty cache
+    fib(20)  # => first call: populates the cache
+    before = fib.cache_info()
+    fib(20)  # => identical call: should be served from cache
+    after = fib.cache_info()
+    assert after.hits > before.hits
+    assert after.misses == before.misses
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Memoization is safe here only because `fib` is pure -- caching an impure function's
+results would silently return stale side effects along with a stale value.
+
+**Why it matters**: An unmemoized recursive `fib` is exponential; `@lru_cache` makes it linear, because
+every unique argument is computed exactly once and reused on every later call. This one-line decorator
+turns a textbook recursion exercise into a production-viable function, and the same trick generalizes to
+any pure function whose argument space is small enough to cache -- parsing a fixed config value, looking
+up a derived constant, or memoizing an expensive but deterministic computation inside a hot loop.
+
+---
+
+### Example 26: A Logging Decorator Wraps a Function
+
+_ex-26 &middot; exercises co-18_
+
+A decorator is a higher-order function that takes a function and returns a wrapped replacement --
+`@log_calls` on `def add(): ...` is exactly `add = log_calls(add)`, spelled with `@` syntax. This
+example wraps `add` with logging and confirms the wrapped result is unchanged.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart TD
+    A["add#40;2, 3#41;<br/>caller's call"]:::blue --> W["wrapper#40;2, 3#41;<br/>logs BEFORE"]:::orange
+    W --> F["original add#40;2, 3#41;<br/>= 5"]:::teal
+    F --> W2["wrapper logs AFTER<br/>returns 5"]:::orange
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 26: A Logging Decorator Wraps a Function."""
+
+from typing import Callable  # => the type shape both the wrapped and wrapper functions share
+
+calls: list[str] = []  # => records what the decorator observed, for verification below
+
+
+def log_calls(fn: Callable[[int, int], int]) -> Callable[[int, int], int]:  # => decorator: fn -> wrapped fn
+    def wrapper(a: int, b: int) -> int:  # => runs INSTEAD of fn when the decorated name is called
+        calls.append(f"calling {fn.__name__}({a}, {b})")  # => logs BEFORE the real call
+        result = fn(a, b)  # => delegates to the original, undecorated function
+        calls.append(f"{fn.__name__} returned {result}")  # => logs AFTER, using the real result
+        return result  # => the wrapper's return value is EXACTLY the original's return value
+
+    return wrapper  # => this function object replaces add everywhere add() is called
+
+
+@log_calls  # => equivalent to: add = log_calls(add)
+def add(a: int, b: int) -> int:  # => the plain function BEFORE decoration wraps it
+    return a + b  # => the ordinary, undecorated computation
+
+
+wrapped_result = add(2, 3)  # => actually calls wrapper(2, 3), which logs then delegates
+print(wrapped_result)  # => Output: 5 -- the wrapped result is unchanged from the plain call
+print(calls)  # => Output: ['calling add(2, 3)', 'add returned 5']
+```
+
+**Output**:
+
+```text
+5
+['calling add(2, 3)', 'add returned 5']
+```
+
+```python
+"""Example 26: pytest verification for A Logging Decorator Wraps a Function."""
+
+from example import add
+
+
+def test_decorator_preserves_the_result() -> None:
+    assert add(2, 3) == 5  # => the wrapped call still returns the correct value
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `@log_calls` on `def add(): ...` is exactly `add = log_calls(add)` -- the `@` syntax
+is sugar over a plain function-to-function transformation, nothing more.
+
+**Why it matters**: Decorators attach cross-cutting behavior -- logging, timing, retrying, caching --
+without touching the decorated function's own body, which keeps that behavior reusable across any
+function it is applied to instead of copy-pasted into each one. Example 43 later shows the one detail
+this example glosses over: without `functools.wraps`, the wrapped function's `__name__` and metadata
+are lost, which breaks introspection tools and confuses debuggers reading a stack trace.
+
+---
+
+### Example 27: A Recursive Factorial (No TCO)
+
+_ex-27 &middot; exercises co-14_
+
+Recursion is the functional idiom for what a loop does imperatively -- but CPython, by explicit design
+choice, performs no tail-call optimization, so every recursive call grows the call stack by one frame.
+This example computes a modest recursive factorial and confirms it stays comfortably under the default
+recursion ceiling.
+
+```python
+"""Example 27: A Recursive Factorial (No TCO)."""
+
+import sys  # => sys.getrecursionlimit -- CPython's hard, load-bearing recursion ceiling
+
+
+def factorial(n: int) -> int:  # => the textbook recursive definition -- one call per n
+    if n <= 1:  # => base case stops the recursion
+        return 1  # => factorial(0) and factorial(1) both bottom out here
+    return n * factorial(n - 1)  # => NOT a tail call reduced away -- CPython keeps every frame
+
+
+result = factorial(10)  # => 10 nested calls deep -- trivially within the default limit
+print(result)  # => Output: 3628800
+
+limit = sys.getrecursionlimit()  # => the default ceiling (commonly 1000) -- CPython has NO TCO
+# => a self-tail-call in Python is NOT collapsed into a loop by the interpreter, unlike Scheme
+print(limit > 100)  # => Output: True -- 10 frames of factorial(10) fit comfortably under this
+print(10 < limit)  # => Output: True -- confirms this call never approaches the ceiling
+```
+
+**Output**:
+
+```text
+3628800
+True
+True
+```
+
+```python
+"""Example 27: pytest verification for A Recursive Factorial (No TCO)."""
+
+from example import factorial
+
+
+def test_factorial_matches_the_known_value() -> None:
+    assert factorial(10) == 3628800
+    assert factorial(0) == 1  # => base case
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Every recursive call in CPython grows the call stack by one frame -- there is no
+tail-call optimization collapsing `n * factorial(n - 1)` into a loop, unlike Scheme or other functional
+languages that guarantee it.
+
+**Why it matters**: Recursion is often the most natural way to express a divide-and-conquer or
+tree-shaped computation, but Python's missing TCO is a real, load-bearing limit. Example 44 converts a
+deep recursion into an explicit stack, and Example 66 builds a trampoline -- the two standard workarounds
+this constraint demands.
+
+---
+
+### Example 28: Guarding a None-Returning Function
+
+_ex-28 &middot; exercises co-22_
+
+`dict.get` returns `None` on a missing key instead of raising, making "not found" an ordinary value the
+caller must check before trusting. This example looks up a hit and a miss and confirms both are handled
+explicitly by the same guard pattern.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart TD
+    L["find_user_age#40;...#41;"]:::blue --> Q{"result is<br/>not None?"}:::orange
+    Q -->|Yes: hit| H["use the age"]:::teal
+    Q -->|No: miss| M["handle absence"]:::teal
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 28: Guarding a None-Returning Function."""
+
+
+def find_user_age(users: dict[str, int], name: str) -> int | None:  # => None means "not found"
+    return users.get(name)  # => dict.get returns None on a missing key -- no exception raised
+
+
+directory = {"ana": 30, "budi": 25}  # => the lookup table this example queries
+
+found_age = find_user_age(directory, "ana")  # => a hit -- found_age is 30
+if found_age is not None:  # => the guard: caller MUST check before trusting the value
+    print(f"ana is {found_age}")  # => Output: ana is 30
+else:  # => the miss branch -- never taken for this particular lookup
+    print("ana not found")  # => unreachable here -- ana IS in the directory
+
+missing_age = find_user_age(directory, "citra")  # => a miss -- missing_age is None
+if missing_age is not None:  # => same guard pattern, this time it takes the OTHER branch
+    print(f"citra is {missing_age}")  # => unreachable here -- citra is NOT in the directory
+else:  # => the miss branch -- taken this time, since citra is not in directory
+    print("citra not found")  # => Output: citra not found
+```
+
+**Output**:
+
+```text
+ana is 30
+citra not found
+```
+
+```python
+"""Example 28: pytest verification for Guarding a None-Returning Function."""
+
+from example import find_user_age
+
+
+def test_hit_and_miss_are_both_handled() -> None:
+    directory = {"ana": 30}
+    assert find_user_age(directory, "ana") == 30
+    assert find_user_age(directory, "citra") is None
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `int | None` states in the return type itself that absence is possible -- the `is not
+None` guard is the caller honoring that contract, not defensive boilerplate.
+
+**Why it matters**: A caller that forgets the `None` check crashes later with an unhelpful
+"`NoneType` has no attribute" error, far from where the `None` actually originated. Example 48 replaces
+this pattern with a hand-rolled `Option` type that forces the caller to unwrap explicitly, turning a
+possible runtime crash into a type-level obligation.

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner.md
@@ -2183,3 +2183,7 @@ None` guard is the caller honoring that contract, not defensive boilerplate.
 "`NoneType` has no attribute" error, far from where the `None` actually originated. Example 48 replaces
 this pattern with a hand-rolled `Option` type that forces the caller to unwrap explicitly, turning a
 possible runtime crash into a type-level obligation.
+
+---
+
+← Previous: [Overview](./overview.md) &middot; Next: [Intermediate Examples](./intermediate.md) →

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/_index.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Capstone"
+date: 2026-07-17T00:00:00+07:00
+draft: false
+weight: 900
+---
+
+- [Overview](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/overview)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/bad_transactions.csv
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/bad_transactions.csv
@@ -1,0 +1,6 @@
+category,amount
+Electronics,199.99
+BadRow
+Groceries,abc
+,50.00
+Books,-5.00

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/core.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/core.py
@@ -1,0 +1,384 @@
+"""Capstone -- Functional Core: Transaction Log Analyzer.
+
+Pure parse -> transform -> aggregate pipeline, zero I/O anywhere in this file. Exercises co-01
+(pure functions), co-03 (referential transparency), co-04/co-05 (immutability + structural
+sharing via a fresh Totals on every update), co-11/co-13 (a pipe() composition pipeline built
+from map/filter/reduce), co-22/co-23 (hand-rolled Option and Result types), co-24 (a railway of
+and_then hops inside parse_row), co-25 (Result.map and Option.map used as functors), co-26 (map2,
+an applicative combinator for two independent Results), co-27 (and_then/bind chaining
+Result-returning steps), and co-28 (this whole file IS the functional core half of the split --
+see shell.py for the imperative shell that is the only place with I/O).
+"""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Option[U]'/'Result[U, F]' forward references below
+
+from collections.abc import (
+    Mapping,
+)  # => the read-only VIEW type Totals.by_category exposes to callers
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds every immutable record/variant here
+from functools import (
+    reduce,
+)  # => reduce folds rows into Totals (co-13) and folds pipe()'s steps (co-11)
+from types import (
+    MappingProxyType,
+)  # => wraps every Totals.by_category dict as read-only (co-04)
+from typing import (
+    Callable,
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar/Callable type every generic container below
+
+T = TypeVar(
+    "T"
+)  # => a generic "value this container wraps" type, reused across Option/Result/pipe
+U = TypeVar("U")  # => the type a map/and_then/bind step transforms T into
+V = TypeVar("V")  # => the type map2's two-argument function returns
+E = TypeVar("E")  # => the type of the error an Err wraps (kept distinct from F below)
+F = TypeVar(
+    "F"
+)  # => the error type threaded through and_then's step function, not hardcoded to object
+
+
+# ---------------------------------------------------------------------------
+# Option (co-22): "absence" as a value, plus co-25's functor .map()
+# ---------------------------------------------------------------------------
+
+
+@dataclass(
+    frozen=True
+)  # => marks Some immutable, matching every other record in this file
+class Some(Generic[T]):  # => the "present" variant, carrying exactly one value
+    value: T  # => the single field this variant carries
+
+    def map(
+        self, fn: Callable[[T], U]
+    ) -> "Option[U]":  # => co-25: applies fn INSIDE, without unwrapping
+        return Some(fn(self.value))  # => stays wrapped -- Some in, Some out
+
+
+@dataclass(frozen=True)  # => marks Nothing immutable too
+class Nothing:  # => the "absent" variant, carrying nothing at all
+    def map(
+        self, fn: Callable[[T], U]
+    ) -> "Nothing":  # => NO-OP, generic so a typed fn still type-checks
+        return self  # => there is nothing to apply fn to -- Nothing stays Nothing
+
+
+Option = (
+    Some[T] | Nothing
+)  # => PEP 604 union: an Option[T] is either Some[T] or Nothing
+
+
+# ---------------------------------------------------------------------------
+# Result (co-23): success-or-failure as a value, plus co-24/co-25/co-27
+# ---------------------------------------------------------------------------
+
+
+@dataclass(
+    frozen=True
+)  # => marks Ok immutable, matching the FP style used across this whole topic
+class Ok(Generic[T]):  # => the "success" variant, carrying the computed value
+    value: T  # => the single field this variant carries
+
+    def map(
+        self, fn: Callable[[T], U]
+    ) -> "Ok[U]":  # => co-25: transforms SUCCESS only, error type never widens
+        return Ok(fn(self.value))  # => transforms the value, stays wrapped as Ok
+
+    def and_then(  # => co-27: chains into ANOTHER Result-returning step, without double-wrapping
+        self,
+        fn: Callable[[T], "Result[U, F]"],  # => F is inferred from fn's own error type
+    ) -> "Result[U, F]":  # => closes the multi-line signature above
+        return fn(
+            self.value
+        )  # => runs fn on the unwrapped value; fn itself returns a Result
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(
+    Generic[E]
+):  # => the "failure" variant, carrying the ERROR AS A VALUE, never an exception
+    error: E  # => the single field this variant carries
+
+    def map(
+        self, fn: Callable[[T], U]
+    ) -> "Err[E]":  # => NO-OP: generic so a typed fn still type-checks
+        return self  # => the error passes through UNCHANGED -- fn never runs
+
+    def and_then(
+        self, fn: Callable[[T], U]
+    ) -> "Err[E]":  # => co-24: the short-circuit half of the railway
+        return self  # => once on the failure track, every remaining step is skipped
+
+
+Result = Ok[T] | Err[E]  # => the ADT itself: a Result is EITHER variant
+
+
+# ---------------------------------------------------------------------------
+# Immutable domain records (co-04)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(
+    frozen=True
+)  # => one PARSED, immutable transaction row -- never mutated after construction
+class Row:  # => the class body begins here
+    category: str  # => e.g. "electronics" -- normalized to lowercase by normalize_categories() below
+    amount: (
+        float  # => a non-negative amount, already validated by the time a Row exists
+    )
+
+
+@dataclass(frozen=True)  # => an immutable per-category rollup
+class Totals:  # => the class body begins here
+    by_category: Mapping[
+        str, float
+    ]  # => always a MappingProxyType -- co-04: read-only from the outside
+
+
+EMPTY_TOTALS = Totals(
+    by_category=MappingProxyType({})
+)  # => the monoid IDENTITY element for combine_totals()
+
+
+# ---------------------------------------------------------------------------
+# Composition helper (co-11, co-12): reads left-to-right, execution order
+# ---------------------------------------------------------------------------
+
+
+def pipe(
+    value: T, *fns: Callable[[T], T]
+) -> T:  # => any number of same-shaped steps, applied IN ORDER
+    return reduce(
+        lambda acc, fn: fn(acc), fns, value
+    )  # => co-13: reduce folds each step over the accumulator
+
+
+# ---------------------------------------------------------------------------
+# Row parsing: a railway of Result-returning steps (co-01, co-23, co-24, co-27)
+# ---------------------------------------------------------------------------
+
+
+def split_fields(
+    line: str,
+) -> "Result[tuple[str, str], str]":  # => railway step 1: shape only
+    parts = line.split(
+        ",", 1
+    )  # => splits "electronics,199.99" into ["electronics", "199.99"]
+    if (
+        len(parts) != 2
+    ):  # => the ONLY thing this step checks -- exactly one comma, two fields
+        return Err(f"malformed row (expected 'category,amount'): {line!r}")
+    return Ok(
+        (parts[0].strip(), parts[1].strip())
+    )  # => success: two trimmed fields, still UNVALIDATED
+
+
+def validate_category(
+    fields: tuple[str, str],
+) -> "Result[tuple[str, str], str]":  # => railway step 2
+    category, amount_text = (
+        fields  # => unpacks the tuple split_fields() already produced
+    )
+    if category == "":  # => the ONLY thing THIS step checks
+        return Err(f"category cannot be empty (amount was {amount_text!r})")
+    return Ok(fields)  # => success: fields pass through completely unchanged
+
+
+def parse_amount_field(
+    fields: tuple[str, str],
+) -> "Result[Row, str]":  # => railway step 3: builds the Row
+    category, amount_text = (
+        fields  # => unpacks the tuple the prior two steps already validated
+    )
+    try:
+        amount = float(
+            amount_text
+        )  # => may raise ValueError on "abc" -- CAUGHT below, never escapes
+    except (
+        ValueError
+    ):  # => co-23: the failure becomes a VALUE, not a propagating exception
+        return Err(f"invalid amount for {category!r}: {amount_text!r} is not a number")
+    if (
+        amount < 0
+    ):  # => the SECOND check this step makes, only reached once parsing succeeded
+        return Err(f"negative amount for {category!r}: {amount_text!r}")
+    return Ok(
+        Row(category=category, amount=amount)
+    )  # => all three railway steps passed
+
+
+def parse_row(
+    line: str,
+) -> "Result[Row, str]":  # => co-24: chains all three steps into ONE railway
+    return split_fields(line).and_then(validate_category).and_then(parse_amount_field)
+    # => co-27: each and_then hop only runs if EVERY prior step already succeeded
+
+
+def parse_rows(
+    lines: list[str],
+) -> "Result[tuple[Row, ...], tuple[str, ...]]":  # => across-rows accumulation
+    oks: list[Row] = []  # => collects every SUCCESSFULLY parsed row
+    errors: list[
+        str
+    ] = []  # => collects every FAILURE, across every line, not just the first
+    for line in (
+        lines
+    ):  # => visits EVERY line regardless of earlier failures -- no early return here
+        result = parse_row(line)  # => delegates to the pure per-line railway above
+        if isinstance(result, Ok):  # => this particular line parsed cleanly
+            oks.append(result.value)
+        else:  # => this particular line was malformed somewhere along the railway
+            errors.append(
+                result.error
+            )  # => a bad line contributes its error, parsing CONTINUES
+    if errors:  # => at least one line was malformed
+        return Err(
+            tuple(errors)
+        )  # => reports EVERY malformed line at once, not just the first
+    return Ok(tuple(oks))  # => every line parsed cleanly
+
+
+# ---------------------------------------------------------------------------
+# Pure aggregation pipeline (co-11, co-13)
+# ---------------------------------------------------------------------------
+
+
+def keep_positive_amounts(rows: tuple[Row, ...]) -> tuple[Row, ...]:  # => co-13 filter
+    return tuple(
+        filter(lambda row: row.amount > 0, rows)
+    )  # => drops zero-amount no-op transactions
+
+
+def normalize_categories(rows: tuple[Row, ...]) -> tuple[Row, ...]:  # => co-13 map
+    return tuple(  # => rebuilds a BRAND NEW tuple -- rows itself is never mutated
+        map(lambda row: Row(category=row.category.lower(), amount=row.amount), rows)
+    )  # => lowercases category so "Electronics" and "electronics" group together downstream
+
+
+def add_row(
+    totals: Totals, row: Row
+) -> Totals:  # => a PURE fold step: returns a NEW Totals, never mutates
+    merged = dict(
+        totals.by_category
+    )  # => shallow copy -- co-04/co-05: the OLD totals stays fully intact
+    merged[row.category] = (
+        merged.get(row.category, 0.0) + row.amount
+    )  # => accumulates onto the COPY only
+    return Totals(
+        by_category=MappingProxyType(merged)
+    )  # => wraps the copy back up as read-only
+
+
+def aggregate(
+    rows: tuple[Row, ...],
+) -> Totals:  # => the pure core's aggregation entry point
+    cleaned = pipe(
+        rows, keep_positive_amounts, normalize_categories
+    )  # => co-11/co-12: composed pipeline
+    return reduce(
+        add_row, cleaned, EMPTY_TOTALS
+    )  # => co-13 reduce: folds cleaned rows into one Totals
+
+
+# ---------------------------------------------------------------------------
+# Monoid combine + applicative map2 (co-26)
+# ---------------------------------------------------------------------------
+
+
+def combine_totals(
+    a: Totals, b: Totals
+) -> Totals:  # => the MONOID operation: associative, has an identity
+    merged = dict(
+        a.by_category
+    )  # => starts from a COPY of a -- a itself is never touched
+    for (
+        category,
+        amount,
+    ) in b.by_category.items():  # => folds every entry from b onto the copy
+        merged[category] = merged.get(category, 0.0) + amount
+    return Totals(
+        by_category=MappingProxyType(merged)
+    )  # => EMPTY_TOTALS is this operation's identity element
+
+
+def map2(  # => co-26: the applicative combinator -- combines TWO independently-wrapped Results
+    fn: Callable[[T, U], V],
+    a: "Result[T, tuple[str, ...]]",
+    b: "Result[U, tuple[str, ...]]",
+) -> "Result[V, tuple[str, ...]]":  # => closes the multi-line signature above
+    if isinstance(a, Ok) and isinstance(
+        b, Ok
+    ):  # => the ONLY case where fn actually runs
+        return Ok(
+            fn(a.value, b.value)
+        )  # => unwraps BOTH, applies fn, wraps the combined result back up
+    errors: tuple[
+        str, ...
+    ] = ()  # => co-26 vs co-24: ACCUMULATES from both sides instead of short-circuiting
+    if isinstance(a, Err):  # => a failed -- fold its errors in
+        errors += a.error
+    if isinstance(
+        b, Err
+    ):  # => b failed -- fold its errors in TOO, even if a already failed
+        errors += b.error
+    return Err(
+        errors
+    )  # => reports every failing side at once, not just the first one found
+
+
+# ---------------------------------------------------------------------------
+# Top-level pure entry points
+# ---------------------------------------------------------------------------
+
+
+def analyze(
+    csv_text: str,
+) -> "Result[Totals, tuple[str, ...]]":  # => PURE CORE: text in, Result out, no I/O
+    lines = csv_text.strip().splitlines()[
+        1:
+    ]  # => drops the header row, e.g. "category,amount"
+    return parse_rows(lines).map(
+        aggregate
+    )  # => co-25 functor: transforms success, error rides through untouched
+
+
+def combine_partial_analyses(  # => opens the multi-line signature of the monoid-combine entry point
+    csv_text_a: str,
+    csv_text_b: str,  # => two independently self-headered "files"
+) -> "Result[Totals, tuple[str, ...]]":  # => closes the multi-line signature above
+    return map2(
+        combine_totals, analyze(csv_text_a), analyze(csv_text_b)
+    )  # => co-26 applicative + monoid combine
+
+
+def top_category(
+    totals: Totals,
+) -> "Option[str]":  # => co-22: absence is a VALUE, not a None landmine
+    if not totals.by_category:  # => nothing was ever aggregated
+        return Nothing()
+    best = max(
+        totals.by_category.items(), key=lambda pair: pair[1]
+    )  # => (category, amount) with the max total
+    return Some(best[0])
+
+
+def format_report(totals: Totals) -> str:  # => still PURE: data -> text, zero I/O
+    lines = [
+        f"{category}: {amount:.2f}"
+        for category, amount in sorted(totals.by_category.items())
+    ]
+    headline = top_category(
+        totals
+    ).map(  # => co-25 functor: Option.map builds the headline INSIDE the wrapper
+        lambda category: f"Top category: {category}"
+    )
+    if isinstance(headline, Some):  # => a category actually exists
+        lines.append(headline.value)
+    else:  # => totals.by_category was empty -- top_category() returned Nothing
+        lines.append("Top category: (no transactions)")
+    return "\n".join(lines)  # => a plain string -- the shell decides how to display it

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/pyrightconfig.json
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/pyrightconfig.json
@@ -1,0 +1,5 @@
+{
+  "typeCheckingMode": "strict",
+  "pythonVersion": "3.13",
+  "include": ["."]
+}

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/requirements.txt
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/requirements.txt
@@ -1,0 +1,2 @@
+pytest==9.1.1
+hypothesis==6.156.6

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/sample_transactions.csv
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/sample_transactions.csv
@@ -1,0 +1,8 @@
+category,amount
+Electronics,199.99
+Groceries,45.50
+electronics,89.00
+Books,15.25
+Groceries,12.75
+Apparel,60.00
+Books,0.00

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/shell.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/shell.py
@@ -1,0 +1,62 @@
+"""Capstone -- Imperative Shell: reads a transaction CSV file and prints the report.
+
+Exercises co-28's OTHER half: main() is the ONLY function in this whole capstone that performs
+I/O (reading a file, writing to stdout/stderr). Every actual computation -- parsing, validating,
+aggregating, formatting -- is delegated straight to core.py's pure functions; this file holds no
+transformation logic of its own at all.
+"""
+
+from __future__ import annotations
+
+import sys  # => sys.argv (read) and sys.exit (write the process exit code) -- both I/O boundaries
+from pathlib import (
+    Path,
+)  # => Path.read_text() is this shell's ONE file-reading I/O boundary
+
+from core import (
+    Err,
+    analyze,
+    format_report,
+)  # => everything computational comes from the pure core
+
+
+def main(
+    argv: list[str],
+) -> int:  # => the IMPERATIVE SHELL entry point -- the ONLY place with I/O
+    if (
+        len(argv) != 1
+    ):  # => a tiny bit of shell-level argument handling, still not "business logic"
+        print(
+            "usage: shell.py <transactions.csv>", file=sys.stderr
+        )  # => I/O boundary: stderr
+        return 2  # => a non-zero exit code signals misuse to the calling shell/CI
+    path = Path(
+        argv[0]
+    )  # => resolves the CLI argument into a filesystem path -- no read yet
+    csv_text = (
+        path.read_text()
+    )  # => I/O boundary: the ONE file read in this entire capstone
+    result = analyze(
+        csv_text
+    )  # => delegates EVERYTHING else to the pure core -- zero logic here
+    if isinstance(
+        result, Err
+    ):  # => malformed input: report every collected error, do NOT crash
+        print(f"{len(result.error)} error(s) found:")  # => I/O boundary: stdout
+        for (
+            message
+        ) in result.error:  # => walks EVERY accumulated error, not just the first
+            print(f"  {message}")  # => one printed line per malformed input row
+        return 1  # => a non-zero exit code signals "input had errors" to the calling shell/CI
+    print(
+        format_report(result.value)
+    )  # => I/O boundary: prints the pure core's own report string
+    return 0  # => success
+
+
+if (
+    __name__ == "__main__"
+):  # => only runs when invoked directly, e.g. `python3 shell.py sample.csv`
+    sys.exit(
+        main(sys.argv[1:])
+    )  # => argv[0] is the script name itself -- argv[1:] is the real arguments

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/test_core.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/test_core.py
@@ -1,0 +1,343 @@
+"""Capstone Step 1: pytest suite for the pure core (core.py) -- zero mocking anywhere in this file.
+
+Covers the railway (co-24), the applicative/monoid combine (co-26), the functor .map() calls
+(co-25), and two Hypothesis property tests: purity/referential transparency (co-01, co-03) and
+the monoid-combine invariant Step 4 asks for -- combining two partial aggregates equals
+aggregating the whole file in one pass, checked across many generated inputs, not by hand.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from core import (
+    EMPTY_TOTALS,
+    Err,
+    Nothing,
+    Ok,
+    Row,
+    Some,
+    Totals,
+    aggregate,
+    analyze,
+    combine_partial_analyses,
+    combine_totals,
+    format_report,
+    keep_positive_amounts,
+    map2,
+    normalize_categories,
+    parse_row,
+    parse_rows,
+    pipe,
+    top_category,
+)
+
+# ---------------------------------------------------------------------------
+# parse_row: the railway (co-24) -- each malformed shape triggers a DIFFERENT step
+# ---------------------------------------------------------------------------
+
+
+def test_parse_row_accepts_a_well_formed_line() -> None:
+    assert parse_row("electronics,199.99") == Ok(
+        Row(category="electronics", amount=199.99)
+    )
+
+
+def test_parse_row_rejects_the_wrong_shape() -> None:
+    result = parse_row("not-a-valid-row")
+    assert isinstance(result, Err)
+    assert "malformed row" in result.error
+
+
+def test_parse_row_rejects_an_empty_category() -> None:
+    result = parse_row(",50.00")
+    assert isinstance(result, Err)
+    assert "category cannot be empty" in result.error
+
+
+def test_parse_row_rejects_a_non_numeric_amount() -> None:
+    result = parse_row("groceries,abc")
+    assert isinstance(result, Err)
+    assert "not a number" in result.error
+
+
+def test_parse_row_rejects_a_negative_amount() -> None:
+    result = parse_row("books,-5.00")
+    assert isinstance(result, Err)
+    assert "negative amount" in result.error
+
+
+def test_parse_row_never_raises_on_malformed_input() -> None:
+    # => co-23: failure is a VALUE (Err), never a propagating exception -- this is the whole point
+    for bad_line in ("garbage", ",1.00", "x,abc", "x,-1"):
+        result = parse_row(
+            bad_line
+        )  # => must NOT raise -- if it does, this test fails with an error, not an assert
+        assert isinstance(result, Err)
+
+
+# ---------------------------------------------------------------------------
+# parse_rows: accumulates EVERY error across the whole file (Step 3's requirement)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_rows_collects_every_malformed_line_not_just_the_first() -> None:
+    lines = ["electronics,199.99", "garbage", "groceries,abc", ",50.00", "books,-5.00"]
+    result = parse_rows(lines)
+    assert isinstance(result, Err)
+    assert (
+        len(result.error) == 4
+    )  # => all FOUR malformed lines are reported, not just the first one
+
+
+def test_parse_rows_all_valid_returns_ok_of_every_row() -> None:
+    lines = ["electronics,199.99", "books,15.25"]
+    result = parse_rows(lines)
+    assert result == Ok(
+        (
+            Row(category="electronics", amount=199.99),
+            Row(category="books", amount=15.25),
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# aggregate: the pure map/filter/reduce + pipe() composition pipeline (co-11, co-13)
+# ---------------------------------------------------------------------------
+
+
+def test_keep_positive_amounts_drops_zero_amount_rows() -> None:
+    rows = (Row("a", 10.0), Row("b", 0.0), Row("c", 5.0))
+    assert keep_positive_amounts(rows) == (Row("a", 10.0), Row("c", 5.0))
+
+
+def test_normalize_categories_lowercases_every_row() -> None:
+    rows = (Row("Electronics", 10.0), Row("BOOKS", 5.0))
+    assert normalize_categories(rows) == (Row("electronics", 10.0), Row("books", 5.0))
+
+
+def test_pipe_reads_left_to_right_like_nested_calls() -> None:
+    rows = (Row("Electronics", 10.0), Row("Books", 0.0))
+    piped = pipe(rows, keep_positive_amounts, normalize_categories)
+    nested = normalize_categories(keep_positive_amounts(rows))
+    assert piped == nested == (Row("electronics", 10.0),)
+
+
+def test_aggregate_sums_by_normalized_category_and_drops_zeros() -> None:
+    rows = (Row("Electronics", 199.99), Row("electronics", 89.00), Row("Books", 0.0))
+    totals = aggregate(rows)
+    assert dict(totals.by_category) == {"electronics": 288.99}
+
+
+def test_aggregate_of_empty_rows_is_the_monoid_identity() -> None:
+    assert aggregate(()) == EMPTY_TOTALS
+
+
+# ---------------------------------------------------------------------------
+# combine_totals: the monoid (associativity + identity), map2: the applicative (co-26)
+# ---------------------------------------------------------------------------
+
+
+def test_combine_totals_merges_and_sums_overlapping_categories() -> None:
+    a = Totals(by_category={"electronics": 100.0, "books": 5.0})
+    b = Totals(by_category={"electronics": 50.0, "groceries": 10.0})
+    combined = combine_totals(a, b)
+    assert dict(combined.by_category) == {
+        "electronics": 150.0,
+        "books": 5.0,
+        "groceries": 10.0,
+    }
+
+
+def test_combine_totals_identity_law() -> None:
+    a = Totals(by_category={"electronics": 100.0})
+    assert combine_totals(EMPTY_TOTALS, a) == a  # => left identity
+    assert combine_totals(a, EMPTY_TOTALS) == a  # => right identity
+
+
+def test_combine_totals_never_mutates_either_input() -> None:
+    a = Totals(by_category={"electronics": 100.0})
+    b = Totals(by_category={"electronics": 50.0})
+    combine_totals(a, b)  # => call once, discard the result
+    assert dict(a.by_category) == {"electronics": 100.0}  # => a is provably UNCHANGED
+    assert dict(b.by_category) == {"electronics": 50.0}  # => b is provably UNCHANGED
+
+
+def add_ints(
+    x: int, y: int
+) -> int:  # => a NAMED, fully-typed function -- pins map2's T/U/V at every call
+    return (
+        x + y
+    )  # => a bare lambda here would leave pyright unable to infer T/U from Err-only arguments
+
+
+def test_map2_combines_two_oks_by_running_fn() -> None:
+    result = map2(add_ints, Ok(2), Ok(3))
+    assert result == Ok(5)
+
+
+def test_map2_accumulates_errors_from_both_sides() -> None:
+    result = map2(add_ints, Err(("left broke",)), Err(("right broke",)))
+    assert result == Err(
+        ("left broke", "right broke")
+    )  # => BOTH sides reported, co-26 vs co-24's short-circuit
+
+
+def test_map2_short_circuits_to_the_single_side_that_failed() -> None:
+    assert map2(add_ints, Ok(2), Err(("right broke",))) == Err(("right broke",))
+    assert map2(add_ints, Err(("left broke",)), Ok(3)) == Err(("left broke",))
+
+
+# ---------------------------------------------------------------------------
+# analyze / combine_partial_analyses: the top-level pure entry points (co-28's pure half)
+# ---------------------------------------------------------------------------
+
+
+VALID_CSV = "category,amount\nElectronics,199.99\nGroceries,45.50\nelectronics,89.00\nBooks,0.00\n"
+INVALID_CSV = "category,amount\nElectronics,199.99\ngarbage\nGroceries,abc\n"
+
+
+def test_analyze_on_valid_csv_returns_ok_totals() -> None:
+    result = analyze(VALID_CSV)
+    assert isinstance(result, Ok)
+    assert dict(result.value.by_category) == {"electronics": 288.99, "groceries": 45.50}
+
+
+def test_analyze_on_malformed_csv_returns_err_not_an_exception() -> None:
+    result = analyze(INVALID_CSV)  # => must NOT raise
+    assert isinstance(result, Err)
+    assert len(result.error) == 2  # => both malformed rows collected
+
+
+def test_analyze_called_twice_with_the_same_text_returns_an_equal_result() -> None:
+    # => co-03: referential transparency -- the SAME call always substitutes for the SAME value
+    assert analyze(VALID_CSV) == analyze(VALID_CSV)
+
+
+def test_combine_partial_analyses_equals_analyzing_the_whole_file_at_once() -> None:
+    # => Step 4's literal acceptance check: split into two files, combine, compare to one pass
+    csv_a = "category,amount\nElectronics,199.99\nGroceries,45.50\n"
+    csv_b = "category,amount\nelectronics,89.00\nBooks,0.00\n"
+    combined = combine_partial_analyses(csv_a, csv_b)
+    whole = analyze(
+        VALID_CSV
+    )  # => VALID_CSV's rows ARE exactly csv_a's rows followed by csv_b's rows
+    assert isinstance(combined, Ok) and isinstance(whole, Ok)
+    assert dict(combined.value.by_category) == dict(whole.value.by_category)
+
+
+# ---------------------------------------------------------------------------
+# top_category / format_report: Option's functor .map() (co-22, co-25)
+# ---------------------------------------------------------------------------
+
+
+def test_top_category_on_empty_totals_is_nothing() -> None:
+    assert top_category(EMPTY_TOTALS) == Nothing()
+
+
+def test_top_category_on_nonempty_totals_is_some_of_the_largest() -> None:
+    totals = Totals(by_category={"books": 5.0, "electronics": 288.99})
+    assert top_category(totals) == Some("electronics")
+
+
+def test_format_report_includes_every_category_and_the_top_line() -> None:
+    totals = Totals(by_category={"books": 5.0, "electronics": 288.99})
+    report = format_report(totals)
+    assert "books: 5.00" in report
+    assert "electronics: 288.99" in report
+    assert "Top category: electronics" in report
+
+
+def test_format_report_on_empty_totals_says_so() -> None:
+    assert "Top category: (no transactions)" in format_report(EMPTY_TOTALS)
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis property tests (Step 1's "incl. a Hypothesis invariant" requirement)
+# ---------------------------------------------------------------------------
+
+
+category_strategy = st.sampled_from(
+    ["electronics", "groceries", "books", "apparel", "toys"]
+)
+amount_strategy = st.floats(
+    min_value=0, max_value=1000, allow_nan=False, allow_infinity=False
+).map(
+    lambda x: round(
+        x, 2
+    )  # => rounds to cents -- keeps sums human-checkable, avoids deep float noise
+)
+row_strategy = st.tuples(category_strategy, amount_strategy)
+
+
+def rows_to_csv(rows: list[tuple[str, float]]) -> str:
+    body = "\n".join(f"{category},{amount}" for category, amount in rows)
+    return f"category,amount\n{body}\n" if body else "category,amount\n"
+
+
+def totals_approx_equal(a: Totals, b: Totals, tolerance: float = 1e-6) -> bool:
+    keys = set(a.by_category) | set(
+        b.by_category
+    )  # => every category mentioned by EITHER side
+    return all(
+        abs(a.by_category.get(k, 0.0) - b.by_category.get(k, 0.0)) <= tolerance
+        for k in keys
+    )
+
+
+@given(rows=st.lists(row_strategy, min_size=0, max_size=20))
+def test_property_analyze_is_referentially_transparent(
+    rows: list[tuple[str, float]],
+) -> None:
+    # => co-01/co-03: the SAME csv text, analyzed twice, ALWAYS produces an equal result
+    csv_text = rows_to_csv(rows)
+    first = analyze(csv_text)
+    second = analyze(csv_text)
+    assert first == second
+
+
+@given(
+    rows=st.lists(row_strategy, min_size=0, max_size=20),
+    split_at=st.integers(min_value=0, max_value=20),
+)
+def test_property_combining_partial_aggregates_equals_the_whole_in_one_pass(
+    rows: list[tuple[str, float]], split_at: int
+) -> None:
+    # => Step 4's invariant, checked across MANY generated splits, not one hand-picked example
+    split_index = min(
+        split_at, len(rows)
+    )  # => clamps split_at into the valid range for THIS rows list
+    left, right = rows[:split_index], rows[split_index:]
+    combined = combine_partial_analyses(rows_to_csv(left), rows_to_csv(right))
+    whole = analyze(rows_to_csv(rows))
+    assert isinstance(combined, Ok)
+    assert isinstance(whole, Ok)
+    assert totals_approx_equal(
+        combined.value, whole.value
+    )  # => co-26/monoid: split-then-combine == whole-at-once
+
+
+@given(
+    a=st.dictionaries(category_strategy, amount_strategy),
+    b=st.dictionaries(category_strategy, amount_strategy),
+)
+def test_property_combine_totals_is_associative_with_identity(
+    a: dict[str, float], b: dict[str, float]
+) -> None:
+    totals_a = Totals(by_category=a)
+    totals_b = Totals(by_category=b)
+    # => the two monoid laws combine_totals must satisfy to genuinely BE a monoid, not just "a merge function"
+    assert totals_approx_equal(
+        combine_totals(EMPTY_TOTALS, totals_a), totals_a
+    )  # => left identity
+    assert totals_approx_equal(
+        combine_totals(totals_a, EMPTY_TOTALS), totals_a
+    )  # => right identity
+    assert totals_approx_equal(  # => associativity: grouping never changes the result
+        combine_totals(combine_totals(totals_a, totals_b), EMPTY_TOTALS),
+        combine_totals(totals_a, combine_totals(totals_b, EMPTY_TOTALS)),
+    )
+
+
+# => Run: pytest -q -- Output: 30 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/test_shell.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/code/test_shell.py
@@ -1,0 +1,60 @@
+"""Capstone Step 2: verifies shell.py end to end, as a REAL subprocess CLI invocation.
+
+Runs `python3 shell.py <file>` exactly the way a user would from a terminal, and checks the
+captured stdout/exit code -- the strongest form of "runs end to end from the CLI" this capstone
+can demonstrate, stronger than calling main() in-process.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+CODE_DIR = Path(__file__).parent
+SHELL_PATH = CODE_DIR / "shell.py"
+SAMPLE_CSV = CODE_DIR / "sample_transactions.csv"
+BAD_CSV = CODE_DIR / "bad_transactions.csv"
+
+
+def run_shell(
+    *args: str,
+) -> subprocess.CompletedProcess[str]:  # => the ONE helper every test below reuses
+    return subprocess.run(  # => a REAL child process, exactly like a user typing this at a terminal
+        [sys.executable, str(SHELL_PATH), *args],
+        capture_output=True,
+        text=True,
+        check=False,  # => this suite inspects returncode itself -- a non-zero exit is a valid case, not a crash
+    )
+
+
+def test_shell_on_valid_csv_prints_the_report_and_exits_zero() -> None:
+    completed = run_shell(str(SAMPLE_CSV))
+    assert completed.returncode == 0
+    assert "electronics: 288.99" in completed.stdout
+    assert "groceries: 58.25" in completed.stdout
+    assert "books: 15.25" in completed.stdout
+    assert "apparel: 60.00" in completed.stdout
+    assert "Top category: electronics" in completed.stdout
+
+
+def test_shell_on_malformed_csv_reports_errors_and_exits_nonzero_without_crashing() -> (
+    None
+):
+    completed = run_shell(str(BAD_CSV))
+    assert (
+        completed.returncode == 1
+    )  # => a controlled non-zero exit -- NOT a Python traceback
+    assert "4 error(s) found" in completed.stdout
+    assert (
+        "Traceback" not in completed.stderr
+    )  # => co-23: proves the shell never let an exception escape
+
+
+def test_shell_with_no_arguments_prints_usage_and_exits_two() -> None:
+    completed = run_shell()
+    assert completed.returncode == 2
+    assert "usage: shell.py" in completed.stderr
+
+
+# => Run: pytest -q -- Output: 3 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/overview.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/capstone/overview.md
@@ -1,0 +1,921 @@
+---
+title: "Overview"
+date: 2026-07-17T00:00:00+07:00
+draft: false
+weight: 1
+---
+
+## Goal
+
+Build a small, real data-processing tool -- a **transaction log analyzer** -- as a **functional
+core and imperative shell**: a pure parse-transform-aggregate pipeline built from composition and
+`map`/`filter`/`reduce`, `Result`-based error handling instead of exceptions, immutable data
+throughout, and a thin I/O shell that reads a CSV file and prints a report. This capstone is a
+consolidation, not a new mechanism: every pattern it combines was already taught individually
+across the Beginner, Intermediate, and Advanced tiers of this topic (most directly, Example 57's
+CSV analyzer, Example 71's error-accumulating validation, and Example 80's capstone-preview log
+analyzer).
+
+**The problem**: given a CSV file of `category,amount` transaction rows (one header row, then data
+rows), sum the amounts per category, normalize category names so `Electronics` and `electronics`
+group together, drop zero-amount rows, and report the totals plus the single highest-grossing
+category. A malformed row -- wrong shape, a non-numeric amount, an empty category, or a negative
+amount -- must be reported as a collected error, never a crash.
+
+## Concepts exercised
+
+- [x] pure functions + referential transparency (co-01, co-03)
+- [x] composition pipeline (co-11, co-13)
+- [x] `Result`/`Option` error handling (co-22, co-23, co-24)
+- [x] immutability (co-04, co-05)
+- [x] functional core / imperative shell split (co-28)
+- [x] a functor/applicative/monad pattern used in earnest (co-25, co-26, co-27)
+
+All colocated code lives under `learning/capstone/code/`: the pure functional core in `core.py`,
+the imperative shell in `shell.py`, the full `pytest` suites in `test_core.py` and `test_shell.py`,
+and two sample CSV files (`sample_transactions.csv`, `bad_transactions.csv`). Every listing below is
+the complete file, verbatim -- nothing on this page is truncated or paraphrased.
+
+## Step 1: the pure functional core
+
+_exercises co-01, co-03, co-04, co-05, co-11, co-13, co-22, co-23, co-24, co-25, co-26, co-27_
+
+`core.py` has zero I/O anywhere in it. `Some`/`Nothing` (co-22) and `Ok`/`Err` (co-23) are the same
+hand-rolled, generic, immutable containers this topic builds across Examples 48-51, each carrying a
+`.map()` -- the functor operation (co-25) that transforms a wrapped value without unwrapping it --
+and `Ok`/`Err` additionally carry `.and_then()` -- the monadic chain (co-27) that threads together
+Result-returning steps. `parse_row()` chains `split_fields()` -> `validate_category()` ->
+`parse_amount_field()` through two `.and_then()` hops: this is the railway (co-24) -- each step only
+runs if every prior step already succeeded, and a `ValueError` from `float()` is caught immediately
+and turned into an `Err` value, never allowed to propagate (co-23). `parse_rows()` then visits every
+line regardless of earlier failures and collects every malformed row into one `Err(tuple[str, ...])`,
+so a bad row never stops the rest of the file from being checked. `pipe()` (co-11/co-12) composes
+`keep_positive_amounts()` and `normalize_categories()` -- both built from `filter`/`map` (co-13) --
+into one left-to-right pipeline that `aggregate()` runs before folding rows into a `Totals` with
+`functools.reduce()` (co-13 again). `Totals.by_category` is always a `MappingProxyType` (co-04), and
+`add_row()`/`combine_totals()` always build a brand-new `Totals` rather than mutating the one they
+were handed (co-05). `combine_totals()` is a genuine **monoid**: associative, with `EMPTY_TOTALS` as
+its identity element. `map2()` is the **applicative** combinator (co-26) that combines two
+independent `Result`s with a two-argument function, accumulating errors from _both_ sides instead of
+short-circuiting at the first one -- the concrete contrast with co-24's railway that co-26's own
+definition calls out. `analyze()`, the top-level pure entry point, is `parse_rows(lines).map(aggregate)`
+-- co-25's functor `.map()` used in earnest to run `aggregate()` only on the success path, letting a
+collected `Err` ride straight through untouched.
+
+**`learning/capstone/code/core.py`** (complete file)
+
+```python
+"""Capstone -- Functional Core: Transaction Log Analyzer.
+
+Pure parse -> transform -> aggregate pipeline, zero I/O anywhere in this file. Exercises co-01
+(pure functions), co-03 (referential transparency), co-04/co-05 (immutability + structural
+sharing via a fresh Totals on every update), co-11/co-13 (a pipe() composition pipeline built
+from map/filter/reduce), co-22/co-23 (hand-rolled Option and Result types), co-24 (a railway of
+and_then hops inside parse_row), co-25 (Result.map and Option.map used as functors), co-26 (map2,
+an applicative combinator for two independent Results), co-27 (and_then/bind chaining
+Result-returning steps), and co-28 (this whole file IS the functional core half of the split --
+see shell.py for the imperative shell that is the only place with I/O).
+"""
+
+from __future__ import annotations  # => enables the quoted 'Option[U]'/'Result[U, F]' forward references below
+
+from collections.abc import Mapping  # => the read-only VIEW type Totals.by_category exposes to callers
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds every immutable record/variant here
+from functools import reduce  # => reduce folds rows into Totals (co-13) and folds pipe()'s steps (co-11)
+from types import MappingProxyType  # => wraps every Totals.by_category dict as read-only (co-04)
+from typing import Callable, Generic, TypeVar  # => Generic/TypeVar/Callable type every generic container below
+
+T = TypeVar("T")  # => a generic "value this container wraps" type, reused across Option/Result/pipe
+U = TypeVar("U")  # => the type a map/and_then/bind step transforms T into
+V = TypeVar("V")  # => the type map2's two-argument function returns
+E = TypeVar("E")  # => the type of the error an Err wraps (kept distinct from F below)
+F = TypeVar("F")  # => the error type threaded through and_then's step function, not hardcoded to object
+
+
+# ---------------------------------------------------------------------------
+# Option (co-22): "absence" as a value, plus co-25's functor .map()
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)  # => marks Some immutable, matching every other record in this file
+class Some(Generic[T]):  # => the "present" variant, carrying exactly one value
+    value: T  # => the single field this variant carries
+
+    def map(self, fn: Callable[[T], U]) -> "Option[U]":  # => co-25: applies fn INSIDE, without unwrapping
+        return Some(fn(self.value))  # => stays wrapped -- Some in, Some out
+
+
+@dataclass(frozen=True)  # => marks Nothing immutable too
+class Nothing:  # => the "absent" variant, carrying nothing at all
+    def map(self, fn: Callable[[T], U]) -> "Nothing":  # => NO-OP, generic so a typed fn still type-checks
+        return self  # => there is nothing to apply fn to -- Nothing stays Nothing
+
+
+Option = Some[T] | Nothing  # => PEP 604 union: an Option[T] is either Some[T] or Nothing
+
+
+# ---------------------------------------------------------------------------
+# Result (co-23): success-or-failure as a value, plus co-24/co-25/co-27
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style used across this whole topic
+class Ok(Generic[T]):  # => the "success" variant, carrying the computed value
+    value: T  # => the single field this variant carries
+
+    def map(self, fn: Callable[[T], U]) -> "Ok[U]":  # => co-25: transforms SUCCESS only, error type never widens
+        return Ok(fn(self.value))  # => transforms the value, stays wrapped as Ok
+
+    def and_then(  # => co-27: chains into ANOTHER Result-returning step, without double-wrapping
+        self, fn: Callable[[T], "Result[U, F]"]  # => F is inferred from fn's own error type
+    ) -> "Result[U, F]":  # => closes the multi-line signature above
+        return fn(self.value)  # => runs fn on the unwrapped value; fn itself returns a Result
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(Generic[E]):  # => the "failure" variant, carrying the ERROR AS A VALUE, never an exception
+    error: E  # => the single field this variant carries
+
+    def map(self, fn: Callable[[T], U]) -> "Err[E]":  # => NO-OP: generic so a typed fn still type-checks
+        return self  # => the error passes through UNCHANGED -- fn never runs
+
+    def and_then(self, fn: Callable[[T], U]) -> "Err[E]":  # => co-24: the short-circuit half of the railway
+        return self  # => once on the failure track, every remaining step is skipped
+
+
+Result = Ok[T] | Err[E]  # => the ADT itself: a Result is EITHER variant
+
+
+# ---------------------------------------------------------------------------
+# Immutable domain records (co-04)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)  # => one PARSED, immutable transaction row -- never mutated after construction
+class Row:  # => the class body begins here
+    category: str  # => e.g. "electronics" -- normalized to lowercase by normalize_categories() below
+    amount: float  # => a non-negative amount, already validated by the time a Row exists
+
+
+@dataclass(frozen=True)  # => an immutable per-category rollup
+class Totals:  # => the class body begins here
+    by_category: Mapping[str, float]  # => always a MappingProxyType -- co-04: read-only from the outside
+
+
+EMPTY_TOTALS = Totals(by_category=MappingProxyType({}))  # => the monoid IDENTITY element for combine_totals()
+
+
+# ---------------------------------------------------------------------------
+# Composition helper (co-11, co-12): reads left-to-right, execution order
+# ---------------------------------------------------------------------------
+
+
+def pipe(value: T, *fns: Callable[[T], T]) -> T:  # => any number of same-shaped steps, applied IN ORDER
+    return reduce(lambda acc, fn: fn(acc), fns, value)  # => co-13: reduce folds each step over the accumulator
+
+
+# ---------------------------------------------------------------------------
+# Row parsing: a railway of Result-returning steps (co-01, co-23, co-24, co-27)
+# ---------------------------------------------------------------------------
+
+
+def split_fields(line: str) -> "Result[tuple[str, str], str]":  # => railway step 1: shape only
+    parts = line.split(",", 1)  # => splits "electronics,199.99" into ["electronics", "199.99"]
+    if len(parts) != 2:  # => the ONLY thing this step checks -- exactly one comma, two fields
+        return Err(f"malformed row (expected 'category,amount'): {line!r}")
+    return Ok((parts[0].strip(), parts[1].strip()))  # => success: two trimmed fields, still UNVALIDATED
+
+
+def validate_category(fields: tuple[str, str]) -> "Result[tuple[str, str], str]":  # => railway step 2
+    category, amount_text = fields  # => unpacks the tuple split_fields() already produced
+    if category == "":  # => the ONLY thing THIS step checks
+        return Err(f"category cannot be empty (amount was {amount_text!r})")
+    return Ok(fields)  # => success: fields pass through completely unchanged
+
+
+def parse_amount_field(fields: tuple[str, str]) -> "Result[Row, str]":  # => railway step 3: builds the Row
+    category, amount_text = fields  # => unpacks the tuple the prior two steps already validated
+    try:
+        amount = float(amount_text)  # => may raise ValueError on "abc" -- CAUGHT below, never escapes
+    except ValueError:  # => co-23: the failure becomes a VALUE, not a propagating exception
+        return Err(f"invalid amount for {category!r}: {amount_text!r} is not a number")
+    if amount < 0:  # => the SECOND check this step makes, only reached once parsing succeeded
+        return Err(f"negative amount for {category!r}: {amount_text!r}")
+    return Ok(Row(category=category, amount=amount))  # => all three railway steps passed
+
+
+def parse_row(line: str) -> "Result[Row, str]":  # => co-24: chains all three steps into ONE railway
+    return split_fields(line).and_then(validate_category).and_then(parse_amount_field)
+    # => co-27: each and_then hop only runs if EVERY prior step already succeeded
+
+
+def parse_rows(lines: list[str]) -> "Result[tuple[Row, ...], tuple[str, ...]]":  # => across-rows accumulation
+    oks: list[Row] = []  # => collects every SUCCESSFULLY parsed row
+    errors: list[str] = []  # => collects every FAILURE, across every line, not just the first
+    for line in lines:  # => visits EVERY line regardless of earlier failures -- no early return here
+        result = parse_row(line)  # => delegates to the pure per-line railway above
+        if isinstance(result, Ok):  # => this particular line parsed cleanly
+            oks.append(result.value)
+        else:  # => this particular line was malformed somewhere along the railway
+            errors.append(result.error)  # => a bad line contributes its error, parsing CONTINUES
+    if errors:  # => at least one line was malformed
+        return Err(tuple(errors))  # => reports EVERY malformed line at once, not just the first
+    return Ok(tuple(oks))  # => every line parsed cleanly
+
+
+# ---------------------------------------------------------------------------
+# Pure aggregation pipeline (co-11, co-13)
+# ---------------------------------------------------------------------------
+
+
+def keep_positive_amounts(rows: tuple[Row, ...]) -> tuple[Row, ...]:  # => co-13 filter
+    return tuple(filter(lambda row: row.amount > 0, rows))  # => drops zero-amount no-op transactions
+
+
+def normalize_categories(rows: tuple[Row, ...]) -> tuple[Row, ...]:  # => co-13 map
+    return tuple(  # => rebuilds a BRAND NEW tuple -- rows itself is never mutated
+        map(lambda row: Row(category=row.category.lower(), amount=row.amount), rows)
+    )  # => lowercases category so "Electronics" and "electronics" group together downstream
+
+
+def add_row(totals: Totals, row: Row) -> Totals:  # => a PURE fold step: returns a NEW Totals, never mutates
+    merged = dict(totals.by_category)  # => shallow copy -- co-04/co-05: the OLD totals stays fully intact
+    merged[row.category] = merged.get(row.category, 0.0) + row.amount  # => accumulates onto the COPY only
+    return Totals(by_category=MappingProxyType(merged))  # => wraps the copy back up as read-only
+
+
+def aggregate(rows: tuple[Row, ...]) -> Totals:  # => the pure core's aggregation entry point
+    cleaned = pipe(rows, keep_positive_amounts, normalize_categories)  # => co-11/co-12: composed pipeline
+    return reduce(add_row, cleaned, EMPTY_TOTALS)  # => co-13 reduce: folds cleaned rows into one Totals
+
+
+# ---------------------------------------------------------------------------
+# Monoid combine + applicative map2 (co-26)
+# ---------------------------------------------------------------------------
+
+
+def combine_totals(a: Totals, b: Totals) -> Totals:  # => the MONOID operation: associative, has an identity
+    merged = dict(a.by_category)  # => starts from a COPY of a -- a itself is never touched
+    for category, amount in b.by_category.items():  # => folds every entry from b onto the copy
+        merged[category] = merged.get(category, 0.0) + amount
+    return Totals(by_category=MappingProxyType(merged))  # => EMPTY_TOTALS is this operation's identity element
+
+
+def map2(  # => co-26: the applicative combinator -- combines TWO independently-wrapped Results
+    fn: Callable[[T, U], V], a: "Result[T, tuple[str, ...]]", b: "Result[U, tuple[str, ...]]"
+) -> "Result[V, tuple[str, ...]]":  # => closes the multi-line signature above
+    if isinstance(a, Ok) and isinstance(b, Ok):  # => the ONLY case where fn actually runs
+        return Ok(fn(a.value, b.value))  # => unwraps BOTH, applies fn, wraps the combined result back up
+    errors: tuple[str, ...] = ()  # => co-26 vs co-24: ACCUMULATES from both sides instead of short-circuiting
+    if isinstance(a, Err):  # => a failed -- fold its errors in
+        errors += a.error
+    if isinstance(b, Err):  # => b failed -- fold its errors in TOO, even if a already failed
+        errors += b.error
+    return Err(errors)  # => reports every failing side at once, not just the first one found
+
+
+# ---------------------------------------------------------------------------
+# Top-level pure entry points
+# ---------------------------------------------------------------------------
+
+
+def analyze(csv_text: str) -> "Result[Totals, tuple[str, ...]]":  # => PURE CORE: text in, Result out, no I/O
+    lines = csv_text.strip().splitlines()[1:]  # => drops the header row, e.g. "category,amount"
+    return parse_rows(lines).map(aggregate)  # => co-25 functor: transforms success, error rides through untouched
+
+
+def combine_partial_analyses(  # => opens the multi-line signature of the monoid-combine entry point
+    csv_text_a: str, csv_text_b: str  # => two independently self-headered "files"
+) -> "Result[Totals, tuple[str, ...]]":  # => closes the multi-line signature above
+    return map2(combine_totals, analyze(csv_text_a), analyze(csv_text_b))  # => co-26 applicative + monoid combine
+
+
+def top_category(totals: Totals) -> "Option[str]":  # => co-22: absence is a VALUE, not a None landmine
+    if not totals.by_category:  # => nothing was ever aggregated
+        return Nothing()
+    best = max(totals.by_category.items(), key=lambda pair: pair[1])  # => (category, amount) with the max total
+    return Some(best[0])
+
+
+def format_report(totals: Totals) -> str:  # => still PURE: data -> text, zero I/O
+    lines = [f"{category}: {amount:.2f}" for category, amount in sorted(totals.by_category.items())]
+    headline = top_category(totals).map(  # => co-25 functor: Option.map builds the headline INSIDE the wrapper
+        lambda category: f"Top category: {category}"
+    )
+    if isinstance(headline, Some):  # => a category actually exists
+        lines.append(headline.value)
+    else:  # => totals.by_category was empty -- top_category() returned Nothing
+        lines.append("Top category: (no transactions)")
+    return "\n".join(lines)  # => a plain string -- the shell decides how to display it
+```
+
+**`learning/capstone/code/test_core.py`** (complete file)
+
+```python
+"""Capstone Step 1: pytest suite for the pure core (core.py) -- zero mocking anywhere in this file.
+
+Covers the railway (co-24), the applicative/monoid combine (co-26), the functor .map() calls
+(co-25), and two Hypothesis property tests: purity/referential transparency (co-01, co-03) and
+the monoid-combine invariant Step 4 asks for -- combining two partial aggregates equals
+aggregating the whole file in one pass, checked across many generated inputs, not by hand.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from core import (
+    EMPTY_TOTALS,
+    Err,
+    Nothing,
+    Ok,
+    Row,
+    Some,
+    Totals,
+    aggregate,
+    analyze,
+    combine_partial_analyses,
+    combine_totals,
+    format_report,
+    keep_positive_amounts,
+    map2,
+    normalize_categories,
+    parse_row,
+    parse_rows,
+    pipe,
+    top_category,
+)
+
+# ---------------------------------------------------------------------------
+# parse_row: the railway (co-24) -- each malformed shape triggers a DIFFERENT step
+# ---------------------------------------------------------------------------
+
+
+def test_parse_row_accepts_a_well_formed_line() -> None:
+    assert parse_row("electronics,199.99") == Ok(Row(category="electronics", amount=199.99))
+
+
+def test_parse_row_rejects_the_wrong_shape() -> None:
+    result = parse_row("not-a-valid-row")
+    assert isinstance(result, Err)
+    assert "malformed row" in result.error
+
+
+def test_parse_row_rejects_an_empty_category() -> None:
+    result = parse_row(",50.00")
+    assert isinstance(result, Err)
+    assert "category cannot be empty" in result.error
+
+
+def test_parse_row_rejects_a_non_numeric_amount() -> None:
+    result = parse_row("groceries,abc")
+    assert isinstance(result, Err)
+    assert "not a number" in result.error
+
+
+def test_parse_row_rejects_a_negative_amount() -> None:
+    result = parse_row("books,-5.00")
+    assert isinstance(result, Err)
+    assert "negative amount" in result.error
+
+
+def test_parse_row_never_raises_on_malformed_input() -> None:
+    # => co-23: failure is a VALUE (Err), never a propagating exception -- this is the whole point
+    for bad_line in ("garbage", ",1.00", "x,abc", "x,-1"):
+        result = parse_row(bad_line)  # => must NOT raise -- if it does, this test fails with an error, not an assert
+        assert isinstance(result, Err)
+
+
+# ---------------------------------------------------------------------------
+# parse_rows: accumulates EVERY error across the whole file (Step 3's requirement)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_rows_collects_every_malformed_line_not_just_the_first() -> None:
+    lines = ["electronics,199.99", "garbage", "groceries,abc", ",50.00", "books,-5.00"]
+    result = parse_rows(lines)
+    assert isinstance(result, Err)
+    assert len(result.error) == 4  # => all FOUR malformed lines are reported, not just the first one
+
+
+def test_parse_rows_all_valid_returns_ok_of_every_row() -> None:
+    lines = ["electronics,199.99", "books,15.25"]
+    result = parse_rows(lines)
+    assert result == Ok((Row(category="electronics", amount=199.99), Row(category="books", amount=15.25)))
+
+
+# ---------------------------------------------------------------------------
+# aggregate: the pure map/filter/reduce + pipe() composition pipeline (co-11, co-13)
+# ---------------------------------------------------------------------------
+
+
+def test_keep_positive_amounts_drops_zero_amount_rows() -> None:
+    rows = (Row("a", 10.0), Row("b", 0.0), Row("c", 5.0))
+    assert keep_positive_amounts(rows) == (Row("a", 10.0), Row("c", 5.0))
+
+
+def test_normalize_categories_lowercases_every_row() -> None:
+    rows = (Row("Electronics", 10.0), Row("BOOKS", 5.0))
+    assert normalize_categories(rows) == (Row("electronics", 10.0), Row("books", 5.0))
+
+
+def test_pipe_reads_left_to_right_like_nested_calls() -> None:
+    rows = (Row("Electronics", 10.0), Row("Books", 0.0))
+    piped = pipe(rows, keep_positive_amounts, normalize_categories)
+    nested = normalize_categories(keep_positive_amounts(rows))
+    assert piped == nested == (Row("electronics", 10.0),)
+
+
+def test_aggregate_sums_by_normalized_category_and_drops_zeros() -> None:
+    rows = (Row("Electronics", 199.99), Row("electronics", 89.00), Row("Books", 0.0))
+    totals = aggregate(rows)
+    assert dict(totals.by_category) == {"electronics": 288.99}
+
+
+def test_aggregate_of_empty_rows_is_the_monoid_identity() -> None:
+    assert aggregate(()) == EMPTY_TOTALS
+
+
+# ---------------------------------------------------------------------------
+# combine_totals: the monoid (associativity + identity), map2: the applicative (co-26)
+# ---------------------------------------------------------------------------
+
+
+def test_combine_totals_merges_and_sums_overlapping_categories() -> None:
+    a = Totals(by_category={"electronics": 100.0, "books": 5.0})
+    b = Totals(by_category={"electronics": 50.0, "groceries": 10.0})
+    combined = combine_totals(a, b)
+    assert dict(combined.by_category) == {"electronics": 150.0, "books": 5.0, "groceries": 10.0}
+
+
+def test_combine_totals_identity_law() -> None:
+    a = Totals(by_category={"electronics": 100.0})
+    assert combine_totals(EMPTY_TOTALS, a) == a  # => left identity
+    assert combine_totals(a, EMPTY_TOTALS) == a  # => right identity
+
+
+def test_combine_totals_never_mutates_either_input() -> None:
+    a = Totals(by_category={"electronics": 100.0})
+    b = Totals(by_category={"electronics": 50.0})
+    combine_totals(a, b)  # => call once, discard the result
+    assert dict(a.by_category) == {"electronics": 100.0}  # => a is provably UNCHANGED
+    assert dict(b.by_category) == {"electronics": 50.0}  # => b is provably UNCHANGED
+
+
+def add_ints(x: int, y: int) -> int:  # => a NAMED, fully-typed function -- pins map2's T/U/V at every call
+    return x + y  # => a bare lambda here would leave pyright unable to infer T/U from Err-only arguments
+
+
+def test_map2_combines_two_oks_by_running_fn() -> None:
+    result = map2(add_ints, Ok(2), Ok(3))
+    assert result == Ok(5)
+
+
+def test_map2_accumulates_errors_from_both_sides() -> None:
+    result = map2(add_ints, Err(("left broke",)), Err(("right broke",)))
+    assert result == Err(("left broke", "right broke"))  # => BOTH sides reported, co-26 vs co-24's short-circuit
+
+
+def test_map2_short_circuits_to_the_single_side_that_failed() -> None:
+    assert map2(add_ints, Ok(2), Err(("right broke",))) == Err(("right broke",))
+    assert map2(add_ints, Err(("left broke",)), Ok(3)) == Err(("left broke",))
+
+
+# ---------------------------------------------------------------------------
+# analyze / combine_partial_analyses: the top-level pure entry points (co-28's pure half)
+# ---------------------------------------------------------------------------
+
+
+VALID_CSV = "category,amount\nElectronics,199.99\nGroceries,45.50\nelectronics,89.00\nBooks,0.00\n"
+INVALID_CSV = "category,amount\nElectronics,199.99\ngarbage\nGroceries,abc\n"
+
+
+def test_analyze_on_valid_csv_returns_ok_totals() -> None:
+    result = analyze(VALID_CSV)
+    assert isinstance(result, Ok)
+    assert dict(result.value.by_category) == {"electronics": 288.99, "groceries": 45.50}
+
+
+def test_analyze_on_malformed_csv_returns_err_not_an_exception() -> None:
+    result = analyze(INVALID_CSV)  # => must NOT raise
+    assert isinstance(result, Err)
+    assert len(result.error) == 2  # => both malformed rows collected
+
+
+def test_analyze_called_twice_with_the_same_text_returns_an_equal_result() -> None:
+    # => co-03: referential transparency -- the SAME call always substitutes for the SAME value
+    assert analyze(VALID_CSV) == analyze(VALID_CSV)
+
+
+def test_combine_partial_analyses_equals_analyzing_the_whole_file_at_once() -> None:
+    # => Step 4's literal acceptance check: split into two files, combine, compare to one pass
+    csv_a = "category,amount\nElectronics,199.99\nGroceries,45.50\n"
+    csv_b = "category,amount\nelectronics,89.00\nBooks,0.00\n"
+    combined = combine_partial_analyses(csv_a, csv_b)
+    whole = analyze(VALID_CSV)  # => VALID_CSV's rows ARE exactly csv_a's rows followed by csv_b's rows
+    assert isinstance(combined, Ok) and isinstance(whole, Ok)
+    assert dict(combined.value.by_category) == dict(whole.value.by_category)
+
+
+# ---------------------------------------------------------------------------
+# top_category / format_report: Option's functor .map() (co-22, co-25)
+# ---------------------------------------------------------------------------
+
+
+def test_top_category_on_empty_totals_is_nothing() -> None:
+    assert top_category(EMPTY_TOTALS) == Nothing()
+
+
+def test_top_category_on_nonempty_totals_is_some_of_the_largest() -> None:
+    totals = Totals(by_category={"books": 5.0, "electronics": 288.99})
+    assert top_category(totals) == Some("electronics")
+
+
+def test_format_report_includes_every_category_and_the_top_line() -> None:
+    totals = Totals(by_category={"books": 5.0, "electronics": 288.99})
+    report = format_report(totals)
+    assert "books: 5.00" in report
+    assert "electronics: 288.99" in report
+    assert "Top category: electronics" in report
+
+
+def test_format_report_on_empty_totals_says_so() -> None:
+    assert "Top category: (no transactions)" in format_report(EMPTY_TOTALS)
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis property tests (Step 1's "incl. a Hypothesis invariant" requirement)
+# ---------------------------------------------------------------------------
+
+
+category_strategy = st.sampled_from(["electronics", "groceries", "books", "apparel", "toys"])
+amount_strategy = st.floats(min_value=0, max_value=1000, allow_nan=False, allow_infinity=False).map(
+    lambda x: round(x, 2)  # => rounds to cents -- keeps sums human-checkable, avoids deep float noise
+)
+row_strategy = st.tuples(category_strategy, amount_strategy)
+
+
+def rows_to_csv(rows: list[tuple[str, float]]) -> str:
+    body = "\n".join(f"{category},{amount}" for category, amount in rows)
+    return f"category,amount\n{body}\n" if body else "category,amount\n"
+
+
+def totals_approx_equal(a: Totals, b: Totals, tolerance: float = 1e-6) -> bool:
+    keys = set(a.by_category) | set(b.by_category)  # => every category mentioned by EITHER side
+    return all(abs(a.by_category.get(k, 0.0) - b.by_category.get(k, 0.0)) <= tolerance for k in keys)
+
+
+@given(rows=st.lists(row_strategy, min_size=0, max_size=20))
+def test_property_analyze_is_referentially_transparent(rows: list[tuple[str, float]]) -> None:
+    # => co-01/co-03: the SAME csv text, analyzed twice, ALWAYS produces an equal result
+    csv_text = rows_to_csv(rows)
+    first = analyze(csv_text)
+    second = analyze(csv_text)
+    assert first == second
+
+
+@given(rows=st.lists(row_strategy, min_size=0, max_size=20), split_at=st.integers(min_value=0, max_value=20))
+def test_property_combining_partial_aggregates_equals_the_whole_in_one_pass(
+    rows: list[tuple[str, float]], split_at: int
+) -> None:
+    # => Step 4's invariant, checked across MANY generated splits, not one hand-picked example
+    split_index = min(split_at, len(rows))  # => clamps split_at into the valid range for THIS rows list
+    left, right = rows[:split_index], rows[split_index:]
+    combined = combine_partial_analyses(rows_to_csv(left), rows_to_csv(right))
+    whole = analyze(rows_to_csv(rows))
+    assert isinstance(combined, Ok)
+    assert isinstance(whole, Ok)
+    assert totals_approx_equal(combined.value, whole.value)  # => co-26/monoid: split-then-combine == whole-at-once
+
+
+@given(a=st.dictionaries(category_strategy, amount_strategy), b=st.dictionaries(category_strategy, amount_strategy))
+def test_property_combine_totals_is_associative_with_identity(a: dict[str, float], b: dict[str, float]) -> None:
+    totals_a = Totals(by_category=a)
+    totals_b = Totals(by_category=b)
+    # => the two monoid laws combine_totals must satisfy to genuinely BE a monoid, not just "a merge function"
+    assert totals_approx_equal(combine_totals(EMPTY_TOTALS, totals_a), totals_a)  # => left identity
+    assert totals_approx_equal(combine_totals(totals_a, EMPTY_TOTALS), totals_a)  # => right identity
+    assert totals_approx_equal(  # => associativity: grouping never changes the result
+        combine_totals(combine_totals(totals_a, totals_b), EMPTY_TOTALS),
+        combine_totals(totals_a, combine_totals(totals_b, EMPTY_TOTALS)),
+    )
+
+
+# => Run: pytest -q -- Output: 30 passed
+```
+
+**Verify**
+
+```shell
+pip install -r requirements.txt
+python3 -m pytest test_core.py -q
+```
+
+**Output**
+
+```text
+30 passed
+```
+
+## Step 2: the imperative shell
+
+_exercises co-28_
+
+`shell.py`'s `main()` is the only function in this entire capstone that touches the filesystem or
+prints anything -- `Path.read_text()` reads the CSV, `analyze()` (all logic) runs entirely inside
+`core.py`, and `print()` writes the report or the collected errors. No parsing, validation, or
+aggregation logic lives in this file at all; `main()` is a thin dispatcher between three pure calls
+(`analyze`, the `isinstance` check, `format_report`) and the two I/O boundaries around them.
+
+**`learning/capstone/code/shell.py`** (complete file)
+
+```python
+"""Capstone -- Imperative Shell: reads a transaction CSV file and prints the report.
+
+Exercises co-28's OTHER half: main() is the ONLY function in this whole capstone that performs
+I/O (reading a file, writing to stdout/stderr). Every actual computation -- parsing, validating,
+aggregating, formatting -- is delegated straight to core.py's pure functions; this file holds no
+transformation logic of its own at all.
+"""
+
+from __future__ import annotations
+
+import sys  # => sys.argv (read) and sys.exit (write the process exit code) -- both I/O boundaries
+from pathlib import Path  # => Path.read_text() is this shell's ONE file-reading I/O boundary
+
+from core import Err, analyze, format_report  # => everything computational comes from the pure core
+
+
+def main(argv: list[str]) -> int:  # => the IMPERATIVE SHELL entry point -- the ONLY place with I/O
+    if len(argv) != 1:  # => a tiny bit of shell-level argument handling, still not "business logic"
+        print("usage: shell.py <transactions.csv>", file=sys.stderr)  # => I/O boundary: stderr
+        return 2  # => a non-zero exit code signals misuse to the calling shell/CI
+    path = Path(argv[0])  # => resolves the CLI argument into a filesystem path -- no read yet
+    csv_text = path.read_text()  # => I/O boundary: the ONE file read in this entire capstone
+    result = analyze(csv_text)  # => delegates EVERYTHING else to the pure core -- zero logic here
+    if isinstance(result, Err):  # => malformed input: report every collected error, do NOT crash
+        print(f"{len(result.error)} error(s) found:")  # => I/O boundary: stdout
+        for message in result.error:  # => walks EVERY accumulated error, not just the first
+            print(f"  {message}")  # => one printed line per malformed input row
+        return 1  # => a non-zero exit code signals "input had errors" to the calling shell/CI
+    print(format_report(result.value))  # => I/O boundary: prints the pure core's own report string
+    return 0  # => success
+
+
+if __name__ == "__main__":  # => only runs when invoked directly, e.g. `python3 shell.py sample.csv`
+    sys.exit(main(sys.argv[1:]))  # => argv[0] is the script name itself -- argv[1:] is the real arguments
+```
+
+**`learning/capstone/code/sample_transactions.csv`** (complete file)
+
+```text
+category,amount
+Electronics,199.99
+Groceries,45.50
+electronics,89.00
+Books,15.25
+Groceries,12.75
+Apparel,60.00
+Books,0.00
+```
+
+**Run**
+
+```shell
+python3 shell.py sample_transactions.csv
+```
+
+**Output**
+
+```text
+apparel: 60.00
+books: 15.25
+electronics: 288.99
+groceries: 58.25
+Top category: electronics
+```
+
+`Electronics,199.99` and `electronics,89.00` merged into one `288.99` total under `normalize_categories()`;
+`Books,0.00` never reaches the totals at all because `keep_positive_amounts()` dropped it.
+
+**`learning/capstone/code/test_shell.py`** (complete file)
+
+```python
+"""Capstone Step 2: verifies shell.py end to end, as a REAL subprocess CLI invocation.
+
+Runs `python3 shell.py <file>` exactly the way a user would from a terminal, and checks the
+captured stdout/exit code -- the strongest form of "runs end to end from the CLI" this capstone
+can demonstrate, stronger than calling main() in-process.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+CODE_DIR = Path(__file__).parent
+SHELL_PATH = CODE_DIR / "shell.py"
+SAMPLE_CSV = CODE_DIR / "sample_transactions.csv"
+BAD_CSV = CODE_DIR / "bad_transactions.csv"
+
+
+def run_shell(*args: str) -> subprocess.CompletedProcess[str]:  # => the ONE helper every test below reuses
+    return subprocess.run(  # => a REAL child process, exactly like a user typing this at a terminal
+        [sys.executable, str(SHELL_PATH), *args],
+        capture_output=True,
+        text=True,
+        check=False,  # => this suite inspects returncode itself -- a non-zero exit is a valid case, not a crash
+    )
+
+
+def test_shell_on_valid_csv_prints_the_report_and_exits_zero() -> None:
+    completed = run_shell(str(SAMPLE_CSV))
+    assert completed.returncode == 0
+    assert "electronics: 288.99" in completed.stdout
+    assert "groceries: 58.25" in completed.stdout
+    assert "books: 15.25" in completed.stdout
+    assert "apparel: 60.00" in completed.stdout
+    assert "Top category: electronics" in completed.stdout
+
+
+def test_shell_on_malformed_csv_reports_errors_and_exits_nonzero_without_crashing() -> None:
+    completed = run_shell(str(BAD_CSV))
+    assert completed.returncode == 1  # => a controlled non-zero exit -- NOT a Python traceback
+    assert "4 error(s) found" in completed.stdout
+    assert "Traceback" not in completed.stderr  # => co-23: proves the shell never let an exception escape
+
+
+def test_shell_with_no_arguments_prints_usage_and_exits_two() -> None:
+    completed = run_shell()
+    assert completed.returncode == 2
+    assert "usage: shell.py" in completed.stderr
+
+
+# => Run: pytest -q -- Output: 3 passed
+```
+
+**Verify**
+
+```shell
+python3 -m pytest test_shell.py -q
+```
+
+**Output**
+
+```text
+3 passed
+```
+
+## Step 3: Result replaces exceptions -- grounded against `bad_transactions.csv`
+
+_exercises co-23, co-24_
+
+The core built in Step 1 never used exceptions for malformed input in the first place --
+`parse_amount_field()` catches the one place a real exception could occur (`float()` on a
+non-numeric string) and turns it straight into an `Err` value. Running `parse_row()` directly
+against every kind of malformed line confirms the same thing this topic's tests already check
+(`test_parse_row_never_raises_on_malformed_input`): every failure comes back as a value, not a
+traceback.
+
+**Run**
+
+```shell
+python3 -c "
+from core import parse_row
+for bad_line in ['garbage', ',1.00', 'x,abc', 'x,-1']:
+    print(f'{bad_line!r:>12} -> {parse_row(bad_line)}')
+"
+```
+
+**Output**
+
+```text
+   'garbage' -> Err(error="malformed row (expected 'category,amount'): 'garbage'")
+     ',1.00' -> Err(error="category cannot be empty (amount was '1.00')")
+     'x,abc' -> Err(error="invalid amount for 'x': 'abc' is not a number")
+      'x,-1' -> Err(error="negative amount for 'x': '-1'")
+```
+
+**`learning/capstone/code/bad_transactions.csv`** (complete file)
+
+```text
+category,amount
+Electronics,199.99
+BadRow
+Groceries,abc
+,50.00
+Books,-5.00
+```
+
+**Run**
+
+```shell
+python3 shell.py bad_transactions.csv
+```
+
+**Output**
+
+```text
+4 error(s) found:
+  malformed row (expected 'category,amount'): 'BadRow'
+  invalid amount for 'Groceries': 'abc' is not a number
+  category cannot be empty (amount was '50.00')
+  negative amount for 'Books': '-5.00'
+```
+
+The one genuinely valid row (`Electronics,199.99`) never appears in this output at all -- once
+`parse_rows()` finds any error, `analyze()`'s `Err` path takes over and no partial report is
+printed, exactly the acceptance criterion Step 3 asks for: malformed rows yield a _collected error
+result_, never a crash, and never a silently-partial report either.
+`test_analyze_on_malformed_csv_returns_err_not_an_exception`,
+`test_parse_rows_collects_every_malformed_line_not_just_the_first`, and
+`test_shell_on_malformed_csv_reports_errors_and_exits_nonzero_without_crashing` all check this same
+guarantee from three different layers -- the pure row parser, the pure file-level aggregator, and
+the real subprocess CLI.
+
+## Step 4: a functor/applicative/monoid pattern used in earnest
+
+_exercises co-25, co-26, co-27_
+
+Splitting `sample_transactions.csv`'s rows into two independent CSV "files", analyzing each half
+separately, and combining the two partial `Totals` with `map2(combine_totals, ...)` produces the
+exact same result as analyzing the whole file in one pass -- the concrete demonstration this
+capstone's own Step 4 asks for.
+
+**Run**
+
+```shell
+python3 -c "
+from core import analyze, combine_partial_analyses, Ok
+
+csv_a = 'category,amount\nElectronics,199.99\nGroceries,45.50\n'
+csv_b = 'category,amount\nelectronics,89.00\nBooks,0.00\n'
+whole = 'category,amount\nElectronics,199.99\nGroceries,45.50\nelectronics,89.00\nBooks,0.00\n'
+
+combined = combine_partial_analyses(csv_a, csv_b)
+one_pass = analyze(whole)
+assert isinstance(combined, Ok) and isinstance(one_pass, Ok)
+print('combined:', dict(combined.value.by_category))
+print('one_pass:', dict(one_pass.value.by_category))
+print('equal:', dict(combined.value.by_category) == dict(one_pass.value.by_category))
+"
+```
+
+**Output**
+
+```text
+combined: {'electronics': 288.99, 'groceries': 45.5}
+one_pass: {'electronics': 288.99, 'groceries': 45.5}
+equal: True
+```
+
+Three concepts are in play together here, not just one. `analyze()` uses the **functor** pattern
+(co-25) -- `parse_rows(lines).map(aggregate)` transforms the success value without ever unwrapping
+the `Result` by hand. `map2()` is the **applicative** pattern (co-26) -- it combines _two_
+independently-produced `Result`s (`analyze(csv_a)` and `analyze(csv_b)`) with the two-argument
+`combine_totals()`, and if malformed rows exist on both sides, `map2()` accumulates _both_ sets of
+errors instead of reporting only one, which `test_map2_accumulates_errors_from_both_sides` checks
+directly. `parse_row()`'s own `.and_then()` chain is the **monad** pattern (co-27) already exercised
+throughout Step 1. `combine_totals()` is additionally a genuine monoid: `test_combine_totals_identity_law`
+checks `combine_totals(EMPTY_TOTALS, a) == a` in both directions, and the Hypothesis property
+`test_property_combine_totals_is_associative_with_identity` checks associativity and identity across
+many generated `Totals` pairs, not one hand-picked example. Finally,
+`test_property_combining_partial_aggregates_equals_the_whole_in_one_pass` generalizes the exact
+demonstration above into a property test: for many randomly generated row lists and split points,
+splitting, analyzing each half, and combining always equals analyzing the whole file in one pass.
+
+## Done bar
+
+**Runnable end to end**: `python3 shell.py sample_transactions.csv` prints the five-line report
+above and exits `0`; `python3 shell.py bad_transactions.csv` prints the four collected errors and
+exits `1`; `python3 shell.py` with no arguments prints a usage line to `stderr` and exits `2`.
+
+**Full suite**: `pip install -r requirements.txt && python3 -m pytest -q` from
+`learning/capstone/code/` runs `test_core.py` (30 tests, including three Hypothesis property tests)
+and `test_shell.py` (3 subprocess-driven CLI tests):
+
+```text
+33 passed
+```
+
+**Type safety**: `pyright` in `--strict` mode (`pyrightconfig.json` sets
+`"typeCheckingMode": "strict"`) against every file in `learning/capstone/code/`:
+
+```text
+0 errors, 0 warnings, 0 informations
+```
+
+**Acceptance criteria, verified against specific code and tests**: the core (`core.py`) is pure and
+tested without mocks (`test_core.py` imports nothing but `core` and `hypothesis`); errors are values,
+never exceptions (`parse_amount_field()`'s `try`/`except` converts the one possible `ValueError` into
+an `Err`, and `test_parse_row_never_raises_on_malformed_input` / `test_analyze_on_malformed_csv_returns_err_not_an_exception`
+/ `test_shell_on_malformed_csv_reports_errors_and_exits_nonzero_without_crashing` all check it); the
+shell (`shell.py`) is the only place with I/O (`Path.read_text()` and every `print()` call live
+exclusively inside `main()`); and the tool runs end to end, both directly (the **Run** blocks above)
+and under `pytest` (`test_shell.py`'s subprocess-driven suite).
+
+---
+
+← Previous: [Advanced Examples](../advanced.md) &middot; Next: [Drilling](../../drilling/overview.md) →

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-01-pure-vs-impure-pair/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-01-pure-vs-impure-pair/example.py
@@ -1,0 +1,31 @@
+"""Example 1: Pure vs. Impure -- Same Result Every Time."""
+
+counter_total = 0  # => module-level global state -- the impure twin's playground
+
+
+def add_pure(a: int, b: int) -> int:  # => pure: output depends ONLY on a and b
+    return a + b  # => no write to anything outside this function -- no side effect
+
+
+def add_impure(a: int, b: int) -> int:  # => same signature, very different behavior
+    global counter_total  # => declares intent to MUTATE module-level state
+    counter_total += a + b  # => side effect: writes state outside this function's scope
+    # => the return value now depends on how many times this ran BEFORE, not just a, b
+    return counter_total
+
+
+first_pure = add_pure(2, 3)  # => first_pure is 5
+second_pure = add_pure(2, 3)  # => second_pure is 5 -- SAME args, SAME result
+print(
+    first_pure == second_pure
+)  # => True: repeat calls with identical args always agree
+# => Output: True
+
+first_impure = add_impure(
+    2, 3
+)  # => first_impure is 5 (counter_total was 0 before this)
+second_impure = add_impure(
+    2, 3
+)  # => second_impure is 10 -- SAME args, DIFFERENT result!
+print(first_impure == second_impure)  # => False: hidden global state changed the answer
+# => Output: False

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-01-pure-vs-impure-pair/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-01-pure-vs-impure-pair/test_example.py
@@ -1,0 +1,18 @@
+"""Example 1: pytest verification for Pure vs. Impure -- Same Result Every Time."""
+
+from example import add_impure, add_pure  # => imports both functions under test
+
+
+def test_pure_add_is_repeatable() -> None:
+    first = add_pure(2, 3)  # => first call
+    second = add_pure(2, 3)  # => identical args, called again
+    assert first == second == 5  # => pure function: always the same result
+
+
+def test_impure_add_is_not_repeatable() -> None:
+    first = add_impure(10, 10)  # => mutates the module-level counter as a side effect
+    second = add_impure(10, 10)  # => SAME args, but counter_total has already grown
+    assert first != second  # => impure function: repeat calls disagree
+
+
+# => Run: pytest -- Output: 2 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-02-referential-transparency-substitution/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-02-referential-transparency-substitution/example.py
@@ -1,0 +1,21 @@
+"""Example 2: Referential Transparency by Substitution."""
+
+
+def add(a: int, b: int) -> int:  # => a pure function -- referentially transparent
+    return a + b  # => always returns the same value for the same a, b
+
+
+def price_with_call() -> int:  # => uses the CALL add(2, 3) inside a larger expression
+    return add(2, 3) * 10  # => add(2, 3) is evaluated, then multiplied by 10
+
+
+def price_with_value() -> int:  # => the call REPLACED by its own return value, 5
+    return 5 * 10  # => substituting add(2, 3) -> 5 changes nothing about the result
+
+
+call_result = price_with_call()  # => call_result is 50
+value_result = price_with_value()  # => value_result is 50 -- IDENTICAL to call_result
+print(
+    call_result == value_result
+)  # => True: the call was safely replaceable by its value
+# => Output: True

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-02-referential-transparency-substitution/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-02-referential-transparency-substitution/test_example.py
@@ -1,0 +1,11 @@
+"""Example 2: pytest verification for Referential Transparency by Substitution."""
+
+from example import price_with_call, price_with_value
+
+
+def test_call_and_value_agree() -> None:
+    # => substituting add(2, 3) with its value 5 changes nothing about the result
+    assert price_with_call() == price_with_value() == 50
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-03-detect-side-effect/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-03-detect-side-effect/example.py
@@ -1,0 +1,43 @@
+"""Example 3: Classify Pure vs. Impure Functions."""
+
+log: list[str] = []  # => module-level list -- a target for one function's side effect
+
+
+def loud_double(x: int) -> int:  # => impure: prints, an observable side effect
+    print(
+        f"doubling {x}"
+    )  # => I/O is a side effect -- output visible OUTSIDE the return value
+    return (
+        x * 2
+    )  # => the return value itself is fine; the PRINT above is the side effect
+
+
+def mutate_double(items: list[int]) -> None:  # => impure: mutates the CALLER's own list
+    items.append(
+        items[-1] * 2
+    )  # => appends in place -- the caller's list object changes
+    # => returns None on purpose: the "result" is the mutation itself, not a return value
+
+
+def pure_double(x: int) -> int:  # => pure: only reads x, only returns a new value
+    return x * 2  # => no print, no mutation of any argument, no global touched
+
+
+def is_pure(
+    fn_name: str,
+) -> bool:  # => a tiny classifier keyed by name for this example
+    return fn_name == "pure_double"  # => only pure_double is flagged pure by this check
+
+
+nums = [1, 2]  # => a list the impure mutate_double will mutate below
+mutate_double(nums)  # => side effect: nums is mutated to [1, 2, 4]
+classifications = {  # => a dict recording each function's purity classification
+    "loud_double": is_pure("loud_double"),  # => False -- prints, so it is impure
+    "mutate_double": is_pure("mutate_double"),  # => False -- mutates its argument
+    "pure_double": is_pure("pure_double"),  # => True -- the only one flagged pure
+}  # => three functions, three independent purity verdicts
+print(classifications["pure_double"])  # => Output: True
+print(  # => reads both remaining classifications out of the same dict
+    classifications["loud_double"], classifications["mutate_double"]
+)
+# => Output: False False

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-03-detect-side-effect/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-03-detect-side-effect/test_example.py
@@ -1,0 +1,19 @@
+"""Example 3: pytest verification for Classify Pure vs. Impure Functions."""
+
+from example import is_pure, mutate_double, pure_double
+
+
+def test_only_pure_double_is_flagged_pure() -> None:
+    assert is_pure("pure_double") is True  # => the only function with zero side effects
+    assert is_pure("loud_double") is False  # => prints -- a side effect
+    assert is_pure("mutate_double") is False  # => mutates its argument -- a side effect
+
+
+def test_mutate_double_changes_caller_list() -> None:
+    items = [1, 2]
+    mutate_double(items)  # => appends items[-1] * 2 in place
+    assert items == [1, 2, 4]  # => the CALLER's own list object was mutated
+    assert pure_double(3) == 6  # => pure_double never touches items at all
+
+
+# => Run: pytest -- Output: 2 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-04-immutable-tuple-vs-list/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-04-immutable-tuple-vs-list/example.py
@@ -1,0 +1,26 @@
+"""Example 4: Tuple Immutability vs. List Mutability."""
+
+mutable_list: list[int] = [
+    1,
+    2,
+    3,
+]  # => a list -- mutable, in-place assignment is legal
+mutable_list[0] = 99  # => legal: lists allow item assignment
+print(mutable_list)  # => Output: [99, 2, 3]
+
+immutable_tuple: tuple[int, int, int] = (
+    1,
+    2,
+    3,
+)  # => a tuple -- immutable, fixed after creation
+try:  # => opens a block that expects the next line to raise
+    immutable_tuple[0] = 99  # type: ignore[index]  # => attempts item assignment on a tuple
+    raised = False  # => unreachable if TypeError fires, kept for completeness
+except TypeError as exc:  # => tuples have no __setitem__ -- this is EXPECTED, not a bug
+    raised = True  # => confirms the immutability guarantee was actually enforced
+    print(f"raised: {type(exc).__name__}")  # => Output: raised: TypeError
+
+print(raised)  # => Output: True
+print(
+    immutable_tuple
+)  # => Output: (1, 2, 3) -- unchanged, the assignment never happened

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-04-immutable-tuple-vs-list/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-04-immutable-tuple-vs-list/test_example.py
@@ -1,0 +1,21 @@
+"""Example 4: pytest verification for Tuple Immutability vs. List Mutability."""
+
+
+def test_list_allows_item_assignment() -> None:
+    items = [1, 2, 3]
+    items[0] = 99  # => legal for a list
+    assert items == [99, 2, 3]
+
+
+def test_tuple_rejects_item_assignment() -> None:
+    values = (1, 2, 3)
+    try:
+        values[0] = 99  # type: ignore[index]  # => tuples have no __setitem__
+        raised = False
+    except TypeError:
+        raised = True
+    assert raised is True  # => confirms immutability is actually enforced
+    assert values == (1, 2, 3)  # => unchanged
+
+
+# => Run: pytest -- Output: 2 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-05-frozen-dataclass/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-05-frozen-dataclass/example.py
@@ -1,0 +1,26 @@
+"""Example 5: A Frozen Dataclass Rejects Mutation."""
+
+from dataclasses import (
+    FrozenInstanceError,
+    dataclass,
+)  # => frozen=True raises this on assignment
+
+
+@dataclass(
+    frozen=True
+)  # => generates __init__/__repr__/__eq__ AND blocks attribute assignment
+class Point:  # => an immutable value object -- once built, it cannot change
+    x: int  # => a regular field, just frozen at the class level
+    y: int  # => a second field -- @dataclass generates __init__(self, x, y) from both
+
+
+p = Point(1, 2)  # => __init__ is allowed to set fields ONCE, during construction
+print(p)  # => Output: Point(x=1, y=2)
+
+try:  # => opens a block that expects the assignment below to raise
+    p.x = 99  # type: ignore[misc]  # => any LATER assignment is rejected, not just during init
+    raised = False  # => unreachable if FrozenInstanceError fires first, kept for completeness
+except FrozenInstanceError:  # => the frozen dataclass's own guard fired
+    raised = True  # => confirms mutation was actually blocked, not silently ignored
+print(raised)  # => Output: True
+print(p)  # => Output: Point(x=1, y=2) -- still the original values

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-05-frozen-dataclass/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-05-frozen-dataclass/test_example.py
@@ -1,0 +1,19 @@
+"""Example 5: pytest verification for A Frozen Dataclass Rejects Mutation."""
+
+from dataclasses import FrozenInstanceError
+
+from example import Point
+
+
+def test_frozen_dataclass_rejects_assignment() -> None:
+    p = Point(1, 2)
+    try:
+        p.x = 99  # type: ignore[misc]  # => frozen dataclasses block ALL later assignment
+        raised = False
+    except FrozenInstanceError:
+        raised = True
+    assert raised is True
+    assert p == Point(1, 2)  # => unchanged -- the assignment never took effect
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-06-dataclasses-replace-copy/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-06-dataclasses-replace-copy/example.py
@@ -1,0 +1,26 @@
+"""Example 6: dataclasses.replace Produces a New Record."""
+
+from dataclasses import (
+    dataclass,
+    replace,
+)  # => replace: a shallow copy with fields overridden
+
+
+@dataclass(
+    frozen=True
+)  # => frozen so "updating" MUST go through replace, not assignment
+class Point:  # => the value object replace() will copy-with-overrides below
+    x: int  # => first field -- the one this example overrides via replace
+    y: int  # => second field -- left untouched, copied straight through by replace
+
+
+original = Point(1, 2)  # => the record we will "update" without mutating
+moved = replace(
+    original, x=99
+)  # => builds a NEW Point: x overridden, y copied unchanged
+# => original itself is never touched by replace -- it only READS original's fields
+
+print(original)  # => Output: Point(x=1, y=2) -- untouched
+print(moved)  # => Output: Point(x=99, y=2) -- a distinct object with the new x
+print(original == moved)  # => Output: False -- two different values now
+print(original is moved)  # => Output: False -- two different objects, not aliases

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-06-dataclasses-replace-copy/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-06-dataclasses-replace-copy/test_example.py
@@ -1,0 +1,16 @@
+"""Example 6: pytest verification for dataclasses.replace Produces a New Record."""
+
+from dataclasses import replace
+
+from example import Point
+
+
+def test_replace_leaves_original_untouched() -> None:
+    original = Point(1, 2)
+    moved = replace(original, x=99)  # => a NEW record, y copied unchanged
+    assert original == Point(1, 2)  # => original never mutated
+    assert moved == Point(99, 2)  # => new record has the overridden field
+    assert original is not moved  # => two distinct objects
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-07-structural-sharing-cons/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-07-structural-sharing-cons/example.py
@@ -1,0 +1,46 @@
+"""Example 7: A Persistent Cons-List Prepend."""
+
+from __future__ import (
+    annotations,
+)  # => lets ConsList reference itself in its own field type
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass generates __init__/__repr__/__eq__ for the node
+
+
+@dataclass(frozen=True)  # => frozen: once linked, a node's head/tail never change
+class ConsList:  # => the classic persistent linked list: a head value plus a tail list
+    head: int  # => this node's own value
+    tail: "ConsList | None"  # => None marks the empty tail -- the end of the list
+
+
+def prepend(value: int, lst: "ConsList | None") -> ConsList:  # => builds a NEW node
+    return ConsList(
+        head=value, tail=lst
+    )  # => tail is the OLD list, reused, never copied
+
+
+def to_list(
+    lst: "ConsList | None",
+) -> list[int]:  # => walks nodes into a plain list, for printing
+    result: list[int] = []  # => the plain list this walk accumulates into
+    while lst is not None:  # => walking SHARED structure -- no mutation happens here
+        result.append(lst.head)  # => reads this node's value
+        lst = lst.tail  # => advances to the next shared node, never rewriting it
+    return (
+        result  # => a fresh plain list -- the ConsList nodes themselves stay untouched
+    )
+
+
+empty: ConsList | None = (
+    None  # => the empty list -- the shared base every version points to
+)
+version_a = prepend(1, empty)  # => version_a is [1]
+version_b = prepend(
+    2, version_a
+)  # => version_b is [2, 1] -- REUSES version_a as its tail
+
+print(to_list(version_a))  # => Output: [1]
+print(to_list(version_b))  # => Output: [2, 1]
+print(version_b.tail is version_a)  # => Output: True -- structural sharing, not a copy

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-07-structural-sharing-cons/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-07-structural-sharing-cons/test_example.py
@@ -1,0 +1,15 @@
+"""Example 7: pytest verification for A Persistent Cons-List Prepend."""
+
+from example import ConsList, prepend, to_list
+
+
+def test_prepend_shares_the_old_tail() -> None:
+    version_a: ConsList | None = prepend(1, None)  # => [1]
+    version_b = prepend(2, version_a)  # => [2, 1], reusing version_a as tail
+
+    assert to_list(version_a) == [1]  # => version_a unaffected by building version_b
+    assert to_list(version_b) == [2, 1]
+    assert version_b.tail is version_a  # => structural sharing, not a copy
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-08-function-as-value/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-08-function-as-value/example.py
@@ -1,0 +1,17 @@
+"""Example 8: A Function Assigned to a Variable."""
+
+
+def shout(text: str) -> str:  # => an ordinary function, defined once
+    return text.upper() + "!"  # => uppercases and appends an exclamation mark
+
+
+greeter = shout  # => assigns the FUNCTION OBJECT itself to a new name -- no call, no ()
+# => greeter and shout now both refer to the SAME underlying function object
+
+direct_result = shout("hello")  # => calling through the original name
+aliased_result = greeter("hello")  # => calling through the alias -- identical behavior
+
+print(direct_result)  # => Output: HELLO!
+print(aliased_result)  # => Output: HELLO!
+print(direct_result == aliased_result)  # => Output: True -- same function, same result
+print(greeter is shout)  # => Output: True -- greeter is not a copy, it IS shout

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-08-function-as-value/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-08-function-as-value/test_example.py
@@ -1,0 +1,12 @@
+"""Example 8: pytest verification for A Function Assigned to a Variable."""
+
+from example import shout
+
+
+def test_alias_behaves_identically() -> None:
+    greeter = shout  # => same function object, new name
+    assert greeter is shout  # => not a copy
+    assert greeter("hi") == shout("hi") == "HI!"
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-09-functions-in-a-list/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-09-functions-in-a-list/example.py
@@ -1,0 +1,31 @@
+"""Example 9: Functions Stored in a List."""
+
+
+def double(x: int) -> int:  # => three ordinary, unrelated single-purpose functions
+    return x * 2  # => doubles its argument
+
+
+def square(x: int) -> int:
+    return x * x  # => squares its argument
+
+
+def negate(x: int) -> int:
+    return -x  # => flips the sign of its argument
+
+
+operations = [
+    double,
+    square,
+    negate,
+]  # => a list of FUNCTION OBJECTS, not their results
+# => nothing has been called yet -- the list just holds three callables
+
+results = [
+    op(5) for op in operations
+]  # => calls each stored function with the same input
+# => results is [10, 25, -5]: double(5), square(5), negate(5) in that order
+
+print(results)  # => Output: [10, 25, -5]
+print(
+    all(callable(op) for op in operations)
+)  # => Output: True -- every element is callable

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-09-functions-in-a-list/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-09-functions-in-a-list/test_example.py
@@ -1,0 +1,12 @@
+"""Example 9: pytest verification for Functions Stored in a List."""
+
+from example import double, negate, square
+
+
+def test_stored_functions_are_called_correctly() -> None:
+    operations = [double, square, negate]
+    results = [op(5) for op in operations]
+    assert results == [10, 25, -5]
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-10-higher-order-apply/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-10-higher-order-apply/example.py
@@ -1,0 +1,27 @@
+"""Example 10: A Higher-Order apply Function."""
+
+from typing import Callable  # => the type of "a function taking int, returning int"
+
+
+def apply(
+    fn: Callable[[int], int], x: int
+) -> int:  # => HOF: takes a FUNCTION as an argument
+    return fn(x)  # => apply never needs to know what fn actually does
+
+
+def increment(n: int) -> int:  # => one candidate to pass into apply
+    return n + 1  # => adds exactly one
+
+
+def triple(n: int) -> int:  # => a second, unrelated candidate to pass into apply
+    return n * 3  # => multiplies by three
+
+
+result_increment = apply(increment, 10)  # => apply calls increment(10) internally
+result_triple = apply(triple, 10)  # => same apply, DIFFERENT function passed in
+
+print(result_increment)  # => Output: 11
+print(result_triple)  # => Output: 30
+print(
+    apply(increment, 10) == increment(10)
+)  # => Output: True -- apply just forwards the call

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-10-higher-order-apply/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-10-higher-order-apply/test_example.py
@@ -1,0 +1,14 @@
+"""Example 10: pytest verification for A Higher-Order apply Function."""
+
+from example import apply, increment, triple
+
+
+def test_apply_forwards_to_whichever_function_is_passed() -> None:
+    assert apply(increment, 10) == 11
+    assert apply(triple, 10) == 30
+    assert apply(increment, 10) == increment(
+        10
+    )  # => apply changes nothing about the call
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-11-return-a-function/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-11-return-a-function/example.py
@@ -1,0 +1,28 @@
+"""Example 11: A Function Returning a Closure."""
+
+from typing import (
+    Callable,
+)  # => the return type of multiplier -- "a function int -> int"
+
+
+def multiplier(
+    n: int,
+) -> Callable[[int], int]:  # => HOF: RETURNS a function, doesn't just take one
+    def multiply_by_n(
+        x: int,
+    ) -> int:  # => a closure -- captures n from the enclosing scope
+        return x * n  # => n is remembered even after multiplier() has already returned
+
+    return multiply_by_n  # => the inner function itself is the return value
+
+
+times_three = multiplier(
+    3
+)  # => times_three is now a function that always multiplies by 3
+times_five = multiplier(5)  # => a SEPARATE closure, capturing a different n (5)
+
+print(times_three(4))  # => Output: 12  (4 * 3, using the captured n=3)
+print(times_five(4))  # => Output: 20  (4 * 5, using the captured n=5)
+print(
+    multiplier(3)(4) == 12
+)  # => Output: True -- calling the returned function immediately

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-11-return-a-function/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-11-return-a-function/test_example.py
@@ -1,0 +1,14 @@
+"""Example 11: pytest verification for A Function Returning a Closure."""
+
+from example import multiplier
+
+
+def test_returned_closures_remember_their_own_n() -> None:
+    times_three = multiplier(3)
+    times_five = multiplier(5)
+    assert times_three(4) == 12
+    assert times_five(4) == 20
+    assert multiplier(3)(4) == 12  # => calling the returned function immediately
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-12-closure-captures-config/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-12-closure-captures-config/example.py
@@ -1,0 +1,30 @@
+"""Example 12: A Closure Capturing a Threshold."""
+
+from typing import (
+    Callable,
+)  # => the return type of make_validator -- "a function int -> bool"
+
+
+def make_validator(
+    threshold: int,
+) -> Callable[[int], bool]:  # => bakes threshold into a closure
+    def is_above_threshold(
+        value: int,
+    ) -> bool:  # => captures threshold, no parameter for it
+        return (
+            value > threshold
+        )  # => reads the ENCLOSING threshold, not a fresh argument
+
+    return (
+        is_above_threshold  # => this closure, not a plain value, is what gets returned
+    )
+
+
+passes_ten = make_validator(10)  # => remembers threshold=10 forever
+passes_hundred = make_validator(100)  # => a DIFFERENT closure, remembers threshold=100
+
+print(passes_ten(15))  # => Output: True   (15 > 10)
+print(passes_hundred(15))  # => Output: False  (15 is NOT > 100)
+print(
+    passes_ten(15) != passes_hundred(15)
+)  # => Output: True -- same input, different config

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-12-closure-captures-config/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-12-closure-captures-config/test_example.py
@@ -1,0 +1,13 @@
+"""Example 12: pytest verification for A Closure Capturing a Threshold."""
+
+from example import make_validator
+
+
+def test_closures_vary_with_their_captured_threshold() -> None:
+    passes_ten = make_validator(10)
+    passes_hundred = make_validator(100)
+    assert passes_ten(15) is True
+    assert passes_hundred(15) is False
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-13-map-basic/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-13-map-basic/example.py
@@ -1,0 +1,17 @@
+"""Example 13: map() Uppercases Every Word."""
+
+words = ["functional", "programming", "in", "python"]  # => the source sequence
+
+uppercased = map(str.upper, words)  # => LAZY: map builds an iterator, nothing runs yet
+# => str.upper is an unbound method -- map calls it as str.upper(word) for each word
+
+uppercased_list = list(
+    uppercased
+)  # => forces evaluation -- NOW every word is uppercased
+print(uppercased_list)  # => Output: ['FUNCTIONAL', 'PROGRAMMING', 'IN', 'PYTHON']
+print(
+    len(uppercased_list) == len(words)
+)  # => Output: True -- map is 1:1, never drops elements
+print(
+    all(w.isupper() for w in uppercased_list)
+)  # => Output: True -- every word transformed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-13-map-basic/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-13-map-basic/test_example.py
@@ -1,0 +1,11 @@
+"""Example 13: pytest verification for map() Uppercases Every Word."""
+
+
+def test_map_uppercases_every_element() -> None:
+    words = ["a", "bee", "sea"]
+    result = list(map(str.upper, words))
+    assert result == ["A", "BEE", "SEA"]
+    assert len(result) == len(words)  # => map never drops elements
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-14-filter-basic/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-14-filter-basic/example.py
@@ -1,0 +1,19 @@
+"""Example 14: filter() Keeps Only Evens."""
+
+
+def is_even(n: int) -> bool:  # => the predicate filter will apply to each element
+    return n % 2 == 0  # => True keeps the element, False drops it
+
+
+nums = [1, 2, 3, 4, 5, 6, 7, 8]  # => the source sequence
+
+evens = filter(
+    is_even, nums
+)  # => LAZY: builds an iterator, no filtering has happened yet
+evens_list = list(evens)  # => forces evaluation -- runs is_even on every element
+
+print(evens_list)  # => Output: [2, 4, 6, 8]
+print(len(evens_list))  # => Output: 4 -- exactly half of the original 8 elements
+print(
+    all(n % 2 == 0 for n in evens_list)
+)  # => Output: True -- odds were dropped, not zeroed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-14-filter-basic/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-14-filter-basic/test_example.py
@@ -1,0 +1,12 @@
+"""Example 14: pytest verification for filter() Keeps Only Evens."""
+
+from example import is_even
+
+
+def test_filter_keeps_only_predicate_matches() -> None:
+    nums = [1, 2, 3, 4, 5, 6]
+    result = list(filter(is_even, nums))
+    assert result == [2, 4, 6]
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-15-reduce-sum/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-15-reduce-sum/example.py
@@ -1,0 +1,20 @@
+"""Example 15: reduce() Sums a List."""
+
+from functools import reduce  # => reduce lives in functools, not the builtins
+
+
+def add(
+    a: int, b: int
+) -> int:  # => the "how to combine two values" step reduce repeats
+    return a + b  # => the two-argument combiner reduce calls at every step
+
+
+nums = [1, 2, 3, 4, 5]  # => the source sequence
+
+total = reduce(add, nums, 0)  # => folds nums into ONE value, starting from the seed 0
+# => reduce computes add(add(add(add(add(0,1),2),3),4),5) -- one running accumulator, no loop written
+
+print(total)  # => Output: 15
+print(
+    total == sum(nums)
+)  # => Output: True -- reduce(add, ..., 0) IS how sum() works internally

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-15-reduce-sum/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-15-reduce-sum/test_example.py
@@ -1,0 +1,13 @@
+"""Example 15: pytest verification for reduce() Sums a List."""
+
+from functools import reduce
+
+from example import add
+
+
+def test_reduce_sums_the_sequence() -> None:
+    nums = [1, 2, 3, 4, 5]
+    assert reduce(add, nums, 0) == 15 == sum(nums)
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-16-comprehension-vs-map/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-16-comprehension-vs-map/example.py
@@ -1,0 +1,33 @@
+"""Example 16: A Comprehension Matching map() and filter()."""
+
+nums = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+]  # => the shared source sequence for both approaches
+
+via_map_filter = (
+    list(  # => map(square, filter(is_even, nums)), spelled out with a lambda
+        map(
+            lambda n: n * n, filter(lambda n: n % 2 == 0, nums)
+        )  # => two nested lazy iterators
+    )
+)  # => filter runs first (keeps evens), THEN map squares what survived
+
+via_comprehension = [
+    n * n for n in nums if n % 2 == 0
+]  # => same two steps, ONE expression
+# => "if n % 2 == 0" is the filter step; "n * n" is the map step -- read left to right
+
+print(via_map_filter)  # => Output: [4, 16, 36, 64, 100]
+print(via_comprehension)  # => Output: [4, 16, 36, 64, 100]
+print(
+    via_map_filter == via_comprehension
+)  # => Output: True -- two spellings, identical result

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-16-comprehension-vs-map/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-16-comprehension-vs-map/test_example.py
@@ -1,0 +1,11 @@
+"""Example 16: pytest verification for A Comprehension Matching map() and filter()."""
+
+
+def test_comprehension_matches_map_filter() -> None:
+    nums = list(range(1, 11))
+    via_map_filter = list(map(lambda n: n * n, filter(lambda n: n % 2 == 0, nums)))
+    via_comprehension = [n * n for n in nums if n % 2 == 0]
+    assert via_map_filter == via_comprehension
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-17-curry-manual/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-17-curry-manual/example.py
@@ -1,0 +1,33 @@
+"""Example 17: Hand-Curry a Two-Argument Function."""
+
+from typing import (
+    Callable,
+)  # => the return type of add_curried -- "a function int -> int"
+
+
+def add(a: int, b: int) -> int:  # => the ordinary, uncurried, 2-argument function
+    return a + b  # => both arguments supplied in a SINGLE call
+
+
+def add_curried(
+    a: int,
+) -> Callable[[int], int]:  # => takes ONE argument, returns a function
+    def inner(b: int) -> int:  # => the function waiting for the SECOND argument
+        return a + b  # => a is captured from the enclosing scope, b arrives here
+
+    return inner  # => add_curried(a) is itself a usable, partially-applied function
+
+
+uncurried_result = add(2, 3)  # => the ordinary call -- both arguments at once
+curried_result = add_curried(2)(3)  # => two separate calls: add_curried(2) THEN (3)
+
+print(uncurried_result)  # => Output: 5
+print(curried_result)  # => Output: 5
+print(
+    uncurried_result == curried_result
+)  # => Output: True -- same computation, different shape
+
+add_two = add_curried(
+    2
+)  # => a reusable, specialized function: "add 2 to whatever comes next"
+print(add_two(10))  # => Output: 12

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-17-curry-manual/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-17-curry-manual/test_example.py
@@ -1,0 +1,16 @@
+"""Example 17: pytest verification for Hand-Curry a Two-Argument Function."""
+
+from example import add, add_curried
+
+
+def test_curried_call_matches_uncurried_call() -> None:
+    assert add_curried(2)(3) == add(2, 3) == 5
+
+
+def test_partially_applied_curry_is_reusable() -> None:
+    add_two = add_curried(2)
+    assert add_two(10) == 12
+    assert add_two(20) == 22
+
+
+# => Run: pytest -- Output: 2 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-18-partial-application/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-18-partial-application/example.py
@@ -1,0 +1,19 @@
+"""Example 18: functools.partial Fixes an Argument."""
+
+from functools import partial  # => stdlib's built-in way to pre-fill arguments
+
+
+def power(base: int, exponent: int) -> int:  # => the general 2-argument function
+    return base**exponent  # => base to the exponent power
+
+
+square_of = partial(
+    power, 2
+)  # => fixes base=2, returns a 1-argument function of exponent
+# => no lambda, no hand-written closure -- functools builds the wrapper for us
+
+print(square_of(3))  # => Output: 8  (power(2, 3) == 2**3)
+print(square_of(10))  # => Output: 1024  (power(2, 10) == 2**10)
+print(
+    power(2, 10) == square_of(10)
+)  # => Output: True -- partial just pre-supplies base

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-18-partial-application/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-18-partial-application/test_example.py
@@ -1,0 +1,13 @@
+"""Example 18: pytest verification for functools.partial Fixes an Argument."""
+
+from functools import partial
+
+from example import power
+
+
+def test_partial_fixes_the_first_argument() -> None:
+    square_of = partial(power, 2)
+    assert square_of(10) == power(2, 10) == 1024
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-19-compose-two/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-19-compose-two/example.py
@@ -1,0 +1,30 @@
+"""Example 19: A compose(f, g) Helper."""
+
+from typing import Callable  # => the type of every function this example composes
+
+
+def compose(  # => a HOF: takes two functions, RETURNS a new function
+    f: Callable[[int], int],
+    g: Callable[[int], int],  # => the two functions being combined
+) -> Callable[[int], int]:  # => the return type -- itself a function int -> int
+    def composed(x: int) -> int:  # => the returned function -- runs g FIRST, then f
+        return f(g(x))  # => g(x) computed first; its result feeds into f
+
+    return composed  # => composed itself, not a value, is compose's return value
+
+
+def add_one(x: int) -> int:  # => one of the two small functions being composed together
+    return x + 1  # => adds exactly one
+
+
+def double(x: int) -> int:  # => the other small function being composed together
+    return x * 2  # => doubles its argument
+
+
+add_then_double = compose(double, add_one)  # => reads right-to-left: double(add_one(x))
+result = add_then_double(3)  # => add_one(3) is 4, then double(4) is 8
+
+print(result)  # => Output: 8
+print(
+    add_then_double(3) == double(add_one(3))
+)  # => Output: True -- compose just names f(g(x))

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-19-compose-two/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-19-compose-two/test_example.py
@@ -1,0 +1,11 @@
+"""Example 19: pytest verification for A compose(f, g) Helper."""
+
+from example import add_one, compose, double
+
+
+def test_compose_runs_g_then_f() -> None:
+    add_then_double = compose(double, add_one)
+    assert add_then_double(3) == double(add_one(3)) == 8
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-20-pipe-left-to-right/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-20-pipe-left-to-right/example.py
@@ -1,0 +1,34 @@
+"""Example 20: A Left-to-Right pipe Helper."""
+
+from functools import reduce  # => reduce folds *fns into x one step at a time
+from typing import Callable  # => the type of each step function pipe accepts
+
+
+def pipe(
+    x: int, *fns: Callable[[int], int]
+) -> int:  # => *fns: any number of step functions
+    return reduce(
+        lambda acc, fn: fn(acc), fns, x
+    )  # => applies each fn IN ORDER, left to right
+
+
+def add_one(x: int) -> int:  # => the first step in the pipeline below
+    return x + 1  # => adds exactly one
+
+
+def double(x: int) -> int:  # => the second step in the pipeline below
+    return x * 2  # => doubles its argument
+
+
+piped_result = pipe(
+    3, add_one, double
+)  # => reads top-to-bottom: start at 3, add_one, THEN double
+nested_result = double(
+    add_one(3)
+)  # => the equivalent nested call -- reads inside-out instead
+
+print(piped_result)  # => Output: 8
+print(nested_result)  # => Output: 8
+print(
+    piped_result == nested_result
+)  # => Output: True -- pipe and nesting compute the same thing

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-20-pipe-left-to-right/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-20-pipe-left-to-right/test_example.py
@@ -1,0 +1,10 @@
+"""Example 20: pytest verification for A Left-to-Right pipe Helper."""
+
+from example import add_one, double, pipe
+
+
+def test_pipe_matches_nested_calls() -> None:
+    assert pipe(3, add_one, double) == double(add_one(3)) == 8
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-21-generator-lazy-count/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-21-generator-lazy-count/example.py
@@ -1,0 +1,31 @@
+"""Example 21: A Generator Yields on Demand."""
+
+from typing import Iterator  # => the return type of a generator function
+
+
+def counter(
+    start: int,
+) -> Iterator[int]:  # => a generator FUNCTION -- calling it runs NO code yet
+    n = start  # => the running value, remembered ACROSS yields
+    while (
+        True
+    ):  # => an INFINITE loop -- safe only because yield pauses execution each time
+        yield n  # => pauses here, handing n back to the caller, resuming on the NEXT next()
+        n += 1  # => only runs AFTER the caller pulls again
+
+
+pulled: list[int] = []  # => tracks exactly which values were actually computed
+gen = counter(
+    10
+)  # => creates the generator OBJECT -- the while loop has not run at all yet
+
+pulled.append(
+    next(gen)
+)  # => resumes the generator until the first yield -- pulled: [10]
+pulled.append(next(gen))  # => resumes again from where it paused -- pulled: [10, 11]
+pulled.append(next(gen))  # => a third pull -- pulled: [10, 11, 12]
+
+print(pulled)  # => Output: [10, 11, 12]
+print(
+    len(pulled)
+)  # => Output: 3 -- only 3 values ever computed, despite counter() being infinite

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-21-generator-lazy-count/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-21-generator-lazy-count/test_example.py
@@ -1,0 +1,12 @@
+"""Example 21: pytest verification for A Generator Yields on Demand."""
+
+from example import counter
+
+
+def test_only_pulled_values_are_computed() -> None:
+    gen = counter(10)
+    pulled = [next(gen), next(gen), next(gen)]
+    assert pulled == [10, 11, 12]
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-22-generator-vs-list-memory/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-22-generator-vs-list-memory/example.py
@@ -1,0 +1,30 @@
+"""Example 22: Generator Expression vs. List."""
+
+import sys  # => sys.getsizeof measures the actual object footprint, in bytes
+
+n = 1_000_000  # => a large N -- big enough to make the memory difference obvious
+
+eager_list = [
+    i * i for i in range(n)
+]  # => EAGER: every single square computed and stored NOW
+lazy_generator = (
+    i * i for i in range(n)
+)  # => LAZY: builds a generator object, computes NOTHING yet
+# => same source expression, two entirely different memory strategies
+
+list_bytes = sys.getsizeof(
+    eager_list
+)  # => size of N already-materialized integers' container
+generator_bytes = sys.getsizeof(
+    lazy_generator
+)  # => size of the generator machinery only
+
+print(
+    list_bytes > generator_bytes
+)  # => Output: True -- the list is dramatically larger
+print(
+    generator_bytes < 300
+)  # => Output: True -- a generator's footprint stays tiny regardless of n
+print(
+    next(lazy_generator)
+)  # => Output: 0 -- the FIRST square is only computed on this pull

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-22-generator-vs-list-memory/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-22-generator-vs-list-memory/test_example.py
@@ -1,0 +1,14 @@
+"""Example 22: pytest verification for Generator Expression vs. List."""
+
+import sys
+
+
+def test_generator_footprint_stays_small() -> None:
+    n = 1_000_000
+    eager_list = [i * i for i in range(n)]
+    lazy_generator = (i * i for i in range(n))
+    assert sys.getsizeof(eager_list) > sys.getsizeof(lazy_generator)
+    assert sys.getsizeof(lazy_generator) < 300
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-23-itertools-islice-infinite/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-23-itertools-islice-infinite/example.py
@@ -1,0 +1,23 @@
+"""Example 23: islice Over an Infinite count()."""
+
+from itertools import (
+    count,
+    islice,
+)  # => count(): an infinite counter; islice: a lazy slice
+
+infinite_evens = (n for n in count(0, 2))  # => LAZY, infinite: 0, 2, 4, 6, ... forever
+first_five = list(
+    islice(infinite_evens, 5)
+)  # => islice pulls exactly 5 values, then STOPS
+# => the underlying infinite generator is NEVER exhausted -- islice just stops pulling
+
+print(first_five)  # => Output: [0, 2, 4, 6, 8]
+print(
+    len(first_five)
+)  # => Output: 5 -- islice never tries to exhaust the infinite source
+next_value = next(
+    infinite_evens
+)  # => the underlying generator resumes right where islice left it
+print(
+    next_value
+)  # => Output: 10 -- confirms islice consumed exactly the first 5, no more

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-23-itertools-islice-infinite/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-23-itertools-islice-infinite/test_example.py
@@ -1,0 +1,15 @@
+"""Example 23: pytest verification for islice Over an Infinite count()."""
+
+from itertools import count, islice
+
+
+def test_islice_takes_exactly_n_from_an_infinite_source() -> None:
+    infinite_evens = (n for n in count(0, 2))
+    first_five = list(islice(infinite_evens, 5))
+    assert first_five == [0, 2, 4, 6, 8]
+    assert (
+        next(infinite_evens) == 10
+    )  # => confirms the source resumes right where islice stopped
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-24-itertools-chain-groupby/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-24-itertools-chain-groupby/example.py
@@ -1,0 +1,29 @@
+"""Example 24: chain and groupby Over Data."""
+
+from itertools import (
+    chain,
+    groupby,
+)  # => chain: concatenate iterables; groupby: group consecutive keys
+
+morning = ["apple", "apricot", "banana"]  # => two separately-sourced lists to combine
+evening = [
+    "blueberry",
+    "cherry",
+    "avocado",
+]  # => notice: NOT globally sorted by first letter
+
+combined = list(
+    chain(morning, evening)
+)  # => one flat sequence, morning's items THEN evening's
+print(combined)  # => shows the raw, unsorted concatenation before grouping
+# => Output: ['apple', 'apricot', 'banana', 'blueberry', 'cherry', 'avocado']
+
+grouped = {  # => groupby only groups CONSECUTIVE equal keys -- input must be pre-sorted by key
+    letter: list(items)  # => materialize each lazy group before it is invalidated
+    for letter, items in groupby(  # => sorted() first, so equal first-letters become consecutive
+        sorted(combined),
+        key=lambda w: w[0],  # => the grouping key: each word's first letter
+    )  # => groupby itself is lazy -- list(items) above is what forces each group
+}  # => a plain dict, one entry per distinct first letter seen
+print(grouped["a"])  # => Output: ['apple', 'apricot', 'avocado']
+print(grouped["b"])  # => Output: ['banana', 'blueberry']

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-24-itertools-chain-groupby/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-24-itertools-chain-groupby/test_example.py
@@ -1,0 +1,15 @@
+"""Example 24: pytest verification for chain and groupby Over Data."""
+
+from itertools import chain, groupby
+
+
+def test_chain_then_groupby() -> None:
+    morning = ["apple", "apricot", "banana"]
+    evening = ["blueberry", "cherry", "avocado"]
+    combined = list(chain(morning, evening))
+    grouped = {k: list(v) for k, v in groupby(sorted(combined), key=lambda w: w[0])}
+    assert grouped["a"] == ["apple", "apricot", "avocado"]
+    assert grouped["b"] == ["banana", "blueberry"]
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-25-memoize-lru-cache/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-25-memoize-lru-cache/example.py
@@ -1,0 +1,35 @@
+"""Example 25: @lru_cache on a Recursive fib."""
+
+from functools import (
+    lru_cache,
+)  # => decorator-based memoization, keyed by call arguments
+
+
+@lru_cache(
+    maxsize=None
+)  # => unbounded cache -- every unique n is computed at most once
+def fib(
+    n: int,
+) -> int:  # => the classic exponential-without-caching recursive definition
+    if n < 2:  # => base case: fib(0) = 0, fib(1) = 1
+        return n  # => no further recursion needed below n=2
+    return fib(n - 1) + fib(n - 2)  # => WITHOUT caching this branches exponentially
+
+
+result = fib(
+    30
+)  # => triggers a burst of recursive calls, each cached the FIRST time it runs
+info_after_first = fib.cache_info()  # => snapshot: hits so far, misses so far
+
+fib(
+    30
+)  # => calling AGAIN with the same n=30 -- served entirely from cache, no recursion
+info_after_second = fib.cache_info()  # => hits increased, misses did NOT
+
+print(result)  # => Output: 832040
+print(
+    info_after_second.hits > info_after_first.hits
+)  # => Output: True -- repeat call hit the cache
+print(
+    info_after_second.misses == info_after_first.misses
+)  # => Output: True -- no NEW work happened

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-25-memoize-lru-cache/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-25-memoize-lru-cache/test_example.py
@@ -1,0 +1,16 @@
+"""Example 25: pytest verification for @lru_cache on a Recursive fib."""
+
+from example import fib
+
+
+def test_repeat_call_hits_the_cache() -> None:
+    fib.cache_clear()  # => start from a known, empty cache
+    fib(20)  # => first call: populates the cache
+    before = fib.cache_info()
+    fib(20)  # => identical call: should be served from cache
+    after = fib.cache_info()
+    assert after.hits > before.hits
+    assert after.misses == before.misses
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-26-decorator-log-wrap/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-26-decorator-log-wrap/example.py
@@ -1,0 +1,35 @@
+"""Example 26: A Logging Decorator Wraps a Function."""
+
+from typing import (
+    Callable,
+)  # => the type shape both the wrapped and wrapper functions share
+
+calls: list[str] = []  # => records what the decorator observed, for verification below
+
+
+def log_calls(
+    fn: Callable[[int, int], int],
+) -> Callable[[int, int], int]:  # => decorator: fn -> wrapped fn
+    def wrapper(
+        a: int, b: int
+    ) -> int:  # => runs INSTEAD of fn when the decorated name is called
+        calls.append(f"calling {fn.__name__}({a}, {b})")  # => logs BEFORE the real call
+        result = fn(a, b)  # => delegates to the original, undecorated function
+        calls.append(
+            f"{fn.__name__} returned {result}"
+        )  # => logs AFTER, using the real result
+        return result  # => the wrapper's return value is EXACTLY the original's return value
+
+    return wrapper  # => this function object replaces add everywhere add() is called
+
+
+@log_calls  # => equivalent to: add = log_calls(add)
+def add(a: int, b: int) -> int:  # => the plain function BEFORE decoration wraps it
+    return a + b  # => the ordinary, undecorated computation
+
+
+wrapped_result = add(2, 3)  # => actually calls wrapper(2, 3), which logs then delegates
+print(
+    wrapped_result
+)  # => Output: 5 -- the wrapped result is unchanged from the plain call
+print(calls)  # => Output: ['calling add(2, 3)', 'add returned 5']

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-26-decorator-log-wrap/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-26-decorator-log-wrap/test_example.py
@@ -1,0 +1,10 @@
+"""Example 26: pytest verification for A Logging Decorator Wraps a Function."""
+
+from example import add
+
+
+def test_decorator_preserves_the_result() -> None:
+    assert add(2, 3) == 5  # => the wrapped call still returns the correct value
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-27-recursion-factorial/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-27-recursion-factorial/example.py
@@ -1,0 +1,24 @@
+"""Example 27: A Recursive Factorial (No TCO)."""
+
+import sys  # => sys.getrecursionlimit -- CPython's hard, load-bearing recursion ceiling
+
+
+def factorial(n: int) -> int:  # => the textbook recursive definition -- one call per n
+    if n <= 1:  # => base case stops the recursion
+        return 1  # => factorial(0) and factorial(1) both bottom out here
+    return n * factorial(
+        n - 1
+    )  # => NOT a tail call reduced away -- CPython keeps every frame
+
+
+result = factorial(10)  # => 10 nested calls deep -- trivially within the default limit
+print(result)  # => Output: 3628800
+
+limit = (
+    sys.getrecursionlimit()
+)  # => the default ceiling (commonly 1000) -- CPython has NO TCO
+# => a self-tail-call in Python is NOT collapsed into a loop by the interpreter, unlike Scheme
+print(
+    limit > 100
+)  # => Output: True -- 10 frames of factorial(10) fit comfortably under this
+print(10 < limit)  # => Output: True -- confirms this call never approaches the ceiling

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-27-recursion-factorial/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-27-recursion-factorial/test_example.py
@@ -1,0 +1,11 @@
+"""Example 27: pytest verification for A Recursive Factorial (No TCO)."""
+
+from example import factorial
+
+
+def test_factorial_matches_the_known_value() -> None:
+    assert factorial(10) == 3628800
+    assert factorial(0) == 1  # => base case
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-28-optional-none-guard/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-28-optional-none-guard/example.py
@@ -1,0 +1,28 @@
+"""Example 28: Guarding a None-Returning Function."""
+
+
+def find_user_age(
+    users: dict[str, int], name: str
+) -> int | None:  # => None means "not found"
+    return users.get(
+        name
+    )  # => dict.get returns None on a missing key -- no exception raised
+
+
+directory = {"ana": 30, "budi": 25}  # => the lookup table this example queries
+
+found_age = find_user_age(directory, "ana")  # => a hit -- found_age is 30
+if found_age is not None:  # => the guard: caller MUST check before trusting the value
+    print(f"ana is {found_age}")  # => Output: ana is 30
+else:  # => the miss branch -- never taken for this particular lookup
+    print("ana not found")  # => unreachable here -- ana IS in the directory
+
+missing_age = find_user_age(directory, "citra")  # => a miss -- missing_age is None
+if (
+    missing_age is not None
+):  # => same guard pattern, this time it takes the OTHER branch
+    print(
+        f"citra is {missing_age}"
+    )  # => unreachable here -- citra is NOT in the directory
+else:  # => the miss branch -- taken this time, since citra is not in directory
+    print("citra not found")  # => Output: citra not found

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-28-optional-none-guard/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-28-optional-none-guard/test_example.py
@@ -1,0 +1,12 @@
+"""Example 28: pytest verification for Guarding a None-Returning Function."""
+
+from example import find_user_age
+
+
+def test_hit_and_miss_are_both_handled() -> None:
+    directory = {"ana": 30}
+    assert find_user_age(directory, "ana") == 30
+    assert find_user_age(directory, "citra") is None
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-29-pure-core-extract/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-29-pure-core-extract/example.py
@@ -1,0 +1,47 @@
+"""Example 29: Extract a Pure Core from a Mutating Routine."""
+
+report_log: list[str] = []  # => the ORIGINAL routine's hidden side effect target
+
+
+def process_orders_impure(
+    orders: list[int],
+) -> int:  # => mixes computation AND I/O together
+    total = 0  # => the running sum, mutated below
+    for amount in orders:  # => a loop mutating both total and the module-level log
+        total += amount  # => mutates total AND appends below -- two side effects per iteration
+        report_log.append(
+            f"processed {amount}"
+        )  # => side effect buried inside the loop
+    return total  # => the caller cannot test this without also inspecting report_log
+
+
+def sum_orders_pure(
+    orders: list[int],
+) -> int:  # => the EXTRACTED core -- no I/O, no logging
+    return sum(orders)  # => a pure fold, trivially testable with no mocking
+
+
+def make_log_lines(
+    orders: list[int],
+) -> list[str]:  # => the logging, extracted as its OWN pure function
+    return [
+        f"processed {amount}" for amount in orders
+    ]  # => still pure: builds and returns, doesn't print
+
+
+orders = [10, 20, 30]  # => shared input for both the impure routine and the pure core
+
+impure_total = process_orders_impure(
+    orders
+)  # => also mutates report_log as a side effect
+pure_total = sum_orders_pure(
+    orders
+)  # => computes the SAME total with zero side effects
+
+# => this is the co-28 functional-core/imperative-shell split in miniature
+print(
+    impure_total == pure_total
+)  # => Output: True -- same answer, radically different testability
+print(
+    make_log_lines(orders) == report_log
+)  # => Output: True -- logging extracted without losing it

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-29-pure-core-extract/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-29-pure-core-extract/test_example.py
@@ -1,0 +1,18 @@
+"""Example 29: pytest verification for Extract a Pure Core from a Mutating Routine."""
+
+from example import make_log_lines, sum_orders_pure
+
+
+def test_pure_core_needs_no_mocking() -> None:
+    orders = [1, 2, 3]
+    assert (
+        sum_orders_pure(orders) == 6
+    )  # => tested with plain arguments, no I/O to intercept
+
+
+def test_log_lines_extracted_as_pure_function() -> None:
+    orders = [5, 15]
+    assert make_log_lines(orders) == ["processed 5", "processed 15"]
+
+
+# => Run: pytest -- Output: 2 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-30-persistent-list-prepend/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-30-persistent-list-prepend/example.py
@@ -1,0 +1,44 @@
+"""Example 30: O(1) Sharing on a Persistent Linked List."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'PList | None' forward reference below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds the immutable PList node
+
+
+@dataclass(
+    frozen=True
+)  # => a persistent list node caching its own length -- O(1) to read
+class PList:  # => the node type itself -- see the decorator above for immutability
+    head: int  # => this node's own value
+    tail: "PList | None"  # => the shared, untouched rest of the list
+    length: int  # => cached at construction time -- never recomputed by walking
+
+
+def plist_prepend(
+    value: int, lst: "PList | None"
+) -> PList:  # => O(1): no walk over lst needed
+    previous_length = (
+        lst.length if lst is not None else 0
+    )  # => O(1) read of a cached field
+    return PList(
+        head=value, tail=lst, length=previous_length + 1
+    )  # => reuses lst AS-IS
+
+
+empty: PList | None = None  # => the shared empty base every version points back to
+version_a = plist_prepend(1, empty)  # => version_a.length is 1
+version_b = plist_prepend(
+    2, version_a
+)  # => version_b.length is 2, REUSING version_a untouched
+
+# => structural sharing means version_b costs O(1) extra memory, not O(n)
+print(version_a.length)  # => Output: 1
+print(version_b.length)  # => Output: 2
+print(version_b.tail is version_a)  # => Output: True -- structural sharing, not a copy
+print(
+    version_a.head
+)  # => Output: 1 -- version_a itself was never touched by building version_b

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-30-persistent-list-prepend/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-30-persistent-list-prepend/test_example.py
@@ -1,0 +1,17 @@
+"""Example 30: pytest verification for O(1) Sharing on a Persistent Linked List."""
+
+from example import PList, plist_prepend
+
+
+def test_prepend_is_o1_and_shares_the_tail() -> None:
+    version_a: PList | None = plist_prepend(1, None)
+    version_b = plist_prepend(
+        2, version_a
+    )  # => O(1): only reads version_a.length, never walks it
+
+    assert version_b.length == 2
+    assert version_a.length == 1  # => unaffected by building version_b
+    assert version_b.tail is version_a  # => structural sharing, not a copy
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-31-mappingproxy-readonly/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-31-mappingproxy-readonly/example.py
@@ -1,0 +1,30 @@
+"""Example 31: A Read-Only View via MappingProxyType."""
+
+from types import (
+    MappingProxyType,
+)  # => a read-only VIEW over an existing dict, not a copy
+
+config = {
+    "retries": 3,
+    "timeout": 5,
+}  # => the underlying mutable dict this example protects
+readonly_config = MappingProxyType(
+    config
+)  # => wraps config -- reads pass through, writes are blocked
+# => this is the co-04 "immutability at the boundary" pattern -- share config without risking mutation
+
+print(
+    readonly_config["retries"]
+)  # => Output: 3 -- reads work exactly like a normal dict
+
+try:  # => opens a block that expects the write below to raise
+    readonly_config["retries"] = 99  # type: ignore[index]  # => attempts a write through the view
+    raised = False  # => unreachable if TypeError fires
+except TypeError:  # => MappingProxyType has no __setitem__
+    raised = True  # => confirms the view actually blocked the write
+
+print(raised)  # => Output: True
+config["retries"] = 10  # => the UNDERLYING dict itself is still mutable directly
+print(
+    readonly_config["retries"]
+)  # => Output: 10 -- the view reflects the underlying dict LIVE

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-31-mappingproxy-readonly/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-31-mappingproxy-readonly/test_example.py
@@ -1,0 +1,20 @@
+"""Example 31: pytest verification for A Read-Only View via MappingProxyType."""
+
+from types import MappingProxyType
+
+
+def test_view_blocks_writes_but_reflects_the_underlying_dict() -> None:
+    config = {"retries": 3}
+    readonly_config = MappingProxyType(config)
+    try:
+        readonly_config["retries"] = 99  # type: ignore[index]
+        raised = False
+    except TypeError:
+        raised = True
+    assert raised is True
+
+    config["retries"] = 10  # => mutate the underlying dict directly
+    assert readonly_config["retries"] == 10  # => the view is LIVE, not a snapshot
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-32-closure-counter-vs-pure-fold/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-32-closure-counter-vs-pure-fold/example.py
@@ -1,0 +1,41 @@
+"""Example 32: Stateful Closure Counter vs. Pure Fold."""
+
+from functools import reduce  # => reduce is used by the pure fold below
+from typing import Callable  # => Callable types the closure returned by make_counter
+
+
+def make_counter() -> Callable[[], int]:  # => returns a closure holding MUTABLE state
+    count = 0  # => lives INSIDE the closure -- state lives here, nowhere else
+
+    def increment() -> int:  # => the returned closure itself
+        nonlocal count  # => declares intent to mutate the ENCLOSING count, not a local copy
+        count += 1  # => side effect: mutates state captured by the closure
+        return count  # => returns the count AFTER incrementing
+
+    return increment  # => make_counter itself returns the closure, not a value
+
+
+def count_pure(
+    n: int,
+) -> int:  # => a pure fold: no closure, no mutation, no hidden state
+    return reduce(
+        lambda acc, _: acc + 1, range(n), 0
+    )  # => the SAME total, computed with zero state
+
+
+counter = make_counter()  # => a fresh closure with its own private count
+stateful_result = [
+    counter(),
+    counter(),
+    counter(),
+]  # => each call MUTATES the shared closure state
+pure_result = count_pure(
+    3
+)  # => a single expression, no calls needed, no state anywhere
+
+# => co-08 closures vs co-01 purity: same answer, two different state models
+print(stateful_result)  # => Output: [1, 2, 3]
+print(pure_result)  # => Output: 3
+print(
+    stateful_result[-1] == pure_result
+)  # => Output: True -- same final count, different state model

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-32-closure-counter-vs-pure-fold/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-32-closure-counter-vs-pure-fold/test_example.py
@@ -1,0 +1,14 @@
+"""Example 32: pytest verification for Stateful Closure Counter vs. Pure Fold."""
+
+from example import count_pure, make_counter
+
+
+def test_closure_state_and_pure_fold_agree_on_the_final_count() -> None:
+    counter = make_counter()
+    for _ in range(3):
+        counter()
+    assert counter() == 4  # => state lives IN the closure, mutated across calls
+    assert count_pure(4) == 4  # => the SAME count, computed with zero mutable state
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-33-currying-with-partial/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-33-currying-with-partial/example.py
@@ -1,0 +1,29 @@
+"""Example 33: A Pipeline of partial Calls."""
+
+from functools import partial  # => partial is the currying mechanism used below
+
+
+def scale(
+    factor: int, x: int
+) -> int:  # => a 2-argument function -- factor fixed, x supplied later
+    return factor * x  # => the actual multiplication scale performs
+
+
+def offset(amount: int, x: int) -> int:  # => a second 2-argument function, same shape
+    return amount + x  # => the actual addition offset performs
+
+
+double = partial(scale, 2)  # => fixes factor=2 -- a reusable "double" function
+add_ten = partial(offset, 10)  # => fixes amount=10 -- a reusable "add ten" function
+
+pipeline_result = add_ten(double(5))  # => double(5) is 10, then add_ten(10) is 20
+manual_result = 10 + (
+    2 * 5
+)  # => the equivalent hand-written arithmetic, for comparison
+
+# => partial is Python's practical stand-in for true currying (co-10)
+print(pipeline_result)  # => Output: 20
+print(
+    pipeline_result == manual_result
+)  # => Output: True -- partials compose like ordinary functions
+print(double(100))  # => Output: 200 -- double is REUSABLE across any input, not just 5

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-33-currying-with-partial/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-33-currying-with-partial/test_example.py
@@ -1,0 +1,15 @@
+"""Example 33: pytest verification for A Pipeline of partial Calls."""
+
+from functools import partial
+
+from example import offset, scale
+
+
+def test_chained_partials_compose_like_ordinary_functions() -> None:
+    double = partial(scale, 2)
+    add_ten = partial(offset, 10)
+    assert add_ten(double(5)) == 20
+    assert double(100) == 200  # => double is reusable across any input
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-34-compose-n-functions/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-34-compose-n-functions/example.py
@@ -1,0 +1,39 @@
+"""Example 34: compose(*fns) Folds a List of Functions."""
+
+from functools import reduce  # => reduce folds the chain of functions inside compose
+from typing import Callable  # => Callable types every function compose accepts
+
+
+def compose(
+    *fns: Callable[[int], int],
+) -> Callable[[int], int]:  # => any NUMBER of functions
+    def composed(x: int) -> int:  # => the returned pipeline function
+        return reduce(
+            lambda acc, fn: fn(acc), reversed(fns), x
+        )  # => rightmost fn runs FIRST
+        # => reversed(fns) makes compose(f, g, h)(x) mean f(g(h(x))), matching math notation
+
+    return composed  # => compose itself returns the pipeline function, not a value
+
+
+def add_one(x: int) -> int:  # => the innermost step in the pipeline below
+    return x + 1  # => the actual +1 add_one performs
+
+
+def double(x: int) -> int:  # => the middle step in the pipeline below
+    return x * 2  # => the actual *2 double performs
+
+
+def square(x: int) -> int:  # => the outermost step in the pipeline below
+    return x * x  # => the actual squaring square performs
+
+
+pipeline = compose(
+    square, double, add_one
+)  # => reads right-to-left: square(double(add_one(x)))
+result = pipeline(3)  # => add_one(3)=4, double(4)=8, square(8)=64
+
+print(result)  # => Output: 64
+print(
+    result == square(double(add_one(3)))
+)  # => Output: True -- compose(*fns) matches nested calls

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-34-compose-n-functions/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-34-compose-n-functions/test_example.py
@@ -1,0 +1,11 @@
+"""Example 34: pytest verification for compose(*fns) Folds a List of Functions."""
+
+from example import add_one, compose, double, square
+
+
+def test_compose_star_matches_nested_application_order() -> None:
+    pipeline = compose(square, double, add_one)
+    assert pipeline(3) == square(double(add_one(3))) == 64
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-35-point-free-transform/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-35-point-free-transform/example.py
@@ -1,0 +1,45 @@
+"""Example 35: Rewriting a Lambda Pipeline Point-Free."""
+
+from functools import (
+    partial,
+    reduce,
+)  # => partial curries add/multiply; reduce powers compose
+from typing import (
+    Callable,
+)  # => Callable types the pipeline function returned by compose
+
+
+def compose(
+    *fns: Callable[[int], int],
+) -> Callable[[int], int]:  # => folds fns right-to-left
+    def composed(x: int) -> int:  # => the returned pipeline function
+        return reduce(
+            lambda acc, fn: fn(acc), reversed(fns), x
+        )  # => rightmost fn runs FIRST, matching math notation
+
+    return composed  # => compose itself returns the pipeline function
+
+
+def add(n: int, x: int) -> int:  # => a 2-argument helper, curried via partial below
+    return n + x  # => the actual addition add performs
+
+
+def multiply(n: int, x: int) -> int:  # => a second 2-argument helper, same shape
+    return n * x  # => the actual multiplication multiply performs
+
+
+with_named_arg: Callable[[int], int] = lambda x: multiply(
+    2, add(3, x)
+)  # => POINTED: names x explicitly
+point_free = compose(
+    partial(multiply, 2), partial(add, 3)
+)  # => POINT-FREE: x never named
+
+# => point-free style trades explicit naming for compact composition (co-19)
+print(with_named_arg(5))  # => Output: 16  ((5 + 3) * 2)
+print(
+    point_free(5)
+)  # => Output: 16 -- identical result, x never appears in point_free's own definition
+print(
+    with_named_arg(5) == point_free(5)
+)  # => Output: True -- two styles, one computation

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-35-point-free-transform/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-35-point-free-transform/test_example.py
@@ -1,0 +1,15 @@
+"""Example 35: pytest verification for Rewriting a Lambda Pipeline Point-Free."""
+
+from functools import partial
+from typing import Callable
+
+from example import add, compose, multiply
+
+
+def test_point_free_matches_the_named_argument_version() -> None:
+    with_named_arg: Callable[[int], int] = lambda x: multiply(2, add(3, x))
+    point_free = compose(partial(multiply, 2), partial(add, 3))
+    assert point_free(5) == with_named_arg(5) == 16
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-36-reduce-histogram/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-36-reduce-histogram/example.py
@@ -1,0 +1,27 @@
+"""Example 36: Building a Histogram with reduce."""
+
+from functools import reduce  # => reduce folds words into the histogram below
+
+
+def add_to_histogram(  # => the "how to fold one more element in" step
+    histogram: dict[str, int],
+    word: str,  # => the accumulator and the next element, reduce's own calling convention
+) -> dict[str, int]:  # => closes the multi-line signature above
+    histogram[word] = (
+        histogram.get(word, 0) + 1
+    )  # => increments, defaulting missing keys to 0
+    return histogram  # => reduce expects the combiner to return the NEW accumulator
+
+
+words = ["a", "b", "a", "c", "b", "a"]  # => the source sequence being counted
+
+histogram = reduce(
+    add_to_histogram, words, {}
+)  # => folds words into ONE dict, seeded empty
+
+# => reduce is the general-purpose fold every other aggregation specializes
+print(histogram)  # => Output: {'a': 3, 'b': 2, 'c': 1}
+print(histogram["a"])  # => Output: 3 -- 'a' appeared three times
+print(
+    sum(histogram.values()) == len(words)
+)  # => Output: True -- every word counted exactly once

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-36-reduce-histogram/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-36-reduce-histogram/test_example.py
@@ -1,0 +1,14 @@
+"""Example 36: pytest verification for Building a Histogram with reduce."""
+
+from functools import reduce
+
+from example import add_to_histogram
+
+
+def test_reduce_builds_a_correct_histogram() -> None:
+    words = ["x", "y", "x"]
+    histogram = reduce(add_to_histogram, words, {})
+    assert histogram == {"x": 2, "y": 1}
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-37-map-filter-reduce-pipeline/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-37-map-filter-reduce-pipeline/example.py
@@ -1,0 +1,25 @@
+"""Example 37: Chaining map, filter, and reduce."""
+
+from functools import reduce  # => reduce folds the filtered stream into one total
+
+orders = [12, 7, 25, 3, 18, 9]  # => raw order amounts, some too small to matter
+
+doubled = map(
+    lambda amount: amount * 2, orders
+)  # => LAZY: doubles every order (e.g. a 2x promo)
+significant = filter(
+    lambda amount: amount > 20, doubled
+)  # => LAZY: keeps only large-enough orders
+total = reduce(
+    lambda acc, amount: acc + amount, significant, 0
+)  # => folds survivors into one sum
+# => each stage is lazy until reduce finally pulls every value through the whole pipeline
+
+manual_total = sum(
+    a * 2 for a in orders if a * 2 > 20
+)  # => the equivalent single comprehension
+
+print(total)  # => Output: 110
+print(
+    total == manual_total
+)  # => Output: True -- three separate stages, one verified answer

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-37-map-filter-reduce-pipeline/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-37-map-filter-reduce-pipeline/test_example.py
@@ -1,0 +1,14 @@
+"""Example 37: pytest verification for Chaining map, filter, and reduce."""
+
+from functools import reduce
+
+
+def test_pipeline_matches_the_equivalent_comprehension() -> None:
+    orders = [12, 7, 25, 3, 18, 9]
+    doubled = map(lambda amount: amount * 2, orders)
+    significant = filter(lambda amount: amount > 20, doubled)
+    total = reduce(lambda acc, amount: acc + amount, significant, 0)
+    assert total == sum(a * 2 for a in orders if a * 2 > 20) == 110
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-38-lazy-pipeline-generators/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-38-lazy-pipeline-generators/example.py
@@ -1,0 +1,37 @@
+"""Example 38: A Lazy map/filter Pipeline Pulled by next."""
+
+from typing import Iterator  # => Iterator types the lazy generator below
+
+pulled_from_source: list[
+    int
+] = []  # => tracks exactly which SOURCE values were ever touched
+
+
+def logged_source() -> Iterator[
+    int
+]:  # => a generator that records every value it produces
+    for n in range(1, 1000):  # => a LARGE range -- but nothing runs until pulled
+        pulled_from_source.append(
+            n
+        )  # => only executes when this generator is actually advanced
+        yield n  # => suspends here until the consumer pulls the NEXT value
+
+
+doubled = map(
+    lambda n: n * 2, logged_source()
+)  # => LAZY: wraps the source, still nothing runs
+evens_only = filter(
+    lambda n: n % 4 == 0, doubled
+)  # => LAZY: a second lazy stage on top of the first
+
+first_three = [
+    next(evens_only),
+    next(evens_only),
+    next(evens_only),
+]  # => pulls JUST enough
+
+# => laziness (co-15) means the pipeline computes ONLY what the caller demands
+print(first_three)  # => Output: [4, 8, 12]
+print(
+    len(pulled_from_source) < 10
+)  # => Output: True -- far fewer than 999 source values were touched

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-38-lazy-pipeline-generators/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-38-lazy-pipeline-generators/test_example.py
@@ -1,0 +1,23 @@
+"""Example 38: pytest verification for A Lazy map/filter Pipeline Pulled by next."""
+
+from typing import Iterator
+
+
+def test_pipeline_pulls_only_as_many_source_values_as_needed() -> None:
+    pulled: list[int] = []
+
+    def source() -> Iterator[int]:
+        for n in range(1, 1000):
+            pulled.append(n)
+            yield n
+
+    doubled = map(lambda n: n * 2, source())
+    evens_only = filter(lambda n: n % 4 == 0, doubled)
+    result = [next(evens_only), next(evens_only)]
+    assert result == [4, 8]
+    assert (
+        len(pulled) < 10
+    )  # => the pipeline never touched most of the 999-element range
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-39-itertools-accumulate/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-39-itertools-accumulate/example.py
@@ -1,0 +1,21 @@
+"""Example 39: Running Totals via accumulate."""
+
+from itertools import (
+    accumulate,
+)  # => a lazy iterator of running totals (or any binary op)
+
+deposits = [100, 50, -30, 200]  # => a sequence of account movements
+
+running_balance = list(
+    accumulate(deposits)
+)  # => default op is +: each step is the sum SO FAR
+running_max = list(
+    accumulate(deposits, max)
+)  # => a custom op: running maximum instead of sum
+# => accumulate is itertools' generalized fold-that-keeps-every-intermediate-result
+
+print(running_balance)  # => Output: [100, 150, 120, 320]
+print(running_max)  # => Output: [100, 100, 100, 200]
+print(
+    running_balance[-1] == sum(deposits)
+)  # => Output: True -- the LAST running total is the full sum

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-39-itertools-accumulate/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-39-itertools-accumulate/test_example.py
@@ -1,0 +1,12 @@
+"""Example 39: pytest verification for Running Totals via accumulate."""
+
+from itertools import accumulate
+
+
+def test_accumulate_produces_prefix_sums() -> None:
+    deposits = [10, 20, 30]
+    assert list(accumulate(deposits)) == [10, 30, 60]
+    assert list(accumulate(deposits, max)) == [10, 20, 30]
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-40-itertools-pairwise-tee/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-40-itertools-pairwise-tee/example.py
@@ -1,0 +1,26 @@
+"""Example 40: Adjacent Pairs via pairwise and tee."""
+
+from itertools import (
+    pairwise,
+    tee,
+)  # => pairwise: consecutive pairs; tee: split one iterator in two
+
+readings = [10, 12, 9, 15, 15]  # => a sequence of sensor readings
+
+deltas = [
+    b - a for a, b in pairwise(readings)
+]  # => consecutive differences, one per adjacent pair
+# => pairwise([10, 12, 9, 15, 15]) yields (10,12), (12,9), (9,15), (15,15) -- 4 pairs from 5 readings
+
+original_stream, backup_stream = tee(
+    iter(readings)
+)  # => splits ONE iterator into two INDEPENDENT ones
+first_from_original = next(original_stream)  # => advances original_stream only
+first_from_backup = next(
+    backup_stream
+)  # => backup_stream is UNAFFECTED by the pull above
+
+print(deltas)  # => Output: [2, -3, 6, 0]
+print(
+    first_from_original == first_from_backup
+)  # => Output: True -- both streams start from readings[0]

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-40-itertools-pairwise-tee/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-40-itertools-pairwise-tee/test_example.py
@@ -1,0 +1,16 @@
+"""Example 40: pytest verification for Adjacent Pairs via pairwise and tee."""
+
+from itertools import pairwise, tee
+
+
+def test_pairwise_and_tee() -> None:
+    readings = [1, 2, 4]
+    assert list(pairwise(readings)) == [(1, 2), (2, 4)]
+
+    stream_a, stream_b = tee(iter(readings))
+    assert (
+        next(stream_a) == next(stream_b) == 1
+    )  # => independent streams, same starting point
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-41-memoize-manual-dict/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-41-memoize-manual-dict/example.py
@@ -1,0 +1,39 @@
+"""Example 41: A Hand-Rolled Memoization Dict."""
+
+from typing import Callable  # => Callable types the function memoize wraps
+
+call_count = 0  # => tracks how many times the EXPENSIVE function body actually ran
+
+
+def expensive(n: int) -> int:  # => stands in for a slow, pure computation
+    global call_count  # => declares intent to mutate the MODULE-level counter
+    call_count += 1  # => only increments when the body actually executes
+    return n * n  # => the actual (slow, pure) computation being cached
+
+
+def memoize(
+    fn: Callable[[int], int],
+) -> Callable[[int], int]:  # => a hand-rolled cache, no lru_cache
+    cache: dict[int, int] = {}  # => the memo table, one entry per unique argument
+
+    def wrapper(n: int) -> int:  # => the returned, cache-checking function
+        if n not in cache:  # => cache MISS: compute once and store
+            cache[n] = fn(n)  # => computes ONCE and stores under key n
+        return cache[
+            n
+        ]  # => cache HIT or freshly-stored value, either way no recomputation
+
+    return wrapper  # => memoize itself returns the wrapping function
+
+
+memoized_expensive = memoize(expensive)  # => wraps expensive with the hand-rolled cache
+
+first = memoized_expensive(5)  # => cache miss -- call_count becomes 1
+second = memoized_expensive(5)  # => cache HIT -- call_count stays 1
+third = memoized_expensive(6)  # => a NEW argument -- cache miss, call_count becomes 2
+
+# => memoization trades memory for time, valid ONLY because expensive is pure
+print(first, second, third)  # => Output: 25 25 36
+print(
+    call_count
+)  # => Output: 2 -- expensive body ran exactly twice, for the two unique arguments

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-41-memoize-manual-dict/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-41-memoize-manual-dict/test_example.py
@@ -1,0 +1,19 @@
+"""Example 41: pytest verification for A Hand-Rolled Memoization Dict."""
+
+from example import memoize
+
+
+def test_second_call_is_served_from_cache() -> None:
+    calls: list[int] = []
+
+    def track(n: int) -> int:
+        calls.append(n)
+        return n * n
+
+    memoized = memoize(track)
+    assert memoized(4) == 16
+    assert memoized(4) == 16
+    assert calls == [4]  # => the second call never re-ran the underlying function
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-42-decorator-with-args/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-42-decorator-with-args/example.py
@@ -1,0 +1,59 @@
+"""Example 42: A Parameterized @retry(3) Decorator."""
+
+from typing import Callable  # => Callable types every layer of this decorator factory
+
+attempt_log: list[
+    int
+] = []  # => records which attempt number ran, for verification below
+
+
+def retry(
+    times: int,
+) -> Callable[[Callable[[], str]], Callable[[], str]]:  # => a decorator FACTORY
+    def decorator(
+        fn: Callable[[], str],
+    ) -> Callable[[], str]:  # => the ACTUAL decorator, closes over times
+        def wrapper() -> str:  # => the actual retry loop lives here
+            last_error: Exception | None = (
+                None  # => remembers the most recent failure, if any
+            )
+            for attempt in range(
+                1, times + 1
+            ):  # => tries up to `times` times, closed over from retry()
+                attempt_log.append(attempt)  # => logs every attempt, successful or not
+                try:  # => attempts ONE call to the wrapped function
+                    return fn()  # => success: return immediately, no further attempts
+                except (
+                    ValueError
+                ) as exc:  # => a failed attempt -- remember it and try again
+                    last_error = (
+                        exc  # => remembers the failure so it can be re-raised later
+                    )
+            raise last_error  # type: ignore[misc]  # => every attempt failed -- re-raise the last error
+
+        return wrapper  # => decorator itself returns the retry-wrapped function
+
+    return decorator  # => retry(times) itself returns the decorator
+
+
+calls_before_success = 0  # => simulates a flaky operation succeeding on its 3rd attempt
+
+
+@retry(
+    3
+)  # => equivalent to: flaky = retry(3)(flaky) -- retry(3) runs FIRST, returns a decorator
+def flaky() -> str:  # => the function actually being retried
+    global calls_before_success  # => declares intent to mutate the MODULE-level counter
+    calls_before_success += 1  # => tracks how many times this call has been attempted
+    if calls_before_success < 3:  # => fails on attempts 1 and 2
+        raise ValueError(
+            "not yet"
+        )  # => simulates a transient failure on early attempts
+    return "ok"  # => succeeds on attempt 3
+
+
+result = flaky()  # => retries internally until success, or until times is exhausted
+
+# => a decorator factory is a function that RETURNS a decorator, one extra layer
+print(result)  # => Output: ok
+print(attempt_log)  # => Output: [1, 2, 3] -- three attempts were logged before success

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-42-decorator-with-args/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-42-decorator-with-args/test_example.py
@@ -1,0 +1,20 @@
+"""Example 42: pytest verification for A Parameterized @retry(3) Decorator."""
+
+from example import retry
+
+
+def test_retry_stops_as_soon_as_the_wrapped_call_succeeds() -> None:
+    attempts: list[int] = []
+
+    @retry(5)
+    def sometimes_fails() -> str:
+        attempts.append(len(attempts) + 1)
+        if len(attempts) < 2:
+            raise ValueError("not yet")
+        return "ok"
+
+    assert sometimes_fails() == "ok"
+    assert attempts == [1, 2]  # => stopped retrying the moment it succeeded
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-43-decorator-preserves-metadata/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-43-decorator-preserves-metadata/example.py
@@ -1,0 +1,47 @@
+"""Example 43: functools.wraps Preserves __name__."""
+
+from functools import wraps  # => wraps is the fix demonstrated in careful_decorator
+from typing import Callable  # => Callable types both decorators below
+
+
+def naive_decorator(
+    fn: Callable[[], str],
+) -> Callable[[], str]:  # => WITHOUT functools.wraps
+    def wrapper() -> str:  # => the naive wrapper -- no metadata copied
+        return fn()  # => forwards the call, nothing else
+
+    return (
+        wrapper  # => wrapper has its OWN __name__, "wrapper" -- fn's identity is lost
+    )
+
+
+def careful_decorator(
+    fn: Callable[[], str],
+) -> Callable[[], str]:  # => WITH functools.wraps
+    @wraps(fn)  # => copies __name__, __doc__, and more from fn onto wrapper
+    def wrapper() -> str:  # => the careful wrapper -- decorated with @wraps below
+        return fn()  # => forwards the call, identical behavior to the naive version
+
+    return wrapper  # => wrapper now REPORTS as if it were fn itself
+
+
+@naive_decorator  # => applies the WITHOUT-wraps decorator
+def greet_naive() -> str:  # => the function whose identity gets lost
+    """Say hello, naively decorated."""  # => this docstring is LOST from greet_naive.__doc__ after decoration
+    return "hello"  # => the actual greeting
+
+
+@careful_decorator  # => applies the WITH-wraps decorator
+def greet_careful() -> str:  # => the function whose identity survives decoration
+    """Say hello, carefully decorated."""  # => this docstring IS preserved on greet_careful.__doc__
+    return "hello"  # => the actual greeting
+
+
+# => functools.wraps matters for debugging, introspection, and framework compatibility
+print(
+    greet_naive.__name__
+)  # => Output: wrapper -- identity LOST, unhelpful in tracebacks/introspection
+print(
+    greet_careful.__name__
+)  # => Output: greet_careful -- identity PRESERVED by functools.wraps
+print(greet_careful.__doc__)  # => Output: Say hello, carefully decorated.

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-43-decorator-preserves-metadata/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-43-decorator-preserves-metadata/test_example.py
@@ -1,0 +1,19 @@
+"""Example 43: pytest verification for functools.wraps Preserves __name__."""
+
+from example import careful_decorator, naive_decorator
+
+
+def test_wraps_preserves_name_and_plain_decorator_does_not() -> None:
+    @naive_decorator
+    def naive() -> str:
+        return "x"
+
+    @careful_decorator
+    def careful() -> str:
+        return "x"
+
+    assert naive.__name__ == "wrapper"  # => identity lost without functools.wraps
+    assert careful.__name__ == "careful"  # => identity preserved with functools.wraps
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-44-recursion-to-iteration/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-44-recursion-to-iteration/example.py
@@ -1,0 +1,50 @@
+"""Example 44: Converting Deep Recursion to an Explicit Stack."""
+
+import sys  # => sys.getrecursionlimit reveals the current recursion ceiling
+
+
+def sum_to_n_recursive(
+    n: int,
+) -> int:  # => the natural recursive definition -- one frame per call
+    if n == 0:  # => base case: nothing left to add
+        return 0  # => the base case's value
+    return n + sum_to_n_recursive(
+        n - 1
+    )  # => grows the call stack by exactly one frame per call
+
+
+def sum_to_n_iterative(
+    n: int,
+) -> int:  # => the SAME computation, an explicit stack instead of the call stack
+    stack: list[int] = list(
+        range(1, n + 1)
+    )  # => an explicit, heap-allocated stack -- NOT the call stack
+    total = 0  # => the running total, mutated below
+    while (
+        stack
+    ):  # => pops until the explicit stack is empty -- no Python call frames grow
+        total += (
+            stack.pop()
+        )  # => pops one value at a time -- heap memory, not call-stack frames
+    return total  # => the final total after the explicit stack empties
+
+
+deep_n = sys.getrecursionlimit() + 500  # => deliberately EXCEEDS the recursion ceiling
+
+try:  # => opens a block that expects the recursive call below to raise
+    sum_to_n_recursive(deep_n)  # => this call is expected to blow the call stack
+    recursive_raised = False  # => unreachable if RecursionError fires as expected
+except RecursionError:  # => confirms the exact failure recursion has at this depth
+    recursive_raised = True  # => confirms the recursive version genuinely failed here
+
+iterative_result = sum_to_n_iterative(
+    deep_n
+)  # => the SAME depth, but no call-stack growth at all
+
+# => CPython has NO tail-call optimization -- deep recursion genuinely can crash
+print(
+    recursive_raised
+)  # => Output: True -- the recursive version genuinely fails at this depth
+print(
+    iterative_result == deep_n * (deep_n + 1) // 2
+)  # => Output: True -- the iterative version succeeds

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-44-recursion-to-iteration/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-44-recursion-to-iteration/test_example.py
@@ -1,0 +1,20 @@
+"""Example 44: pytest verification for Converting Deep Recursion to an Explicit Stack."""
+
+import sys
+
+from example import sum_to_n_iterative, sum_to_n_recursive
+
+
+def test_iterative_version_survives_a_depth_that_breaks_recursion() -> None:
+    deep_n = sys.getrecursionlimit() + 500
+    try:
+        sum_to_n_recursive(deep_n)
+        recursive_raised = False
+    except RecursionError:
+        recursive_raised = True
+    assert recursive_raised is True
+
+    assert sum_to_n_iterative(deep_n) == deep_n * (deep_n + 1) // 2
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-45-adt-sum-type-dataclasses/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-45-adt-sum-type-dataclasses/example.py
@@ -1,0 +1,47 @@
+"""Example 45: A Shape ADT as a Union of Frozen Dataclasses."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted forward references used below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds each immutable variant
+
+
+@dataclass(
+    frozen=True
+)  # => one VARIANT of the Shape ADT -- only the field a circle needs
+class Circle:  # => the Circle variant's body
+    radius: float  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => a SECOND variant -- only the field a square needs
+class Square:  # => the Square variant's body
+    side: float  # => the single field this variant carries
+
+
+Shape = (
+    Circle | Square
+)  # => PEP 604 union syntax (3.10+): a Shape IS EITHER a Circle OR a Square
+
+
+def area(
+    shape: Shape,
+) -> float:  # => accepts EITHER variant -- illegal combinations don't type-check
+    if isinstance(shape, Circle):  # => narrows shape to Circle inside this branch
+        return 3.14159 * shape.radius**2  # => the actual circle-area formula
+    return (
+        shape.side**2
+    )  # => shape is narrowed to Square here (the only remaining case)
+
+
+circle_shape: Shape = Circle(radius=2.0)  # => constructs the Circle variant
+square_shape: Shape = Square(side=3.0)  # => constructs the Square variant
+
+# => a sum type restricts callers to EXACTLY the variants the ADT defines
+print(round(area(circle_shape), 2))  # => Output: 12.57
+print(area(square_shape))  # => Output: 9.0
+print(
+    isinstance(circle_shape, Square)
+)  # => Output: False -- a Circle can never ALSO be a Square

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-45-adt-sum-type-dataclasses/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-45-adt-sum-type-dataclasses/test_example.py
@@ -1,0 +1,11 @@
+"""Example 45: pytest verification for A Shape ADT as a Union of Frozen Dataclasses."""
+
+from example import Circle, Square, area
+
+
+def test_each_variant_computes_its_own_area() -> None:
+    assert round(area(Circle(radius=1.0)), 2) == 3.14
+    assert area(Square(side=4.0)) == 16.0
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-46-match-case-over-adt/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-46-match-case-over-adt/example.py
@@ -1,0 +1,41 @@
+"""Example 46: match/case Dispatches Over the Shape ADT."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted forward references used below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds each immutable variant
+
+
+@dataclass(frozen=True)  # => marks Circle immutable, matching the FP style
+class Circle:  # => the Circle variant's body
+    radius: float  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Square immutable, matching the FP style
+class Square:  # => the Square variant's body
+    side: float  # => the single field this variant carries
+
+
+Shape = Circle | Square  # => the ADT itself: a Shape is EITHER variant
+
+
+def describe(
+    shape: Shape,
+) -> str:  # => match/case, the structural-pattern-matching alternative to isinstance
+    match shape:  # => picks the FIRST case whose pattern matches shape's shape
+        case Circle(radius=r):  # => destructures a Circle, binding its radius to r
+            return f"circle with radius {r}"  # => the Circle branch's result
+        case Square(side=s):  # => destructures a Square, binding its side to s
+            return f"square with side {s}"  # => the Square branch's result
+        case _:  # => NOTE: match/case has NO compile-time exhaustiveness check -- a manual safety net
+            raise ValueError(
+                "unreachable for a Circle | Square"
+            )  # => defends against a THIRD variant appearing later
+
+
+# => match/case reads like the ADT's own shape, not a chain of isinstance checks
+print(describe(Circle(radius=2.0)))  # => Output: circle with radius 2.0
+print(describe(Square(side=5.0)))  # => Output: square with side 5.0

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-46-match-case-over-adt/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-46-match-case-over-adt/test_example.py
@@ -1,0 +1,11 @@
+"""Example 46: pytest verification for match/case Dispatches Over the Shape ADT."""
+
+from example import Circle, Square, describe
+
+
+def test_each_branch_fires_for_its_own_variant() -> None:
+    assert describe(Circle(radius=1.0)) == "circle with radius 1.0"
+    assert describe(Square(side=2.0)) == "square with side 2.0"
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-47-match-guards/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-47-match-guards/example.py
@@ -1,0 +1,20 @@
+"""Example 47: case Clauses With if Guards."""
+
+
+def classify(n: int) -> str:  # => match/case WITH guards -- a pattern PLUS a condition
+    match n:  # => opens the match/case block over n
+        case int(value) if value < 0:  # => guard: only matches negative ints
+            return "negative"  # => the negative branch's result
+        case 0:  # => an exact-value pattern, no guard needed
+            return "zero"  # => the zero branch's result
+        case int(value) if value % 2 == 0:  # => guard: only matches even positive ints
+            return "positive even"  # => the positive-even branch's result
+        case _:  # => catches everything else -- positive odd ints
+            return "positive odd"  # => the positive-odd branch's result
+
+
+# => guards let one case pattern cover many related conditions
+print(classify(-5))  # => Output: negative
+print(classify(0))  # => Output: zero
+print(classify(4))  # => Output: positive even
+print(classify(7))  # => Output: positive odd

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-47-match-guards/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-47-match-guards/test_example.py
@@ -1,0 +1,13 @@
+"""Example 47: pytest verification for case Clauses With if Guards."""
+
+from example import classify
+
+
+def test_guards_select_the_right_branch() -> None:
+    assert classify(-1) == "negative"
+    assert classify(0) == "zero"
+    assert classify(2) == "positive even"
+    assert classify(3) == "positive odd"
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-48-option-some-nothing/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-48-option-some-nothing/example.py
@@ -1,0 +1,59 @@
+"""Example 48: A Hand-Rolled Some/Nothing With map."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Option[U]' forward reference below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds both Option variants
+from typing import (
+    Callable,
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar make Some[T] a proper generic container
+
+T = TypeVar("T")  # => the type of the value a Some wraps
+U = TypeVar("U")  # => the type map's function returns
+
+
+@dataclass(frozen=True)  # => marks Some immutable, matching the FP style
+class Some(Generic[T]):  # => the "present" variant, carrying exactly one value
+    value: T  # => the single field this variant carries
+
+    def map(
+        self, fn: Callable[[T], U]
+    ) -> "Option[U]":  # => applies fn INSIDE the wrapper
+        return Some(fn(self.value))  # => stays wrapped -- Some in, Some out
+
+
+@dataclass(frozen=True)  # => marks Nothing immutable too
+class Nothing:  # => the "absent" variant, carrying nothing
+    def map(
+        self, fn: Callable[[T], U]
+    ) -> "Nothing":  # => NO-OP: still generic so it type-checks like Some.map
+        return self  # => there is nothing to apply fn to -- Nothing stays Nothing
+
+
+Option = (
+    Some[T] | Nothing
+)  # => PEP 604 union: an Option[T] is either Some[T] or Nothing
+
+
+present: Option[int] = Some(5)  # => an Option holding a real value
+absent: Option[int] = Nothing()  # => an Option holding nothing at all
+
+increment: Callable[[int], int] = lambda x: (
+    x + 1
+)  # => explicit annotation pins T/U to int at both call sites
+mapped_present = present.map(increment)  # => Some(5).map(+1) -- the function DOES run
+mapped_absent = absent.map(
+    increment
+)  # => Nothing.map(+1) -- the function is SKIPPED entirely
+
+# => Option replaces None with a type the reader (and a type checker) can reason about
+print(mapped_present)  # => Output: Some(value=6)
+print(mapped_absent)  # => Output: Nothing()
+print(
+    mapped_absent == Nothing()
+)  # => Output: True -- map never turns Nothing into Some

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-48-option-some-nothing/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-48-option-some-nothing/test_example.py
@@ -1,0 +1,14 @@
+"""Example 48: pytest verification for A Hand-Rolled Some/Nothing With map."""
+
+from typing import Callable
+
+from example import Nothing, Some
+
+
+def test_map_runs_on_some_and_is_skipped_on_nothing() -> None:
+    increment: Callable[[int], int] = lambda x: x + 1
+    assert Some(5).map(increment) == Some(6)
+    assert Nothing().map(increment) == Nothing()
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-49-option-chaining/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-49-option-chaining/example.py
@@ -1,0 +1,62 @@
+"""Example 49: Chaining Option-Returning Lookups."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Option[T]' forward reference below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds both Option variants
+from typing import (
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar make Some[T] a proper generic container
+
+T = TypeVar("T")  # => the type of the value a Some wraps
+
+
+@dataclass(frozen=True)  # => marks Some immutable, matching the FP style
+class Some(Generic[T]):  # => the "present" variant, carrying exactly one value
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Nothing immutable too
+class Nothing:  # => the "absent" variant
+    pass  # => carries no data at all
+
+
+Option = Some[T] | Nothing  # => the ADT itself: an Option is EITHER variant
+
+
+def find(
+    table: dict[str, T], key: str
+) -> "Option[T]":  # => an Option-returning lookup, no None
+    return (
+        Some(table[key]) if key in table else Nothing()
+    )  # => success wraps, miss returns Nothing
+
+
+def find_user_then_city(  # => opens the multi-line signature of the chained lookup
+    users: dict[str, str],
+    cities: dict[str, str],
+    username: str,  # => the two lookup tables plus the key to chase
+) -> "Option[str]":  # => closes the multi-line signature above
+    user_result = find(users, username)  # => first Option-returning lookup
+    if isinstance(
+        user_result, Nothing
+    ):  # => SHORT-CIRCUITS immediately on the first miss
+        return Nothing()  # => never even attempts the second lookup
+    return find(
+        cities, user_result.value
+    )  # => chains into a SECOND Option-returning lookup
+
+
+users = {"ana": "jakarta"}  # => maps username -> city key
+cities = {"jakarta": "Jakarta, Indonesia"}  # => maps city key -> display name
+
+hit = find_user_then_city(users, cities, "ana")  # => both lookups succeed
+miss = find_user_then_city(users, cities, "budi")  # => the FIRST lookup already misses
+
+# => chaining Option lookups avoids nested None-checks entirely
+print(hit)  # => Output: Some(value='Jakarta, Indonesia')
+print(miss)  # => Output: Nothing()

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-49-option-chaining/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-49-option-chaining/test_example.py
@@ -1,0 +1,14 @@
+"""Example 49: pytest verification for Chaining Option-Returning Lookups."""
+
+from example import Nothing, Some, find_user_then_city
+
+
+def test_chain_short_circuits_on_the_first_miss() -> None:
+    users = {"ana": "jakarta"}
+    cities = {"jakarta": "Jakarta, Indonesia"}
+
+    assert find_user_then_city(users, cities, "ana") == Some("Jakarta, Indonesia")
+    assert find_user_then_city(users, cities, "budi") == Nothing()
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-50-result-ok-err/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-50-result-ok-err/example.py
@@ -1,0 +1,50 @@
+"""Example 50: A Hand-Rolled Ok/Err Result Type."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Result[float, str]' forward reference below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds both Result variants
+from typing import (
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar make Ok[T] and Err[E] proper generic containers
+
+T = TypeVar("T")  # => the type of the value an Ok wraps
+E = TypeVar("E")  # => the type of the error an Err wraps
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the "success" variant, carrying the computed value
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(
+    Generic[E]
+):  # => the "failure" variant, carrying the ERROR AS A VALUE, not an exception
+    error: E  # => the single field this variant carries
+
+
+Result = Ok[T] | Err[E]  # => PEP 604 union: a Result is either Ok[T] or Err[E]
+
+
+def divide(
+    a: int, b: int
+) -> "Result[float, str]":  # => the failure mode is IN the return type
+    if b == 0:  # => a caller reading this signature already knows failure is possible
+        return Err("division by zero")  # => the error travels as an ordinary VALUE
+    return Ok(a / b)  # => success wraps the computed value
+
+
+success = divide(10, 2)  # => Ok(5.0)
+failure = divide(10, 0)  # => Err('division by zero') -- NO exception was raised
+
+# => Result makes failure part of the TYPE, not a hidden exception path
+print(success)  # => Output: Ok(value=5.0)
+print(failure)  # => Output: Err(error='division by zero')
+print(
+    isinstance(failure, Err)
+)  # => Output: True -- the caller can inspect this without a try/except

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-50-result-ok-err/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-50-result-ok-err/test_example.py
@@ -1,0 +1,11 @@
+"""Example 50: pytest verification for A Hand-Rolled Ok/Err Result Type."""
+
+from example import Err, Ok, divide
+
+
+def test_result_carries_success_or_failure_as_a_value() -> None:
+    assert divide(10, 2) == Ok(5.0)
+    assert divide(10, 0) == Err("division by zero")
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-51-result-map-and-then/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-51-result-map-and-then/example.py
@@ -1,0 +1,80 @@
+"""Example 51: map and and_then on a Result."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Result[U, object]' forward references below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds both Result variants
+from typing import (
+    Callable,
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar/Callable type the map and and_then methods
+
+T = TypeVar("T")  # => the type of the value an Ok wraps
+U = TypeVar("U")  # => the type map/and_then transform T into
+E = TypeVar("E")  # => the type of the error an Err wraps
+F = TypeVar(
+    "F"
+)  # => the error type threaded through and_then's step function, not hardcoded to object
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the success variant's body
+    value: T  # => the single field this variant carries
+
+    def map(
+        self, fn: Callable[[T], U]
+    ) -> "Result[U, object]":  # => transforms the SUCCESS value only
+        return Ok(fn(self.value))  # => transforms the value, stays wrapped as Ok
+
+    def and_then(  # => chains into ANOTHER Result-returning step, without double-wrapping
+        self,
+        fn: Callable[
+            [T], "Result[U, F]"
+        ],  # => F is inferred from fn's own error type, not widened to object
+    ) -> "Result[U, F]":  # => the chained Result keeps fn's REAL error type
+        return fn(
+            self.value
+        )  # => runs fn on the unwrapped value; fn itself returns a Result
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(Generic[E]):  # => the failure variant's body
+    error: E  # => the single field this variant carries
+
+    def map(
+        self, fn: Callable[[T], U]
+    ) -> "Err[E]":  # => NO-OP: generic so a typed fn still passes the check
+        return self  # => the error passes through UNCHANGED -- fn never runs
+
+    def and_then(
+        self, fn: Callable[[T], U]
+    ) -> "Err[E]":  # => and_then is ALSO a no-op on Err, generic likewise
+        return self  # => short-circuits: fn never runs once the pipeline has already failed
+
+
+Result = Ok[T] | Err[E]  # => the ADT itself: a Result is EITHER variant
+
+
+def parse_positive(
+    text: str,
+) -> "Result[int, str]":  # => an and_then STEP: str -> Result[int, str]
+    value = int(text)  # => may raise, but this example only feeds it valid ints
+    return (
+        Ok(value) if value > 0 else Err(f"{value} is not positive")
+    )  # => the and_then step itself: may succeed or fail
+
+
+times_ten: Callable[[int], int] = lambda n: (
+    n * 10
+)  # => explicit annotation pins map's generic parameter to int
+
+ok_chain = Ok("5").and_then(parse_positive).map(times_ten)  # => success end to end
+err_chain = Ok("-5").and_then(parse_positive).map(times_ten)  # => fails at and_then
+
+# => map transforms success; and_then chains into ANOTHER fallible step
+print(ok_chain)  # => Output: Ok(value=50)
+print(err_chain)  # => Output: Err(error='-5 is not positive')

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-51-result-map-and-then/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-51-result-map-and-then/test_example.py
@@ -1,0 +1,17 @@
+"""Example 51: pytest verification for map and and_then on a Result."""
+
+from typing import Callable
+
+from example import Err, Ok, parse_positive
+
+
+def test_pipeline_stops_at_the_first_err() -> None:
+    times_ten: Callable[[int], int] = lambda n: n * 10
+    ok_chain = Ok("5").and_then(parse_positive).map(times_ten)
+    err_chain = Ok("-5").and_then(parse_positive).map(times_ten)
+
+    assert ok_chain == Ok(50)
+    assert err_chain == Err("-5 is not positive")
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-52-railway-parse-pipeline/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-52-railway-parse-pipeline/example.py
@@ -1,0 +1,71 @@
+"""Example 52: A Validation Pipeline Threading Result."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Result[int, str]' forward references below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds both Result variants
+from typing import (
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar make Ok[T] and Err[E] proper generic containers
+
+T = TypeVar("T")  # => the type of the value an Ok wraps
+E = TypeVar("E")  # => the type of the error an Err wraps
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the success variant's body
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(Generic[E]):  # => the failure variant's body
+    error: E  # => the single field this variant carries
+
+
+Result = Ok[T] | Err[E]  # => the ADT itself: a Result is EITHER variant
+
+
+def validate_age(
+    age: int,
+) -> "Result[int, str]":  # => railway step 1: switches to the failure track on error
+    if age < 0:  # => the ONLY failure condition this step checks
+        return Err("age cannot be negative")  # => switches to the failure track
+    return Ok(age)  # => the success track, value unchanged
+
+
+def validate_name(name: str) -> "Result[str, str]":  # => railway step 2
+    if not name:  # => the ONLY failure condition this step checks
+        return Err("name cannot be empty")  # => switches to the failure track
+    return Ok(name)  # => the success track, value unchanged
+
+
+def validate_form(
+    name: str, age: int
+) -> "Result[str, str]":  # => threads BOTH steps in sequence
+    name_result = validate_name(name)  # => the FIRST switch point
+    if isinstance(
+        name_result, Err
+    ):  # => already on the failure track -- age is never checked
+        return name_result  # => the original error rides through untouched
+    age_result = validate_age(
+        age
+    )  # => the SECOND switch point, only reached if step 1 succeeded
+    if isinstance(age_result, Err):  # => the SECOND switch point
+        return age_result  # => propagates the second step's failure
+    return Ok(f"{name_result.value}, age {age_result.value}")  # => both checks passed
+
+
+valid = validate_form("Ana", 30)  # => both checks succeed
+bad_name = validate_form(
+    "", 30
+)  # => fails at the FIRST check -- age is never even validated
+bad_age = validate_form("Ana", -1)  # => passes name, fails at the SECOND check
+
+# => this is the railway-oriented programming pattern: one track, two rails
+print(valid)  # => Output: Ok(value='Ana, age 30')
+print(bad_name)  # => Output: Err(error='name cannot be empty')
+print(bad_age)  # => Output: Err(error='age cannot be negative')

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-52-railway-parse-pipeline/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-52-railway-parse-pipeline/test_example.py
@@ -1,0 +1,12 @@
+"""Example 52: pytest verification for A Validation Pipeline Threading Result."""
+
+from example import Err, Ok, validate_form
+
+
+def test_one_bad_field_short_circuits_the_rest() -> None:
+    assert validate_form("Ana", 30) == Ok("Ana, age 30")
+    assert validate_form("", 30) == Err("name cannot be empty")
+    assert validate_form("Ana", -1) == Err("age cannot be negative")
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-53-functor-law-identity/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-53-functor-law-identity/example.py
@@ -1,0 +1,41 @@
+"""Example 53: The Functor Identity Law by Example."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Box[U]' forward reference below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds the immutable Box
+from typing import (
+    Callable,
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar/Callable type the minimal functor below
+
+T = TypeVar("T")  # => the type of the value a Box wraps
+U = TypeVar("U")  # => the type map's function returns
+
+
+def identity(x: T) -> T:  # => the identity function: returns its argument UNCHANGED
+    return x  # => identity's entire body: returns its argument, unchanged
+
+
+@dataclass(frozen=True)  # => marks Box immutable, matching the FP style
+class Box(Generic[T]):  # => a minimal functor: any container with a lawful map
+    value: T  # => the single field this container carries
+
+    def map(
+        self, fn: Callable[[T], U]
+    ) -> "Box[U]":  # => applies fn inside, stays wrapped
+        return Box(fn(self.value))  # => applies fn inside, re-wraps as Box
+
+
+original = Box(42)  # => the container BEFORE the identity law is applied
+mapped_with_identity = original.map(identity)  # => container.map(identity)
+
+# => the functor identity law is a correctness check any lawful map must pass
+print(
+    mapped_with_identity == original
+)  # => Output: True -- the FUNCTOR IDENTITY LAW, verified
+print(
+    mapped_with_identity is original
+)  # => Output: False -- EQUAL, but a distinct object (still immutable)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-53-functor-law-identity/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-53-functor-law-identity/test_example.py
@@ -1,0 +1,11 @@
+"""Example 53: pytest verification for The Functor Identity Law by Example."""
+
+from example import Box, identity
+
+
+def test_mapping_identity_changes_nothing_but_the_wrapper() -> None:
+    original = Box(7)
+    assert original.map(identity) == original  # => the functor identity law
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-54-functor-over-list-and-option/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-54-functor-over-list-and-option/example.py
@@ -1,0 +1,54 @@
+"""Example 54: One fmap Working on list and Option."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Option[T]' forward references below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds both Option variants
+from typing import (
+    Callable,
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar/Callable type the shared fmap below
+
+T = TypeVar("T")  # => the type of the value a container wraps
+U = TypeVar("U")  # => the type fn transforms T into
+
+
+@dataclass(frozen=True)  # => marks Some immutable, matching the FP style
+class Some(Generic[T]):  # => the present variant's body
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Nothing immutable too
+class Nothing:  # => the absent variant's body
+    pass  # => carries no data at all
+
+
+Option = Some[T] | Nothing  # => the ADT itself: an Option is EITHER variant
+
+
+def fmap(
+    fn: Callable[[T], U], container: "list[T] | Some[T] | Nothing"
+) -> object:  # => ONE signature, THREE possible container shapes
+    # => ONE function, dispatching on the container's actual shape -- the functor pattern made concrete
+    if isinstance(container, list):  # => a list is mappable via a comprehension
+        return [fn(item) for item in container]  # => applies fn to every element
+    if isinstance(container, Some):  # => an Option is mappable via its own map rule
+        return Some(fn(container.value))  # => applies fn to the single wrapped value
+    return Nothing()  # => Nothing maps to Nothing, regardless of fn
+
+
+double: Callable[[int], int] = lambda n: (
+    n * 2
+)  # => explicit annotation lets fmap solve T=int from fn, not the lambda body
+
+mapped_list = fmap(double, [1, 2, 3])  # => the list case
+mapped_some = fmap(double, Some(5))  # => the Option case, present
+mapped_nothing = fmap(double, Nothing())  # => the Option case, absent
+
+print(mapped_list)  # => Output: [2, 4, 6]
+print(mapped_some)  # => Output: Some(value=10)
+print(mapped_nothing)  # => Output: Nothing()

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-54-functor-over-list-and-option/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-54-functor-over-list-and-option/test_example.py
@@ -1,0 +1,15 @@
+"""Example 54: pytest verification for One fmap Working on list and Option."""
+
+from typing import Callable
+
+from example import Nothing, Some, fmap
+
+
+def test_the_same_fmap_dispatches_on_container_shape() -> None:
+    double: Callable[[int], int] = lambda n: n * 2
+    assert fmap(double, [1, 2]) == [2, 4]
+    assert fmap(double, Some(3)) == Some(6)
+    assert fmap(double, Nothing()) == Nothing()
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-55-applicative-combine-options/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-55-applicative-combine-options/example.py
@@ -1,0 +1,59 @@
+"""Example 55: map2 Combines Two Options."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Option[V]' forward reference below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds both Option variants
+from typing import (
+    Callable,
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar/Callable type the applicative map2 below
+
+T = TypeVar("T")  # => the type of the first wrapped value
+U = TypeVar("U")  # => the type of the second wrapped value
+V = TypeVar("V")  # => the type fn returns after combining both
+
+
+@dataclass(frozen=True)  # => marks Some immutable, matching the FP style
+class Some(Generic[T]):  # => the present variant's body
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Nothing immutable too
+class Nothing:  # => the absent variant's body
+    pass  # => carries no data at all
+
+
+Option = Some[T] | Nothing  # => the ADT itself: an Option is EITHER variant
+
+
+def map2(  # => the applicative pattern: combine TWO wrapped values with a 2-arg function
+    fn: Callable[[T, U], V],
+    opt_a: "Option[T]",
+    opt_b: "Option[U]",  # => the 2-arg combiner plus the two Options it combines
+) -> "Option[V]":  # => closes the multi-line signature above
+    if isinstance(opt_a, Nothing) or isinstance(
+        opt_b, Nothing
+    ):  # => EITHER absent short-circuits
+        return Nothing()  # => no partial combination -- both-or-nothing
+    return Some(
+        fn(opt_a.value, opt_b.value)
+    )  # => both present: unwrap both, apply fn, rewrap
+
+
+def add(
+    a: int, b: int
+) -> int:  # => the 2-argument function map2 combines two Options with
+    return a + b  # => the actual addition add performs
+
+
+both_present = map2(add, Some(2), Some(3))  # => both wrapped values ARE present
+one_missing = map2(add, Some(2), Nothing())  # => the second value is ABSENT
+
+# => applicative map2 generalizes map to functions of MORE than one argument
+print(both_present)  # => Output: Some(value=5)
+print(one_missing)  # => Output: Nothing()

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-55-applicative-combine-options/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-55-applicative-combine-options/test_example.py
@@ -1,0 +1,12 @@
+"""Example 55: pytest verification for map2 Combines Two Options."""
+
+from example import Nothing, Some, add, map2
+
+
+def test_map2_combines_when_both_present_and_short_circuits_otherwise() -> None:
+    assert map2(add, Some(2), Some(3)) == Some(5)
+    assert map2(add, Some(2), Nothing()) == Nothing()
+    assert map2(add, Nothing(), Some(3)) == Nothing()
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-56-monad-bind-chain/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-56-monad-bind-chain/example.py
@@ -1,0 +1,70 @@
+"""Example 56: bind/flat_map Chaining Result Steps."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Result[U, object]' forward references below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds both Result variants
+from typing import (
+    Callable,
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar/Callable type the bind chain below
+
+T = TypeVar("T")  # => the type of the value an Ok wraps
+U = TypeVar("U")  # => the type bind's step function returns
+E = TypeVar("E")  # => the type of the error an Err wraps
+F = TypeVar(
+    "F"
+)  # => the error type threaded through bind's step function, not hardcoded to object
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the success variant's body
+    value: T  # => the single field this variant carries
+
+    def bind(
+        self, fn: Callable[[T], "Result[U, F]"]
+    ) -> "Result[U, F]":  # => F comes from fn's OWN error type
+        # => bind/and_then/flat_map -- three names for the SAME monadic chaining operation
+        return fn(
+            self.value
+        )  # => unwraps, runs fn (which itself returns a Result), no double-wrap
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(Generic[E]):  # => the failure variant's body
+    error: E  # => the single field this variant carries
+
+    def bind(
+        self, fn: Callable[[T], U]
+    ) -> "Err[E]":  # => NO-OP, generic so a typed fn still passes the check
+        return self  # => fn never runs once the chain has already failed
+
+
+Result = Ok[T] | Err[E]  # => the ADT itself: a Result is EITHER variant
+
+
+def half(n: int) -> "Result[float, str]":  # => a bind STEP: fails if n is odd
+    if n % 2 != 0:  # => the ONLY failure condition this step checks
+        return Err(f"{n} is odd")  # => switches to the failure track
+    return Ok(n / 2)  # => the success track: n halved
+
+
+def to_positive(
+    x: float,
+) -> "Result[float, str]":  # => a second bind STEP: fails if not positive
+    return (
+        Ok(x) if x > 0 else Err(f"{x} is not positive")
+    )  # => the second bind step: may succeed or fail
+
+
+chained_success = Ok(8).bind(half).bind(to_positive)  # => 8 -> 4.0 -> still positive
+chained_failure = (
+    Ok(7).bind(half).bind(to_positive)
+)  # => 7 is odd -- fails at the FIRST bind
+
+print(chained_success)  # => Output: Ok(value=4.0)
+print(chained_failure)  # => Output: Err(error='7 is odd')

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-56-monad-bind-chain/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-56-monad-bind-chain/test_example.py
@@ -1,0 +1,11 @@
+"""Example 56: pytest verification for bind/flat_map Chaining Result Steps."""
+
+from example import Err, Ok, half, to_positive
+
+
+def test_bind_chains_and_short_circuits_on_the_first_error() -> None:
+    assert Ok(8).bind(half).bind(to_positive) == Ok(4.0)
+    assert Ok(7).bind(half).bind(to_positive) == Err("7 is odd")
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-57-functional-core-imperative-shell-tool/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-57-functional-core-imperative-shell-tool/example.py
@@ -1,0 +1,64 @@
+"""Example 57: A CSV Analyzer Split into a Pure Core and an I/O Shell."""
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds the immutable Sale record
+
+
+@dataclass(
+    frozen=True
+)  # => an immutable value object -- no sale record mutates after parsing
+class Sale:  # => one parsed CSV row
+    product: str  # => the product name column
+    amount: float  # => the sale amount column
+
+
+def parse_sales(
+    csv_text: str,
+) -> list[Sale]:  # => PURE CORE: text in, data out, zero I/O
+    rows = csv_text.strip().splitlines()[
+        1:
+    ]  # => strips the header row, keeps only data rows
+    sales: list[Sale] = []  # => the accumulator this pure function builds and returns
+    for row in rows:  # => walks every data row exactly once
+        product, amount = row.split(",")  # => splits "apple,10.0" into two fields
+        sales.append(
+            Sale(product=product, amount=float(amount))
+        )  # => builds one immutable Sale
+    return sales  # => a plain list -- testable with a string literal, no file needed
+
+
+def total_by_product(
+    sales: list[Sale],
+) -> dict[str, float]:  # => PURE CORE: aggregate step
+    totals: dict[
+        str, float
+    ] = {}  # => the running per-product total, local to this call
+    for sale in sales:  # => folds every sale into the totals dict
+        totals[sale.product] = (
+            totals.get(sale.product, 0.0) + sale.amount
+        )  # => accumulates per product
+    return totals  # => a fresh dict -- the input list itself is never mutated
+
+
+def format_report(
+    totals: dict[str, float],
+) -> str:  # => PURE CORE: data -> text, still no I/O
+    lines = [
+        f"{product}: {amount:.2f}" for product, amount in sorted(totals.items())
+    ]  # => one line per product
+    return "\n".join(lines)  # => a plain string -- the shell decides how to display it
+
+
+def run_shell(
+    csv_text: str,
+) -> None:  # => the IMPERATIVE SHELL -- the ONLY function that prints
+    sales = parse_sales(csv_text)  # => delegates to the pure core
+    totals = total_by_product(sales)  # => delegates to the pure core
+    report = format_report(totals)  # => delegates to the pure core
+    print(report)  # => the topic's single I/O side effect, isolated to this one line
+
+
+csv_text = "product,amount\napple,10.0\nbanana,5.0\napple,3.0\n"  # => stands in for a real file's contents
+# => this is the functional-core/imperative-shell pattern (co-28) at real-tool scale
+run_shell(csv_text)  # => Output: apple: 13.00 then banana: 5.00

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-57-functional-core-imperative-shell-tool/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-57-functional-core-imperative-shell-tool/test_example.py
@@ -1,0 +1,14 @@
+"""Example 57: pytest verification for A CSV Analyzer Split into a Pure Core and an I/O Shell."""
+
+from example import format_report, parse_sales, total_by_product
+
+
+def test_pure_core_needs_no_file_and_no_mocking() -> None:
+    csv_text = "product,amount\nx,1.0\nx,2.0\n"
+    sales = parse_sales(csv_text)
+    totals = total_by_product(sales)
+    assert totals == {"x": 3.0}
+    assert format_report(totals) == "x: 3.00"
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-58-property-test-purity/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-58-property-test-purity/example.py
@@ -1,0 +1,36 @@
+"""Example 58: Property-Testing Purity Without a Third-Party Library."""
+
+import random  # => stdlib source of pseudo-random test inputs -- no third-party library needed
+
+
+def normalize_score(
+    raw: int,
+) -> int:  # => the function under test: clamps a raw score into 0..100
+    return max(0, min(100, raw))  # => pure: same raw always clamps to the same result
+
+
+random.seed(
+    1234
+)  # => a FIXED seed makes this "random" test fully reproducible on every run
+generated_inputs = [
+    random.randint(-500, 500) for _ in range(200)
+]  # => 200 pseudo-random raw scores
+
+first_pass = [
+    normalize_score(x) for x in generated_inputs
+]  # => calls the function ONCE per input
+second_pass = [
+    normalize_score(x) for x in generated_inputs
+]  # => calls it AGAIN, same inputs, later
+
+purity_property_holds = (
+    first_pass == second_pass
+)  # => THE property: two independent runs agree exactly
+
+# => property-based testing checks an invariant across MANY generated inputs, not one
+print(
+    purity_property_holds
+)  # => Output: True -- purity verified across all 200 generated inputs, not one
+print(
+    len(generated_inputs)
+)  # => Output: 200 -- a property test checks MANY cases, not a single example

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-58-property-test-purity/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-58-property-test-purity/test_example.py
@@ -1,0 +1,18 @@
+"""Example 58: pytest verification for Property-Testing Purity Without a Third-Party Library."""
+
+import random
+
+from example import normalize_score
+
+
+def test_purity_holds_across_many_generated_inputs() -> None:
+    random.seed(
+        99
+    )  # => a different fixed seed than example.py, still fully reproducible
+    inputs = [random.randint(-1000, 1000) for _ in range(500)]
+    first_pass = [normalize_score(x) for x in inputs]
+    second_pass = [normalize_score(x) for x in inputs]
+    assert first_pass == second_pass
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-59-persistent-tree-update/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-59-persistent-tree-update/example.py
@@ -1,0 +1,53 @@
+"""Example 59: A Persistent Binary Tree With a Structural-Sharing Update."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Tree | None' forward references below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds the immutable Tree node
+
+
+@dataclass(frozen=True)  # => an immutable binary search tree node
+class Tree:  # => the node type itself
+    value: int  # => this node's own value
+    left: "Tree | None"  # => the left subtree, or None
+    right: "Tree | None"  # => the right subtree, or None
+
+
+def insert(
+    tree: "Tree | None", value: int
+) -> Tree:  # => builds a NEW path, reuses the rest
+    if tree is None:  # => base case: an empty spot becomes a new leaf
+        return Tree(value=value, left=None, right=None)  # => the freshly-created leaf
+    if value < tree.value:  # => goes left -- only the LEFT spine gets rebuilt
+        return Tree(
+            value=tree.value, left=insert(tree.left, value), right=tree.right
+        )  # => right subtree REUSED
+    if value > tree.value:  # => goes right -- only the RIGHT spine gets rebuilt
+        return Tree(
+            value=tree.value, left=tree.left, right=insert(tree.right, value)
+        )  # => left subtree REUSED
+    return tree  # => value already present -- no change needed, return the SAME node
+
+
+def to_sorted_list(
+    tree: "Tree | None",
+) -> list[int]:  # => in-order walk, for verification only
+    if tree is None:  # => base case: an empty subtree contributes nothing
+        return []  # => an empty list, the recursion's base result
+    return (
+        to_sorted_list(tree.left) + [tree.value] + to_sorted_list(tree.right)
+    )  # => left, self, right
+
+
+root_a = insert(insert(insert(None, 5), 3), 8)  # => builds {5: left=3, right=8}
+root_b = insert(root_a, 1)  # => inserts 1, which goes LEFT of 3
+
+# => persistent trees generalize the persistent list's O(1)-sharing idea to branching structures
+print(to_sorted_list(root_a))  # => Output: [3, 5, 8]
+print(to_sorted_list(root_b))  # => Output: [1, 3, 5, 8]
+print(
+    root_b.right is root_a.right
+)  # => Output: True -- the untouched right subtree (8) is REUSED

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-59-persistent-tree-update/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-59-persistent-tree-update/test_example.py
@@ -1,0 +1,16 @@
+"""Example 59: pytest verification for A Persistent Binary Tree With a Structural-Sharing Update."""
+
+from example import insert, to_sorted_list
+
+
+def test_insert_shares_the_untouched_subtree() -> None:
+    root_a = insert(insert(None, 10), 20)
+    root_b = insert(root_a, 5)
+    assert to_sorted_list(root_a) == [10, 20]
+    assert to_sorted_list(root_b) == [5, 10, 20]
+    assert (
+        root_b.right is root_a.right
+    )  # => the untouched right subtree is reused, not rebuilt
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-60-immutable-state-reducer/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-60-immutable-state-reducer/example.py
@@ -1,0 +1,77 @@
+"""Example 60: A Redux-Style Pure (state, action) -> state Reducer."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted forward references used below
+
+from dataclasses import (
+    dataclass,
+    replace,
+)  # => replace builds a NEW state from an OLD one
+
+
+@dataclass(frozen=True)  # => the entire application state, immutable
+class CartState:  # => the class body begins here
+    items: tuple[
+        str, ...
+    ]  # => an immutable tuple of item names, never mutated in place
+    total: float  # => the running total, replaced wholesale on every action
+
+
+@dataclass(frozen=True)  # => an action: describes WHAT happened, carries no behavior
+class AddItem:  # => the class body begins here
+    name: str  # => the item being added
+    price: float  # => the item's price
+
+
+@dataclass(frozen=True)  # => a second action variant, carrying no data at all
+class ClearCart:  # => the class body begins here
+    pass  # => no fields -- this action needs no data to be meaningful
+
+
+Action = AddItem | ClearCart  # => the ADT of every possible action this reducer accepts
+
+
+def reducer(
+    state: CartState, action: Action
+) -> CartState:  # => PURE: (state, action) -> NEW state
+    if isinstance(action, AddItem):  # => narrows action to AddItem inside this branch
+        return replace(
+            state, items=state.items + (action.name,), total=state.total + action.price
+        )  # => the AddItem branch's new state
+    return replace(
+        state, items=(), total=0.0
+    )  # => ClearCart resets everything, still a NEW CartState
+
+
+initial_state = CartState(
+    items=(), total=0.0
+)  # => the starting state before any actions
+actions: list[Action] = [  # => the sequence of actions this example replays
+    AddItem("apple", 2.0),  # => action 1: adds an item
+    AddItem("bread", 3.5),  # => action 2: adds a second item
+    ClearCart(),  # => action 3: resets the cart entirely
+    AddItem("milk", 4.0),  # => action 4: adds an item AFTER the reset
+]  # => closes the actions list literal
+
+final_state = (
+    initial_state  # => the accumulator this replay loop rebinds, never mutates
+)
+for action in actions:  # => REPLAYS every action, one reducer call each
+    final_state = reducer(
+        final_state, action
+    )  # => each call returns a BRAND NEW state, never mutates
+
+replayed_state = (
+    initial_state  # => a SECOND independent replay, from the SAME starting state
+)
+for action in actions:  # => replays the SAME action list a SECOND time
+    replayed_state = reducer(
+        replayed_state, action
+    )  # => identical steps, identical inputs
+
+# => this is the Redux/Elm reducer pattern: state transitions as pure function calls
+print(final_state)  # => Output: CartState(items=('milk',), total=4.0)
+print(
+    final_state == replayed_state
+)  # => Output: True -- replaying identical actions reproduces the SAME state

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-60-immutable-state-reducer/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-60-immutable-state-reducer/test_example.py
@@ -1,0 +1,19 @@
+"""Example 60: pytest verification for A Redux-Style Pure Reducer."""
+
+from example import Action, AddItem, CartState, reducer
+
+
+def test_replaying_actions_reproduces_the_state() -> None:
+    actions: list[Action] = [AddItem("a", 1.0), AddItem("b", 2.0)]
+    state_1 = CartState(items=(), total=0.0)
+    for action in actions:
+        state_1 = reducer(state_1, action)
+
+    state_2 = CartState(items=(), total=0.0)
+    for action in actions:
+        state_2 = reducer(state_2, action)
+
+    assert state_1 == state_2 == CartState(items=("a", "b"), total=3.0)
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-61-compose-with-result/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-61-compose-with-result/example.py
@@ -1,0 +1,77 @@
+"""Example 61: Composing Result-Returning Functions (Kleisli Composition)."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Result[U, str]' forward references below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds both Result variants
+from typing import (
+    Callable,
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar/Callable type kleisli_compose below
+
+T = TypeVar("T")  # => the type kleisli_compose's INPUT function consumes
+U = TypeVar("U")  # => the type kleisli_compose's OUTPUT function produces
+E = TypeVar("E")  # => the type of the error an Err wraps
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the success variant's body
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(Generic[E]):  # => the failure variant's body
+    error: E  # => the single field this variant carries
+
+
+Result = Ok[T] | Err[E]  # => the ADT itself: a Result is EITHER variant
+
+
+def kleisli_compose(  # => composes TWO Result-returning functions into ONE, like compose but Result-aware
+    f: Callable[[T], "Result[U, str]"],
+    g: Callable[[U], "Result[U, str]"],  # => the two steps kleisli_compose chains
+) -> Callable[[T], "Result[U, str]"]:  # => closes the multi-line signature above
+    def composed(
+        x: T,
+    ) -> "Result[U, str]":  # => the returned, composed pipeline function
+        first = f(x)  # => runs the FIRST step
+        if isinstance(
+            first, Err
+        ):  # => short-circuits: g never runs if f already failed
+            return first  # => propagates f's failure untouched
+        return g(first.value)  # => chains g onto f's unwrapped success value
+
+    return composed  # => kleisli_compose itself returns the composed pipeline function
+
+
+def parse_int(text: str) -> "Result[int, str]":  # => step 1: str -> Result[int, str]
+    try:  # => attempts the conversion
+        return Ok(int(text))  # => success: wraps the parsed int
+    except ValueError:  # => text was not a valid integer
+        return Err(
+            f"'{text}' is not an integer"
+        )  # => the error travels as an ordinary VALUE
+
+
+def reciprocal(n: int) -> "Result[int, str]":  # => step 2: int -> Result[int, str]
+    if n == 0:  # => the ONLY failure condition this step checks
+        return Err(
+            "cannot take the reciprocal of zero"
+        )  # => switches to the failure track
+    return Ok(
+        1 // n if n == 1 else 0
+    )  # => simplified integer reciprocal, just for this example
+
+
+pipeline = kleisli_compose(
+    parse_int, reciprocal
+)  # => ONE composed function: str -> Result[int, str]
+
+# => Kleisli composition is compose specialized to Result-returning functions
+print(pipeline("1"))  # => Output: Ok(value=1)
+print(pipeline("0"))  # => Output: Err(error='cannot take the reciprocal of zero')
+print(pipeline("x"))  # => Output: Err(error="'x' is not an integer")

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-61-compose-with-result/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-61-compose-with-result/test_example.py
@@ -1,0 +1,13 @@
+"""Example 61: pytest verification for Composing Result-Returning Functions."""
+
+from example import Err, Ok, kleisli_compose, parse_int, reciprocal
+
+
+def test_composed_pipeline_propagates_the_first_failure() -> None:
+    pipeline = kleisli_compose(parse_int, reciprocal)
+    assert pipeline("1") == Ok(1)
+    assert pipeline("bad") == Err("'bad' is not an integer")
+    assert pipeline("0") == Err("cannot take the reciprocal of zero")
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-62-curry-decorator/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-62-curry-decorator/example.py
@@ -1,0 +1,53 @@
+"""Example 62: A @curry Decorator Auto-Currying by Arity."""
+
+import inspect  # => inspects fn's own signature to learn how many arguments it needs
+from functools import wraps  # => preserves add3's identity through the decorator
+from typing import (
+    Any,
+    Callable,
+)  # => Any/Callable type this deliberately dynamic decorator
+
+
+def curry(
+    fn: Callable[..., Any],
+) -> Callable[..., Any]:  # => a decorator that auto-curries fn
+    arity = len(
+        inspect.signature(fn).parameters
+    )  # => how many arguments fn ultimately needs
+
+    @wraps(fn)  # => preserves fn's __name__/__doc__ on the curried wrapper
+    def curried(*args: Any) -> Any:  # => accumulates arguments across MULTIPLE calls
+        if (
+            len(args) >= arity
+        ):  # => enough arguments collected -- call the real function NOW
+            return fn(*args)  # => the real call, with every argument finally in hand
+
+        def more_needed(
+            *more: Any,
+        ) -> Any:  # => named + fully typed -- an untyped lambda can't carry annotations
+            return curried(
+                *args, *more
+            )  # => not enough yet -- keeps accumulating arguments
+
+        return more_needed  # => returns the function wanting more arguments
+
+    return curried  # => curry itself returns the auto-currying wrapper
+
+
+@curry  # => wraps add3 so it can be called one argument at a time, or all at once
+def add3(a: int, b: int, c: int) -> int:  # => an ordinary 3-argument function
+    return a + b + c  # => the actual sum
+
+
+all_at_once = add3(
+    1, 2, 3
+)  # => calling with all 3 arguments works like the undecorated function
+one_at_a_time = add3(1)(2)(
+    3
+)  # => calling one argument per call ALSO reaches the same result
+mixed = add3(1, 2)(3)  # => and any grouping in between works too
+
+# => auto-currying via inspect.signature makes ANY function callable one argument at a time
+print(all_at_once)  # => Output: 6
+print(one_at_a_time)  # => Output: 6
+print(mixed)  # => Output: 6

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-62-curry-decorator/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-62-curry-decorator/test_example.py
@@ -1,0 +1,12 @@
+"""Example 62: pytest verification for A @curry Decorator Auto-Currying by Arity."""
+
+from example import add3
+
+
+def test_partial_calls_accumulate_arguments_until_full_arity() -> None:
+    assert add3(1, 2, 3) == 6
+    assert add3(1)(2)(3) == 6
+    assert add3(1, 2)(3) == 6
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-63-lazy-infinite-sieve/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-63-lazy-infinite-sieve/example.py
@@ -1,0 +1,36 @@
+"""Example 63: A Lazy Prime Sieve Over an Infinite Generator."""
+
+from itertools import (
+    count,
+    islice,
+)  # => count: infinite lazy range; islice: pulls a bounded slice
+from typing import Iterator  # => Iterator types both generators below
+
+
+def natural_numbers_from(
+    start: int,
+) -> Iterator[int]:  # => an INFINITE generator -- never runs out
+    yield from count(start)  # => delegates to itertools.count, lazily, forever
+
+
+def sieve(
+    numbers: Iterator[int],
+) -> Iterator[int]:  # => a lazy, recursive Eratosthenes-style sieve
+    first = next(
+        numbers
+    )  # => the next number is prime by construction (nothing smaller divided it)
+    yield first  # => yields it immediately -- consumer can use it before the rest is computed
+    yield from sieve(
+        n for n in numbers if n % first != 0
+    )  # => filters multiples, sieves the REST lazily
+
+
+primes = sieve(
+    natural_numbers_from(2)
+)  # => an infinite lazy stream of primes -- nothing computed yet
+first_ten = list(
+    islice(primes, 10)
+)  # => pulls EXACTLY 10 primes, the ONLY work this line forces
+
+# => the classic functional demonstration that laziness makes infinite structures usable
+print(first_ten)  # => Output: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-63-lazy-infinite-sieve/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-63-lazy-infinite-sieve/test_example.py
@@ -1,0 +1,13 @@
+"""Example 63: pytest verification for A Lazy Prime Sieve Over an Infinite Generator."""
+
+from itertools import islice
+
+from example import natural_numbers_from, sieve
+
+
+def test_sieve_produces_the_correct_first_primes() -> None:
+    primes = sieve(natural_numbers_from(2))
+    assert list(islice(primes, 5)) == [2, 3, 5, 7, 11]
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-64-generator-coroutine-pipeline/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-64-generator-coroutine-pipeline/example.py
@@ -1,0 +1,38 @@
+"""Example 64: A Pull Pipeline of yield Stages."""
+
+from typing import Iterator  # => Iterator types every stage in this pipeline
+
+
+def read_lines(
+    text: str,
+) -> Iterator[str]:  # => stage 1: text -> a lazy stream of lines
+    for line in text.splitlines():  # => walks the raw text one line at a time
+        yield line  # => suspends after EACH line, waiting for the next pull
+
+
+def strip_blank(
+    lines: Iterator[str],
+) -> Iterator[str]:  # => stage 2: filters out blank lines, lazily
+    for line in lines:  # => pulls from stage 1 ONE line at a time
+        if line.strip():  # => only forwards lines with real content
+            yield line  # => only forwards non-blank lines downstream
+
+
+def uppercase(
+    lines: Iterator[str],
+) -> Iterator[str]:  # => stage 3: transforms each surviving line
+    for line in lines:  # => pulls from stage 2 ONE line at a time
+        yield line.upper()  # => the actual transformation this stage performs
+
+
+text = "hello\n\nworld\n   \nfp"  # => a raw multi-line string, including blank/whitespace-only lines
+pipeline = uppercase(
+    strip_blank(read_lines(text))
+)  # => THREE stages chained, nothing runs yet
+
+result = list(
+    pipeline
+)  # => pulling into a list is what finally forces every stage to run
+
+# => each stage suspends independently -- no stage ever buffers its whole output
+print(result)  # => Output: ['HELLO', 'WORLD', 'FP']

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-64-generator-coroutine-pipeline/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-64-generator-coroutine-pipeline/test_example.py
@@ -1,0 +1,12 @@
+"""Example 64: pytest verification for A Pull Pipeline of yield Stages."""
+
+from example import read_lines, strip_blank, uppercase
+
+
+def test_pipeline_streams_through_all_three_stages() -> None:
+    text = "a\n\nb"
+    pipeline = uppercase(strip_blank(read_lines(text)))
+    assert list(pipeline) == ["A", "B"]
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-65-memoize-bounded-lru/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-65-memoize-bounded-lru/example.py
@@ -1,0 +1,59 @@
+"""Example 65: A Memoization Decorator With a Bounded maxsize."""
+
+from collections import (
+    OrderedDict,
+)  # => insertion-ordered dict -- the basis of this LRU cache
+from typing import Callable  # => Callable types every layer of this decorator factory
+
+
+def bounded_memoize(
+    maxsize: int,
+) -> Callable[[Callable[[int], int]], Callable[[int], int]]:  # => a decorator FACTORY
+    def decorator(
+        fn: Callable[[int], int],
+    ) -> Callable[[int], int]:  # => the actual decorator
+        cache: OrderedDict[int, int] = (
+            OrderedDict()
+        )  # => insertion order tracks recency
+
+        def wrapper(n: int) -> int:  # => the cache-checking, eviction-aware wrapper
+            if n in cache:  # => cache HIT: refresh its recency, return the stored value
+                cache.move_to_end(n)  # => marks n as the MOST recently used entry
+                return cache[n]  # => the stored value, no recomputation
+            result = fn(n)  # => cache MISS: run the real computation
+            cache[n] = result  # => stores the fresh result as the newest entry
+            if (
+                len(cache) > maxsize
+            ):  # => over budget -- evict the LEAST recently used entry
+                cache.popitem(
+                    last=False
+                )  # => last=False pops the OLDEST inserted/touched key
+            return result  # => the freshly computed value
+
+        return wrapper  # => decorator itself returns the cache-checking wrapper
+
+    return decorator  # => bounded_memoize itself returns the decorator
+
+
+calls: list[
+    int
+] = []  # => records every argument that actually triggered a real computation
+
+
+@bounded_memoize(
+    maxsize=2
+)  # => keeps at most 2 cached results -- the THIRD distinct key evicts one
+def track(n: int) -> int:  # => the function being memoized
+    calls.append(n)  # => only runs on a cache MISS
+    return n * n  # => the actual (slow, pure) computation being cached
+
+
+track(1)  # => miss: cache holds {1}
+track(2)  # => miss: cache holds {1, 2}
+track(1)  # => HIT: 1 becomes the most recently used entry, no new call recorded
+track(3)  # => miss, over budget: evicts 2 (least recently used); cache holds {1, 3}
+track(2)  # => 2 was evicted -- this is a MISS again, not a hit
+track(1)  # => 1 was ALSO evicted by the previous miss -- another MISS
+
+# => bounding a cache trades perfect memoization for a fixed memory budget
+print(calls)  # => Output: [1, 2, 3, 2, 1] -- five real computations out of six calls

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-65-memoize-bounded-lru/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-65-memoize-bounded-lru/test_example.py
@@ -1,0 +1,20 @@
+"""Example 65: pytest verification for A Memoization Decorator With a Bounded maxsize."""
+
+from example import bounded_memoize
+
+
+def test_lru_eviction_forces_a_recompute_for_the_oldest_key() -> None:
+    calls: list[int] = []
+
+    @bounded_memoize(maxsize=1)
+    def track(n: int) -> int:
+        calls.append(n)
+        return n
+
+    track(1)  # => miss
+    track(2)  # => miss, evicts 1 (maxsize=1)
+    track(1)  # => 1 was evicted -- miss again
+    assert calls == [1, 2, 1]
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-66-tail-recursion-trampoline/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-66-tail-recursion-trampoline/example.py
@@ -1,0 +1,49 @@
+"""Example 66: A Trampoline Simulating Tail-Call Optimization."""
+
+from typing import (
+    Callable,
+)  # => Callable types the zero-arg thunk; "Bounce | int" uses PEP 604 union syntax
+
+
+class Bounce:  # => a marker: "not done yet, call this thunk next" -- NOT the final answer
+    def __init__(
+        self, thunk: Callable[[], "Bounce | int"]
+    ) -> None:  # => wraps a zero-arg step function
+        self.thunk = (
+            thunk  # => stored for the trampoline loop to call on its NEXT iteration
+        )
+
+
+def trampoline(
+    result: "Bounce | int",
+) -> int:  # => drives the loop -- ONE stack frame, however deep
+    while isinstance(
+        result, Bounce
+    ):  # => keeps bouncing as long as we get another Bounce back
+        result = (
+            result.thunk()
+        )  # => calls the next step -- reuses THIS loop's frame, not a new one
+    return result  # => once it's a plain int, the computation is actually done
+
+
+def sum_to_n_trampolined(
+    n: int, acc: int = 0
+) -> "Bounce | int":  # => "recursive-looking" but returns a Bounce
+    if n == 0:  # => base case: nothing left to add
+        return acc  # => a plain int, stops the trampoline
+    return Bounce(
+        lambda: sum_to_n_trampolined(n - 1, acc + n)
+    )  # => NOT a real recursive call -- returns immediately
+
+
+deep_n = 50_000  # => far past CPython's default recursion limit if called naively
+
+result = trampoline(
+    sum_to_n_trampolined(deep_n)
+)  # => the WHILE LOOP does the "recursion," not the call stack
+
+# => the trampoline pattern is Python's manual workaround for missing tail-call optimization
+print(result)  # => Output: 1250025000
+print(
+    result == deep_n * (deep_n + 1) // 2
+)  # => Output: True -- correct despite the extreme depth

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-66-tail-recursion-trampoline/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-66-tail-recursion-trampoline/test_example.py
@@ -1,0 +1,12 @@
+"""Example 66: pytest verification for A Trampoline Simulating Tail-Call Optimization."""
+
+from example import sum_to_n_trampolined, trampoline
+
+
+def test_trampoline_handles_depth_that_would_break_plain_recursion() -> None:
+    deep_n = 50_000
+    result = trampoline(sum_to_n_trampolined(deep_n))
+    assert result == deep_n * (deep_n + 1) // 2
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-67-adt-expression-evaluator/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-67-adt-expression-evaluator/example.py
@@ -1,0 +1,51 @@
+"""Example 67: An Expression AST as an ADT With a match Evaluator."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Expr' forward references below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds each AST node variant
+
+
+@dataclass(frozen=True)  # => a leaf node: a literal number
+class Num:  # => the class body begins here
+    value: float  # => the literal's own value
+
+
+@dataclass(frozen=True)  # => a branch node: left + right
+class Add:  # => the class body begins here
+    left: "Expr"  # => the left operand, itself an Expr
+    right: "Expr"  # => the right operand, itself an Expr
+
+
+@dataclass(frozen=True)  # => a branch node: left * right
+class Mul:  # => the class body begins here
+    left: "Expr"  # => the left operand, itself an Expr
+    right: "Expr"  # => the right operand, itself an Expr
+
+
+Expr = (
+    Num | Add | Mul
+)  # => the ADT: any expression is EXACTLY one of these three shapes
+
+
+def evaluate(
+    expr: Expr,
+) -> float:  # => match/case walks the AST, one branch per variant
+    match expr:  # => opens the match/case block over expr
+        case Num(value=v):  # => a leaf -- just return its value
+            return v  # => the leaf's own value
+        case Add(left=l, right=r):  # => recurse into both children, then add
+            return evaluate(l) + evaluate(r)  # => the actual addition Add represents
+        case Mul(left=l, right=r):  # => recurse into both children, then multiply
+            return evaluate(l) * evaluate(
+                r
+            )  # => the actual multiplication Mul represents
+
+
+expression = Add(Num(2.0), Mul(Num(3.0), Num(4.0)))  # => represents "2.0 + (3.0 * 4.0)"
+
+# => an interpreter is the canonical use case for ADTs plus match/case together
+print(evaluate(expression))  # => Output: 14.0

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-67-adt-expression-evaluator/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-67-adt-expression-evaluator/test_example.py
@@ -1,0 +1,11 @@
+"""Example 67: pytest verification for An Expression AST as an ADT With a match Evaluator."""
+
+from example import Add, Mul, Num, evaluate
+
+
+def test_evaluator_respects_precedence_baked_into_the_tree_shape() -> None:
+    expr = Add(Num(2), Mul(Num(3), Num(4)))
+    assert evaluate(expr) == 14.0
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-68-option-do-style-sequence/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-68-option-do-style-sequence/example.py
@@ -1,0 +1,88 @@
+"""Example 68: Sequencing Option Computations, Do-Style."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Option[U]' forward reference below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds both Option variants
+from typing import (
+    Callable,
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar/Callable type and_then below
+
+T = TypeVar("T")  # => the type of the value a Some wraps
+U = TypeVar("U")  # => the type and_then's step function returns
+
+
+@dataclass(frozen=True)  # => marks Some immutable, matching the FP style
+class Some(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this variant carries
+
+    def and_then(
+        self, fn: Callable[[T], "Option[U]"]
+    ) -> "Option[U]":  # => the sequencing operation
+        return fn(
+            self.value
+        )  # => runs fn on the unwrapped value; fn itself returns an Option
+
+
+@dataclass(frozen=True)  # => marks Nothing immutable too
+class Nothing:  # => the class body begins here
+    def and_then(
+        self, fn: Callable[[T], U]
+    ) -> "Nothing":  # => short-circuits, generic so union calls stay typed
+        return self  # => Nothing stays Nothing, regardless of fn
+
+
+Option = Some[T] | Nothing  # => the ADT itself: an Option is EITHER variant
+
+
+def safe_div(
+    a: float, b: float
+) -> "Option[float]":  # => a step that may be absent (division by zero)
+    return (
+        Nothing() if b == 0 else Some(a / b)
+    )  # => success wraps, failure returns Nothing
+
+
+def safe_sqrt(
+    x: float,
+) -> "Option[float]":  # => a step that may be absent (negative input)
+    return (
+        Nothing() if x < 0 else Some(x**0.5)
+    )  # => success wraps, failure returns Nothing
+
+
+def sqrt_step(
+    ratio: float,
+) -> (
+    "Option[float]"
+):  # => named + typed and_then step -- a bare lambda can't carry annotations
+    return safe_sqrt(
+        ratio
+    )  # => same behavior as the inline version, now with a concrete float param
+
+
+def scale_step(
+    root: float,
+) -> "Option[float]":  # => named + typed and_then step, same reasoning
+    return Some(root * 100)  # => wraps the scaled result back into Some
+
+
+def compute(
+    a: float, b: float
+) -> "Option[float]":  # => "do-style": each step reads like a statement
+    return (  # => opens the do-style chain of and_then calls
+        safe_div(a, b)  # => step 1
+        .and_then(sqrt_step)  # => step 2, only runs if step 1 succeeded
+        .and_then(scale_step)  # => step 3, only runs if step 2 succeeded
+    )  # => closes the do-style chain of and_then calls
+
+
+# => chained and_then calls read like a sequence of statements, not nested callbacks
+print(compute(100, 4))  # => Output: Some(value=500.0)
+print(compute(100, 0))  # => Output: Nothing() -- short-circuits at the FIRST step
+print(compute(-100, 4))  # => Output: Nothing() -- short-circuits at the SECOND step

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-68-option-do-style-sequence/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-68-option-do-style-sequence/test_example.py
@@ -1,0 +1,12 @@
+"""Example 68: pytest verification for Sequencing Option Computations, Do-Style."""
+
+from example import Nothing, Some, compute
+
+
+def test_do_style_chain_short_circuits_on_absence() -> None:
+    assert compute(100, 4) == Some(500.0)
+    assert compute(100, 0) == Nothing()
+    assert compute(-100, 4) == Nothing()
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-69-result-form-validation/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-69-result-form-validation/example.py
@@ -1,0 +1,73 @@
+"""Example 69: Validating a Form, Short-Circuiting on the First Failing Rule."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Result[str, str]' forward references below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds both Result variants
+from typing import (
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar make Ok[T] and Err[E] proper generic containers
+
+T = TypeVar("T")  # => the type of the value an Ok wraps
+E = TypeVar("E")  # => the type of the error an Err wraps
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(Generic[E]):  # => the class body begins here
+    error: E  # => the single field this variant carries
+
+
+Result = Ok[T] | Err[E]  # => the ADT itself: a Result is EITHER variant
+
+
+def check_username(username: str) -> "Result[str, str]":  # => rule 1
+    return (
+        Ok(username) if len(username) >= 3 else Err("username too short")
+    )  # => the ONLY check this rule makes
+
+
+def check_password(password: str) -> "Result[str, str]":  # => rule 2
+    return (
+        Ok(password) if len(password) >= 8 else Err("password too short")
+    )  # => the ONLY check this rule makes
+
+
+def check_age(age: int) -> "Result[int, str]":  # => rule 3
+    return (
+        Ok(age) if age >= 13 else Err("must be at least 13")
+    )  # => the ONLY check this rule makes
+
+
+def validate_signup(
+    username: str, password: str, age: int
+) -> "Result[str, str]":  # => threads all 3 rules
+    username_result = check_username(username)  # => rule 1's switch point
+    if isinstance(username_result, Err):  # => STOP: rules 2 and 3 never run
+        return username_result  # => reports THIS rule as the failing one
+    password_result = check_password(password)  # => rule 2's switch point
+    if isinstance(password_result, Err):  # => STOP: rule 3 never runs
+        return password_result  # => reports THIS rule as the failing one
+    age_result = check_age(age)  # => rule 3's switch point
+    if isinstance(age_result, Err):  # => the last possible failure point
+        return age_result  # => reports THIS rule as the failing one
+    return Ok(f"welcome, {username_result.value}")  # => all three rules passed
+
+
+# => real forms usually have more than two fields -- this scales the railway pattern to three
+print(validate_signup("ana", "longenough", 20))  # => Output: Ok(value='welcome, ana')
+print(
+    validate_signup("an", "longenough", 20)
+)  # => Output: Err(error='username too short')
+print(validate_signup("ana", "short", 20))  # => Output: Err(error='password too short')
+print(
+    validate_signup("ana", "longenough", 10)
+)  # => Output: Err(error='must be at least 13')

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-69-result-form-validation/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-69-result-form-validation/test_example.py
@@ -1,0 +1,13 @@
+"""Example 69: pytest verification for Validating a Form, Short-Circuiting on the First Failing Rule."""
+
+from example import Err, Ok, validate_signup
+
+
+def test_the_failing_rule_is_the_one_reported() -> None:
+    assert validate_signup("ana", "longenough", 20) == Ok("welcome, ana")
+    assert validate_signup("an", "longenough", 20) == Err("username too short")
+    assert validate_signup("ana", "short", 20) == Err("password too short")
+    assert validate_signup("ana", "longenough", 10) == Err("must be at least 13")
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-70-functor-laws-property-checked/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-70-functor-laws-property-checked/example.py
@@ -1,0 +1,67 @@
+"""Example 70: Property-Checking the Functor Identity and Composition Laws."""
+
+import random  # => stdlib source of pseudo-random Box values -- no third-party library needed
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds the immutable Box
+from typing import (
+    Callable,
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar/Callable type the functor below
+
+T = TypeVar("T")  # => the type of the value a Box wraps
+U = TypeVar("U")  # => the type map's function returns
+
+
+@dataclass(frozen=True)  # => the functor under test
+class Box(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this container carries
+
+    def map(
+        self, fn: Callable[[T], U]
+    ) -> "Box[U]":  # => applies fn inside, stays wrapped
+        return Box(fn(self.value))  # => applies fn inside, re-wraps as Box
+
+
+def identity(x: int) -> int:  # => the identity function, used by the identity law
+    return x  # => returns its argument unchanged
+
+
+def add_one(x: int) -> int:  # => one of the two functions used by the composition law
+    return x + 1  # => the actual +1
+
+
+def double(x: int) -> int:  # => the second function used by the composition law
+    return x * 2  # => the actual *2
+
+
+def check_identity_law(box: "Box[int]") -> bool:  # => box.map(identity) == box
+    return box.map(identity) == box  # => the identity law's own definition
+
+
+def check_composition_law(
+    box: "Box[int]",
+) -> bool:  # => box.map(f).map(g) == box.map(compose(g, f))
+    mapped_twice = box.map(add_one).map(
+        double
+    )  # => two SEPARATE map calls, one after another
+    mapped_once = box.map(
+        lambda x: double(add_one(x))
+    )  # => ONE map call with the composed function
+    return mapped_twice == mapped_once  # => the composition law's own definition
+
+
+random.seed(42)  # => fixed seed -- this property check is fully reproducible
+generated_boxes = [
+    Box(random.randint(-1000, 1000)) for _ in range(300)
+]  # => 300 random Box values
+
+identity_law_holds = all(
+    check_identity_law(b) for b in generated_boxes
+)  # => checks ALL 300, not one
+composition_law_holds = all(
+    check_composition_law(b) for b in generated_boxes
+)  # => checks ALL 300, not one
+
+# => checking BOTH functor laws together is what makes a map implementation trustworthy
+print(identity_law_holds)  # => Output: True
+print(composition_law_holds)  # => Output: True

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-70-functor-laws-property-checked/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-70-functor-laws-property-checked/test_example.py
@@ -1,0 +1,15 @@
+"""Example 70: pytest verification for Property-Checking the Functor Identity and Composition Laws."""
+
+import random
+
+from example import Box, check_composition_law, check_identity_law
+
+
+def test_both_functor_laws_hold_across_many_generated_boxes() -> None:
+    random.seed(7)
+    boxes = [Box(random.randint(-500, 500)) for _ in range(100)]
+    assert all(check_identity_law(b) for b in boxes)
+    assert all(check_composition_law(b) for b in boxes)
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-71-applicative-validation-accumulate/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-71-applicative-validation-accumulate/example.py
@@ -1,0 +1,90 @@
+"""Example 71: An Applicative Validation That Accumulates All Errors."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Validated[T]' forward references below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds both Validated variants
+from typing import (
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar make Valid[T] a proper generic container
+
+T = TypeVar("T")  # => the type of the value a Valid wraps
+
+
+@dataclass(frozen=True)  # => success, carrying the validated value
+class Valid(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => failure, carrying EVERY error found, not just the first
+class Invalid:  # => the class body begins here
+    errors: tuple[
+        str, ...
+    ]  # => one entry per failing rule, accumulated across all checks
+
+
+Validated = (
+    Valid[T] | Invalid
+)  # => this topic's SECOND Result-shaped type -- accumulates instead of short-circuits
+
+
+def validate_username(
+    username: str,
+) -> "Validated[str]":  # => rule 1, independent of the others
+    return (
+        Valid(username) if len(username) >= 3 else Invalid(("username too short",))
+    )  # => the ONLY check this rule makes
+
+
+def validate_password(
+    password: str,
+) -> "Validated[str]":  # => rule 2, independent of the others
+    return (
+        Valid(password) if len(password) >= 8 else Invalid(("password too short",))
+    )  # => the ONLY check this rule makes
+
+
+def validate_age(age: int) -> "Validated[int]":  # => rule 3, independent of the others
+    return (
+        Valid(age) if age >= 13 else Invalid(("must be at least 13",))
+    )  # => the ONLY check this rule makes
+
+
+def combine3(  # => the applicative combinator: runs ALL THREE checks, merges ALL failures
+    a: "Validated[str]",
+    b: "Validated[str]",
+    c: "Validated[int]",  # => the three independent checks to combine
+) -> "Validated[str]":  # => closes the multi-line signature above
+    errors: list[str] = []  # => collects failures from EVERY input, not just the first
+    for result in (
+        a,
+        b,
+        c,
+    ):  # => visits all three, regardless of whether earlier ones already failed
+        if isinstance(result, Invalid):  # => this particular check failed
+            errors.extend(
+                result.errors
+            )  # => appends THIS check's errors onto the running list
+    if errors:  # => at least one check failed
+        return Invalid(
+            tuple(errors)
+        )  # => reports EVERY failing rule, not just the first
+    return Valid(f"welcome, {a.value}")  # type: ignore[union-attr]  # => all three checks passed
+
+
+all_valid = combine3(
+    validate_username("ana"), validate_password("longenough"), validate_age(20)
+)  # => every check passes
+all_invalid = combine3(
+    validate_username("an"), validate_password("short"), validate_age(10)
+)  # => every check fails
+
+# => this is railway-oriented programming's opposite: gather everything, stop for nothing
+print(all_valid)  # => Output: Valid(value='welcome, ana')
+print(
+    all_invalid
+)  # => Output: Invalid(errors=('username too short', 'password too short', 'must be at least 13'))

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-71-applicative-validation-accumulate/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-71-applicative-validation-accumulate/test_example.py
@@ -1,0 +1,19 @@
+"""Example 71: pytest verification for An Applicative Validation That Accumulates All Errors."""
+
+from example import (
+    Invalid,
+    combine3,
+    validate_age,
+    validate_password,
+    validate_username,
+)
+
+
+def test_every_failing_rule_is_collected_not_just_the_first() -> None:
+    result = combine3(validate_username("a"), validate_password("x"), validate_age(5))
+    assert result == Invalid(
+        ("username too short", "password too short", "must be at least 13")
+    )
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-72-monad-laws-intuition/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-72-monad-laws-intuition/example.py
@@ -1,0 +1,82 @@
+"""Example 72: Left-Identity, Right-Identity, and Associativity for Result."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Result[U, object]' forward references below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds both Result variants
+from typing import (
+    Callable,
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar/Callable type bind and unit below
+
+T = TypeVar("T")  # => the type of the value an Ok wraps
+U = TypeVar("U")  # => the type bind's step function returns
+E = TypeVar("E")  # => the type of the error an Err wraps
+F = TypeVar(
+    "F"
+)  # => the error type threaded through bind's step function, not hardcoded to object
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this variant carries
+
+    def bind(
+        self, fn: Callable[[T], "Result[U, F]"]
+    ) -> "Result[U, F]":  # => F comes from fn's OWN error type
+        return fn(
+            self.value
+        )  # => unwraps, runs fn (which itself returns a Result), no double-wrap
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(Generic[E]):  # => the class body begins here
+    error: E  # => the single field this variant carries
+
+    def bind(
+        self, fn: Callable[[T], U]
+    ) -> "Err[E]":  # => NO-OP, generic so a typed fn still passes the check
+        return self  # => fn never runs once the chain has already failed
+
+
+Result = Ok[T] | Err[E]  # => the ADT itself: a Result is EITHER variant
+
+
+def unit(
+    x: T,
+) -> (
+    "Result[T, object]"
+):  # => the monad's "wrap a plain value" operation, a.k.a. return/pure
+    return Ok(x)  # => the simplest possible success
+
+
+def half(
+    n: int,
+) -> "Result[float, str]":  # => an arbitrary bind step, reused by all three law checks
+    return (
+        Ok(n / 2) if n % 2 == 0 else Err(f"{n} is odd")
+    )  # => succeeds on even n, fails on odd n
+
+
+def add_ten(
+    x: float,
+) -> "Result[float, str]":  # => a SECOND arbitrary bind step, for associativity
+    return Ok(x + 10)  # => always succeeds
+
+
+left_identity_holds = unit(8).bind(half) == half(8)  # => unit(x).bind(f) == f(x)
+right_identity_holds = Ok(8).bind(unit) == Ok(8)  # => m.bind(unit) == m
+associativity_holds = Ok(8).bind(half).bind(add_ten) == Ok(
+    8
+).bind(  # => m.bind(f).bind(g)
+    lambda x: half(x).bind(add_ten)  # => == m.bind(lambda x: f(x).bind(g))
+)  # => closes the associativity check's multi-line expression
+
+# => these three laws are what makes 'monad' a precise term, not just a vague design pattern
+print(left_identity_holds)  # => Output: True
+print(right_identity_holds)  # => Output: True
+print(associativity_holds)  # => Output: True

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-72-monad-laws-intuition/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-72-monad-laws-intuition/test_example.py
@@ -1,0 +1,14 @@
+"""Example 72: pytest verification for the three monad laws on Result."""
+
+from example import Ok, add_ten, half, unit
+
+
+def test_all_three_monad_laws_hold() -> None:
+    assert unit(8).bind(half) == half(8)  # => left identity
+    assert Ok(8).bind(unit) == Ok(8)  # => right identity
+    assert Ok(8).bind(half).bind(add_ten) == Ok(8).bind(
+        lambda x: half(x).bind(add_ten)
+    )  # => associativity
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-73-point-free-combinator-lib/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-73-point-free-combinator-lib/example.py
@@ -1,0 +1,78 @@
+"""Example 73: A Small Point-Free Combinator Library."""
+
+from functools import reduce  # => reduce powers pipe's left-to-right fold
+from typing import (
+    Any,
+    Callable,
+    TypeVar,
+)  # => Callable/TypeVar type this small combinator library; Any types pipe's dynamic arity
+
+A = TypeVar("A")  # => a generic type parameter shared by const
+B = TypeVar("B")  # => a second generic type parameter shared by flip
+
+
+def pipe(
+    *fns: Callable[..., Any],
+) -> Callable[..., Any]:  # => LEFT-to-right composition -- the first fn runs FIRST
+    def apply_step(
+        acc: Any, fn: Callable[..., Any]
+    ) -> Any:  # => named + typed -- one fold step, calls fn on acc
+        return fn(
+            acc
+        )  # => applies ONE fn to the running accumulator, returns the next accumulator
+
+    def piped(
+        x: Any,
+    ) -> Any:  # => named + typed -- an untyped lambda can't carry these annotations
+        return reduce(apply_step, fns, x)  # => folds fns in ORDER, unlike compose
+
+    return piped  # => pipe itself returns the composed pipeline function
+
+
+def const(
+    value: A,
+) -> Callable[..., A]:  # => a combinator: ignores its argument(s), always returns value
+    return lambda *_ignored: (
+        value
+    )  # => the returned function discards WHATEVER it's called with
+
+
+def flip(
+    fn: Callable[[A, B], A],
+) -> Callable[[B, A], A]:  # => a combinator: swaps a 2-arg function's order
+    return lambda b, a: fn(a, b)  # => calls fn with its two arguments REVERSED
+
+
+def subtract(
+    a: int, b: int
+) -> int:  # => an ordinary 2-argument function, order matters
+    return a - b  # => the actual subtraction
+
+
+always_zero = const(0)  # => a function of ANY arguments that always returns 0
+flipped_subtract = flip(subtract)  # => subtract with its arguments swapped
+
+
+def add_one(
+    x: int,
+) -> (
+    int
+):  # => named + typed -- pipe's Callable[..., Any] gives lambdas no param context
+    return x + 1  # => adds 1 to x -- one plain step for pipe/flip to compose over
+
+
+def double(x: int) -> int:  # => named + typed, same reasoning
+    return x * 2  # => doubles x -- the second plain step in the transform pipeline
+
+
+transform = pipe(
+    add_one, double, str
+)  # => a combined "add 1, double, stringify" pipeline
+
+# => a tiny combinator library is how point-free style scales beyond one-off rewrites
+print(transform(3))  # => Output: 8  (str of (3+1)*2)
+print(always_zero(1, 2, 3))  # => Output: 0 -- ignores every argument it was given
+print(subtract(10, 3))  # => Output: 7
+print(
+    flipped_subtract(10, 3)
+)  # => Output: -7 -- same two arguments, swapped order changes the answer

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-73-point-free-combinator-lib/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-73-point-free-combinator-lib/test_example.py
@@ -1,0 +1,25 @@
+"""Example 73: pytest verification for A Small Point-Free Combinator Library."""
+
+from example import const, flip, pipe, subtract
+
+
+def _add_one(x: int) -> int:
+    return x + 1
+
+
+def _double(x: int) -> int:
+    return x * 2
+
+
+def test_pipe_const_and_flip_compose_correctly() -> None:
+    transform = pipe(_add_one, _double)
+    assert transform(3) == 8
+
+    always_five = const(5)
+    assert always_five(1, 2, 3) == 5
+
+    flipped_subtract = flip(subtract)
+    assert flipped_subtract(10, 3) == -7
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-74-pipe-vs-nested-readability/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-74-pipe-vs-nested-readability/example.py
@@ -1,0 +1,56 @@
+"""Example 74: A Deep pipe vs. Nested Calls on Real Data."""
+
+from functools import reduce  # => reduce powers pipe's left-to-right fold
+from typing import (
+    Any,
+    Callable,
+)  # => Callable types the pipe helper below; Any types its dynamic arity
+
+
+def pipe(
+    *fns: Callable[..., Any],
+) -> Callable[..., Any]:  # => reads TOP-TO-BOTTOM / LEFT-TO-RIGHT: first fn runs first
+    def apply_step(
+        acc: Any, fn: Callable[..., Any]
+    ) -> Any:  # => named + typed -- one fold step, calls fn on acc
+        return fn(acc)
+
+    def piped(
+        x: Any,
+    ) -> Any:  # => named + typed -- an untyped lambda can't carry these annotations
+        return reduce(apply_step, fns, x)  # => folds fns in ORDER, not reversed
+
+    return piped  # => pipe itself returns the composed pipeline function
+
+
+def strip_whitespace(text: str) -> str:  # => step 1
+    return text.strip()  # => removes leading/trailing whitespace
+
+
+def to_lowercase(text: str) -> str:  # => step 2
+    return text.lower()  # => normalizes case
+
+
+def split_words(text: str) -> list[str]:  # => step 3
+    return text.split()  # => splits on any run of whitespace
+
+
+def count_words(words: list[str]) -> int:  # => step 4
+    return len(words)  # => the final count
+
+
+raw = "  Hello  World  from   FUNCTIONAL Python  "  # => messy real-world input
+
+nested_result = count_words(
+    split_words(to_lowercase(strip_whitespace(raw)))
+)  # => reads INSIDE-OUT
+piped_result = pipe(strip_whitespace, to_lowercase, split_words, count_words)(
+    raw
+)  # => reads TOP-TO-BOTTOM
+
+# => the exact same computation, argued for on READABILITY grounds alone
+print(nested_result)  # => Output: 5
+print(piped_result)  # => Output: 5
+print(
+    nested_result == piped_result
+)  # => Output: True -- IDENTICAL computation, two different reading orders

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-74-pipe-vs-nested-readability/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-74-pipe-vs-nested-readability/test_example.py
@@ -1,0 +1,13 @@
+"""Example 74: pytest verification for A Deep pipe vs. Nested Calls on Real Data."""
+
+from example import count_words, pipe, split_words, strip_whitespace, to_lowercase
+
+
+def test_pipe_and_nested_calls_compute_the_identical_answer() -> None:
+    raw = "  A  B  C  "
+    nested = count_words(split_words(to_lowercase(strip_whitespace(raw))))
+    piped = pipe(strip_whitespace, to_lowercase, split_words, count_words)(raw)
+    assert nested == piped == 3
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-75-immutability-perf-cost/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-75-immutability-perf-cost/example.py
@@ -1,0 +1,62 @@
+"""Example 75: Measuring Persistent-Update Cost vs. In-Place Mutation."""
+
+import time  # => times both code paths for a rough, qualitative comparison
+from dataclasses import (
+    dataclass,
+    replace,
+)  # => replace builds a NEW ImmutablePoint from an OLD one
+
+
+@dataclass(
+    frozen=True
+)  # => the IMMUTABLE version: every "update" allocates a new object
+class ImmutablePoint:  # => the class body begins here
+    x: int  # => the coordinate this example bumps repeatedly
+    y: int  # => unused by this example, kept for a realistic shape
+
+
+class MutablePoint:  # => the MUTABLE version: "update" writes in place, no allocation
+    def __init__(self, x: int, y: int) -> None:  # => an ordinary, non-frozen class
+        self.x = x  # => a plain, mutable attribute
+        self.y = y  # => a plain, mutable attribute
+
+
+def bump_immutable(
+    p: ImmutablePoint, n: int
+) -> ImmutablePoint:  # => allocates a NEW object each call
+    for _ in range(n):  # => repeats the "update" n times
+        p = replace(
+            p, x=p.x + 1
+        )  # => n allocations total -- one frozen dataclass per step
+    return p  # => the final, newest ImmutablePoint
+
+
+def bump_mutable(
+    p: MutablePoint, n: int
+) -> MutablePoint:  # => mutates the SAME object each call
+    for _ in range(n):  # => repeats the "update" n times
+        p.x += 1  # => zero extra allocations -- writes directly into existing memory
+    return p  # => the SAME object, just with x changed n times
+
+
+iterations = 200_000  # => enough repetitions to make the cost difference measurable
+
+start = time.perf_counter()  # => marks the start of the immutable-path timing
+result_immutable = bump_immutable(
+    ImmutablePoint(0, 0), iterations
+)  # => n allocations happen here
+immutable_seconds = time.perf_counter() - start  # => elapsed time for n allocations
+
+start = time.perf_counter()  # => marks the start of the mutable-path timing
+result_mutable = bump_mutable(
+    MutablePoint(0, 0), iterations
+)  # => n in-place writes happen here
+mutable_seconds = time.perf_counter() - start  # => elapsed time for n in-place writes
+
+# => this is the honest cost side of the immutability trade-off this topic advocates
+print(
+    result_immutable.x == result_mutable.x == iterations
+)  # => Output: True -- BOTH reach the correct answer
+print(
+    immutable_seconds > 0 and mutable_seconds > 0
+)  # => Output: True -- both measured a nonzero duration

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-75-immutability-perf-cost/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-75-immutability-perf-cost/test_example.py
@@ -1,0 +1,12 @@
+"""Example 75: pytest verification for Measuring Persistent-Update Cost vs. In-Place Mutation."""
+
+from example import ImmutablePoint, MutablePoint, bump_immutable, bump_mutable
+
+
+def test_both_versions_reach_the_correct_final_value() -> None:
+    n = 100
+    assert bump_immutable(ImmutablePoint(0, 0), n).x == n
+    assert bump_mutable(MutablePoint(0, 0), n).x == n
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-76-reduce-shared-state-refactor/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-76-reduce-shared-state-refactor/example.py
@@ -1,0 +1,43 @@
+"""Example 76: Refactoring Shared-Mutable Code to Pass State Explicitly."""
+
+_shared_balance = (
+    0  # => the BEFORE state: a module-level global every function silently depends on
+)
+
+
+def deposit_impure(
+    amount: int,
+) -> int:  # => reads AND writes the hidden global -- a shared-state trap
+    global _shared_balance  # => declares intent to mutate the MODULE-level balance
+    _shared_balance += (
+        amount  # => any other function could ALSO be mutating this concurrently
+    )
+    return _shared_balance  # => the new, globally-visible balance
+
+
+def deposit_pure(
+    balance: int, amount: int
+) -> int:  # => the AFTER state: balance passed explicitly
+    return (
+        balance + amount
+    )  # => no globals, no hidden dependency -- callers control the state directly
+
+
+_shared_balance = 0  # => resets the impure global before demonstrating it
+impure_result_1 = deposit_impure(100)  # => mutates _shared_balance to 100
+impure_result_2 = deposit_impure(
+    50
+)  # => mutates _shared_balance to 150 -- depends on the call BEFORE it
+
+pure_result_1 = deposit_pure(0, 100)  # => explicit starting balance, explicit result
+pure_result_2 = deposit_pure(
+    pure_result_1, 50
+)  # => explicit threading -- no hidden state anywhere
+
+# => this refactor is functional-core/imperative-shell applied to a single function pair
+print(
+    impure_result_2 == pure_result_2
+)  # => Output: True -- same final answer, radically different design
+print(
+    _shared_balance
+)  # => Output: 150 -- the global STILL exists in the impure version

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-76-reduce-shared-state-refactor/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-76-reduce-shared-state-refactor/test_example.py
@@ -1,0 +1,14 @@
+"""Example 76: pytest verification for Refactoring Shared-Mutable Code to Pass State Explicitly."""
+
+from example import deposit_pure
+
+
+def test_explicit_state_threading_needs_no_global_reset_between_tests() -> None:
+    balance = deposit_pure(0, 100)
+    balance = deposit_pure(balance, 50)
+    assert (
+        balance == 150
+    )  # => reproducible without resetting any module-level global first
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-77-decorator-stack-composition/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-77-decorator-stack-composition/example.py
@@ -1,0 +1,49 @@
+"""Example 77: Stacking Multiple Decorators and Reasoning About Order."""
+
+from functools import (
+    wraps,
+)  # => preserves double's identity through both decorator layers
+from typing import Callable  # => Callable types the logged decorator factory below
+
+call_order: list[
+    str
+] = []  # => records the ACTUAL order decorators run in, top-to-bottom vs inside-out
+
+
+def logged(
+    label: str,
+) -> Callable[[Callable[[int], int]], Callable[[int], int]]:  # => a decorator factory
+    def decorator(
+        fn: Callable[[int], int],
+    ) -> Callable[[int], int]:  # => the actual decorator
+        @wraps(fn)  # => preserves fn's identity through this layer
+        def wrapper(
+            x: int,
+        ) -> int:  # => logs entry/exit around whatever fn this layer wraps
+            call_order.append(f"{label} enter")  # => runs BEFORE the wrapped function
+            result = fn(
+                x
+            )  # => calls the NEXT layer in (or the real function, if innermost)
+            call_order.append(f"{label} exit")  # => runs AFTER the wrapped function
+            return result  # => forwards the inner result unchanged
+
+        return wrapper  # => decorator itself returns the logging wrapper
+
+    return decorator  # => logged(label) itself returns the decorator
+
+
+@logged(
+    "outer"
+)  # => applied SECOND -- wraps whatever @logged("inner") already produced
+@logged("inner")  # => applied FIRST -- wraps the raw function directly
+def double(x: int) -> int:  # => the innermost function, wrapped twice
+    return x * 2  # => the actual computation, untouched by either decorator
+
+
+result = double(5)  # => triggers BOTH wrapper layers, in a specific nesting order
+
+# => decorator stacking is function composition wearing different syntax
+print(result)  # => Output: 10
+print(
+    call_order
+)  # => Output: ['outer enter', 'inner enter', 'inner exit', 'outer exit']

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-77-decorator-stack-composition/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-77-decorator-stack-composition/test_example.py
@@ -1,0 +1,12 @@
+"""Example 77: pytest verification for Stacking Multiple Decorators and Reasoning About Order."""
+
+from example import call_order, double
+
+
+def test_decorators_nest_outermost_first_innermost_last() -> None:
+    call_order.clear()
+    double(5)
+    assert call_order == ["outer enter", "inner enter", "inner exit", "outer exit"]
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-78-lazy-vs-eager-tradeoff/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-78-lazy-vs-eager-tradeoff/example.py
@@ -1,0 +1,53 @@
+"""Example 78: A Case Where Laziness Saves Work, and One Where It Hides a Cost."""
+
+from typing import Iterator  # => Iterator types the lazy generator below
+
+work_done: list[str] = []  # => records every "expensive" step actually performed
+
+
+def expensive_step(n: int) -> int:  # => stands in for a slow computation
+    work_done.append(f"computed {n}")  # => only runs when this step is ACTUALLY reached
+    return n * n  # => the "expensive" result
+
+
+def lazy_squares(numbers: range) -> Iterator[int]:  # => LAZY: nothing runs until pulled
+    for n in numbers:  # => walks the range one value at a time, on demand
+        yield expensive_step(n)  # => suspends here between pulls
+
+
+def eager_squares(
+    numbers: range,
+) -> list[int]:  # => EAGER: computes EVERY value immediately
+    return [
+        expensive_step(n) for n in numbers
+    ]  # => materializes the WHOLE list before returning
+
+
+work_done.clear()  # => resets the log before Case 1
+lazy_stream = lazy_squares(range(1, 1000))  # => nothing computed yet
+first_over_50 = next(
+    n for n in lazy_stream if n > 50
+)  # => stops pulling the instant it finds one
+lazy_work_count = len(work_done)  # => far fewer than 999
+
+work_done.clear()  # => resets the log before Case 2
+lazy_stream_2 = lazy_squares(range(1, 4))  # => a FRESH lazy generator
+first_pass = list(lazy_stream_2)  # => first pass: 3 values computed
+second_pass = list(
+    lazy_stream_2
+)  # => generator already EXHAUSTED -- silently yields nothing
+hidden_cost_count = len(
+    work_done
+)  # => still 3, NOT 6 -- the second pass did nothing at all, silently
+
+# => laziness is a trade-off, not a free win -- both sides of it matter
+print(first_over_50)  # => Output: 64
+print(
+    lazy_work_count < 10
+)  # => Output: True -- laziness saved most of the 999 possible computations
+print(
+    second_pass
+)  # => Output: [] -- the SILENT trap: re-iterating an exhausted generator gives nothing
+print(
+    hidden_cost_count
+)  # => Output: 3 -- proves the second pass computed NOTHING, not that it recomputed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-78-lazy-vs-eager-tradeoff/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-78-lazy-vs-eager-tradeoff/test_example.py
@@ -1,0 +1,18 @@
+"""Example 78: pytest verification for A Case Where Laziness Saves Work, and One Where It Hides a Cost."""
+
+from example import lazy_squares, work_done
+
+
+def test_reiterating_an_exhausted_generator_yields_nothing_silently() -> None:
+    work_done.clear()
+    stream = lazy_squares(range(1, 4))
+    first_pass = list(stream)  # => consumes the generator fully
+    assert first_pass == [1, 4, 9]
+    assert len(work_done) == 3
+
+    second_pass = list(stream)  # => the SAME (now exhausted) generator object
+    assert second_pass == []  # => silently empty -- no error, no recomputation
+    assert len(work_done) == 3  # => confirms NOTHING extra was computed
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-79-monad-option-vs-result/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-79-monad-option-vs-result/example.py
@@ -1,0 +1,112 @@
+"""Example 79: The Same Pipeline in Option vs. Result."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted forward references used below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds all four variants below
+from typing import (
+    Callable,
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar/Callable type both and_then methods
+
+T = TypeVar("T")  # => the type of the value a Some or Ok wraps
+U = TypeVar("U")  # => the type each and_then's step function returns
+
+
+@dataclass(frozen=True)  # => marks Some immutable, matching the FP style
+class Some(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this variant carries
+
+    def and_then(
+        self, fn: Callable[[T], "Option[U]"]
+    ) -> "Option[U]":  # => Option's chaining operation
+        return fn(self.value)  # => runs fn on the unwrapped value
+
+
+@dataclass(frozen=True)  # => marks Nothing immutable too
+class Nothing:  # => the class body begins here
+    def and_then(
+        self, fn: Callable[[T], U]
+    ) -> "Nothing":  # => short-circuits, generic so union calls stay typed
+        return self  # => Nothing carries NO explanation for why
+
+
+Option = Some[T] | Nothing  # => the Option ADT: EITHER variant
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this variant carries
+
+    def and_then(
+        self, fn: Callable[[T], "Res[U]"]
+    ) -> "Res[U]":  # => Result's chaining operation
+        return fn(self.value)  # => runs fn on the unwrapped value
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err:  # => the class body begins here
+    error: str  # => Result CARRIES a reason -- Option's Nothing cannot
+
+    def and_then(
+        self, fn: Callable[[T], U]
+    ) -> "Err":  # => short-circuits, generic so union calls stay typed
+        return self  # => the REASON rides through untouched
+
+
+Res = Ok[T] | Err  # => the Result ADT: EITHER variant
+
+
+def parse_option(
+    text: str,
+) -> "Option[int]":  # => same parsing logic, Option's error model: just absence
+    return (
+        Some(int(text)) if text.isdigit() else Nothing()
+    )  # => success wraps, failure loses all context
+
+
+def parse_result(
+    text: str,
+) -> "Res[int]":  # => same parsing logic, Result's error model: WHY it failed
+    return (
+        Ok(int(text)) if text.isdigit() else Err(f"'{text}' is not a digit string")
+    )  # => failure keeps context
+
+
+def double_option(
+    n: int,
+) -> (
+    "Option[int]"
+):  # => named + typed -- a bare lambda loses its param type on the union call
+    return Some(
+        n * 2
+    )  # => same "double" step as double_result, wrapped in Option's variant
+
+
+def double_result(
+    n: int,
+) -> "Res[int]":  # => named + typed, same reasoning as double_option
+    return Ok(
+        n * 2
+    )  # => same "double" step as double_option, wrapped in Result's variant
+
+
+option_pipeline = parse_option("42").and_then(double_option)  # => Option pipeline
+result_pipeline = parse_result("42").and_then(
+    double_result
+)  # => Result pipeline, same shape
+
+option_failure = parse_option("bad")  # => Nothing -- no explanation attached
+result_failure = parse_result("bad")  # => Err carrying a human-readable reason
+
+# => the SAME chain, two error models -- pick based on whether the reason matters
+print(option_pipeline)  # => Output: Some(value=84)
+print(result_pipeline)  # => Output: Ok(value=84)
+print(option_failure)  # => Output: Nothing() -- WHY it failed is not represented at all
+print(
+    result_failure
+)  # => Output: Err(error="'bad' is not a digit string") -- the reason IS represented

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-79-monad-option-vs-result/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-79-monad-option-vs-result/test_example.py
@@ -1,0 +1,21 @@
+"""Example 79: pytest verification for The Same Pipeline in Option vs. Result."""
+
+from example import Err, Nothing, Ok, Option, Res, Some, parse_option, parse_result
+
+
+def _increment_option(n: int) -> Option[int]:
+    return Some(n + 1)
+
+
+def _increment_result(n: int) -> Res[int]:
+    return Ok(n + 1)
+
+
+def test_option_discards_the_reason_result_keeps_it() -> None:
+    assert parse_option("bad") == Nothing()
+    assert parse_result("bad") == Err("'bad' is not a digit string")
+    assert parse_option("5").and_then(_increment_option) == Some(6)
+    assert parse_result("5").and_then(_increment_result) == Ok(6)
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-80-capstone-preview-log-analyzer/example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-80-capstone-preview-log-analyzer/example.py
@@ -1,0 +1,113 @@
+"""Example 80: A Functional-Core Log Analyzer With Result Errors and an Applicative Combine."""
+
+from __future__ import (
+    annotations,
+)  # => enables the quoted 'Result[T]'/'Result[list[LogEntry]]' references below
+
+from dataclasses import (
+    dataclass,
+)  # => @dataclass(frozen=True) builds every immutable record here
+from typing import (
+    Generic,
+    TypeVar,
+)  # => Generic/TypeVar make Ok[T] a proper generic container
+
+T = TypeVar("T")  # => the type of the value an Ok wraps
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the class body begins here
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err:  # => the class body begins here
+    errors: tuple[str, ...]  # => accumulates every malformed line, not just the first
+
+
+Result = Ok[T] | Err  # => the ADT itself: a Result is EITHER variant
+
+
+@dataclass(frozen=True)  # => one PARSED, immutable log line
+class LogEntry:  # => the class body begins here
+    level: str  # => INFO, WARN, or ERROR
+    message: str  # => the rest of the line, trimmed
+
+
+def parse_line(
+    line: str, line_number: int
+) -> "Result[LogEntry]":  # => PURE CORE: one line -> Result
+    parts = line.split(
+        ":", 1
+    )  # => splits "ERROR:disk full" into ["ERROR", "disk full"]
+    if len(parts) != 2 or parts[0] not in (
+        "INFO",
+        "WARN",
+        "ERROR",
+    ):  # => the ONLY validity rule
+        return Err(
+            (f"line {line_number}: malformed entry '{line}'",)
+        )  # => a single-error Err, keyed to this line
+    return Ok(
+        LogEntry(level=parts[0], message=parts[1].strip())
+    )  # => success wraps the parsed entry
+
+
+def parse_all(
+    lines: list[str],
+) -> "Result[list[LogEntry]]":  # => applicative combine: ALL lines, ALL errors
+    entries: list[LogEntry] = []  # => collects every SUCCESSFULLY parsed entry
+    errors: list[
+        str
+    ] = []  # => collects every FAILURE, across every line, not just the first
+    for i, line in enumerate(
+        lines, start=1
+    ):  # => visits EVERY line regardless of earlier failures
+        result = parse_line(line, i)  # => delegates to the pure per-line parser
+        if isinstance(result, Ok):  # => this particular line parsed cleanly
+            entries.append(result.value)  # => a good line contributes an entry
+        else:  # => this particular line was malformed
+            errors.extend(
+                result.errors
+            )  # => a bad line contributes its error, parsing CONTINUES
+    if errors:  # => at least one line was malformed
+        return Err(tuple(errors))  # => reports EVERY malformed line at once
+    return Ok(entries)  # => every line parsed cleanly
+
+
+def count_by_level(
+    entries: list[LogEntry],
+) -> dict[str, int]:  # => PURE CORE: aggregation step
+    counts: dict[str, int] = {}  # => the running per-level total
+    for entry in entries:  # => folds every entry into the counts dict
+        counts[entry.level] = counts.get(entry.level, 0) + 1  # => accumulates per level
+    return counts  # => a fresh dict -- the input list itself is never mutated
+
+
+def run_shell(
+    raw_text: str,
+) -> None:  # => IMPERATIVE SHELL: the only function that prints
+    lines = raw_text.strip().splitlines()  # => splits the "file contents" into lines
+    parsed = parse_all(lines)  # => delegates to the pure, error-accumulating core
+    if isinstance(
+        parsed, Err
+    ):  # => reports every problem found, still just ONE code path
+        print(
+            f"{len(parsed.errors)} error(s) found:"
+        )  # => the shell's own summary line
+        for (
+            error
+        ) in parsed.errors:  # => walks EVERY accumulated error, not just the first
+            print(f"  {error}")  # => one printed line per malformed input line
+        return  # => stops here -- no report is generated from partially-bad input
+    counts = count_by_level(parsed.value)  # => delegates to the pure aggregation core
+    for level in sorted(counts):  # => alphabetical report, deterministic output
+        print(f"{level}: {counts[level]}")  # => one printed line per log level
+
+
+good_log = "INFO:started\nWARN:low disk\nERROR:crashed\nINFO:restarted"  # => stands in for a real log file
+# => this preview is a smaller version of what the capstone builds end to end
+run_shell(good_log)  # => Output: ERROR: 1, then INFO: 2, then WARN: 1
+
+bad_log = "INFO:ok\nnonsense line\nERROR:bad\nanother bad one"  # => two malformed lines mixed in
+run_shell(bad_log)  # => Output: 2 error(s) found, both listed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-80-capstone-preview-log-analyzer/test_example.py
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/code/ex-80-capstone-preview-log-analyzer/test_example.py
@@ -1,0 +1,20 @@
+"""Example 80: pytest verification for A Functional-Core Log Analyzer With Result Errors and an Applicative Combine."""
+
+from example import Err, Ok, count_by_level, parse_all
+
+
+def test_core_accumulates_every_malformed_line_and_counts_the_rest() -> None:
+    good = ["INFO:a", "WARN:b", "INFO:c"]
+    result = parse_all(good)
+    assert isinstance(result, Ok)
+    assert count_by_level(result.value) == {"INFO": 2, "WARN": 1}
+
+    bad = ["INFO:a", "nonsense", "also nonsense"]
+    bad_result = parse_all(bad)
+    assert isinstance(bad_result, Err)
+    assert (
+        len(bad_result.errors) == 2
+    )  # => BOTH malformed lines reported, not just the first
+
+
+# => Run: pytest -- Output: 1 passed

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate.md
@@ -2651,3 +2651,7 @@ moving between languages more than the concept itself does -- Haskell and Scala 
 the SAME chaining operation under different names is what lets this topic's monad-law example
 (Example 78 in the Advanced tier) verify the same three laws regardless of which name a particular
 codebase happens to use.
+
+---
+
+← Previous: [Beginner Examples](./beginner.md) &middot; Next: [Advanced Examples](./advanced.md) →

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate.md
@@ -1,0 +1,2653 @@
+---
+title: "Intermediate Examples"
+date: 2026-07-17T00:00:00+07:00
+draft: false
+weight: 20
+---
+
+Examples 29-56 move from vocabulary to machinery: extracting a pure core from a mutating routine as
+this topic's first hands-on functional-core/imperative-shell split (co-28, co-01), a persistent linked
+list proving O(1) sharing with a cached length field (co-05), `MappingProxyType` as a read-only
+boundary (co-04), a closure and a pure fold carrying the same count two different ways (co-08),
+`functools.partial` pipelines feeding into an N-ary `compose` and a point-free rewrite (co-09 through
+co-11, co-19), the full `map`/`filter`/`reduce` trio plus a lazy generator pipeline pulled by `next`
+(co-13, co-15), `itertools.accumulate`/`pairwise`/`tee` (co-16), a hand-rolled memoization dict and a
+parameterized `@retry(3)` decorator with `functools.wraps` (co-17, co-18), converting recursion past
+CPython's missing tail-call optimization into an explicit stack (co-14), a `Shape` sum-type ADT
+dispatched with `match`/`case` and guards (co-20, co-21), and this topic's first hand-rolled `Option`
+and `Result` types with `map`, `and_then`, a railway-oriented validation pipeline, the functor identity
+law, one `fmap` over two containers, applicative `map2`, and monadic `bind` chaining (co-22 through
+co-27). Every example below is a complete, self-contained `example.py` colocated under
+`learning/code/ex-NN-slug/`, run with `python3 example.py` to capture the **Output** block shown, and
+verified a second way with a colocated `test_example.py` under `pytest -q`.
+
+---
+
+### Example 29: Extract a Pure Core from a Mutating Routine
+
+_ex-29 &middot; exercises co-01, co-28_
+
+A routine that mixes computation with I/O is hard to test because verifying its answer also means
+intercepting its side effects. This example splits `process_orders_impure` into a pure
+`sum_orders_pure` core plus a pure `make_log_lines` helper, and confirms both give the identical
+answer the original mutating routine produced.
+
+```python
+"""Example 29: Extract a Pure Core from a Mutating Routine."""
+
+report_log: list[str] = []  # => the ORIGINAL routine's hidden side effect target
+
+
+def process_orders_impure(orders: list[int]) -> int:  # => mixes computation AND I/O together
+    total = 0  # => the running sum, mutated below
+    for amount in orders:  # => a loop mutating both total and the module-level log
+        total += amount  # => mutates total AND appends below -- two side effects per iteration
+        report_log.append(f"processed {amount}")  # => side effect buried inside the loop
+    return total  # => the caller cannot test this without also inspecting report_log
+
+
+def sum_orders_pure(orders: list[int]) -> int:  # => the EXTRACTED core -- no I/O, no logging
+    return sum(orders)  # => a pure fold, trivially testable with no mocking
+
+
+def make_log_lines(orders: list[int]) -> list[str]:  # => the logging, extracted as its OWN pure function
+    return [f"processed {amount}" for amount in orders]  # => still pure: builds and returns, doesn't print
+
+
+orders = [10, 20, 30]  # => shared input for both the impure routine and the pure core
+
+impure_total = process_orders_impure(orders)  # => also mutates report_log as a side effect
+pure_total = sum_orders_pure(orders)  # => computes the SAME total with zero side effects
+
+# => this is the co-28 functional-core/imperative-shell split in miniature
+print(impure_total == pure_total)  # => Output: True -- same answer, radically different testability
+print(make_log_lines(orders) == report_log)  # => Output: True -- logging extracted without losing it
+```
+
+**Output**:
+
+```text
+True
+True
+```
+
+```python
+"""Example 29: pytest verification for Extract a Pure Core from a Mutating Routine."""
+
+from example import make_log_lines, sum_orders_pure
+
+
+def test_pure_core_needs_no_mocking() -> None:
+    orders = [1, 2, 3]
+    assert sum_orders_pure(orders) == 6  # => tested with plain arguments, no I/O to intercept
+
+
+def test_log_lines_extracted_as_pure_function() -> None:
+    orders = [5, 15]
+    assert make_log_lines(orders) == ["processed 5", "processed 15"]
+
+
+# => Run: pytest -- Output: 2 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+2 passed
+```
+
+**Key takeaway**: Extracting the pure computation from its side effects turns "test this by mocking a
+log" into "test this with plain arguments and a plain return value."
+
+**Why it matters**: Most production bugs hide at the seam between computation and I/O, because that
+seam is exactly where hidden state sneaks in. The functional-core/imperative-shell pattern (co-28)
+makes that seam explicit: push every side effect to the thin outer shell, keep the core a pure function
+of its arguments. This example is the smallest possible version of the pattern this topic's capstone
+(Example 80) applies at the scale of an entire log analyzer -- a functional core wrapped by a shell
+that reads files and prints results.
+
+---
+
+### Example 30: O(1) Sharing on a Persistent Linked List
+
+_ex-30 &middot; exercises co-05_
+
+Example 7 already showed a persistent cons-list shares structure instead of copying it; this example
+makes the O(1) cost of that sharing concrete by caching each node's own length so prepending never
+walks the list to compute it. `plist_prepend` reads `lst.length` -- a single field access -- rather
+than traversing to count nodes.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05
+flowchart LR
+    B["version_b<br/>head=2, length=2"]:::orange -->|tail| A["version_a<br/>head=1, length=1"]:::blue
+    A -->|tail| N["None<br/>empty list"]:::blue
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 30: O(1) Sharing on a Persistent Linked List."""
+
+from __future__ import annotations  # => enables the quoted 'PList | None' forward reference below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds the immutable PList node
+
+
+@dataclass(frozen=True)  # => a persistent list node caching its own length -- O(1) to read
+class PList:  # => the node type itself -- see the decorator above for immutability
+    head: int  # => this node's own value
+    tail: "PList | None"  # => the shared, untouched rest of the list
+    length: int  # => cached at construction time -- never recomputed by walking
+
+
+def plist_prepend(value: int, lst: "PList | None") -> PList:  # => O(1): no walk over lst needed
+    previous_length = lst.length if lst is not None else 0  # => O(1) read of a cached field
+    return PList(head=value, tail=lst, length=previous_length + 1)  # => reuses lst AS-IS
+
+
+empty: PList | None = None  # => the shared empty base every version points back to
+version_a = plist_prepend(1, empty)  # => version_a.length is 1
+version_b = plist_prepend(2, version_a)  # => version_b.length is 2, REUSING version_a untouched
+
+# => structural sharing means version_b costs O(1) extra memory, not O(n)
+print(version_a.length)  # => Output: 1
+print(version_b.length)  # => Output: 2
+print(version_b.tail is version_a)  # => Output: True -- structural sharing, not a copy
+print(version_a.head)  # => Output: 1 -- version_a itself was never touched by building version_b
+```
+
+**Output**:
+
+```text
+1
+2
+True
+1
+```
+
+```python
+"""Example 30: pytest verification for O(1) Sharing on a Persistent Linked List."""
+
+from example import PList, plist_prepend
+
+
+def test_prepend_is_o1_and_shares_the_tail() -> None:
+    version_a: PList | None = plist_prepend(1, None)
+    version_b = plist_prepend(2, version_a)  # => O(1): only reads version_a.length, never walks it
+
+    assert version_b.length == 2
+    assert version_a.length == 1  # => unaffected by building version_b
+    assert version_b.tail is version_a  # => structural sharing, not a copy
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Persistent data structures are efficient specifically because operations like
+prepend touch a constant number of nodes, not the whole structure -- caching derived data like length
+is one common way to keep it that way.
+
+**Why it matters**: Without cached length, discovering "how long is this list" after each prepend
+would require an O(n) walk, silently turning what looks like an O(1) operation into something
+quadratic across a chain of updates. Real persistent structures (Clojure's vectors, the structural
+sharing behind many immutable collection libraries) apply the same trick more broadly: reuse untouched
+substructure, cache anything a caller is likely to ask for immediately.
+
+---
+
+### Example 31: A Read-Only View via MappingProxyType
+
+_ex-31 &middot; exercises co-04_
+
+`types.MappingProxyType` wraps an existing dict in a view that raises `TypeError` on any write while
+reads pass straight through -- a cheap way to hand out "read-only" configuration without copying it.
+This example confirms the view blocks a write attempt and also confirms it is a LIVE view, not a
+snapshot: mutating the underlying dict is still visible through it.
+
+```python
+"""Example 31: A Read-Only View via MappingProxyType."""
+
+from types import MappingProxyType  # => a read-only VIEW over an existing dict, not a copy
+
+config = {"retries": 3, "timeout": 5}  # => the underlying mutable dict this example protects
+readonly_config = MappingProxyType(config)  # => wraps config -- reads pass through, writes are blocked
+# => this is the co-04 "immutability at the boundary" pattern -- share config without risking mutation
+
+print(readonly_config["retries"])  # => Output: 3 -- reads work exactly like a normal dict
+
+try:  # => opens a block that expects the write below to raise
+    readonly_config["retries"] = 99  # type: ignore[index]  # => attempts a write through the view
+    raised = False  # => unreachable if TypeError fires
+except TypeError:  # => MappingProxyType has no __setitem__
+    raised = True  # => confirms the view actually blocked the write
+
+print(raised)  # => Output: True
+config["retries"] = 10  # => the UNDERLYING dict itself is still mutable directly
+print(readonly_config["retries"])  # => Output: 10 -- the view reflects the underlying dict LIVE
+```
+
+**Output**:
+
+```text
+3
+True
+10
+```
+
+```python
+"""Example 31: pytest verification for A Read-Only View via MappingProxyType."""
+
+from types import MappingProxyType
+
+
+def test_view_blocks_writes_but_reflects_the_underlying_dict() -> None:
+    config = {"retries": 3}
+    readonly_config = MappingProxyType(config)
+    try:
+        readonly_config["retries"] = 99  # type: ignore[index]
+        raised = False
+    except TypeError:
+        raised = True
+    assert raised is True
+
+    config["retries"] = 10  # => mutate the underlying dict directly
+    assert readonly_config["retries"] == 10  # => the view is LIVE, not a snapshot
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: MappingProxyType is not immutability in the frozen-dataclass sense -- it is a
+read-only boundary around data that is still mutable from the "owning" side.
+
+**Why it matters**: Handing a plain dict to a function you don't control means trusting it not to
+mutate your config; handing a MappingProxyType means a runtime `TypeError` enforces that trust instead
+of a code review comment. It is the cheapest tool in this topic's immutability toolbox -- no copy, no
+dataclass, just a wrapper -- and it is the right choice whenever the underlying dict keeps changing but
+callers should only ever read it.
+
+---
+
+### Example 32: Stateful Closure Counter vs. Pure Fold
+
+_ex-32 &middot; exercises co-08, co-01_
+
+A closure over a `nonlocal` variable is one of the most common ways Python code carries mutable state
+between calls. This example builds a `make_counter` closure that increments a hidden `count` alongside
+a `count_pure` function that reaches the identical final number via `functools.reduce` with zero
+mutable state anywhere.
+
+```python
+"""Example 32: Stateful Closure Counter vs. Pure Fold."""
+
+from functools import reduce  # => reduce is used by the pure fold below
+from typing import Callable  # => Callable types the closure returned by make_counter
+
+
+def make_counter() -> Callable[[], int]:  # => returns a closure holding MUTABLE state
+    count = 0  # => lives INSIDE the closure -- state lives here, nowhere else
+
+    def increment() -> int:  # => the returned closure itself
+        nonlocal count  # => declares intent to mutate the ENCLOSING count, not a local copy
+        count += 1  # => side effect: mutates state captured by the closure
+        return count  # => returns the count AFTER incrementing
+
+    return increment  # => make_counter itself returns the closure, not a value
+
+
+def count_pure(n: int) -> int:  # => a pure fold: no closure, no mutation, no hidden state
+    return reduce(lambda acc, _: acc + 1, range(n), 0)  # => the SAME total, computed with zero state
+
+
+counter = make_counter()  # => a fresh closure with its own private count
+stateful_result = [counter(), counter(), counter()]  # => each call MUTATES the shared closure state
+pure_result = count_pure(3)  # => a single expression, no calls needed, no state anywhere
+
+# => co-08 closures vs co-01 purity: same answer, two different state models
+print(stateful_result)  # => Output: [1, 2, 3]
+print(pure_result)  # => Output: 3
+print(stateful_result[-1] == pure_result)  # => Output: True -- same final count, different state model
+```
+
+**Output**:
+
+```text
+[1, 2, 3]
+3
+True
+```
+
+```python
+"""Example 32: pytest verification for Stateful Closure Counter vs. Pure Fold."""
+
+from example import count_pure, make_counter
+
+
+def test_closure_state_and_pure_fold_agree_on_the_final_count() -> None:
+    counter = make_counter()
+    for _ in range(3):
+        counter()
+    assert counter() == 4  # => state lives IN the closure, mutated across calls
+    assert count_pure(4) == 4  # => the SAME count, computed with zero mutable state
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: A closure and a pure fold can compute the same answer, but only the fold's history is
+fully visible from its arguments -- the closure's answer depends on how many times it happens to have
+already been called.
+
+**Why it matters**: Closures over mutable state are genuinely useful, but every closure that carries
+state is a small piece of code whose behavior depends on call order -- the same class of bug purity
+eliminates. Recognizing "this is a stateful closure" the instant you see `nonlocal` is what lets you
+reach for the pure alternative when call-order independence actually matters, and keep the closure when
+it doesn't.
+
+---
+
+### Example 33: A Pipeline of partial Calls
+
+_ex-33 &middot; exercises co-10, co-09_
+
+`functools.partial` fixes some of a function's arguments ahead of time, returning a new function that
+only needs the rest -- Python's practical stand-in for true currying. This example builds `double` and
+`add_ten` from two-argument functions and chains them into a pipeline that matches hand-written
+arithmetic exactly.
+
+```python
+"""Example 33: A Pipeline of partial Calls."""
+
+from functools import partial  # => partial is the currying mechanism used below
+
+
+def scale(factor: int, x: int) -> int:  # => a 2-argument function -- factor fixed, x supplied later
+    return factor * x  # => the actual multiplication scale performs
+
+
+def offset(amount: int, x: int) -> int:  # => a second 2-argument function, same shape
+    return amount + x  # => the actual addition offset performs
+
+
+double = partial(scale, 2)  # => fixes factor=2 -- a reusable "double" function
+add_ten = partial(offset, 10)  # => fixes amount=10 -- a reusable "add ten" function
+
+pipeline_result = add_ten(double(5))  # => double(5) is 10, then add_ten(10) is 20
+manual_result = 10 + (2 * 5)  # => the equivalent hand-written arithmetic, for comparison
+
+# => partial is Python's practical stand-in for true currying (co-10)
+print(pipeline_result)  # => Output: 20
+print(pipeline_result == manual_result)  # => Output: True -- partials compose like ordinary functions
+print(double(100))  # => Output: 200 -- double is REUSABLE across any input, not just 5
+```
+
+**Output**:
+
+```text
+20
+True
+200
+```
+
+```python
+"""Example 33: pytest verification for A Pipeline of partial Calls."""
+
+from functools import partial
+
+from example import offset, scale
+
+
+def test_chained_partials_compose_like_ordinary_functions() -> None:
+    double = partial(scale, 2)
+    add_ten = partial(offset, 10)
+    assert add_ten(double(5)) == 20
+    assert double(100) == 200  # => double is reusable across any input
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `partial(fn, arg)` is not calling `fn` -- it is building a new, reusable function
+with `arg` permanently supplied, ready to be called (or passed around, or composed) later.
+
+**Why it matters**: Currying in the strict sense -- every function takes exactly one argument and
+returns another function -- isn't idiomatic Python, but the practical benefit (fixing some arguments
+now, supplying the rest later) is available via `partial` without changing how any function is defined.
+This is the mechanism Example 34's `compose` and Example 35's point-free rewrite both build directly on
+top of.
+
+---
+
+### Example 34: `compose(*fns)` Folds a List of Functions
+
+_ex-34 &middot; exercises co-11_
+
+A two-argument `compose` only chains two functions; this example generalizes it to `compose(*fns)`,
+folding an arbitrary-length tuple of functions into one pipeline function with `functools.reduce`,
+applying the rightmost function first to match ordinary mathematical composition notation.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart LR
+    X["x = 3"]:::blue --> A["add_one#40;x#41;<br/>= 4"]:::orange
+    A --> D["double#40;4#41;<br/>= 8"]:::teal
+    D --> S["square#40;8#41;<br/>= 64"]:::blue
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 34: compose(*fns) Folds a List of Functions."""
+
+from functools import reduce  # => reduce folds the chain of functions inside compose
+from typing import Callable  # => Callable types every function compose accepts
+
+
+def compose(*fns: Callable[[int], int]) -> Callable[[int], int]:  # => any NUMBER of functions
+    def composed(x: int) -> int:  # => the returned pipeline function
+        return reduce(lambda acc, fn: fn(acc), reversed(fns), x)  # => rightmost fn runs FIRST
+        # => reversed(fns) makes compose(f, g, h)(x) mean f(g(h(x))), matching math notation
+
+    return composed  # => compose itself returns the pipeline function, not a value
+
+
+def add_one(x: int) -> int:  # => the innermost step in the pipeline below
+    return x + 1  # => the actual +1 add_one performs
+
+
+def double(x: int) -> int:  # => the middle step in the pipeline below
+    return x * 2  # => the actual *2 double performs
+
+
+def square(x: int) -> int:  # => the outermost step in the pipeline below
+    return x * x  # => the actual squaring square performs
+
+
+pipeline = compose(square, double, add_one)  # => reads right-to-left: square(double(add_one(x)))
+result = pipeline(3)  # => add_one(3)=4, double(4)=8, square(8)=64
+
+print(result)  # => Output: 64
+print(result == square(double(add_one(3))))  # => Output: True -- compose(*fns) matches nested calls
+```
+
+**Output**:
+
+```text
+64
+True
+```
+
+```python
+"""Example 34: pytest verification for compose(*fns) Folds a List of Functions."""
+
+from example import add_one, compose, double, square
+
+
+def test_compose_star_matches_nested_application_order() -> None:
+    pipeline = compose(square, double, add_one)
+    assert pipeline(3) == square(double(add_one(3))) == 64
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `compose(*fns)(x)` reads right-to-left -- the LAST function in the argument list runs
+FIRST -- which matches how `f(g(h(x)))` is read in mathematics, not how a left-to-right pipeline reads.
+
+**Why it matters**: A three-step hand-written pipeline and a five-step one look identical in complexity
+when read left-to-right, but nesting gets genuinely hard to read past three or four steps.
+`compose(*fns)` keeps that nesting's exact evaluation order while making the pipeline's SHAPE -- a flat
+list of steps -- visible at a glance, which is why Example 35 reuses it to demonstrate point-free
+style.
+
+---
+
+### Example 35: Rewriting a Lambda Pipeline Point-Free
+
+_ex-35 &middot; exercises co-19_
+
+Point-free (or "tacit") style defines a function without ever naming the argument it operates on. This
+example rewrites `lambda x: multiply(2, add(3, x))` as
+`compose(partial(multiply, 2), partial(add, 3))`, confirming both forms compute the identical answer
+for the same input.
+
+```python
+"""Example 35: Rewriting a Lambda Pipeline Point-Free."""
+
+from functools import partial, reduce  # => partial curries add/multiply; reduce powers compose
+from typing import Callable  # => Callable types the pipeline function returned by compose
+
+
+def compose(*fns: Callable[[int], int]) -> Callable[[int], int]:  # => folds fns right-to-left
+    def composed(x: int) -> int:  # => the returned pipeline function
+        return reduce(lambda acc, fn: fn(acc), reversed(fns), x)  # => rightmost fn runs FIRST, matching math notation
+
+    return composed  # => compose itself returns the pipeline function
+
+
+def add(n: int, x: int) -> int:  # => a 2-argument helper, curried via partial below
+    return n + x  # => the actual addition add performs
+
+
+def multiply(n: int, x: int) -> int:  # => a second 2-argument helper, same shape
+    return n * x  # => the actual multiplication multiply performs
+
+
+with_named_arg: Callable[[int], int] = lambda x: multiply(2, add(3, x))  # => POINTED: names x explicitly
+point_free = compose(partial(multiply, 2), partial(add, 3))  # => POINT-FREE: x never named
+
+# => point-free style trades explicit naming for compact composition (co-19)
+print(with_named_arg(5))  # => Output: 16  ((5 + 3) * 2)
+print(point_free(5))  # => Output: 16 -- identical result, x never appears in point_free's own definition
+print(with_named_arg(5) == point_free(5))  # => Output: True -- two styles, one computation
+```
+
+**Output**:
+
+```text
+16
+16
+True
+```
+
+```python
+"""Example 35: pytest verification for Rewriting a Lambda Pipeline Point-Free."""
+
+from functools import partial
+from typing import Callable
+
+from example import add, compose, multiply
+
+
+def test_point_free_matches_the_named_argument_version() -> None:
+    with_named_arg: Callable[[int], int] = lambda x: multiply(2, add(3, x))
+    point_free = compose(partial(multiply, 2), partial(add, 3))
+    assert point_free(5) == with_named_arg(5) == 16
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Point-free style isn't about being clever -- it's `compose` and `partial` working
+together so the pipeline's SHAPE is visible without an explicit argument name threading through every
+step.
+
+**Why it matters**: Point-free code can become a genuine readability trap once composed deeply, but
+used sparingly -- two or three steps, like this example -- it removes a layer of naming noise a reader
+has to track. Knowing how to write it, and when NOT to reach for it, are both part of using functional
+style deliberately rather than performatively.
+
+---
+
+### Example 36: Building a Histogram with reduce
+
+_ex-36 &middot; exercises co-13_
+
+`functools.reduce` is the general-purpose fold every other aggregation function specializes. This
+example builds a word-frequency histogram by folding a list of words into one dict, one word at a
+time, with `add_to_histogram` as the combining step.
+
+```python
+"""Example 36: Building a Histogram with reduce."""
+
+from functools import reduce  # => reduce folds words into the histogram below
+
+
+def add_to_histogram(  # => the "how to fold one more element in" step
+    histogram: dict[str, int], word: str  # => the accumulator and the next element, reduce's own calling convention
+) -> dict[str, int]:  # => closes the multi-line signature above
+    histogram[word] = histogram.get(word, 0) + 1  # => increments, defaulting missing keys to 0
+    return histogram  # => reduce expects the combiner to return the NEW accumulator
+
+
+words = ["a", "b", "a", "c", "b", "a"]  # => the source sequence being counted
+
+histogram = reduce(add_to_histogram, words, {})  # => folds words into ONE dict, seeded empty
+
+# => reduce is the general-purpose fold every other aggregation specializes
+print(histogram)  # => Output: {'a': 3, 'b': 2, 'c': 1}
+print(histogram["a"])  # => Output: 3 -- 'a' appeared three times
+print(sum(histogram.values()) == len(words))  # => Output: True -- every word counted exactly once
+```
+
+**Output**:
+
+```text
+{'a': 3, 'b': 2, 'c': 1}
+3
+True
+```
+
+```python
+"""Example 36: pytest verification for Building a Histogram with reduce."""
+
+from functools import reduce
+
+from example import add_to_histogram
+
+
+def test_reduce_builds_a_correct_histogram() -> None:
+    words = ["x", "y", "x"]
+    histogram = reduce(add_to_histogram, words, {})
+    assert histogram == {"x": 2, "y": 1}
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: reduce's combining function always has the same shape --
+`(accumulator, next_element) -> new_accumulator` -- whether the accumulator ends up being a number, a
+list, or, as here, a dict.
+
+**Why it matters**: `sum()`, `any()`, `all()`, and even list comprehensions can all be expressed as a
+`reduce` with a specific combining function; seeing `reduce` build something as structurally different
+as a histogram makes clear it isn't "the numeric-total function," it's the fold every other aggregation
+is a special case of. That generality is also `reduce`'s biggest readability cost -- a specialized name
+(like the histogram-specific helper this example writes) usually communicates intent better than a bare
+`reduce` call.
+
+---
+
+### Example 37: Chaining map, filter, and reduce
+
+_ex-37 &middot; exercises co-13, co-11_
+
+This example chains all three of Python's core higher-order sequence functions in one pipeline -- `map`
+doubles every order, `filter` keeps only the large ones, `reduce` folds the survivors into a single
+total -- and confirms the three-stage pipeline matches an equivalent single comprehension.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart LR
+    O["orders<br/>6 values"]:::blue --> M["map#40;doubled#41;<br/>6 values"]:::orange
+    M --> Fi["filter#40;#62;20#41;<br/>3 values"]:::teal
+    Fi --> R["reduce#40;sum#41;<br/>110"]:::blue
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 37: Chaining map, filter, and reduce."""
+
+from functools import reduce  # => reduce folds the filtered stream into one total
+
+orders = [12, 7, 25, 3, 18, 9]  # => raw order amounts, some too small to matter
+
+doubled = map(lambda amount: amount * 2, orders)  # => LAZY: doubles every order (e.g. a 2x promo)
+significant = filter(lambda amount: amount > 20, doubled)  # => LAZY: keeps only large-enough orders
+total = reduce(lambda acc, amount: acc + amount, significant, 0)  # => folds survivors into one sum
+# => each stage is lazy until reduce finally pulls every value through the whole pipeline
+
+manual_total = sum(a * 2 for a in orders if a * 2 > 20)  # => the equivalent single comprehension
+
+print(total)  # => Output: 110
+print(total == manual_total)  # => Output: True -- three separate stages, one verified answer
+```
+
+**Output**:
+
+```text
+110
+True
+```
+
+```python
+"""Example 37: pytest verification for Chaining map, filter, and reduce."""
+
+from functools import reduce
+
+
+def test_pipeline_matches_the_equivalent_comprehension() -> None:
+    orders = [12, 7, 25, 3, 18, 9]
+    doubled = map(lambda amount: amount * 2, orders)
+    significant = filter(lambda amount: amount > 20, doubled)
+    total = reduce(lambda acc, amount: acc + amount, significant, 0)
+    assert total == sum(a * 2 for a in orders if a * 2 > 20) == 110
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `map`/`filter`/`reduce` compose exactly like any other functions -- each stage's
+output is simply the next stage's input, with no special glue code required between them.
+
+**Why it matters**: This three-stage shape -- transform, then select, then aggregate -- appears
+constantly in real data-processing code, whether it's built from `map`/`filter`/`reduce`, a
+comprehension, or a database query. Recognizing the SAME three-stage shape underneath very different
+syntax is what makes it possible to translate between them, and to reach for whichever one is clearest
+in a given codebase's idioms.
+
+---
+
+### Example 38: A Lazy map/filter Pipeline Pulled by next
+
+_ex-38 &middot; exercises co-15, co-13_
+
+`map` and `filter` in Python 3 are lazy -- wrapping a generator in `map`/`filter` builds a pipeline
+that computes nothing until something pulls a value out of it. This example instruments a generator to
+log every value it produces and confirms only a handful of the 999 possible source values were ever
+touched to satisfy three `next()` calls.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart LR
+    Src["logged_source#40;#41;<br/>range 1..999"]:::blue -->|pulled one at a time| Map["map#40;n * 2#41;"]:::orange
+    Map -->|pulled one at a time| Filt["filter#40;n % 4 == 0#41;"]:::teal
+    Filt -->|next#40;#41; x3| Out["4, 8, 12"]:::blue
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 38: A Lazy map/filter Pipeline Pulled by next."""
+
+from typing import Iterator  # => Iterator types the lazy generator below
+
+pulled_from_source: list[int] = []  # => tracks exactly which SOURCE values were ever touched
+
+
+def logged_source() -> Iterator[int]:  # => a generator that records every value it produces
+    for n in range(1, 1000):  # => a LARGE range -- but nothing runs until pulled
+        pulled_from_source.append(n)  # => only executes when this generator is actually advanced
+        yield n  # => suspends here until the consumer pulls the NEXT value
+
+
+doubled = map(lambda n: n * 2, logged_source())  # => LAZY: wraps the source, still nothing runs
+evens_only = filter(lambda n: n % 4 == 0, doubled)  # => LAZY: a second lazy stage on top of the first
+
+first_three = [next(evens_only), next(evens_only), next(evens_only)]  # => pulls JUST enough
+
+# => laziness (co-15) means the pipeline computes ONLY what the caller demands
+print(first_three)  # => Output: [4, 8, 12]
+print(len(pulled_from_source) < 10)  # => Output: True -- far fewer than 999 source values were touched
+```
+
+**Output**:
+
+```text
+[4, 8, 12]
+True
+```
+
+```python
+"""Example 38: pytest verification for A Lazy map/filter Pipeline Pulled by next."""
+
+from typing import Iterator
+
+
+def test_pipeline_pulls_only_as_many_source_values_as_needed() -> None:
+    pulled: list[int] = []
+
+    def source() -> Iterator[int]:
+        for n in range(1, 1000):
+            pulled.append(n)
+            yield n
+
+    doubled = map(lambda n: n * 2, source())
+    evens_only = filter(lambda n: n % 4 == 0, doubled)
+    result = [next(evens_only), next(evens_only)]
+    assert result == [4, 8]
+    assert len(pulled) < 10  # => the pipeline never touched most of the 999-element range
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: A lazy pipeline's cost is proportional to how much a caller actually consumes, not to
+how large the source range COULD be -- the 999-element range in this example never gets close to fully
+evaluated.
+
+**Why it matters**: Building a map/filter pipeline over an unbounded (or merely very large) source is
+only safe because of laziness -- an eager equivalent would try to materialize the entire
+doubled-and-filtered list before returning anything. This is the same property Example 68's infinite
+prime sieve in the Advanced tier depends on: a pipeline over a genuinely infinite source only works
+because nothing runs until pulled.
+
+---
+
+### Example 39: Running Totals via accumulate
+
+_ex-39 &middot; exercises co-16_
+
+`itertools.accumulate` generalizes reduce to keep every intermediate result instead of just the final
+one -- a running total (the default `+`) or, with a custom binary operator like `max`, a running
+maximum. This example builds both a running balance and a running maximum from the same list of
+deposits.
+
+```python
+"""Example 39: Running Totals via accumulate."""
+
+from itertools import accumulate  # => a lazy iterator of running totals (or any binary op)
+
+deposits = [100, 50, -30, 200]  # => a sequence of account movements
+
+running_balance = list(accumulate(deposits))  # => default op is +: each step is the sum SO FAR
+running_max = list(accumulate(deposits, max))  # => a custom op: running maximum instead of sum
+# => accumulate is itertools' generalized fold-that-keeps-every-intermediate-result
+
+print(running_balance)  # => Output: [100, 150, 120, 320]
+print(running_max)  # => Output: [100, 100, 100, 200]
+print(running_balance[-1] == sum(deposits))  # => Output: True -- the LAST running total is the full sum
+```
+
+**Output**:
+
+```text
+[100, 150, 120, 320]
+[100, 100, 100, 200]
+True
+```
+
+```python
+"""Example 39: pytest verification for Running Totals via accumulate."""
+
+from itertools import accumulate
+
+
+def test_accumulate_produces_prefix_sums() -> None:
+    deposits = [10, 20, 30]
+    assert list(accumulate(deposits)) == [10, 30, 60]
+    assert list(accumulate(deposits, max)) == [10, 20, 30]
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `accumulate(xs)` and `reduce(op, xs)` compute the same FINAL value; `accumulate`
+additionally hands back every step along the way, which `reduce` discards.
+
+**Why it matters**: "What was the running total after each transaction" is a genuinely different
+question from "what is the final total," and `accumulate` answers the first one without a manual loop
+that manages its own accumulator variable. This is `itertools`' general pattern -- take a fold-shaped
+operation, keep it lazy, and expose the intermediate structure a plain `reduce` throws away.
+
+---
+
+### Example 40: Adjacent Pairs via pairwise and tee
+
+_ex-40 &middot; exercises co-16_
+
+`itertools.pairwise` yields every pair of consecutive elements -- useful for computing deltas between
+adjacent readings -- while `itertools.tee` splits one iterator into several independent ones that can
+each be advanced separately. This example computes deltas with `pairwise` and confirms `tee`'s two
+streams start from the identical first value without interfering with each other.
+
+```python
+"""Example 40: Adjacent Pairs via pairwise and tee."""
+
+from itertools import pairwise, tee  # => pairwise: consecutive pairs; tee: split one iterator in two
+
+readings = [10, 12, 9, 15, 15]  # => a sequence of sensor readings
+
+deltas = [b - a for a, b in pairwise(readings)]  # => consecutive differences, one per adjacent pair
+# => pairwise([10, 12, 9, 15, 15]) yields (10,12), (12,9), (9,15), (15,15) -- 4 pairs from 5 readings
+
+original_stream, backup_stream = tee(iter(readings))  # => splits ONE iterator into two INDEPENDENT ones
+first_from_original = next(original_stream)  # => advances original_stream only
+first_from_backup = next(backup_stream)  # => backup_stream is UNAFFECTED by the pull above
+
+print(deltas)  # => Output: [2, -3, 6, 0]
+print(first_from_original == first_from_backup)  # => Output: True -- both streams start from readings[0]
+```
+
+**Output**:
+
+```text
+[2, -3, 6, 0]
+True
+```
+
+```python
+"""Example 40: pytest verification for Adjacent Pairs via pairwise and tee."""
+
+from itertools import pairwise, tee
+
+
+def test_pairwise_and_tee() -> None:
+    readings = [1, 2, 4]
+    assert list(pairwise(readings)) == [(1, 2), (2, 4)]
+
+    stream_a, stream_b = tee(iter(readings))
+    assert next(stream_a) == next(stream_b) == 1  # => independent streams, same starting point
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `pairwise` turns "process element i and element i+1 together" into a single iteration
+with no manual index bookkeeping; `tee` turns "I need to iterate this sequence twice" into two
+independent iterators instead of a list you'd have to materialize first.
+
+**Why it matters**: Both functions solve a specific, common annoyance with plain iterators --
+`pairwise` avoids off-by-one index errors in adjacent-element comparisons, and `tee` avoids either
+materializing a whole iterator into a list (defeating its laziness) or re-running whatever produced it.
+Knowing they exist in the stdlib means reaching for them instead of hand-rolling equivalent,
+easier-to-get-wrong loop logic.
+
+---
+
+### Example 41: A Hand-Rolled Memoization Dict
+
+_ex-41 &middot; exercises co-17_
+
+Memoization caches a function's previous results keyed by its arguments, safe to do only because the
+wrapped function is pure -- the same arguments always produce the same answer. This example hand-rolls
+the cache dict itself (rather than reaching for `functools.lru_cache`) to make the mechanism visible: a
+cache miss computes and stores, a cache hit returns the stored value without recomputing.
+
+```python
+"""Example 41: A Hand-Rolled Memoization Dict."""
+
+from typing import Callable  # => Callable types the function memoize wraps
+
+call_count = 0  # => tracks how many times the EXPENSIVE function body actually ran
+
+
+def expensive(n: int) -> int:  # => stands in for a slow, pure computation
+    global call_count  # => declares intent to mutate the MODULE-level counter
+    call_count += 1  # => only increments when the body actually executes
+    return n * n  # => the actual (slow, pure) computation being cached
+
+
+def memoize(fn: Callable[[int], int]) -> Callable[[int], int]:  # => a hand-rolled cache, no lru_cache
+    cache: dict[int, int] = {}  # => the memo table, one entry per unique argument
+
+    def wrapper(n: int) -> int:  # => the returned, cache-checking function
+        if n not in cache:  # => cache MISS: compute once and store
+            cache[n] = fn(n)  # => computes ONCE and stores under key n
+        return cache[n]  # => cache HIT or freshly-stored value, either way no recomputation
+
+    return wrapper  # => memoize itself returns the wrapping function
+
+
+memoized_expensive = memoize(expensive)  # => wraps expensive with the hand-rolled cache
+
+first = memoized_expensive(5)  # => cache miss -- call_count becomes 1
+second = memoized_expensive(5)  # => cache HIT -- call_count stays 1
+third = memoized_expensive(6)  # => a NEW argument -- cache miss, call_count becomes 2
+
+# => memoization trades memory for time, valid ONLY because expensive is pure
+print(first, second, third)  # => Output: 25 25 36
+print(call_count)  # => Output: 2 -- expensive body ran exactly twice, for the two unique arguments
+```
+
+**Output**:
+
+```text
+25 25 36
+2
+```
+
+```python
+"""Example 41: pytest verification for A Hand-Rolled Memoization Dict."""
+
+from example import memoize
+
+
+def test_second_call_is_served_from_cache() -> None:
+    calls: list[int] = []
+
+    def track(n: int) -> int:
+        calls.append(n)
+        return n * n
+
+    memoized = memoize(track)
+    assert memoized(4) == 16
+    assert memoized(4) == 16
+    assert calls == [4]  # => the second call never re-ran the underlying function
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Memoization is purity's most direct practical payoff -- it is UNSAFE to cache the
+result of an impure function, because a cached answer would silently ignore whatever hidden state has
+changed since the cache was filled.
+
+**Why it matters**: `functools.lru_cache` (used earlier in this topic's recursion examples) is the
+production-ready version of exactly this pattern -- a dict keyed by arguments, checked before falling
+through to the real computation. Building the manual version once makes clear WHY the decorator is safe
+to apply: only to functions whose purity guarantees a cached answer never goes stale.
+
+---
+
+### Example 42: A Parameterized @retry(3) Decorator
+
+_ex-42 &middot; exercises co-18_
+
+A decorator factory is a function that itself returns a decorator -- `retry(3)` returns the actual
+decorator, which then wraps `flaky`. This example's `flaky` function fails on its first two calls and
+succeeds on the third, and the retry loop logs every attempt before returning the eventual success.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart TD
+    A["attempt 1"]:::orange -->|ValueError| B["attempt 2"]:::orange
+    B -->|ValueError| C["attempt 3"]:::teal
+    C -->|success| D["return 'ok'"]:::blue
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 42: A Parameterized @retry(3) Decorator."""
+
+from typing import Callable  # => Callable types every layer of this decorator factory
+
+attempt_log: list[int] = []  # => records which attempt number ran, for verification below
+
+
+def retry(times: int) -> Callable[[Callable[[], str]], Callable[[], str]]:  # => a decorator FACTORY
+    def decorator(fn: Callable[[], str]) -> Callable[[], str]:  # => the ACTUAL decorator, closes over times
+        def wrapper() -> str:  # => the actual retry loop lives here
+            last_error: Exception | None = None  # => remembers the most recent failure, if any
+            for attempt in range(1, times + 1):  # => tries up to `times` times, closed over from retry()
+                attempt_log.append(attempt)  # => logs every attempt, successful or not
+                try:  # => attempts ONE call to the wrapped function
+                    return fn()  # => success: return immediately, no further attempts
+                except ValueError as exc:  # => a failed attempt -- remember it and try again
+                    last_error = exc  # => remembers the failure so it can be re-raised later
+            raise last_error  # type: ignore[misc]  # => every attempt failed -- re-raise the last error
+
+        return wrapper  # => decorator itself returns the retry-wrapped function
+
+    return decorator  # => retry(times) itself returns the decorator
+
+
+calls_before_success = 0  # => simulates a flaky operation succeeding on its 3rd attempt
+
+
+@retry(3)  # => equivalent to: flaky = retry(3)(flaky) -- retry(3) runs FIRST, returns a decorator
+def flaky() -> str:  # => the function actually being retried
+    global calls_before_success  # => declares intent to mutate the MODULE-level counter
+    calls_before_success += 1  # => tracks how many times this call has been attempted
+    if calls_before_success < 3:  # => fails on attempts 1 and 2
+        raise ValueError("not yet")  # => simulates a transient failure on early attempts
+    return "ok"  # => succeeds on attempt 3
+
+
+result = flaky()  # => retries internally until success, or until times is exhausted
+
+# => a decorator factory is a function that RETURNS a decorator, one extra layer
+print(result)  # => Output: ok
+print(attempt_log)  # => Output: [1, 2, 3] -- three attempts were logged before success
+```
+
+**Output**:
+
+```text
+ok
+[1, 2, 3]
+```
+
+```python
+"""Example 42: pytest verification for A Parameterized @retry(3) Decorator."""
+
+from example import retry
+
+
+def test_retry_stops_as_soon_as_the_wrapped_call_succeeds() -> None:
+    attempts: list[int] = []
+
+    @retry(5)
+    def sometimes_fails() -> str:
+        attempts.append(len(attempts) + 1)
+        if len(attempts) < 2:
+            raise ValueError("not yet")
+        return "ok"
+
+    assert sometimes_fails() == "ok"
+    assert attempts == [1, 2]  # => stopped retrying the moment it succeeded
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `@retry(3)` involves TWO calls before the wrapped function ever runs: `retry(3)`
+returns a decorator, and THAT decorator is applied to `flaky` -- one extra layer of indirection
+compared to a plain `@decorator`.
+
+**Why it matters**: Retrying transient failures (a flaky network call, a database lock) is common
+enough to warrant a reusable decorator, and parameterizing it (how many times, what exception types) is
+what makes ONE decorator implementation useful across many call sites instead of hand-writing a retry
+loop at each one. The decorator-factory shape here -- a function returning a function returning a
+function -- is the same shape Example 75's decorator-stack composition example builds on in the
+Advanced tier.
+
+---
+
+### Example 43: `functools.wraps` Preserves `__name__`
+
+_ex-43 &middot; exercises co-18_
+
+A decorator that returns a plain inner `wrapper` function silently replaces the original function's
+`__name__`, `__doc__`, and other metadata with the wrapper's own -- `functools.wraps` fixes this by
+copying that metadata across. This example builds a naive decorator and a careful one side by side and
+confirms only the careful one preserves the decorated function's identity.
+
+```python
+"""Example 43: functools.wraps Preserves __name__."""
+
+from functools import wraps  # => wraps is the fix demonstrated in careful_decorator
+from typing import Callable  # => Callable types both decorators below
+
+
+def naive_decorator(fn: Callable[[], str]) -> Callable[[], str]:  # => WITHOUT functools.wraps
+    def wrapper() -> str:  # => the naive wrapper -- no metadata copied
+        return fn()  # => forwards the call, nothing else
+
+    return wrapper  # => wrapper has its OWN __name__, "wrapper" -- fn's identity is lost
+
+
+def careful_decorator(fn: Callable[[], str]) -> Callable[[], str]:  # => WITH functools.wraps
+    @wraps(fn)  # => copies __name__, __doc__, and more from fn onto wrapper
+    def wrapper() -> str:  # => the careful wrapper -- decorated with @wraps below
+        return fn()  # => forwards the call, identical behavior to the naive version
+
+    return wrapper  # => wrapper now REPORTS as if it were fn itself
+
+
+@naive_decorator  # => applies the WITHOUT-wraps decorator
+def greet_naive() -> str:  # => the function whose identity gets lost
+    """Say hello, naively decorated."""  # => this docstring is LOST from greet_naive.__doc__ after decoration
+    return "hello"  # => the actual greeting
+
+
+@careful_decorator  # => applies the WITH-wraps decorator
+def greet_careful() -> str:  # => the function whose identity survives decoration
+    """Say hello, carefully decorated."""  # => this docstring IS preserved on greet_careful.__doc__
+    return "hello"  # => the actual greeting
+
+
+# => functools.wraps matters for debugging, introspection, and framework compatibility
+print(greet_naive.__name__)  # => Output: wrapper -- identity LOST, unhelpful in tracebacks/introspection
+print(greet_careful.__name__)  # => Output: greet_careful -- identity PRESERVED by functools.wraps
+print(greet_careful.__doc__)  # => Output: Say hello, carefully decorated.
+```
+
+**Output**:
+
+```text
+wrapper
+greet_careful
+Say hello, carefully decorated.
+```
+
+```python
+"""Example 43: pytest verification for functools.wraps Preserves __name__."""
+
+from example import careful_decorator, naive_decorator
+
+
+def test_wraps_preserves_name_and_plain_decorator_does_not() -> None:
+    @naive_decorator
+    def naive() -> str:
+        return "x"
+
+    @careful_decorator
+    def careful() -> str:
+        return "x"
+
+    assert naive.__name__ == "wrapper"  # => identity lost without functools.wraps
+    assert careful.__name__ == "careful"  # => identity preserved with functools.wraps
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `@wraps(fn)` inside a decorator is not optional polish -- without it, every decorated
+function reports as `"wrapper"` in tracebacks, debuggers, and `help()`, actively hiding which function
+actually ran.
+
+**Why it matters**: Frameworks (web routers, CLI argument parsers, test runners) frequently introspect
+a function's `__name__` or `__doc__` to build behavior around it -- a decorator missing `@wraps` can
+silently break that introspection in ways that are hard to trace back to "the decorator ate my
+function's identity." This is a small habit with an outsized payoff: every decorator this topic writes
+from here forward includes it.
+
+---
+
+### Example 44: Converting Deep Recursion to an Explicit Stack
+
+_ex-44 &middot; exercises co-14_
+
+CPython has no tail-call optimization, so a recursive function's call depth is bounded by
+`sys.getrecursionlimit()`. This example deliberately calls a recursive sum past that limit to trigger a
+genuine `RecursionError`, then computes the identical total with an explicit list-based stack that
+never grows the call stack at all.
+
+```python
+"""Example 44: Converting Deep Recursion to an Explicit Stack."""
+
+import sys  # => sys.getrecursionlimit reveals the current recursion ceiling
+
+
+def sum_to_n_recursive(n: int) -> int:  # => the natural recursive definition -- one frame per call
+    if n == 0:  # => base case: nothing left to add
+        return 0  # => the base case's value
+    return n + sum_to_n_recursive(n - 1)  # => grows the call stack by exactly one frame per call
+
+
+def sum_to_n_iterative(n: int) -> int:  # => the SAME computation, an explicit stack instead of the call stack
+    stack: list[int] = list(range(1, n + 1))  # => an explicit, heap-allocated stack -- NOT the call stack
+    total = 0  # => the running total, mutated below
+    while stack:  # => pops until the explicit stack is empty -- no Python call frames grow
+        total += stack.pop()  # => pops one value at a time -- heap memory, not call-stack frames
+    return total  # => the final total after the explicit stack empties
+
+
+deep_n = sys.getrecursionlimit() + 500  # => deliberately EXCEEDS the recursion ceiling
+
+try:  # => opens a block that expects the recursive call below to raise
+    sum_to_n_recursive(deep_n)  # => this call is expected to blow the call stack
+    recursive_raised = False  # => unreachable if RecursionError fires as expected
+except RecursionError:  # => confirms the exact failure recursion has at this depth
+    recursive_raised = True  # => confirms the recursive version genuinely failed here
+
+iterative_result = sum_to_n_iterative(deep_n)  # => the SAME depth, but no call-stack growth at all
+
+# => CPython has NO tail-call optimization -- deep recursion genuinely can crash
+print(recursive_raised)  # => Output: True -- the recursive version genuinely fails at this depth
+print(iterative_result == deep_n * (deep_n + 1) // 2)  # => Output: True -- the iterative version succeeds
+```
+
+**Output**:
+
+```text
+True
+True
+```
+
+```python
+"""Example 44: pytest verification for Converting Deep Recursion to an Explicit Stack."""
+
+import sys
+
+from example import sum_to_n_iterative, sum_to_n_recursive
+
+
+def test_iterative_version_survives_a_depth_that_breaks_recursion() -> None:
+    deep_n = sys.getrecursionlimit() + 500
+    try:
+        sum_to_n_recursive(deep_n)
+        recursive_raised = False
+    except RecursionError:
+        recursive_raised = True
+    assert recursive_raised is True
+
+    assert sum_to_n_iterative(deep_n) == deep_n * (deep_n + 1) // 2
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: "Just make it recursive" is not a free readability win in Python the way it can be in
+a language with proper tail calls -- past a few hundred levels, recursion becomes a genuine crash risk,
+not just a style preference.
+
+**Why it matters**: Every recursive function this topic writes needs a mental note about how deep its
+input could realistically go, because CPython will not turn deep recursion into a loop automatically.
+Example 66's trampoline in the Advanced tier is the general-purpose fix for functions that GENUINELY
+want to look recursive without paying this cost -- this example is the concrete failure that motivates
+building one.
+
+---
+
+### Example 45: A Shape ADT as a Union of Frozen Dataclasses
+
+_ex-45 &middot; exercises co-20_
+
+An algebraic sum type restricts a value to being EXACTLY one of a fixed set of variants. This example
+defines `Shape = Circle | Square` from two frozen dataclasses, each carrying only the field its own
+variant needs, and computes area with an `isinstance` check that narrows the type inside each branch.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05
+flowchart TD
+    S["Shape: Circle or Square"]:::blue --> C["Circle#40;radius#41;"]:::orange
+    S --> Q["Square#40;side#41;"]:::orange
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 45: A Shape ADT as a Union of Frozen Dataclasses."""
+
+from __future__ import annotations  # => enables the quoted forward references used below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds each immutable variant
+
+
+@dataclass(frozen=True)  # => one VARIANT of the Shape ADT -- only the field a circle needs
+class Circle:  # => the Circle variant's body
+    radius: float  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => a SECOND variant -- only the field a square needs
+class Square:  # => the Square variant's body
+    side: float  # => the single field this variant carries
+
+
+Shape = Circle | Square  # => PEP 604 union syntax (3.10+): a Shape IS EITHER a Circle OR a Square
+
+
+def area(shape: Shape) -> float:  # => accepts EITHER variant -- illegal combinations don't type-check
+    if isinstance(shape, Circle):  # => narrows shape to Circle inside this branch
+        return 3.14159 * shape.radius**2  # => the actual circle-area formula
+    return shape.side**2  # => shape is narrowed to Square here (the only remaining case)
+
+
+circle_shape: Shape = Circle(radius=2.0)  # => constructs the Circle variant
+square_shape: Shape = Square(side=3.0)  # => constructs the Square variant
+
+# => a sum type restricts callers to EXACTLY the variants the ADT defines
+print(round(area(circle_shape), 2))  # => Output: 12.57
+print(area(square_shape))  # => Output: 9.0
+print(isinstance(circle_shape, Square))  # => Output: False -- a Circle can never ALSO be a Square
+```
+
+**Output**:
+
+```text
+12.57
+9.0
+False
+```
+
+```python
+"""Example 45: pytest verification for A Shape ADT as a Union of Frozen Dataclasses."""
+
+from example import Circle, Square, area
+
+
+def test_each_variant_computes_its_own_area() -> None:
+    assert round(area(Circle(radius=1.0)), 2) == 3.14
+    assert area(Square(side=4.0)) == 16.0
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `Circle | Square` isn't "any object with a radius or a side" -- it's exactly two
+possible shapes, and a type checker can verify a function handling `Shape` covers both.
+
+**Why it matters**: Without a sum type, "a shape is either a circle or a square" usually gets modeled
+with an inheritance hierarchy that invites accidentally-shared behavior, or a dict with an optional
+radius AND an optional side that allows nonsensical states like both being set, or neither. A sum type
+makes the illegal states genuinely unrepresentable: there is no way to construct a `Shape` that is not
+one of the two defined variants.
+
+---
+
+### Example 46: match/case Dispatches Over the Shape ADT
+
+_ex-46 &middot; exercises co-21, co-20_
+
+Python's `match`/`case` statement (3.10+) reads like the ADT's own shape rather than a chain of
+`isinstance` checks. This example destructures `Circle` and `Square` directly in each case pattern,
+binding their fields to local names, with a `case _` catch-all defending against a hypothetical third
+variant.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart TD
+    M["match shape"]:::blue --> C["case Circle#40;radius=r#41;"]:::orange
+    M --> Q["case Square#40;side=s#41;"]:::teal
+    M --> U["case _<br/>unreachable"]:::blue
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 46: match/case Dispatches Over the Shape ADT."""
+
+from __future__ import annotations  # => enables the quoted forward references used below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds each immutable variant
+
+
+@dataclass(frozen=True)  # => marks Circle immutable, matching the FP style
+class Circle:  # => the Circle variant's body
+    radius: float  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Square immutable, matching the FP style
+class Square:  # => the Square variant's body
+    side: float  # => the single field this variant carries
+
+
+Shape = Circle | Square  # => the ADT itself: a Shape is EITHER variant
+
+
+def describe(shape: Shape) -> str:  # => match/case, the structural-pattern-matching alternative to isinstance
+    match shape:  # => picks the FIRST case whose pattern matches shape's shape
+        case Circle(radius=r):  # => destructures a Circle, binding its radius to r
+            return f"circle with radius {r}"  # => the Circle branch's result
+        case Square(side=s):  # => destructures a Square, binding its side to s
+            return f"square with side {s}"  # => the Square branch's result
+        case _:  # => NOTE: match/case has NO compile-time exhaustiveness check -- a manual safety net
+            raise ValueError("unreachable for a Circle | Square")  # => defends against a THIRD variant appearing later
+
+
+# => match/case reads like the ADT's own shape, not a chain of isinstance checks
+print(describe(Circle(radius=2.0)))  # => Output: circle with radius 2.0
+print(describe(Square(side=5.0)))  # => Output: square with side 5.0
+```
+
+**Output**:
+
+```text
+circle with radius 2.0
+square with side 5.0
+```
+
+```python
+"""Example 46: pytest verification for match/case Dispatches Over the Shape ADT."""
+
+from example import Circle, Square, describe
+
+
+def test_each_branch_fires_for_its_own_variant() -> None:
+    assert describe(Circle(radius=1.0)) == "circle with radius 1.0"
+    assert describe(Square(side=2.0)) == "square with side 2.0"
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: match/case has NO compile-time exhaustiveness check in Python -- the `case _` branch
+here is a manual safety net, not something the language enforces the way a true sum-type-aware language
+would.
+
+**Why it matters**: Reading `case Circle(radius=r):` communicates "this branch handles a Circle, and r
+is its radius" in one line, versus an `isinstance` check followed by a separate `shape.radius` access.
+The lack of exhaustiveness checking is a genuine gap versus languages built around ADTs from the ground
+up -- the defensive `case _` branch is how Python code compensates for that gap by hand.
+
+---
+
+### Example 47: case Clauses With if Guards
+
+_ex-47 &middot; exercises co-21_
+
+A `case` pattern can carry an `if` guard -- a condition checked only after the pattern itself matches
+-- letting one case cover a whole family of related values. This example classifies an integer into
+four buckets (negative, zero, positive-even, positive-odd) using guards on an `int(value)` capture
+pattern.
+
+```python
+"""Example 47: case Clauses With if Guards."""
+
+
+def classify(n: int) -> str:  # => match/case WITH guards -- a pattern PLUS a condition
+    match n:  # => opens the match/case block over n
+        case int(value) if value < 0:  # => guard: only matches negative ints
+            return "negative"  # => the negative branch's result
+        case 0:  # => an exact-value pattern, no guard needed
+            return "zero"  # => the zero branch's result
+        case int(value) if value % 2 == 0:  # => guard: only matches even positive ints
+            return "positive even"  # => the positive-even branch's result
+        case _:  # => catches everything else -- positive odd ints
+            return "positive odd"  # => the positive-odd branch's result
+
+
+# => guards let one case pattern cover many related conditions
+print(classify(-5))  # => Output: negative
+print(classify(0))  # => Output: zero
+print(classify(4))  # => Output: positive even
+print(classify(7))  # => Output: positive odd
+```
+
+**Output**:
+
+```text
+negative
+zero
+positive even
+positive odd
+```
+
+```python
+"""Example 47: pytest verification for case Clauses With if Guards."""
+
+from example import classify
+
+
+def test_guards_select_the_right_branch() -> None:
+    assert classify(-1) == "negative"
+    assert classify(0) == "zero"
+    assert classify(2) == "positive even"
+    assert classify(3) == "positive odd"
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: A guard runs AFTER its case's pattern already matched -- `case int(value) if
+value < 0` only evaluates `value < 0` once `value` is confirmed to be an int, not before.
+
+**Why it matters**: Without guards, expressing "negative int" as a pattern alone would require either a
+much more elaborate pattern syntax or falling back to a plain if/elif chain inside the case body,
+losing match/case's structural-matching benefit entirely. Guards keep the dispatch logic in ONE place
+-- the case list -- rather than splitting it between pattern matching and nested conditionals.
+
+---
+
+### Example 48: A Hand-Rolled Some/Nothing With map
+
+_ex-48 &middot; exercises co-22, co-25_
+
+An Option type replaces `None` with a value the reader (and a type checker) can reason about
+explicitly. This example hand-rolls `Some`/`Nothing` as frozen dataclasses, each with its own `map`
+method, and confirms `map` transforms a present value but is a safe no-op on an absent one.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Gray #808080
+flowchart LR
+    S["Some#40;5#41;"]:::blue -->|map#40;+1#41;| S2["Some#40;6#41;"]:::blue
+    N["Nothing#40;#41;"]:::gray -->|map#40;+1#41; skipped| N2["Nothing#40;#41;"]:::gray
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef gray fill:#808080,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 48: A Hand-Rolled Some/Nothing With map."""
+
+from __future__ import annotations  # => enables the quoted 'Option[U]' forward reference below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds both Option variants
+from typing import Callable, Generic, TypeVar  # => Generic/TypeVar make Some[T] a proper generic container
+
+T = TypeVar("T")  # => the type of the value a Some wraps
+U = TypeVar("U")  # => the type map's function returns
+
+
+@dataclass(frozen=True)  # => marks Some immutable, matching the FP style
+class Some(Generic[T]):  # => the "present" variant, carrying exactly one value
+    value: T  # => the single field this variant carries
+
+    def map(self, fn: Callable[[T], U]) -> "Option[U]":  # => applies fn INSIDE the wrapper
+        return Some(fn(self.value))  # => stays wrapped -- Some in, Some out
+
+
+@dataclass(frozen=True)  # => marks Nothing immutable too
+class Nothing:  # => the "absent" variant, carrying nothing
+    def map(self, fn: Callable[[T], U]) -> "Nothing":  # => NO-OP: still generic so it type-checks like Some.map
+        return self  # => there is nothing to apply fn to -- Nothing stays Nothing
+
+
+Option = Some[T] | Nothing  # => PEP 604 union: an Option[T] is either Some[T] or Nothing
+
+
+present: Option[int] = Some(5)  # => an Option holding a real value
+absent: Option[int] = Nothing()  # => an Option holding nothing at all
+
+increment: Callable[[int], int] = lambda x: x + 1  # => explicit annotation pins T/U to int at both call sites
+mapped_present = present.map(increment)  # => Some(5).map(+1) -- the function DOES run
+mapped_absent = absent.map(increment)  # => Nothing.map(+1) -- the function is SKIPPED entirely
+
+# => Option replaces None with a type the reader (and a type checker) can reason about
+print(mapped_present)  # => Output: Some(value=6)
+print(mapped_absent)  # => Output: Nothing()
+print(mapped_absent == Nothing())  # => Output: True -- map never turns Nothing into Some
+```
+
+**Output**:
+
+```text
+Some(value=6)
+Nothing()
+True
+```
+
+```python
+"""Example 48: pytest verification for A Hand-Rolled Some/Nothing With map."""
+
+from typing import Callable
+
+from example import Nothing, Some
+
+
+def test_map_runs_on_some_and_is_skipped_on_nothing() -> None:
+    increment: Callable[[int], int] = lambda x: x + 1
+    assert Some(5).map(increment) == Some(6)
+    assert Nothing().map(increment) == Nothing()
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `Nothing().map(fn)` never calls `fn` at all -- the absence propagates through the
+pipeline automatically, without the caller writing a single `if value is not None` check.
+
+**Why it matters**: Example 28's `int | None` return type already introduced "absence as a value," but
+a caller there still has to remember the `is not None` check every single time. Wrapping absence in its
+own type with its own `map` method means the ABSENCE-HANDLING LOGIC lives in one place instead of being
+repeated at every call site -- this is the functor pattern made structural.
+
+---
+
+### Example 49: Chaining Option-Returning Lookups
+
+_ex-49 &middot; exercises co-22_
+
+Two dict lookups chained together -- find a user's city, then find that city's display name --
+normally require a nested `if` for each possible miss. This example's `find` function returns an
+Option instead of `None`, and `find_user_then_city` short-circuits on the FIRST miss without ever
+attempting the second lookup.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Gray #808080
+flowchart LR
+    U["find users, 'ana'"]:::blue -->|Some#40;'jakarta'#41;| C["find cities, 'jakarta'"]:::orange
+    C -->|Some#40;'Jakarta, Indonesia'#41;| R1["hit"]:::blue
+    U2["find users, 'budi'"]:::gray -->|Nothing#40;#41; short-circuits| R2["miss"]:::gray
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef gray fill:#808080,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 49: Chaining Option-Returning Lookups."""
+
+from __future__ import annotations  # => enables the quoted 'Option[T]' forward reference below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds both Option variants
+from typing import Generic, TypeVar  # => Generic/TypeVar make Some[T] a proper generic container
+
+T = TypeVar("T")  # => the type of the value a Some wraps
+
+
+@dataclass(frozen=True)  # => marks Some immutable, matching the FP style
+class Some(Generic[T]):  # => the "present" variant, carrying exactly one value
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Nothing immutable too
+class Nothing:  # => the "absent" variant
+    pass  # => carries no data at all
+
+
+Option = Some[T] | Nothing  # => the ADT itself: an Option is EITHER variant
+
+
+def find(table: dict[str, T], key: str) -> "Option[T]":  # => an Option-returning lookup, no None
+    return Some(table[key]) if key in table else Nothing()  # => success wraps, miss returns Nothing
+
+
+def find_user_then_city(  # => opens the multi-line signature of the chained lookup
+    users: dict[str, str], cities: dict[str, str], username: str  # => the two lookup tables plus the key to chase
+) -> "Option[str]":  # => closes the multi-line signature above
+    user_result = find(users, username)  # => first Option-returning lookup
+    if isinstance(user_result, Nothing):  # => SHORT-CIRCUITS immediately on the first miss
+        return Nothing()  # => never even attempts the second lookup
+    return find(cities, user_result.value)  # => chains into a SECOND Option-returning lookup
+
+
+users = {"ana": "jakarta"}  # => maps username -> city key
+cities = {"jakarta": "Jakarta, Indonesia"}  # => maps city key -> display name
+
+hit = find_user_then_city(users, cities, "ana")  # => both lookups succeed
+miss = find_user_then_city(users, cities, "budi")  # => the FIRST lookup already misses
+
+# => chaining Option lookups avoids nested None-checks entirely
+print(hit)  # => Output: Some(value='Jakarta, Indonesia')
+print(miss)  # => Output: Nothing()
+```
+
+**Output**:
+
+```text
+Some(value='Jakarta, Indonesia')
+Nothing()
+```
+
+```python
+"""Example 49: pytest verification for Chaining Option-Returning Lookups."""
+
+from example import Nothing, Some, find_user_then_city
+
+
+def test_chain_short_circuits_on_the_first_miss() -> None:
+    users = {"ana": "jakarta"}
+    cities = {"jakarta": "Jakarta, Indonesia"}
+
+    assert find_user_then_city(users, cities, "ana") == Some("Jakarta, Indonesia")
+    assert find_user_then_city(users, cities, "budi") == Nothing()
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Chaining Option-returning lookups replaces "two nested if-not-None checks" with
+"check once, return early" -- the second lookup's code doesn't even need to defend against the first
+one having failed.
+
+**Why it matters**: Real lookup chains are rarely just two steps -- a user's account, then their team,
+then their team's billing plan -- and nested None-checks for each step get unreadable fast. This
+chaining pattern is exactly what Example 51's `and_then` and Example 56's `bind` generalize into a
+reusable method, so the SAME short-circuiting logic doesn't have to be hand-written at every chain.
+
+---
+
+### Example 50: A Hand-Rolled Ok/Err Result Type
+
+_ex-50 &middot; exercises co-23_
+
+A Result type makes a function's failure mode part of its RETURN TYPE instead of a hidden exception
+path. This example's `divide` returns `Ok(value)` on success or `Err(message)` on division by zero, and
+a caller can inspect which one it got with a plain `isinstance` check, no `try`/`except` required.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05
+flowchart LR
+    D1["divide#40;10, 2#41;"]:::blue -->|success| Ok1["Ok#40;5.0#41;"]:::blue
+    D2["divide#40;10, 0#41;"]:::orange -->|failure| Err1["Err#40;'division by zero'#41;"]:::orange
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 50: A Hand-Rolled Ok/Err Result Type."""
+
+from __future__ import annotations  # => enables the quoted 'Result[float, str]' forward reference below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds both Result variants
+from typing import Generic, TypeVar  # => Generic/TypeVar make Ok[T] and Err[E] proper generic containers
+
+T = TypeVar("T")  # => the type of the value an Ok wraps
+E = TypeVar("E")  # => the type of the error an Err wraps
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the "success" variant, carrying the computed value
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(Generic[E]):  # => the "failure" variant, carrying the ERROR AS A VALUE, not an exception
+    error: E  # => the single field this variant carries
+
+
+Result = Ok[T] | Err[E]  # => PEP 604 union: a Result is either Ok[T] or Err[E]
+
+
+def divide(a: int, b: int) -> "Result[float, str]":  # => the failure mode is IN the return type
+    if b == 0:  # => a caller reading this signature already knows failure is possible
+        return Err("division by zero")  # => the error travels as an ordinary VALUE
+    return Ok(a / b)  # => success wraps the computed value
+
+
+success = divide(10, 2)  # => Ok(5.0)
+failure = divide(10, 0)  # => Err('division by zero') -- NO exception was raised
+
+# => Result makes failure part of the TYPE, not a hidden exception path
+print(success)  # => Output: Ok(value=5.0)
+print(failure)  # => Output: Err(error='division by zero')
+print(isinstance(failure, Err))  # => Output: True -- the caller can inspect this without a try/except
+```
+
+**Output**:
+
+```text
+Ok(value=5.0)
+Err(error='division by zero')
+True
+```
+
+```python
+"""Example 50: pytest verification for A Hand-Rolled Ok/Err Result Type."""
+
+from example import Err, Ok, divide
+
+
+def test_result_carries_success_or_failure_as_a_value() -> None:
+    assert divide(10, 2) == Ok(5.0)
+    assert divide(10, 0) == Err("division by zero")
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `Result[T, E]` puts "this can fail, and here is what the failure looks like" directly
+in the function's signature -- a caller reading `divide(a, b) -> Result[float, str]` already knows
+failure is possible before reading a single line of the implementation.
+
+**Why it matters**: Exceptions are invisible in a function's type signature -- nothing about
+`def divide(a, b) -> float` warns a caller that a `ZeroDivisionError` is possible without reading the
+implementation. Result makes the failure mode visible and, because Ok/Err are ordinary values,
+composable: Example 51's map/and_then chain multiple Result-returning steps together without a single
+try/except appearing anywhere in the chain.
+
+---
+
+### Example 51: map and and_then on a Result
+
+_ex-51 &middot; exercises co-23, co-27_
+
+`map` transforms a Result's success value while leaving `Err` untouched; `and_then` chains into ANOTHER
+Result-returning step without double-wrapping the outcome. This example chains `parse_positive` (an
+`and_then` step) with a `map(lambda n: n * 10)`, and confirms the chain short-circuits the moment
+`parse_positive` returns an `Err`.
+
+```python
+"""Example 51: map and and_then on a Result."""
+
+from __future__ import annotations  # => enables the quoted 'Result[U, object]' forward references below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds both Result variants
+from typing import Callable, Generic, TypeVar  # => Generic/TypeVar/Callable type the map and and_then methods
+
+T = TypeVar("T")  # => the type of the value an Ok wraps
+U = TypeVar("U")  # => the type map/and_then transform T into
+E = TypeVar("E")  # => the type of the error an Err wraps
+F = TypeVar("F")  # => the error type threaded through and_then's step function, not hardcoded to object
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the success variant's body
+    value: T  # => the single field this variant carries
+
+    def map(self, fn: Callable[[T], U]) -> "Result[U, object]":  # => transforms the SUCCESS value only
+        return Ok(fn(self.value))  # => transforms the value, stays wrapped as Ok
+
+    def and_then(  # => chains into ANOTHER Result-returning step, without double-wrapping
+        self, fn: Callable[[T], "Result[U, F]"]  # => F is inferred from fn's own error type, not widened to object
+    ) -> "Result[U, F]":  # => the chained Result keeps fn's REAL error type
+        return fn(self.value)  # => runs fn on the unwrapped value; fn itself returns a Result
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(Generic[E]):  # => the failure variant's body
+    error: E  # => the single field this variant carries
+
+    def map(self, fn: Callable[[T], U]) -> "Err[E]":  # => NO-OP: generic so a typed fn still passes the check
+        return self  # => the error passes through UNCHANGED -- fn never runs
+
+    def and_then(self, fn: Callable[[T], U]) -> "Err[E]":  # => and_then is ALSO a no-op on Err, generic likewise
+        return self  # => short-circuits: fn never runs once the pipeline has already failed
+
+
+Result = Ok[T] | Err[E]  # => the ADT itself: a Result is EITHER variant
+
+
+def parse_positive(text: str) -> "Result[int, str]":  # => an and_then STEP: str -> Result[int, str]
+    value = int(text)  # => may raise, but this example only feeds it valid ints
+    return Ok(value) if value > 0 else Err(f"{value} is not positive")  # => the and_then step itself: may succeed or fail
+
+
+times_ten: Callable[[int], int] = lambda n: n * 10  # => explicit annotation pins map's generic parameter to int
+
+ok_chain = Ok("5").and_then(parse_positive).map(times_ten)  # => success end to end
+err_chain = Ok("-5").and_then(parse_positive).map(times_ten)  # => fails at and_then
+
+# => map transforms success; and_then chains into ANOTHER fallible step
+print(ok_chain)  # => Output: Ok(value=50)
+print(err_chain)  # => Output: Err(error='-5 is not positive')
+```
+
+**Output**:
+
+```text
+Ok(value=50)
+Err(error='-5 is not positive')
+```
+
+```python
+"""Example 51: pytest verification for map and and_then on a Result."""
+
+from typing import Callable
+
+from example import Err, Ok, parse_positive
+
+
+def test_pipeline_stops_at_the_first_err() -> None:
+    times_ten: Callable[[int], int] = lambda n: n * 10
+    ok_chain = Ok("5").and_then(parse_positive).map(times_ten)
+    err_chain = Ok("-5").and_then(parse_positive).map(times_ten)
+
+    assert ok_chain == Ok(50)
+    assert err_chain == Err("-5 is not positive")
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: map's function returns a plain value (rewrapped as Ok automatically); and_then's
+function returns ANOTHER Result (not rewrapped, to avoid Result-inside-Result nesting) -- using the
+wrong one either double-wraps or fails to unwrap.
+
+**Why it matters**: A validation-then-transform pipeline typically mixes both kinds of steps -- some
+that always succeed once they run (a good fit for `map`) and some that can themselves fail (a good fit
+for `and_then`). Distinguishing them is what keeps a long Result chain flat instead of accumulating
+nested `Ok(Ok(Ok(...)))` wrappers, and it's the exact distinction Example 56 revisits under the name
+`bind` -- the same operation, one more common name for it.
+
+---
+
+### Example 52: A Validation Pipeline Threading Result
+
+_ex-52 &middot; exercises co-24, co-23_
+
+Railway-oriented programming models a validation pipeline as two parallel tracks -- success and failure
+-- where each step either stays on the success track or switches permanently to failure. This example's
+`validate_form` threads `validate_name` then `validate_age`, confirming a failure in the FIRST check
+means the second is never even attempted.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05
+flowchart LR
+    Start["validate_form"]:::blue --> N["validate_name"]:::blue
+    N -->|Ok| A["validate_age"]:::blue
+    N -->|Err| F1["failure track"]:::orange
+    A -->|Ok| S["success"]:::blue
+    A -->|Err| F2["failure track"]:::orange
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 52: A Validation Pipeline Threading Result."""
+
+from __future__ import annotations  # => enables the quoted 'Result[int, str]' forward references below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds both Result variants
+from typing import Generic, TypeVar  # => Generic/TypeVar make Ok[T] and Err[E] proper generic containers
+
+T = TypeVar("T")  # => the type of the value an Ok wraps
+E = TypeVar("E")  # => the type of the error an Err wraps
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the success variant's body
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(Generic[E]):  # => the failure variant's body
+    error: E  # => the single field this variant carries
+
+
+Result = Ok[T] | Err[E]  # => the ADT itself: a Result is EITHER variant
+
+
+def validate_age(age: int) -> "Result[int, str]":  # => railway step 1: switches to the failure track on error
+    if age < 0:  # => the ONLY failure condition this step checks
+        return Err("age cannot be negative")  # => switches to the failure track
+    return Ok(age)  # => the success track, value unchanged
+
+
+def validate_name(name: str) -> "Result[str, str]":  # => railway step 2
+    if not name:  # => the ONLY failure condition this step checks
+        return Err("name cannot be empty")  # => switches to the failure track
+    return Ok(name)  # => the success track, value unchanged
+
+
+def validate_form(name: str, age: int) -> "Result[str, str]":  # => threads BOTH steps in sequence
+    name_result = validate_name(name)  # => the FIRST switch point
+    if isinstance(name_result, Err):  # => already on the failure track -- age is never checked
+        return name_result  # => the original error rides through untouched
+    age_result = validate_age(age)  # => the SECOND switch point, only reached if step 1 succeeded
+    if isinstance(age_result, Err):  # => the SECOND switch point
+        return age_result  # => propagates the second step's failure
+    return Ok(f"{name_result.value}, age {age_result.value}")  # => both checks passed
+
+
+valid = validate_form("Ana", 30)  # => both checks succeed
+bad_name = validate_form("", 30)  # => fails at the FIRST check -- age is never even validated
+bad_age = validate_form("Ana", -1)  # => passes name, fails at the SECOND check
+
+# => this is the railway-oriented programming pattern: one track, two rails
+print(valid)  # => Output: Ok(value='Ana, age 30')
+print(bad_name)  # => Output: Err(error='name cannot be empty')
+print(bad_age)  # => Output: Err(error='age cannot be negative')
+```
+
+**Output**:
+
+```text
+Ok(value='Ana, age 30')
+Err(error='name cannot be empty')
+Err(error='age cannot be negative')
+```
+
+```python
+"""Example 52: pytest verification for A Validation Pipeline Threading Result."""
+
+from example import Err, Ok, validate_form
+
+
+def test_one_bad_field_short_circuits_the_rest() -> None:
+    assert validate_form("Ana", 30) == Ok("Ana, age 30")
+    assert validate_form("", 30) == Err("name cannot be empty")
+    assert validate_form("Ana", -1) == Err("age cannot be negative")
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: Once a railway pipeline switches to the failure track, every later step is skipped
+automatically -- the pipeline's shape enforces "stop at the first failure" without a single explicit
+early-return check written by hand at each step.
+
+**Why it matters**: A multi-field form validator written with nested if/else quickly turns into a
+pyramid of indentation, one level per field; a railway-style pipeline instead reads as a flat sequence
+of steps, each returning Result, with the failure-track behavior handled once by `and_then`'s own logic
+rather than repeated at every step. This is the shape Example 79's applicative validation in the
+Advanced tier deliberately breaks from -- sometimes collecting ALL errors matters more than stopping at
+the first one.
+
+---
+
+### Example 53: The Functor Identity Law by Example
+
+_ex-53 &middot; exercises co-25_
+
+A functor's `map` must obey the identity law -- mapping the identity function over a container changes
+nothing but produces an equal container back. This example verifies `Box(42).map(identity) == Box(42)`
+directly, confirming the law holds for this minimal `Box` functor while noting the result is equal but
+not the SAME object.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Teal #029E73
+flowchart LR
+    B["Box#40;42#41;"]:::blue -->|map#40;identity#41;| B2["Box#40;42#41;"]:::teal
+    B2 -.->|equals| B
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 53: The Functor Identity Law by Example."""
+
+from __future__ import annotations  # => enables the quoted 'Box[U]' forward reference below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds the immutable Box
+from typing import Callable, Generic, TypeVar  # => Generic/TypeVar/Callable type the minimal functor below
+
+T = TypeVar("T")  # => the type of the value a Box wraps
+U = TypeVar("U")  # => the type map's function returns
+
+
+def identity(x: T) -> T:  # => the identity function: returns its argument UNCHANGED
+    return x  # => identity's entire body: returns its argument, unchanged
+
+
+@dataclass(frozen=True)  # => marks Box immutable, matching the FP style
+class Box(Generic[T]):  # => a minimal functor: any container with a lawful map
+    value: T  # => the single field this container carries
+
+    def map(self, fn: Callable[[T], U]) -> "Box[U]":  # => applies fn inside, stays wrapped
+        return Box(fn(self.value))  # => applies fn inside, re-wraps as Box
+
+
+original = Box(42)  # => the container BEFORE the identity law is applied
+mapped_with_identity = original.map(identity)  # => container.map(identity)
+
+# => the functor identity law is a correctness check any lawful map must pass
+print(mapped_with_identity == original)  # => Output: True -- the FUNCTOR IDENTITY LAW, verified
+print(mapped_with_identity is original)  # => Output: False -- EQUAL, but a distinct object (still immutable)
+```
+
+**Output**:
+
+```text
+True
+False
+```
+
+```python
+"""Example 53: pytest verification for The Functor Identity Law by Example."""
+
+from example import Box, identity
+
+
+def test_mapping_identity_changes_nothing_but_the_wrapper() -> None:
+    original = Box(7)
+    assert original.map(identity) == original  # => the functor identity law
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: The identity law is a correctness check, not just a curiosity -- a `map`
+implementation that fails it (say, one that accidentally transforms the value even when given
+identity) is a functor with a bug, whether or not any test happens to catch it.
+
+**Why it matters**: Every functor this topic has built so far -- list's own map, Option's
+Some/Nothing, and now this minimal Box -- implicitly relies on this law holding, because code that
+chains `.map(f).map(g)` assumes mapping never introduces changes beyond what `f` and `g` themselves
+cause. Verifying the law explicitly, even on a toy container, is the same discipline that catches a
+broken map implementation before it corrupts every pipeline built on top of it.
+
+---
+
+### Example 54: One fmap Working on list and Option
+
+_ex-54 &middot; exercises co-25_
+
+The functor pattern is "any container with a lawful map," and this example makes that literal -- a
+single `fmap` function dispatches on whether its container is a `list`, a `Some`, or a `Nothing`,
+applying the SAME transformation logic through three different container shapes.
+
+```python
+"""Example 54: One fmap Working on list and Option."""
+
+from __future__ import annotations  # => enables the quoted 'Option[T]' forward references below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds both Option variants
+from typing import Callable, Generic, TypeVar  # => Generic/TypeVar/Callable type the shared fmap below
+
+T = TypeVar("T")  # => the type of the value a container wraps
+U = TypeVar("U")  # => the type fn transforms T into
+
+
+@dataclass(frozen=True)  # => marks Some immutable, matching the FP style
+class Some(Generic[T]):  # => the present variant's body
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Nothing immutable too
+class Nothing:  # => the absent variant's body
+    pass  # => carries no data at all
+
+
+Option = Some[T] | Nothing  # => the ADT itself: an Option is EITHER variant
+
+
+def fmap(fn: Callable[[T], U], container: "list[T] | Some[T] | Nothing") -> object:  # => ONE signature, THREE possible container shapes
+    # => ONE function, dispatching on the container's actual shape -- the functor pattern made concrete
+    if isinstance(container, list):  # => a list is mappable via a comprehension
+        return [fn(item) for item in container]  # => applies fn to every element
+    if isinstance(container, Some):  # => an Option is mappable via its own map rule
+        return Some(fn(container.value))  # => applies fn to the single wrapped value
+    return Nothing()  # => Nothing maps to Nothing, regardless of fn
+
+
+double: Callable[[int], int] = lambda n: n * 2  # => explicit annotation lets fmap solve T=int from fn, not the lambda body
+
+mapped_list = fmap(double, [1, 2, 3])  # => the list case
+mapped_some = fmap(double, Some(5))  # => the Option case, present
+mapped_nothing = fmap(double, Nothing())  # => the Option case, absent
+
+print(mapped_list)  # => Output: [2, 4, 6]
+print(mapped_some)  # => Output: Some(value=10)
+print(mapped_nothing)  # => Output: Nothing()
+```
+
+**Output**:
+
+```text
+[2, 4, 6]
+Some(value=10)
+Nothing()
+```
+
+```python
+"""Example 54: pytest verification for One fmap Working on list and Option."""
+
+from typing import Callable
+
+from example import Nothing, Some, fmap
+
+
+def test_the_same_fmap_dispatches_on_container_shape() -> None:
+    double: Callable[[int], int] = lambda n: n * 2
+    assert fmap(double, [1, 2]) == [2, 4]
+    assert fmap(double, Some(3)) == Some(6)
+    assert fmap(double, Nothing()) == Nothing()
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `fmap` treats `list` and `Option` identically from the caller's perspective -- "apply
+this function to whatever's inside, however many somethings there are" -- even though their internal
+`map` implementations are completely different.
+
+**Why it matters**: Recognizing that lists, Options, Results, and similar wrapper types all share this
+"container with map" shape is what makes the functor concept genuinely useful rather than an abstract
+label -- it means learning ONE mental model (map preserves structure, transforms contents) that
+transfers directly across every container this topic covers, instead of learning each one's
+transformation rules from scratch.
+
+---
+
+### Example 55: map2 Combines Two Options
+
+_ex-55 &middot; exercises co-26_
+
+The applicative pattern generalizes `map` to functions that take MORE than one wrapped argument --
+`map2` combines two Options with a 2-argument function, succeeding only if BOTH are present and
+short-circuiting to `Nothing` the instant either one is absent.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart LR
+    A["Some#40;2#41;"]:::blue --> M["map2#40;add#41;"]:::teal
+    B["Some#40;3#41;"]:::orange --> M
+    M --> R["Some#40;5#41;"]:::teal
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 55: map2 Combines Two Options."""
+
+from __future__ import annotations  # => enables the quoted 'Option[V]' forward reference below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds both Option variants
+from typing import Callable, Generic, TypeVar  # => Generic/TypeVar/Callable type the applicative map2 below
+
+T = TypeVar("T")  # => the type of the first wrapped value
+U = TypeVar("U")  # => the type of the second wrapped value
+V = TypeVar("V")  # => the type fn returns after combining both
+
+
+@dataclass(frozen=True)  # => marks Some immutable, matching the FP style
+class Some(Generic[T]):  # => the present variant's body
+    value: T  # => the single field this variant carries
+
+
+@dataclass(frozen=True)  # => marks Nothing immutable too
+class Nothing:  # => the absent variant's body
+    pass  # => carries no data at all
+
+
+Option = Some[T] | Nothing  # => the ADT itself: an Option is EITHER variant
+
+
+def map2(  # => the applicative pattern: combine TWO wrapped values with a 2-arg function
+    fn: Callable[[T, U], V], opt_a: "Option[T]", opt_b: "Option[U]"  # => the 2-arg combiner plus the two Options it combines
+) -> "Option[V]":  # => closes the multi-line signature above
+    if isinstance(opt_a, Nothing) or isinstance(opt_b, Nothing):  # => EITHER absent short-circuits
+        return Nothing()  # => no partial combination -- both-or-nothing
+    return Some(fn(opt_a.value, opt_b.value))  # => both present: unwrap both, apply fn, rewrap
+
+
+def add(a: int, b: int) -> int:  # => the 2-argument function map2 combines two Options with
+    return a + b  # => the actual addition add performs
+
+
+both_present = map2(add, Some(2), Some(3))  # => both wrapped values ARE present
+one_missing = map2(add, Some(2), Nothing())  # => the second value is ABSENT
+
+# => applicative map2 generalizes map to functions of MORE than one argument
+print(both_present)  # => Output: Some(value=5)
+print(one_missing)  # => Output: Nothing()
+```
+
+**Output**:
+
+```text
+Some(value=5)
+Nothing()
+```
+
+```python
+"""Example 55: pytest verification for map2 Combines Two Options."""
+
+from example import Nothing, Some, add, map2
+
+
+def test_map2_combines_when_both_present_and_short_circuits_otherwise() -> None:
+    assert map2(add, Some(2), Some(3)) == Some(5)
+    assert map2(add, Some(2), Nothing()) == Nothing()
+    assert map2(add, Nothing(), Some(3)) == Nothing()
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `map2` is both-or-nothing -- there is no partial result when one input is present and
+the other is absent, only a clean `Nothing`.
+
+**Why it matters**: A plain `map` can't combine two independently-wrapped values (there's no single
+container to call `.map` on), which is exactly the gap the applicative pattern fills. Validating two
+independent form fields and combining them into one result only if BOTH pass is the same shape as
+`map2` -- Example 79's Advanced-tier applicative validation extends this exact idea to accumulate ALL
+failing fields' errors instead of stopping at the first one.
+
+---
+
+### Example 56: bind/flat_map Chaining Result Steps
+
+_ex-56 &middot; exercises co-27_
+
+`bind` (also called `flat_map`, or `and_then` as in Example 51) is the monad's defining operation:
+chain a Result-producing step onto another Result, without the caller ever double-wrapping the outcome.
+This example chains `half` then `to_positive` on `Ok(8)` (succeeding) and on `Ok(7)` (failing at the
+FIRST bind, because 7 is odd).
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73
+flowchart LR
+    O8["Ok#40;8#41;"]:::blue -->|bind#40;half#41;| O4["Ok#40;4.0#41;"]:::teal
+    O4 -->|bind#40;to_positive#41;| O4b["Ok#40;4.0#41;"]:::teal
+    O7["Ok#40;7#41;"]:::orange -->|bind#40;half#41; fails: odd| E["Err#40;'7 is odd'#41;"]:::orange
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+```python
+"""Example 56: bind/flat_map Chaining Result Steps."""
+
+from __future__ import annotations  # => enables the quoted 'Result[U, object]' forward references below
+
+from dataclasses import dataclass  # => @dataclass(frozen=True) builds both Result variants
+from typing import Callable, Generic, TypeVar  # => Generic/TypeVar/Callable type the bind chain below
+
+T = TypeVar("T")  # => the type of the value an Ok wraps
+U = TypeVar("U")  # => the type bind's step function returns
+E = TypeVar("E")  # => the type of the error an Err wraps
+F = TypeVar("F")  # => the error type threaded through bind's step function, not hardcoded to object
+
+
+@dataclass(frozen=True)  # => marks Ok immutable, matching the FP style
+class Ok(Generic[T]):  # => the success variant's body
+    value: T  # => the single field this variant carries
+
+    def bind(self, fn: Callable[[T], "Result[U, F]"]) -> "Result[U, F]":  # => F comes from fn's OWN error type
+        # => bind/and_then/flat_map -- three names for the SAME monadic chaining operation
+        return fn(self.value)  # => unwraps, runs fn (which itself returns a Result), no double-wrap
+
+
+@dataclass(frozen=True)  # => marks Err immutable too
+class Err(Generic[E]):  # => the failure variant's body
+    error: E  # => the single field this variant carries
+
+    def bind(self, fn: Callable[[T], U]) -> "Err[E]":  # => NO-OP, generic so a typed fn still passes the check
+        return self  # => fn never runs once the chain has already failed
+
+
+Result = Ok[T] | Err[E]  # => the ADT itself: a Result is EITHER variant
+
+
+def half(n: int) -> "Result[float, str]":  # => a bind STEP: fails if n is odd
+    if n % 2 != 0:  # => the ONLY failure condition this step checks
+        return Err(f"{n} is odd")  # => switches to the failure track
+    return Ok(n / 2)  # => the success track: n halved
+
+
+def to_positive(x: float) -> "Result[float, str]":  # => a second bind STEP: fails if not positive
+    return Ok(x) if x > 0 else Err(f"{x} is not positive")  # => the second bind step: may succeed or fail
+
+
+chained_success = Ok(8).bind(half).bind(to_positive)  # => 8 -> 4.0 -> still positive
+chained_failure = Ok(7).bind(half).bind(to_positive)  # => 7 is odd -- fails at the FIRST bind
+
+print(chained_success)  # => Output: Ok(value=4.0)
+print(chained_failure)  # => Output: Err(error='7 is odd')
+```
+
+**Output**:
+
+```text
+Ok(value=4.0)
+Err(error='7 is odd')
+```
+
+```python
+"""Example 56: pytest verification for bind/flat_map Chaining Result Steps."""
+
+from example import Err, Ok, half, to_positive
+
+
+def test_bind_chains_and_short_circuits_on_the_first_error() -> None:
+    assert Ok(8).bind(half).bind(to_positive) == Ok(4.0)
+    assert Ok(7).bind(half).bind(to_positive) == Err("7 is odd")
+
+
+# => Run: pytest -- Output: 1 passed
+```
+
+**Verify**: `pytest -q`
+
+**Output**:
+
+```text
+1 passed
+```
+
+**Key takeaway**: `bind`, `and_then`, and `flat_map` are three names for the identical operation --
+"run this next Result-producing step on my current success value, and let the SAME short-circuiting
+apply if either one fails."
+
+**Why it matters**: The vocabulary difference (`bind` vs. `and_then` vs. `flat_map`) trips up readers
+moving between languages more than the concept itself does -- Haskell and Scala favor `bind` or the
+`>>=` operator, JavaScript Promises use `then`, Rust's `Result` uses `and_then`. Recognizing they are
+the SAME chaining operation under different names is what lets this topic's monad-law example
+(Example 78 in the Advanced tier) verify the same three laws regardless of which name a particular
+codebase happens to use.

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/overview.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/overview.md
@@ -1,0 +1,706 @@
+---
+title: "Overview"
+date: 2026-07-17T00:00:00+07:00
+draft: false
+weight: 1
+---
+
+## Prerequisites
+
+- **Prior topics**: [4 · Just Enough Python](../../just-enough-python/learning/overview.md) covers the
+  functions, closures, comprehensions, and generators this topic builds on directly; [7 · Data
+  Structures & Algorithms Essentials](../../data-structures-and-algorithms-essentials/learning/overview.md)
+  supplies the sequences and trees the transformation pipelines below operate over. This topic
+  deliberately contrasts against [8 · Object-Oriented Programming Essentials](../../object-oriented-programming-essentials/learning/overview.md) --
+  bundling state and behavior together is the opposite move from keeping functions pure and data
+  immutable. Topic 22, Programming Paradigms, already introduced the functional lens through contrast
+  and explicitly deferred the deep dive to this topic -- reading it first is a natural on-ramp but not
+  required.
+- **Tools & environment**: a macOS/Linux terminal; **Python 3.13.12**; `pytest` (9.1.1) installed for
+  running every example's locking test. Every `example.py` in this topic is fully type-annotated
+  (PEP 484): parameters, return types, and non-obvious local variables all carry explicit type hints.
+  Only the standard library is required -- `functools`, `itertools`, `dataclasses`, and `types` ship
+  with Python, so nothing here needs `pip install`.
+- **Assumed knowledge**: writing Python functions, closures, comprehensions, and generators
+  comfortably; the idea of a side effect; basic familiarity with `tuple`/`list`/`dict`.
+
+## Why this exists -- the big idea
+
+**The problem before the solution**: shared mutable state is the root of the hardest bugs to
+reproduce -- action at a distance, a value that changed somewhere you didn't expect, a codebase you're
+afraid to touch because nothing about it is local. **Keep this if you forget everything else**: push
+side effects to the edges and keep a pure core -- code that only maps inputs to outputs is code you
+can test without mocks, reason about without tracing the whole call graph, and run twice (or in
+parallel) without fear.
+
+**Cross-cutting big ideas**: `taming-state` is the central move this whole topic makes -- quarantine
+state and effects instead of abolishing them. `determinism-vs-emergence` names what purity buys:
+deterministic, replayable behavior instead of an unpredictable one. `abstraction-and-its-cost` is the
+honest counterweight -- immutability allocates, and the algebraic patterns (`Result`, functors,
+monads) buy composability at the price of a learning tax and, sometimes, real indirection.
+
+**Where this comes from**: functional programming traces to Church's lambda calculus (1930s) -- a
+model of computation as pure function application that predates stored-program machines entirely. It
+stayed mostly academic (Lisp 1958, ML, Haskell 1990) until multicore hardware and distributed systems
+made shared mutable state the industry's dominant source of pain, and referential transparency --
+the property FP had all along -- became the practical answer to concurrency and testability bugs.
+That is why "reduce shared mutable state" now shows up inside mainstream object-oriented languages too
+(immutable records, `map`/`filter`, `Optional`): the lesson was never purity-as-religion, it was that
+_controlling where state and effects live_ is the leverage.
+
+**Scope note**: this topic teaches functional programming as an everyday, practical discipline in
+Python -- purity, immutability, higher-order functions, composition, and the algebraic
+error-handling patterns (`Option`/`Result`) -- plus a gentle, code-first first exposure to
+functors/applicatives/monads as patterns you can recognize and use, not as a rigorous,
+law-checking treatment. The deeper, law-checking side of that material lives in a later topic, Type
+Systems, further along in this journey -- nothing here requires reading that first.
+
+## How verification works in this topic
+
+Every one of this topic's 80 worked examples is a complete, self-contained `example.py` colocated
+under `learning/code/ex-NN-slug/`, runnable in isolation with `python3 example.py` -- its expected
+output is shown two ways: inline, as a `# => Output: ...` comment directly beneath the `print()` call
+that produces it, and as a captured, verbatim `python3 example.py` run in this page's **Output**
+block. Every example also ships a colocated `test_example.py`, verified with `pytest -q` and shown
+the same way. Nothing on the following pages is a description of what Python "should" do -- every
+claim is independently run against Python 3.13.12, and every code/test pair is fully type-annotated
+by hand.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC, Brown #CA9161, Gray #808080
+%% Six concept clusters, in the order this page teaches them (co-01 through co-28)
+graph TD
+    A["Purity, referential transparency,<br/>immutability & sharing<br/>co-01 to co-05"]:::blue
+    B["Functions as values: first-class,<br/>higher-order, closures, currying,<br/>composition, pipe<br/>co-06 to co-12"]:::orange
+    C["Sequence transforms, recursion,<br/>laziness, itertools, memoization<br/>co-13 to co-17"]:::teal
+    D["Decorators, point-free style,<br/>ADTs & pattern matching<br/>co-18 to co-21"]:::purple
+    E["Option/Result, railway errors,<br/>functor/applicative/monad<br/>co-22 to co-27"]:::brown
+    F["Functional core,<br/>imperative shell<br/>co-28"]:::gray
+
+    A --> B
+    B --> C
+    C --> D
+    D --> E
+    E --> F
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef brown fill:#CA9161,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef gray fill:#808080,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+## Concepts
+
+Every worked example in this topic's follow-up pages cites the `co-NN` concept it exercises -- this
+section is the 1:1 reference those citations point back to. Read it in the order presented: purity
+and immutability first (the vocabulary everything else depends on), then functions as values, then
+the sequence-transform and laziness toolkit, then decorators and algebraic data types, then the
+`Option`/`Result` error-as-value patterns and their functor/applicative/monad shape, and finally the
+functional-core/imperative-shell split that ties the whole topic together.
+
+### co-01: Pure Functions
+
+A pure function's output depends only on its inputs, and it produces no observable side effect --
+no mutating an argument, no writing to a global, no printing, no touching a file or the network. Call
+it twice with the same arguments and you get the same result, every time, with nothing else in the
+program changed by the call.
+
+**Why it matters**: a pure function is trivially safe to call twice, safe to call from multiple
+threads at once, and easy to test with nothing but its arguments and its return value -- no database,
+no mock, no setup. Every other concept in this topic that "buys reasoning" (immutability, referential
+transparency, the functional core in co-28) ultimately routes back through this one property.
+
+**Verify it**: Example 1 contrasts a pure `add(a, b)` against an impure twin mutating a global, and
+confirms the pure one gives the same result on repeat calls; Example 29 extracts a pure core from a
+mutating routine and tests it with zero I/O; Example 32 contrasts a stateful closure counter against a
+pure fold computing the identical count; Example 57's functional-core/imperative-shell CSV analyzer
+pure-tests its core; Example 58 property-tests purity itself across 200 generated inputs; Example 60
+verifies that replaying a pure `(state, action) -> state` reducer reproduces the same final state.
+
+### co-02: Side Effects and the Purity Boundary
+
+A **side effect** is anything a function does besides computing and returning a value -- printing,
+mutating an argument the caller can see, writing a file, incrementing a counter outside the function's
+own scope. Naming exactly where that boundary sits -- which functions are pure and which are not -- is
+a design decision, not an accident.
+
+**Why it matters**: code that never names its purity boundary lets side effects creep in anywhere,
+which is precisely what makes large imperative codebases hard to test: every function might secretly
+touch global state, so nothing can be verified in isolation. Drawing the boundary explicitly is the
+first step toward the functional-core/imperative-shell split this whole topic builds toward (co-28).
+
+**Verify it**: Example 1's impure twin mutates a global counter as its side effect; Example 3
+classifies three functions -- one that prints, one that mutates an argument, one that is pure -- and
+confirms only the pure one is flagged pure.
+
+### co-03: Referential Transparency
+
+A call is **referentially transparent** if it can be replaced by its own return value anywhere in the
+program without changing what the program does. `add(2, 3)` can always be replaced by `5`; a call that
+also logs, or that depends on a mutable global, cannot be substituted this freely.
+
+**Why it matters**: referential transparency is what makes equational reasoning possible -- you can
+simplify an expression by substituting a call for its value the same way you simplify algebra, without
+having to trace side effects to check the substitution is safe. Compilers and optimizers exploit the
+identical property (constant folding, memoization) for the same underlying reason.
+
+**Verify it**: Example 2 replaces a call with its literal value inside a larger expression and confirms
+the program's output is unchanged; Example 58's property test asserts a function is pure and idempotent
+across generated inputs, which is referential transparency checked mechanically rather than by hand.
+
+### co-04: Immutability
+
+Immutable data cannot be mutated after construction -- Python's `tuple` and `frozenset` are built-in
+immutable containers; `@dataclass(frozen=True)` makes a custom record immutable and raises
+`FrozenInstanceError` on an attempted attribute set; `types.MappingProxyType` wraps an existing `dict`
+in a read-only view. `dataclasses.replace` (a shallow copy with named fields overridden) is how you
+"update" a frozen record without mutating it -- this topic uses `dataclasses.replace`, not the newer
+`copy.replace` (Python 3.13+), to stay compatible with Python 3.10.
+
+**Why it matters**: an object nobody can mutate is an object that is always safe to hand to another
+function, another thread, or another part of the codebase -- there is no way for that code to corrupt
+what you still hold a reference to. Every later paradigm-level guarantee in this topic (persistent data
+in co-05, safe sharing across the functional-core boundary in co-28) ultimately rests on this one
+property being true.
+
+**Verify it**: Example 4 attempts to mutate a `tuple` and catches the resulting `TypeError`; Example 5
+shows `@dataclass(frozen=True)` rejecting an attribute set with `FrozenInstanceError`; Example 6 uses
+`dataclasses.replace` to produce a new record and confirms the original is untouched; Example 31 wraps
+a `dict` in `types.MappingProxyType` and confirms writes through the view raise; Example 60's reducer
+never mutates its state argument; Example 75 measures the concrete allocation cost of immutable updates
+against in-place mutation; Example 76 refactors shared-mutable code so no globals remain.
+
+### co-05: Persistent Data and Structural Sharing
+
+A **persistent** data structure keeps every old version reachable after an "update" -- because the
+update never mutates anything, it just builds a new version that shares whatever structure didn't
+change with the old one. A cons-list `prepend` is the simplest case: the new head points at the
+existing tail, so the old list is still completely intact and usable.
+
+**Why it matters**: structural sharing is what makes immutability affordable -- without it, every
+"update" would have to deep-copy the entire structure, which is both slow and memory-hungry at scale.
+Sharing the unchanged parts means an immutable update can be as cheap as `O(1)` (prepend) or `O(log n)`
+(a balanced tree), not `O(n)`.
+
+**Verify it**: Example 6's `dataclasses.replace` demonstrates the shallow-copy half of this idea;
+Example 7 prepends onto a persistent cons-list and confirms the old version is still intact after the
+update; Example 30 confirms `O(1)` sharing on a persistent linked-list prepend; Example 59 updates a
+persistent binary tree and confirms the old root is untouched; Example 75 measures the performance
+trade-off of persistent updates against in-place mutation, numerically.
+
+### co-06: First-Class Functions
+
+Functions in Python are ordinary values -- you can assign one to a variable, store several in a list
+or dict, pass one as an argument, and return one from another function, all without any special
+syntax. `double = lambda x: x * 2` puts a function in a variable exactly the way `n = 5` puts an int
+in one.
+
+**Why it matters**: once functions are values, behavior itself becomes something you can pass around,
+store, and compose -- which is the seed every other concept in this section (co-07 through co-12)
+grows from. Without first-class functions, none of higher-order functions, closures, currying,
+composition, or decorators would be expressible at all.
+
+**Verify it**: Example 8 assigns a function to a variable and calls through it, confirming the same
+result as calling it directly; Example 9 stores several functions in a list and calls each one in
+turn, confirming every one is invoked with the right output.
+
+### co-07: Higher-Order Functions
+
+A **higher-order function** takes another function as an argument, returns one, or both. `apply(fn,
+x)` returning `fn(x)` is the smallest possible example -- it works identically whether `fn` doubles,
+squares, or does something else entirely, because `apply` never needs to know what `fn` actually does.
+
+**Why it matters**: higher-order functions let you factor "the shape of the computation" apart from
+"what specifically happens at each step" -- the same `apply_all` helper works for any function you
+hand it. This is the mechanism underneath decorators (co-18), `map`/`filter`/`reduce` (co-13), and
+every composition/pipe utility in this topic.
+
+**Verify it**: Example 10's `apply(fn, x)` returns `fn(x)` and is verified against two different
+functions; Example 11's `multiplier(n)` returns a closure, and `multiplier(3)(4) == 12` confirms a
+function is being both returned and called correctly.
+
+### co-08: Closures for Configuration
+
+A **closure** is a function that captures a variable from its enclosing scope and keeps using that
+captured value even after the enclosing function has returned. `multiplier(3)` returns a function that
+remembers `3` forever -- calling `multiplier(3)(4)` multiplies by the captured `3`, not by some value
+passed in fresh each time.
+
+**Why it matters**: closures let you "bake in" configuration once and get back a specialized function
+that behaves according to that configuration on every future call, without threading a parameter
+through every call site by hand. This is the direct ancestor of `functools.partial` (co-10) and every
+parameterized decorator (co-18) in this topic.
+
+**Verify it**: Example 11's `multiplier(n)` closes over `n`; Example 12's closure captures a threshold
+and its behavior is shown to vary with the captured value; Example 32 contrasts a stateful closure
+counter (state lives in the closure) against a pure fold computing the identical total (state lives
+nowhere), naming exactly where each one's state actually lives.
+
+### co-09: Currying
+
+**Currying** turns an `n`-argument function into a chain of one-argument functions -- a 2-argument
+`add(a, b)` becomes `add(a)(b)`, where `add(a)` returns a new one-argument function that remembers
+`a` and waits for `b`. Each application peels off exactly one argument.
+
+**Why it matters**: a curried function lets you fix arguments one at a time and get back a smaller,
+reusable function at every intermediate step -- `add(5)` alone is a perfectly usable "add five to
+this" function, no wrapper needed. This is closely related to but distinct from partial application
+(co-10): currying is always one argument at a time by construction, while `functools.partial` can fix
+any number of arguments at once.
+
+**Verify it**: Example 17 hand-curries a 2-argument function into `f(a)(b)` and confirms the result
+matches the uncurried call; Example 33 builds a pipeline out of `functools.partial` calls composed
+together; Example 62's `@curry` decorator auto-curries by counting a function's arity and verifies
+partial calls accumulate arguments correctly.
+
+### co-10: Partial Application
+
+**Partial application** fixes some of a function's arguments right now and returns a smaller function
+waiting for the rest. `functools.partial(pow, 2)` fixes the base at `2` and returns a one-argument
+function computing `2**n` -- no lambda, no manual closure, the standard library does it directly.
+
+**Why it matters**: `functools.partial` is the stdlib's built-in answer to "I want this function, but
+with some arguments already decided" -- it is more discoverable and more efficient than hand-writing a
+wrapping lambda for the same purpose, and it composes cleanly with `functools.reduce` and decorator
+pipelines elsewhere in this topic.
+
+**Verify it**: Example 18's `functools.partial(pow, 2)` is verified to compute `2**n`; Example 33
+chains several `partial` calls into a composed transform and verifies the result.
+
+### co-11: Function Composition
+
+**Composition** builds a new function `f ∘ g` out of two existing ones, so that calling the composed
+function on `x` runs `g(x)` first and feeds its result into `f`. A hand-written `compose(f, g)` helper
+computes exactly `f(g(x))`, and `compose(*fns)` generalizes this to a whole list of functions folded
+together.
+
+**Why it matters**: composition is how small, single-purpose functions become a larger pipeline
+without ever being fused into one big function body -- each piece stays independently readable and
+independently testable, and the pipeline itself is just data (a sequence of functions) that can be
+built, inspected, and reused. This is the backbone every `pipe` utility (co-12) and every
+`Result`-returning Kleisli composition (co-27) in this topic builds on.
+
+**Verify it**: Example 19's `compose(f, g)` is verified to compute `f(g(x))`; Example 20's `pipe(x, f,
+g)` is verified to equal the nested calls, read left-to-right instead of inside-out; Example 34's
+`compose(*fns)` folds a whole list of functions and the application order is verified; Example 37 chains
+map/filter/reduce with composition for a data summary; Example 61 composes `Result`-returning functions
+(a Kleisli composition) and verifies error propagation through the chain; Example 74 contrasts a deep
+`pipe` against the equivalent nested calls on real data, noting the readability difference; Example 77's
+decorator stack composition makes the order-dependent behavior of stacked decorators explicit.
+
+### co-12: Pipe Utilities
+
+A **pipe** utility reads a computation left-to-right in the order it actually executes -- `pipe(x, f,
+g)` means "start with `x`, apply `f`, then apply `g`" -- instead of the inside-out reading order of
+nested calls (`g(f(x))` reads right-to-left relative to execution order).
+
+**Why it matters**: `pipe` and `compose` compute the identical thing but read in opposite directions;
+for a chain of more than two or three steps, reading left-to-right in execution order is measurably
+easier to follow than unwinding nested parentheses from the inside out. This is purely a readability
+trade, not a difference in what gets computed.
+
+**Verify it**: Example 20's `pipe(x, f, g)` is verified equal to the nested-call equivalent; Example 73
+builds a small point-free combinator library including a `pipe`-style combinator, verified against a
+composed transform; Example 74 directly contrasts a deep `pipe` chain against nested calls on real
+data and notes where the readability actually diverges.
+
+### co-13: Map, Filter, Reduce
+
+The three core sequence transforms replace hand-written accumulation loops: `map` applies a function to
+every element, `filter` keeps only the elements a predicate accepts, and `reduce` (from `functools`)
+folds a sequence down to a single accumulated value. A list comprehension can express `map` + `filter`
+together, and often reads more clearly than the equivalent stdlib-function chain.
+
+**Why it matters**: these three functions cover the overwhelming majority of "loop over a collection
+and do something" code without a single explicit mutable accumulator variable exposed to the caller --
+`reduce(add, nums, 0)` states "sum these numbers" as one expression instead of a loop with an
+initialized-then-mutated running total. Recognizing when a loop is secretly a `map`, a `filter`, or a
+`reduce` is one of the most immediately useful skills this topic teaches.
+
+**Verify it**: Example 13's `map(str.upper, words)` uppercases every word; Example 14's `filter(is_even,
+nums)` keeps only evens; Example 15's `reduce(add, nums, 0)` computes the total; Example 16 confirms a
+comprehension produces an identical list to the equivalent `map`+`filter`; Example 36 builds a `dict`
+histogram with `reduce`; Example 37 chains all three for a data summary; Example 38 pulls a lazy
+`map`/`filter` generator pipeline with `next`, confirming laziness end to end.
+
+### co-14: Recursion and Python's Missing TCO
+
+Recursion expresses repetition as a function calling itself with a smaller version of the problem, the
+functional idiom for what a loop does imperatively. CPython, by explicit design choice (Guido van
+Rossum's own stated stance), performs **no tail-call optimization** -- a deeply recursive call still
+grows the call stack one frame per call and eventually raises `RecursionError`, unlike languages that
+optimize a self-tail-call into a loop automatically.
+
+**Why it matters**: recursion is often the most natural way to express a divide-and-conquer or
+tree-shaped computation, but in Python it comes with a real, load-bearing limit that other functional
+languages don't share -- know that limit exists before reaching for deep recursion in production code,
+and know the two standard workarounds (an explicit stack, or a trampoline) for when recursion depth
+would otherwise be unbounded.
+
+**Verify it**: Example 27 computes a recursive factorial and notes explicitly that CPython has no TCO;
+Example 44 converts a deep recursion into an explicit stack and verifies the same result on an input
+that would otherwise raise `RecursionError`; Example 66 builds a trampoline that simulates TCO and
+verifies a deep recursion completes without ever raising `RecursionError`.
+
+### co-15: Lazy Evaluation and Generators
+
+**Lazy evaluation** computes a value only when it is actually needed, instead of eagerly computing
+everything up front. Python's generators (functions using `yield`) are the concrete mechanism: a
+generator expression builds no list at all -- each value is produced on demand, one `next()` call at a
+time, which is what makes an infinite sequence (like `itertools.count()`) usable in the first place.
+
+**Why it matters**: laziness lets you write a pipeline over a sequence of unknown or infinite size
+without ever materializing that sequence in memory -- you only pay for the values you actually pull.
+The cost is that laziness can also hide real work: a lazy pipeline recomputed on every pull, instead of
+once, can be slower overall than the eager version it was meant to optimize.
+
+**Verify it**: Example 21's generator yields on demand, and only pulled values are shown to be
+computed; Example 22 contrasts a generator expression against a list built from the same data,
+confirming the generator doesn't materialize eagerly; Example 23 uses `itertools.islice` over an
+infinite `count()` to take the first N values; Example 38's `map`/`filter` generator pipeline is pulled
+by `next`, confirming laziness end to end; Example 63 builds a lazy, infinite prime sieve and verifies
+the first N primes; Example 64 pulls a coroutine-style `yield` pipeline for a streaming result; Example
+78 contrasts a case where laziness saves real work against a case where it quietly hides cost.
+
+### co-16: The itertools Toolkit
+
+`itertools` is the standard library's composable, lazy building-block toolkit for iteration: `islice`
+takes a slice of any iterable (including an infinite one) without materializing it, `chain` concatenates
+iterables, `accumulate` produces running totals, `groupby` groups consecutive equal keys, `tee` splits
+one iterator into several independent ones, and `pairwise` yields consecutive element pairs. Every one
+of these functions is itself lazy -- none of them build an intermediate list.
+
+**Why it matters**: `itertools` is where "write your own generator by hand" stops being necessary for
+most common iteration patterns -- reaching for `accumulate` instead of a hand-rolled running-total loop,
+or `groupby` instead of a hand-rolled grouping dict, is both less code and composes cleanly with the
+rest of this topic's lazy-pipeline style.
+
+**Verify it**: Example 23 uses `islice` over an infinite `count()`; Example 24 chains `chain` and
+`groupby` over data and verifies the grouped output; Example 39 verifies prefix sums via `accumulate`;
+Example 40 verifies adjacent pairs via `pairwise` and independent streams via `tee`; Example 63's lazy
+prime sieve composes several `itertools` building blocks together.
+
+### co-17: Memoization
+
+**Memoization** caches a pure function's results keyed by its arguments, so a repeated call with the
+same arguments returns the cached result instead of recomputing it. `functools.lru_cache` is the
+stdlib's decorator-based implementation; a hand-rolled `dict` cache is the same idea made explicit,
+useful when `lru_cache`'s exact eviction policy doesn't fit.
+
+**Why it matters**: memoization is only safe to apply because the function being cached is pure
+(co-01) -- caching an impure function's results would silently return stale side effects along with a
+stale value. A recursive `fib` without memoization is exponential; with `@lru_cache`, it becomes
+linear, because every unique argument is computed exactly once.
+
+**Verify it**: Example 25 puts `@lru_cache` on a recursive `fib` and confirms `cache_info()` shows
+cache hits on repeated calls; Example 41 hand-rolls a memo `dict` for an expensive function and confirms
+the second call is served from the cache; Example 65 builds a memoize decorator with a bounded
+`maxsize` and confirms the oldest entry is evicted once the bound is exceeded.
+
+### co-18: Decorators as Higher-Order Functions
+
+A **decorator** is a higher-order function that takes a function and returns a wrapped replacement --
+`@log_calls` on `def greet(): ...` is exactly `greet = log_calls(greet)`, spelled with `@` syntax
+instead of a manual reassignment. Decorators can take their own arguments (`@retry(3)`), and
+`functools.wraps` preserves the wrapped function's `__name__` and other metadata so introspection still
+sees the original function's identity.
+
+**Why it matters**: decorators let you attach cross-cutting behavior (logging, caching, retrying,
+timing) to a function without touching that function's own body at all -- the wrapped behavior is
+composable and reusable across any function, and stacking several decorators applies them in a
+well-defined, ordered sequence.
+
+**Verify it**: Example 26 wraps a function with a logging decorator and confirms the wrapped result is
+unchanged; Example 42's parameterized `@retry(3)` decorator has its retry count verified; Example 43
+confirms `functools.wraps` preserves `__name__` through the wrapper; Example 62's `@curry` decorator
+auto-curries by arity; Example 65's bounded memoize decorator is itself a decorator; Example 77 stacks
+multiple decorators and verifies the order-dependent behavior that results.
+
+### co-19: Point-Free Style
+
+**Point-free style** expresses a transformation by composing functions together without ever naming the
+argument the data flows through -- a pipeline built entirely from `compose`/`pipe` calls has no `lambda
+x: ...` anywhere, because the "point" (the argument) is never explicitly written.
+
+**Why it matters**: point-free style pushes composition to its logical extreme -- when it reads well,
+it emphasizes the shape of the transformation (which functions, in which order) over the mechanics of
+threading a named variable through each step. Taken too far, though, it can obscure what's actually
+happening; this topic treats it as one more tool, not a stylistic mandate.
+
+**Verify it**: Example 35 rewrites a lambda-based pipeline in point-free style and confirms identical
+output; Example 73 builds a small point-free combinator library and verifies a composed transform built
+entirely from it.
+
+### co-20: Algebraic Data Types in Python
+
+An **algebraic data type** (ADT) models a "one of several shapes" value as a union of frozen
+dataclasses -- `Circle | Square` (PEP 604 union syntax, Python 3.10+) says a `Shape` is either a
+`Circle` or a `Square`, each carrying only the fields relevant to that variant, instead of one class
+with optional fields for every possible shape.
+
+**Why it matters**: an ADT makes illegal states unrepresentable at the type level -- there is no way to
+construct a `Circle` with a `side_length` field, because that field doesn't exist on `Circle` at all.
+This is a stronger guarantee than a single class with nullable fields, where nothing stops a `Circle`
+instance from also carrying a stray `side_length` value that means nothing.
+
+**Verify it**: Example 45 models a shape as a union of frozen dataclasses (`Circle | Square`) and
+verifies each variant; Example 46 pattern-matches over the ADT with `match`/`case`; Example 67 models an
+expression AST as an ADT with a `match`-based evaluator, verified against an arithmetic result.
+
+### co-21: Structural Pattern Matching
+
+Python's `match`/`case` (PEP 634, Python 3.10+) destructures a value against a series of patterns,
+picking the first branch whose shape matches -- particularly natural for dispatching over an ADT's
+variants (co-20). `case` clauses can carry `if` guards for conditions the pattern shape alone can't
+express.
+
+**Why it matters**: `match`/`case` reads as "what shape is this value, and what do I do for each shape"
+directly, instead of an `isinstance` chain or a dict-based dispatch table. The one fact to hold onto:
+Python's `match`/`case` has **no compile-time exhaustiveness checking** -- an unmatched value simply
+falls through with no error unless you add an explicit wildcard `case _` and raise there yourself. The
+rigorous, exhaustiveness-checked treatment of this idea lives in the type-systems topic referenced
+above.
+
+**Verify it**: Example 23 dispatches on a command tag with `match`/`case`; Example 46 matches over the
+`Circle | Square` ADT and confirms every branch fires, with an explicit note on the lack of
+exhaustiveness checking; Example 47 adds `if` guards to `case` clauses and confirms the guard selects
+the right branch; Example 52 dispatches over an ADT with `match`/`case`; Example 67's expression
+evaluator dispatches on AST node shape with `match`/`case`.
+
+### co-22: The Option/Maybe Type
+
+An **Option** (also called `Maybe`) makes "this value might be absent" a value in its own right,
+instead of overloading `None` (or an exception) to mean absence. This topic hand-rolls `Some`/`Nothing`
+as frozen dataclasses mirroring Rust's `Option` -- stdlib-only, no third-party functional-programming
+library required.
+
+**Why it matters**: a function that returns `Optional[int]` still lets a caller forget the `None` check
+and crash later with a "`NoneType` has no attribute" error, far from where the `None` actually
+originated. An `Option`-returning function forces the caller to unwrap the result explicitly (or `map`
+through it), turning a possible runtime crash into a type-level obligation the caller cannot silently
+skip.
+
+**Verify it**: Example 28 guards a `None`-returning function's result at the call site; Example 48
+builds a hand-rolled `Some`/`Nothing` with `map`, and confirms `map` is skipped on `Nothing`; Example 49
+chains `Option`-returning lookups and confirms the chain short-circuits on the first miss; Example 68
+sequences several `Option` computations readably and confirms short-circuit on absence; Example 79
+compares the same pipeline built on `Option` against the same pipeline built on `Result`.
+
+### co-23: The Result/Either Type
+
+A **Result** (also called `Either`) carries success-or-failure as a value -- this topic hand-rolls
+`Ok`/`Err` as frozen dataclasses mirroring Rust's `Result`, stdlib-only. Unlike an exception, a
+`Result` shows up in the function's own return type, so a caller can see at the call site that failure
+is possible without reading the function's implementation.
+
+**Why it matters**: exceptions are invisible in a function's signature -- nothing in `def parse(s: str)
+-> int` tells you it can raise -- while `def parse(s: str) -> Result[int, str]` states the failure mode
+directly in the type callers see. This makes failure an ordinary value you can `map` over, compose, and
+inspect, instead of a special control-flow mechanism that unwinds the stack.
+
+**Verify it**: Example 50 carries an error as a value through a hand-rolled `Ok`/`Err`; Example 51
+chains `map`/`and_then` on a `Result` and confirms the pipeline stops at the first `Err`; Example 52
+threads `Result` through a validation pipeline and confirms one bad field short-circuits the rest;
+Example 61 composes `Result`-returning functions and verifies error propagation through the
+composition; Example 69 validates a form with `Result`, reporting the specific failing rule; Example 79
+compares the identical pipeline built on `Result` against the same pipeline built on `Option`.
+
+### co-24: Railway-Oriented Error Handling
+
+**Railway-oriented programming** threads a `Result` through a pipeline of steps where each step can
+switch the computation from the "success track" to the "failure track" -- once on the failure track,
+every remaining step is skipped and the original error rides through to the end untouched, the way a
+train switches tracks and stays on the new one.
+
+**Why it matters**: this pattern replaces a pyramid of nested `if err != nil` checks (or a scattered set
+of `try`/`except` blocks) with a single linear chain that reads top-to-bottom -- the short-circuiting
+behavior is handled once, by the `Result` type's own `and_then`/`map` machinery, instead of being
+re-implemented by hand at every step.
+
+**Verify it**: Example 52's validation pipeline threads `Result` through several checks, and one bad
+field is confirmed to short-circuit the rest; Example 69 validates a form the same way and reports
+exactly which rule failed; Example 71 builds an _applicative_ variant that accumulates every error
+instead of stopping at the first one, making the trade-off between short-circuiting and
+error-accumulation explicit.
+
+### co-25: Functor Intuition
+
+A **functor**, in this topic's practical sense, is anything "mappable" -- a container type with a
+`map` method that applies a function to the value(s) inside without ever unwrapping the container
+itself. `Some(5).map(lambda x: x + 1)` returns `Some(6)`, still wrapped; `Nothing.map(f)` returns
+`Nothing` untouched, because there is nothing inside to apply `f` to.
+
+**Why it matters**: `map` on `Option`/`Result` is the exact same idea as `map` on a `list` -- "apply
+this function to whatever's inside, however many things that is (zero, one, or many)" -- which is why
+recognizing the functor pattern lets you transfer intuition about list `map` directly onto `Option`,
+`Result`, and any other wrapped-value type you build. The identity law (`container.map(identity) ==
+container`) is the concrete, checkable statement of "mapping changes nothing but the wrapped value."
+
+**Verify it**: Example 48's `Some`/`Nothing` `map` implementation is the first hands-on functor;
+Example 53 shows `container.map(identity) == container` by example, the functor identity law made
+concrete; Example 54 applies one `fmap` function to both a `list` and an `Option` and confirms both are
+mapped correctly; Example 70 property-tests the functor identity and composition laws and confirms both
+hold.
+
+### co-26: Applicative Intuition
+
+An **applicative** combines several independently-wrapped values with a multi-argument function --
+`map2(add, Some(2), Some(3))` unwraps both `Option`s and calls `add(2, 3)`, wrapping the result back up
+as `Some(5)`; if either input is `Nothing`, the whole combination short-circuits to `Nothing`.
+
+**Why it matters**: `map`/functor (co-25) only handles a function of one wrapped argument; applicative
+is the natural next step for combining _several_ independently-wrapped values at once, without nesting
+one `map` inside another by hand. The applicative-vs-railway (co-24) contrast is concrete and useful:
+an applicative combination can be built to accumulate every error instead of stopping at the first one,
+which a strictly sequential railway chain cannot do without extra machinery.
+
+**Verify it**: Example 55's `map2` combines two `Option`s with a 2-argument function, verified to
+combine when both are present and to short-circuit when either is absent; Example 71 builds an
+applicative that accumulates every validation error instead of stopping at the first; Example 80's
+capstone-preview log analyzer combines partial aggregates with an applicative pattern.
+
+### co-27: Monad Intuition
+
+A **monad**, in this topic's practical sense, chains functions that each return an already-wrapped
+value -- `bind` (also called `and_then` or `flat_map`) takes a wrapped value and a function returning
+another wrapped value, and flattens the result instead of producing a wrapped-wrapped value.
+`Ok(5).and_then(lambda x: Ok(x + 1))` returns `Ok(6)`, not `Ok(Ok(6))`.
+
+**Why it matters**: `map` (co-25) can't chain functions that themselves return a wrapped value without
+producing a nested wrapper; `bind`/`and_then` is exactly the extra piece that makes chaining such
+functions work cleanly. This is the mechanism underneath every `Result`-pipeline in this topic (co-23,
+co-24) and every `Option`-chaining example (co-22) -- naming it as "the monad pattern" mostly matters
+for recognizing the same shape when you meet it in another library or language.
+
+**Verify it**: Example 51's `and_then` on `Result` chains steps and stops at the first `Err`; Example 56
+chains `bind`/`flat_map` across several `Result`-returning steps, verifying the monadic sequencing;
+Example 61 composes `Result`-returning functions in a Kleisli composition; Example 68 sequences
+`Option` computations do-notation-style; Example 72 shows left-identity, right-identity, and
+associativity by example for `Result`, the three monad laws made concrete; Example 79 compares the
+identical monadic pipeline built on `Option` against the same pipeline built on `Result`.
+
+### co-28: Functional Core, Imperative Shell
+
+A **functional core, imperative shell** design splits a program into a pure transformation core (parse,
+transform, aggregate -- no I/O anywhere) surrounded by a thin imperative shell that holds every effect
+(reading a file, writing output, talking to a network). The core is tested directly, with no mocking,
+because it has nothing to mock; the shell is tested (if at all) end to end, because it's where the real
+world actually happens.
+
+**Why it matters**: this is the topic's answer to "how do you get the benefits of purity in a program
+that unavoidably has to do I/O somewhere" -- you don't eliminate the I/O, you quarantine it at the
+edges and keep everything else pure. This is the same move underneath co-02's purity boundary, made
+into a concrete architectural pattern, and it is the pattern this topic's own capstone builds end to
+end.
+
+**Verify it**: Example 29 extracts a pure core from a mutating routine and tests it with zero I/O;
+Example 57 splits a CSV analyzer into a pure core and an I/O shell, with the core pure-tested and the
+shell holding all I/O; Example 76 refactors shared-mutable code to pass state explicitly, confirming no
+globals remain; Example 80's capstone-preview log analyzer combines a functional core, `Result`-based
+error handling, and an applicative combine into one end-to-end report.
+
+## Tensions & trade-offs -- when NOT to reach for this
+
+- **Purity vs. the machine**: immutability allocates, and a tight numeric loop or a huge in-place
+  buffer is a place an imperative core is honestly faster -- insisting on purity there is dogma, not
+  engineering (Example 75).
+- **Monad-all-the-things**: the algebraic patterns (`Result`/`Option`, functors, monads) buy
+  composability and charge indirection plus a learning tax; a `Result` chain three layers deep can read
+  _worse_ than an early `raise` -- reach for them where error-as-value genuinely simplifies, not
+  everywhere (Example 79).
+- **When NOT to use it**: a fundamentally stateful, mutation-heavy domain -- a game loop, a physics
+  simulation, a device driver -- fights this paradigm head-on. The move is functional-core /
+  imperative-shell to _quarantine_ the state (co-28), not a crusade to abolish it.
+
+## Examples by Level
+
+### Beginner (Examples 1–28)
+
+- [Example 1: Pure vs. Impure -- Same Result Every Time](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-1-pure-vs-impure----same-result-every-time)
+- [Example 2: Referential Transparency by Substitution](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-2-referential-transparency-by-substitution)
+- [Example 3: Classify Pure vs. Impure Functions](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-3-classify-pure-vs-impure-functions)
+- [Example 4: Tuple Immutability vs. List Mutability](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-4-tuple-immutability-vs-list-mutability)
+- [Example 5: A Frozen Dataclass Rejects Mutation](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-5-a-frozen-dataclass-rejects-mutation)
+- [Example 6: dataclasses.replace Produces a New Record](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-6-dataclassesreplace-produces-a-new-record)
+- [Example 7: A Persistent Cons-List Prepend](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-7-a-persistent-cons-list-prepend)
+- [Example 8: A Function Assigned to a Variable](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-8-a-function-assigned-to-a-variable)
+- [Example 9: Functions Stored in a List](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-9-functions-stored-in-a-list)
+- [Example 10: A Higher-Order apply Function](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-10-a-higher-order-apply-function)
+- [Example 11: A Function Returning a Closure](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-11-a-function-returning-a-closure)
+- [Example 12: A Closure Capturing a Threshold](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-12-a-closure-capturing-a-threshold)
+- [Example 13: map() Uppercases Every Word](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-13-map-uppercases-every-word)
+- [Example 14: filter() Keeps Only Evens](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-14-filter-keeps-only-evens)
+- [Example 15: reduce() Sums a List](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-15-reduce-sums-a-list)
+- [Example 16: A Comprehension Matching map() and filter()](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-16-a-comprehension-matching-map-and-filter)
+- [Example 17: Hand-Curry a Two-Argument Function](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-17-hand-curry-a-two-argument-function)
+- [Example 18: functools.partial Fixes an Argument](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-18-functoolspartial-fixes-an-argument)
+- [Example 19: A compose(f, g) Helper](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-19-a-composef-g-helper)
+- [Example 20: A Left-to-Right pipe Helper](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-20-a-left-to-right-pipe-helper)
+- [Example 21: A Generator Yields on Demand](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-21-a-generator-yields-on-demand)
+- [Example 22: Generator Expression vs. List](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-22-generator-expression-vs-list)
+- [Example 23: islice Over an Infinite count()](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-23-islice-over-an-infinite-count)
+- [Example 24: chain and groupby Over Data](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-24-chain-and-groupby-over-data)
+- [Example 25: @lru_cache on a Recursive fib](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-25-lru_cache-on-a-recursive-fib)
+- [Example 26: A Logging Decorator Wraps a Function](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-26-a-logging-decorator-wraps-a-function)
+- [Example 27: A Recursive Factorial (No TCO)](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-27-a-recursive-factorial-no-tco)
+- [Example 28: Guarding a None-Returning Function](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/beginner#example-28-guarding-a-none-returning-function)
+
+### Intermediate (Examples 29–56)
+
+- [Example 29: Extract a Pure Core from a Mutating Routine](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-29-extract-a-pure-core-from-a-mutating-routine)
+- [Example 30: O(1) Sharing on a Persistent Linked List](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-30-o1-sharing-on-a-persistent-linked-list)
+- [Example 31: A Read-Only View via MappingProxyType](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-31-a-read-only-view-via-mappingproxytype)
+- [Example 32: Stateful Closure Counter vs. Pure Fold](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-32-stateful-closure-counter-vs-pure-fold)
+- [Example 33: A Pipeline of partial Calls](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-33-a-pipeline-of-partial-calls)
+- [Example 34: `compose(*fns)` Folds a List of Functions](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-34-composefns-folds-a-list-of-functions)
+- [Example 35: Rewriting a Lambda Pipeline Point-Free](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-35-rewriting-a-lambda-pipeline-point-free)
+- [Example 36: Building a Histogram with reduce](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-36-building-a-histogram-with-reduce)
+- [Example 37: Chaining map, filter, and reduce](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-37-chaining-map-filter-and-reduce)
+- [Example 38: A Lazy map/filter Pipeline Pulled by next](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-38-a-lazy-mapfilter-pipeline-pulled-by-next)
+- [Example 39: Running Totals via accumulate](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-39-running-totals-via-accumulate)
+- [Example 40: Adjacent Pairs via pairwise and tee](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-40-adjacent-pairs-via-pairwise-and-tee)
+- [Example 41: A Hand-Rolled Memoization Dict](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-41-a-hand-rolled-memoization-dict)
+- [Example 42: A Parameterized @retry(3) Decorator](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-42-a-parameterized-retry3-decorator)
+- [Example 43: `functools.wraps` Preserves `__name__`](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-43-functoolswraps-preserves-__name__)
+- [Example 44: Converting Deep Recursion to an Explicit Stack](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-44-converting-deep-recursion-to-an-explicit-stack)
+- [Example 45: A Shape ADT as a Union of Frozen Dataclasses](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-45-a-shape-adt-as-a-union-of-frozen-dataclasses)
+- [Example 46: match/case Dispatches Over the Shape ADT](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-46-matchcase-dispatches-over-the-shape-adt)
+- [Example 47: case Clauses With if Guards](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-47-case-clauses-with-if-guards)
+- [Example 48: A Hand-Rolled Some/Nothing With map](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-48-a-hand-rolled-somenothing-with-map)
+- [Example 49: Chaining Option-Returning Lookups](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-49-chaining-option-returning-lookups)
+- [Example 50: A Hand-Rolled Ok/Err Result Type](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-50-a-hand-rolled-okerr-result-type)
+- [Example 51: map and and_then on a Result](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-51-map-and-and_then-on-a-result)
+- [Example 52: A Validation Pipeline Threading Result](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-52-a-validation-pipeline-threading-result)
+- [Example 53: The Functor Identity Law by Example](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-53-the-functor-identity-law-by-example)
+- [Example 54: One fmap Working on list and Option](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-54-one-fmap-working-on-list-and-option)
+- [Example 55: map2 Combines Two Options](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-55-map2-combines-two-options)
+- [Example 56: bind/flat_map Chaining Result Steps](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/intermediate#example-56-bindflat_map-chaining-result-steps)
+
+### Advanced (Examples 57–80)
+
+- [Example 57: A CSV Analyzer Split into a Pure Core and an I/O Shell](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-57-a-csv-analyzer-split-into-a-pure-core-and-an-io-shell)
+- [Example 58: Property-Testing Purity Without a Third-Party Library](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-58-property-testing-purity-without-a-third-party-library)
+- [Example 59: A Persistent Binary Tree With a Structural-Sharing Update](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-59-a-persistent-binary-tree-with-a-structural-sharing-update)
+- [Example 60: A Redux-Style Pure `(state, action) -> state` Reducer](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-60-a-redux-style-pure-state-action---state-reducer)
+- [Example 61: Composing `Result`-Returning Functions (Kleisli Composition)](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-61-composing-result-returning-functions-kleisli-composition)
+- [Example 62: A `@curry` Decorator Auto-Currying by Arity](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-62-a-curry-decorator-auto-currying-by-arity)
+- [Example 63: A Lazy Prime Sieve Over an Infinite Generator](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-63-a-lazy-prime-sieve-over-an-infinite-generator)
+- [Example 64: A Pull Pipeline of `yield` Stages](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-64-a-pull-pipeline-of-yield-stages)
+- [Example 65: A Memoization Decorator With a Bounded `maxsize`](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-65-a-memoization-decorator-with-a-bounded-maxsize)
+- [Example 66: A Trampoline Simulating Tail-Call Optimization](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-66-a-trampoline-simulating-tail-call-optimization)
+- [Example 67: An Expression AST as an ADT With a `match` Evaluator](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-67-an-expression-ast-as-an-adt-with-a-match-evaluator)
+- [Example 68: Sequencing `Option` Computations, Do-Style](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-68-sequencing-option-computations-do-style)
+- [Example 69: Validating a Form, Short-Circuiting on the First Failing Rule](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-69-validating-a-form-short-circuiting-on-the-first-failing-rule)
+- [Example 70: Property-Checking the Functor Identity and Composition Laws](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-70-property-checking-the-functor-identity-and-composition-laws)
+- [Example 71: An Applicative Validation That Accumulates All Errors](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-71-an-applicative-validation-that-accumulates-all-errors)
+- [Example 72: Left-Identity, Right-Identity, and Associativity for `Result`](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-72-left-identity-right-identity-and-associativity-for-result)
+- [Example 73: A Small Point-Free Combinator Library](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-73-a-small-point-free-combinator-library)
+- [Example 74: A Deep `pipe` vs. Nested Calls on Real Data](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-74-a-deep-pipe-vs-nested-calls-on-real-data)
+- [Example 75: Measuring Persistent-Update Cost vs. In-Place Mutation](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-75-measuring-persistent-update-cost-vs-in-place-mutation)
+- [Example 76: Refactoring Shared-Mutable Code to Pass State Explicitly](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-76-refactoring-shared-mutable-code-to-pass-state-explicitly)
+- [Example 77: Stacking Multiple Decorators and Reasoning About Order](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-77-stacking-multiple-decorators-and-reasoning-about-order)
+- [Example 78: A Case Where Laziness Saves Work, and One Where It Hides a Cost](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-78-a-case-where-laziness-saves-work-and-one-where-it-hides-a-cost)
+- [Example 79: The Same Pipeline in `Option` vs. `Result`](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-79-the-same-pipeline-in-option-vs-result)
+- [Example 80: A Functional-Core Log Analyzer With `Result` Errors and an Applicative Combine](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-80-a-functional-core-log-analyzer-with-result-errors-and-an-applicative-combine)

--- a/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/overview.md
+++ b/apps/ayokoding-www/content/en/learn/fundamentally-strong/software-engineer/functional-programming/learning/overview.md
@@ -704,3 +704,7 @@ error handling, and an applicative combine into one end-to-end report.
 - [Example 78: A Case Where Laziness Saves Work, and One Where It Hides a Cost](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-78-a-case-where-laziness-saves-work-and-one-where-it-hides-a-cost)
 - [Example 79: The Same Pipeline in `Option` vs. `Result`](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-79-the-same-pipeline-in-option-vs-result)
 - [Example 80: A Functional-Core Log Analyzer With `Result` Errors and an Applicative Combine](/en/c/learn/fundamentally-strong/software-engineer/functional-programming/learning/advanced#example-80-a-functional-core-log-analyzer-with-result-errors-and-an-applicative-combine)
+
+---
+
+← Previous: [22 · Programming Paradigms Drilling](../../programming-paradigms/drilling/overview.md) &middot; Next: [Beginner Examples](./beginner.md) →

--- a/plans/in-progress/fundamentally-strong-software-engineer/delivery.md
+++ b/plans/in-progress/fundamentally-strong-software-engineer/delivery.md
@@ -4692,132 +4692,132 @@ fundamentally-strong-software-engineer/<phase-slug>`), do this phase's work, the
 Row: By Example · Python · topic wt 330 · Learn 123 / Drill 223 · **subject**. Template →
 [`syllabus/23-functional-programming.md`](./syllabus/23-functional-programming.md).
 
-- [ ] **[AI] V** — `web-researcher` for `functional-programming`; resolve every Accuracy-notes "to verify" line in
+- [x] **[AI] V** — `web-researcher` for `functional-programming`; resolve every Accuracy-notes "to verify" line in
       [`syllabus/23-functional-programming.md`](./syllabus/23-functional-programming.md) and fold dated findings back into that file.
       **Acceptance**: no unresolved "verify" line remains.
-- [ ] **[AI] A1-concepts** — Author `CONTENT/functional-programming/learning/` teaching **every** concept in
+- [x] **[AI] A1-concepts** — Author `CONTENT/functional-programming/learning/` teaching **every** concept in
       `syllabus/23-functional-programming.md` §Concepts (DD-34 1:1 mirror; concepts before examples). One checkbox per `co-NN`:
-  - [ ] co-01 · pure-functions
-  - [ ] co-02 · side-effects-and-purity
-  - [ ] co-03 · referential-transparency
-  - [ ] co-04 · immutability
-  - [ ] co-05 · persistent-data-and-structural-sharing
-  - [ ] co-06 · first-class-functions
-  - [ ] co-07 · higher-order-functions
-  - [ ] co-08 · closures-for-configuration
-  - [ ] co-09 · currying
-  - [ ] co-10 · partial-application
-  - [ ] co-11 · function-composition
-  - [ ] co-12 · pipe-utilities
-  - [ ] co-13 · map-filter-reduce
-  - [ ] co-14 · recursion-and-pythons-missing-tco
-  - [ ] co-15 · lazy-evaluation-and-generators
-  - [ ] co-16 · itertools-toolkit
-  - [ ] co-17 · memoization
-  - [ ] co-18 · decorators-as-higher-order-functions
-  - [ ] co-19 · point-free-style
-  - [ ] co-20 · algebraic-data-types-in-python
-  - [ ] co-21 · structural-pattern-matching
-  - [ ] co-22 · option-maybe-type
-  - [ ] co-23 · result-either-type
-  - [ ] co-24 · railway-oriented-error-handling
-  - [ ] co-25 · functor-intuition
-  - [ ] co-26 · applicative-intuition
-  - [ ] co-27 · monad-intuition
-  - [ ] co-28 · functional-core-imperative-shell
-- [ ] **[AI] A1-examples** — Author `CONTENT/functional-programming/learning/code/` (runnable sources, DD-20/DD-30) rendering
+  - [x] co-01 · pure-functions
+  - [x] co-02 · side-effects-and-purity
+  - [x] co-03 · referential-transparency
+  - [x] co-04 · immutability
+  - [x] co-05 · persistent-data-and-structural-sharing
+  - [x] co-06 · first-class-functions
+  - [x] co-07 · higher-order-functions
+  - [x] co-08 · closures-for-configuration
+  - [x] co-09 · currying
+  - [x] co-10 · partial-application
+  - [x] co-11 · function-composition
+  - [x] co-12 · pipe-utilities
+  - [x] co-13 · map-filter-reduce
+  - [x] co-14 · recursion-and-pythons-missing-tco
+  - [x] co-15 · lazy-evaluation-and-generators
+  - [x] co-16 · itertools-toolkit
+  - [x] co-17 · memoization
+  - [x] co-18 · decorators-as-higher-order-functions
+  - [x] co-19 · point-free-style
+  - [x] co-20 · algebraic-data-types-in-python
+  - [x] co-21 · structural-pattern-matching
+  - [x] co-22 · option-maybe-type
+  - [x] co-23 · result-either-type
+  - [x] co-24 · railway-oriented-error-handling
+  - [x] co-25 · functor-intuition
+  - [x] co-26 · applicative-intuition
+  - [x] co-27 · monad-intuition
+  - [x] co-28 · functional-core-imperative-shell
+- [x] **[AI] A1-examples** — Author `CONTENT/functional-programming/learning/code/` (runnable sources, DD-20/DD-30) rendering
       **every** Worked example in `syllabus/23-functional-programming.md`. One checkbox per `ex-NN` (1:1 mirror):
-  - [ ] ex-01 · pure-vs-impure-pair — verify the pure one gives the same result on repeat calls
-  - [ ] ex-02 · referential-transparency-substitution — verify output unchanged after substitution
-  - [ ] ex-03 · detect-side-effect — verify only the pure one is flagged pure
-  - [ ] ex-04 · immutable-tuple-vs-list — verify TypeError on tuple mutation
-  - [ ] ex-05 · frozen-dataclass — verify FrozenInstanceError
-  - [ ] ex-06 · dataclasses-replace-copy — verify original unchanged, copy differs
-  - [ ] ex-07 · structural-sharing-cons — verify old version intact after update
-  - [ ] ex-08 · function-as-value — verify same result via the variable
-  - [ ] ex-09 · functions-in-a-list — verify all invoked with the right output
-  - [ ] ex-10 · higher-order-apply — verify apply(fn, x) works for two functions
-  - [ ] ex-11 · return-a-function — verify multiplier(3)(4) == 12
-  - [ ] ex-12 · closure-captures-config — verify behavior varies with captured config
-  - [ ] ex-13 · map-basic — verify every word uppercased
-  - [ ] ex-14 · filter-basic — verify only evens remain
-  - [ ] ex-15 · reduce-sum — verify the total
-  - [ ] ex-16 · comprehension-vs-map — verify identical list
-  - [ ] ex-17 · curry-manual — verify curried result matches uncurried
-  - [ ] ex-18 · partial-application — verify it computes 2\*\*n
-  - [ ] ex-19 · compose-two — verify f(g(x))
-  - [ ] ex-20 · pipe-left-to-right — verify equals nested calls
-  - [ ] ex-21 · generator-lazy-count — verify only pulled values computed
-  - [ ] ex-22 · generator-vs-list-memory — verify generator doesn't materialize eagerly
-  - [ ] ex-23 · itertools-islice-infinite — verify first N values taken
-  - [ ] ex-24 · itertools-chain-groupby — verify grouped output
-  - [ ] ex-25 · memoize-lru-cache — verify cache_info() shows hits
-  - [ ] ex-26 · decorator-log-wrap — verify wrapped result unchanged
-  - [ ] ex-27 · recursion-factorial — verify value; note no TCO
-  - [ ] ex-28 · optional-none-guard — verify the miss is handled
-  - [ ] ex-29 · pure-core-extract — verify core tested with no I/O
-  - [ ] ex-30 · persistent-list-prepend — verify O(1) sharing and old list intact
-  - [ ] ex-31 · mappingproxy-readonly — verify writes through the view raise
-  - [ ] ex-32 · closure-counter-vs-pure-fold — verify both count, contrast state
-  - [ ] ex-33 · currying-with-partial — verify the composed transform
-  - [ ] ex-34 · compose-n-functions — verify application order
-  - [ ] ex-35 · point-free-transform — verify identical output
-  - [ ] ex-36 · reduce-histogram — verify the counts
-  - [ ] ex-37 · map-filter-reduce-pipeline — verify the result
-  - [ ] ex-38 · lazy-pipeline-generators — verify laziness end to end
-  - [ ] ex-39 · itertools-accumulate — verify prefix sums
-  - [ ] ex-40 · itertools-pairwise-tee — verify adjacent pairs
-  - [ ] ex-41 · memoize-manual-dict — verify second call cached
-  - [ ] ex-42 · decorator-with-args — verify retries counted
-  - [ ] ex-43 · decorator-preserves-metadata — verify **name** preserved
-  - [ ] ex-44 · recursion-to-iteration — verify same result on RecursionError-scale input
-  - [ ] ex-45 · adt-sum-type-dataclasses — verify each variant
-  - [ ] ex-46 · match-case-over-adt — verify each branch; note no exhaustiveness check
-  - [ ] ex-47 · match-guards — verify guard selects the right branch
-  - [ ] ex-48 · option-some-nothing — verify map is skipped on Nothing
-  - [ ] ex-49 · option-chaining — verify short-circuit on first miss
-  - [ ] ex-50 · result-ok-err — verify error carried as a value
-  - [ ] ex-51 · result-map-and-then — verify pipeline stops at first Err
-  - [ ] ex-52 · railway-parse-pipeline — verify one bad field short-circuits
-  - [ ] ex-53 · functor-law-identity — verify identity law holds by example
-  - [ ] ex-54 · functor-over-list-and-option — verify both mapped
-  - [ ] ex-55 · applicative-combine-options — verify both-present combines, any-absent short-circuits
-  - [ ] ex-56 · monad-bind-chain — verify monadic sequencing
-  - [ ] ex-57 · functional-core-imperative-shell-tool — verify core pure-tested, shell holds all I/O
-  - [ ] ex-58 · property-test-purity — verify the property holds across generated inputs
-  - [ ] ex-59 · persistent-tree-update — verify old root intact
-  - [ ] ex-60 · immutable-state-reducer — verify replay reproduces state
-  - [ ] ex-61 · compose-with-result — verify error propagation through composition
-  - [ ] ex-62 · curry-decorator — verify partial calls accumulate arguments
-  - [ ] ex-63 · lazy-infinite-sieve — verify first N primes
-  - [ ] ex-64 · generator-coroutine-pipeline — verify the streaming result
-  - [ ] ex-65 · memoize-bounded-lru — verify eviction of the oldest entry
-  - [ ] ex-66 · tail-recursion-trampoline — verify deep recursion completes without RecursionError
-  - [ ] ex-67 · adt-expression-evaluator — verify an arithmetic result
-  - [ ] ex-68 · option-do-style-sequence — verify short-circuit on absence
-  - [ ] ex-69 · result-form-validation — verify the failing rule is reported
-  - [ ] ex-70 · functor-laws-property-checked — verify identity + composition laws hold
-  - [ ] ex-71 · applicative-validation-accumulate — verify every error is collected
-  - [ ] ex-72 · monad-laws-intuition — verify the three laws hold
-  - [ ] ex-73 · point-free-combinator-lib — verify a composed transform
-  - [ ] ex-74 · pipe-vs-nested-readability — verify identical output, note readability
-  - [ ] ex-75 · immutability-perf-cost — verify both correct, note allocation cost
-  - [ ] ex-76 · reduce-shared-state-refactor — verify no globals remain, output unchanged
-  - [ ] ex-77 · decorator-stack-composition — verify order-dependent behavior
-  - [ ] ex-78 · lazy-vs-eager-tradeoff — verify both behaviors
-  - [ ] ex-79 · monad-option-vs-result — verify each carries its own error model
-  - [ ] ex-80 · capstone-preview-log-analyzer — verify the end-to-end report
-- [ ] **[AI] A2 (capstone)** — Author `CONTENT/functional-programming/learning/capstone/` (`_index.md` weight 900) per the
+  - [x] ex-01 · pure-vs-impure-pair — verify the pure one gives the same result on repeat calls
+  - [x] ex-02 · referential-transparency-substitution — verify output unchanged after substitution
+  - [x] ex-03 · detect-side-effect — verify only the pure one is flagged pure
+  - [x] ex-04 · immutable-tuple-vs-list — verify TypeError on tuple mutation
+  - [x] ex-05 · frozen-dataclass — verify FrozenInstanceError
+  - [x] ex-06 · dataclasses-replace-copy — verify original unchanged, copy differs
+  - [x] ex-07 · structural-sharing-cons — verify old version intact after update
+  - [x] ex-08 · function-as-value — verify same result via the variable
+  - [x] ex-09 · functions-in-a-list — verify all invoked with the right output
+  - [x] ex-10 · higher-order-apply — verify apply(fn, x) works for two functions
+  - [x] ex-11 · return-a-function — verify multiplier(3)(4) == 12
+  - [x] ex-12 · closure-captures-config — verify behavior varies with captured config
+  - [x] ex-13 · map-basic — verify every word uppercased
+  - [x] ex-14 · filter-basic — verify only evens remain
+  - [x] ex-15 · reduce-sum — verify the total
+  - [x] ex-16 · comprehension-vs-map — verify identical list
+  - [x] ex-17 · curry-manual — verify curried result matches uncurried
+  - [x] ex-18 · partial-application — verify it computes 2\*\*n
+  - [x] ex-19 · compose-two — verify f(g(x))
+  - [x] ex-20 · pipe-left-to-right — verify equals nested calls
+  - [x] ex-21 · generator-lazy-count — verify only pulled values computed
+  - [x] ex-22 · generator-vs-list-memory — verify generator doesn't materialize eagerly
+  - [x] ex-23 · itertools-islice-infinite — verify first N values taken
+  - [x] ex-24 · itertools-chain-groupby — verify grouped output
+  - [x] ex-25 · memoize-lru-cache — verify cache_info() shows hits
+  - [x] ex-26 · decorator-log-wrap — verify wrapped result unchanged
+  - [x] ex-27 · recursion-factorial — verify value; note no TCO
+  - [x] ex-28 · optional-none-guard — verify the miss is handled
+  - [x] ex-29 · pure-core-extract — verify core tested with no I/O
+  - [x] ex-30 · persistent-list-prepend — verify O(1) sharing and old list intact
+  - [x] ex-31 · mappingproxy-readonly — verify writes through the view raise
+  - [x] ex-32 · closure-counter-vs-pure-fold — verify both count, contrast state
+  - [x] ex-33 · currying-with-partial — verify the composed transform
+  - [x] ex-34 · compose-n-functions — verify application order
+  - [x] ex-35 · point-free-transform — verify identical output
+  - [x] ex-36 · reduce-histogram — verify the counts
+  - [x] ex-37 · map-filter-reduce-pipeline — verify the result
+  - [x] ex-38 · lazy-pipeline-generators — verify laziness end to end
+  - [x] ex-39 · itertools-accumulate — verify prefix sums
+  - [x] ex-40 · itertools-pairwise-tee — verify adjacent pairs
+  - [x] ex-41 · memoize-manual-dict — verify second call cached
+  - [x] ex-42 · decorator-with-args — verify retries counted
+  - [x] ex-43 · decorator-preserves-metadata — verify **name** preserved
+  - [x] ex-44 · recursion-to-iteration — verify same result on RecursionError-scale input
+  - [x] ex-45 · adt-sum-type-dataclasses — verify each variant
+  - [x] ex-46 · match-case-over-adt — verify each branch; note no exhaustiveness check
+  - [x] ex-47 · match-guards — verify guard selects the right branch
+  - [x] ex-48 · option-some-nothing — verify map is skipped on Nothing
+  - [x] ex-49 · option-chaining — verify short-circuit on first miss
+  - [x] ex-50 · result-ok-err — verify error carried as a value
+  - [x] ex-51 · result-map-and-then — verify pipeline stops at first Err
+  - [x] ex-52 · railway-parse-pipeline — verify one bad field short-circuits
+  - [x] ex-53 · functor-law-identity — verify identity law holds by example
+  - [x] ex-54 · functor-over-list-and-option — verify both mapped
+  - [x] ex-55 · applicative-combine-options — verify both-present combines, any-absent short-circuits
+  - [x] ex-56 · monad-bind-chain — verify monadic sequencing
+  - [x] ex-57 · functional-core-imperative-shell-tool — verify core pure-tested, shell holds all I/O
+  - [x] ex-58 · property-test-purity — verify the property holds across generated inputs
+  - [x] ex-59 · persistent-tree-update — verify old root intact
+  - [x] ex-60 · immutable-state-reducer — verify replay reproduces state
+  - [x] ex-61 · compose-with-result — verify error propagation through composition
+  - [x] ex-62 · curry-decorator — verify partial calls accumulate arguments
+  - [x] ex-63 · lazy-infinite-sieve — verify first N primes
+  - [x] ex-64 · generator-coroutine-pipeline — verify the streaming result
+  - [x] ex-65 · memoize-bounded-lru — verify eviction of the oldest entry
+  - [x] ex-66 · tail-recursion-trampoline — verify deep recursion completes without RecursionError
+  - [x] ex-67 · adt-expression-evaluator — verify an arithmetic result
+  - [x] ex-68 · option-do-style-sequence — verify short-circuit on absence
+  - [x] ex-69 · result-form-validation — verify the failing rule is reported
+  - [x] ex-70 · functor-laws-property-checked — verify identity + composition laws hold
+  - [x] ex-71 · applicative-validation-accumulate — verify every error is collected
+  - [x] ex-72 · monad-laws-intuition — verify the three laws hold
+  - [x] ex-73 · point-free-combinator-lib — verify a composed transform
+  - [x] ex-74 · pipe-vs-nested-readability — verify identical output, note readability
+  - [x] ex-75 · immutability-perf-cost — verify both correct, note allocation cost
+  - [x] ex-76 · reduce-shared-state-refactor — verify no globals remain, output unchanged
+  - [x] ex-77 · decorator-stack-composition — verify order-dependent behavior
+  - [x] ex-78 · lazy-vs-eager-tradeoff — verify both behaviors
+  - [x] ex-79 · monad-option-vs-result — verify each carries its own error model
+  - [x] ex-80 · capstone-preview-log-analyzer — verify the end-to-end report
+- [x] **[AI] A2 (capstone)** — Author `CONTENT/functional-programming/learning/capstone/` (`_index.md` weight 900) per the
       syllabus `## Capstone spec`. **Acceptance**: the done bar is met and the concepts-exercised checklist
       is fully hit.
-- [ ] **[AI] A3/D/F/G** — `apps-ayokoding-www-by-example-checker` + `apps-ayokoding-www-link-checker` +
+- [x] **[AI] A3/D/F/G** — `apps-ayokoding-www-by-example-checker` + `apps-ayokoding-www-link-checker` +
       `apps-ayokoding-www-facts-checker` clean (resolve via matching fixer); author
       `CONTENT/functional-programming/drilling/_index.md` (wt 223) covering the same Items with mocked/self-contained
       inputs; `npx nx run ayokoding-www:build` + `npm run lint:md` exit 0.
 
 ### Phase 26 Gate
 
-- [ ] [AI] `functional-programming/` complete: `_index.md` wt 330, `learning/_index.md` wt 123,
+- [x] [AI] `functional-programming/` complete: `_index.md` wt 330, `learning/_index.md` wt 123,
       `drilling/_index.md` wt 223, capstone wt 900; all 28 concepts + 80 worked examples + capstone present;
       checkers + facts-checker clean; build + `lint:md` exit 0.
 


### PR DESCRIPTION
## Summary

Phase 26 of `plans/in-progress/fundamentally-strong-software-engineer/`: adds the Functional Programming By-Example tutorial topic (Topic 23) to ayokoding-www.

- 28 concepts (co-01..co-28) spanning purity, referential transparency, immutability, persistent data structures, first-class/higher-order functions, closures, currying/partial application, composition/pipe, map/filter/reduce, recursion (and Python's missing TCO), lazy evaluation/generators, itertools, memoization, decorators, point-free style, algebraic data types, structural pattern matching, Option/Result types, railway-oriented error handling, and functor/applicative/monad intuition
- 80 worked examples (ex-01..ex-80), each runnable Python with a passing pytest suite
- Capstone: functional-core/imperative-shell transaction-log analyzer, with hand-rolled Option/Result monads and Hypothesis property-based tests (precedented by `software-testing` and `capstone-first-working-software` topics)
- Drilling set: 10 katas, applied problems, recall Q&A, self-check checklist, elaborative-interrogation prompts
- Nav-wired into `fundamentally-strong/_index.md` and `fundamentally-strong/software-engineer/_index.md` after Topic 22
- All 191 Python files (80 examples + capstone + 10 katas) pass `pyright --strict` — applied proactively this time after the sibling Phase 25 PR needed two extra review cycles to close the same gap

## Test plan

- [x] All 80 example scripts + pytest suites pass (`python3 example.py`, `pytest`)
- [x] Capstone: 33 tests pass (incl. 3 Hypothesis property tests)
- [x] All 10 drilling katas verified before/after
- [x] `pyright --strict` clean across all 191 Python files
- [x] `apps-ayokoding-www-by-example-checker`-equivalent validation clean (density, structure, counts)
- [x] `apps-ayokoding-www-link-checker`-equivalent validation clean (internal links + anchors)
- [x] `apps-ayokoding-www-facts-checker`-equivalent validation clean
- [x] `npx nx run ayokoding-www:build` exit 0
- [x] `npm run lint:md` exit 0
- [ ] 3-cycle PR review (pr-review-maker / pr-review-fixer) — in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)