### PR TITLE
feat(rhino-cli): detect Rule/Feature-level @skip/@fixme in e2e-coverage gap detector

### DIFF
--- a/apps/rhino-cli/src/application/e2e_coverage/parser.rs
+++ b/apps/rhino-cli/src/application/e2e_coverage/parser.rs
@@ -109,35 +109,97 @@ pub fn scan_unbound_describe_titles(spec_js: &str) -> Vec<String> {
     result
 }
 
-/// Scans playwright-bdd generated `.spec.js` source for a `Scenario
-/// Outline`'s wrapping `test.describe.skip(...)` or `test.describe.fixme(...)`
-/// block — playwright-bdd's rendering for an Outline-level `@skip`/`@fixme`
-/// FIRST-CLASS special tag (distinct from an ordinary Gherkin tag; see
-/// `node_modules/playwright-bdd/dist/generate/specialTags.js`), returning
-/// each such block's own title.
+/// Scans playwright-bdd generated `.spec.js` source for a `Feature`-,
+/// `Rule`-, or `Scenario Outline`-level wrapping `test.describe.skip(...)`
+/// or `test.describe.fixme(...)` block — playwright-bdd's rendering for a
+/// FIRST-CLASS `@skip`/`@fixme` special tag (distinct from an ordinary
+/// Gherkin tag; see
+/// `node_modules/playwright-bdd/dist/generate/specialTags.js`) at any of
+/// those three levels — returning both the block's own title AND every
+/// plain (unsuffixed) `test(...)`/`test.describe(...)` title nested
+/// anywhere inside its span, at any depth.
 ///
-/// Playwright enforces a `.skip`/`.fixme`-suffixed suite entirely at the
-/// PARENT level — none of its nested Examples-row tests are individually
-/// re-marked `test.fixme`, they remain ordinary bound `test(...)` calls (see
-/// `node_modules/playwright-bdd/dist/generate/formatter.js`'s
-/// `withSubFunction`, which chooses the suffix once for the whole block).
-/// [`scan_unbound_describe_titles`] alone can therefore never see this case —
-/// it requires a NESTED `test.fixme` — and because the generic `describe`
-/// title matching matches ANY `.method` suffix uniformly, the block's title
-/// still lands in
-/// [`scan_all_rendered_titles`]'s `rendered` set, making a fully
-/// `@skip`/`@fixme`-tagged Outline structurally indistinguishable from a
-/// genuinely covered one unless this function's result is folded into the
-/// `unbound` set too (see the command layer's `scan_fixme_dir`).
+/// `renderDescribe` (`node_modules/playwright-bdd/dist/generate/file.js`) is
+/// the SAME shared rendering path for a `Feature` node and a `Rule` node —
+/// `renderChild` recurses into `renderDescribe` for a `Rule` child exactly
+/// like `renderRootSuite` calls it for the top-level `Feature` — so a
+/// first-class `@skip`/`@fixme` tag at either level produces the identical
+/// `.skip`/`.fixme`-suffixed wrapping shape a `Scenario Outline` already
+/// produced. Playwright enforces the skip/fixme entirely at the PARENT
+/// level — none of the wrapped children (a directly-declared `Scenario`, a
+/// nested `Scenario Outline`, or a nested `Rule`) are individually
+/// re-marked `test.fixme`/`.skip` themselves; they remain ordinary plain
+/// `test(...)`/`test.describe(...)` calls, since a child's own special-tag
+/// suffix is built from its OWN AST tags only, never inherited from an
+/// ancestor Rule/Feature tag (see
+/// `node_modules/playwright-bdd/dist/generate/test/index.js`'s
+/// `SpecialTags` construction).
+///
+/// This nested-title collection matters because a `Scenario Outline`'s
+/// title IS the declared entity (its Examples-row children are auto-titled
+/// `Example #<N>` by default, which never matches any real declared
+/// scenario), but a `Rule`'s or `Feature`'s nested `Scenario` children carry
+/// their OWN declared titles that never equal the wrapping `Rule`'s/
+/// `Feature`'s own name — so for the command layer's `is_unbound_or_absent`
+/// to correctly flag a `Scenario` nested under a skipped `Rule`/`Feature`,
+/// this function must surface that `Scenario`'s own title too, not just the
+/// wrapping block's title. Recursing into nested content is harmless for
+/// the `Scenario Outline` case: it simply adds `Example #<N>`-shaped
+/// entries alongside the outline's own title, and those auto-generated
+/// titles never collide with a real declared scenario title.
+///
+/// A block's extent is found the same way as in
+/// [`scan_unbound_describe_titles`]: matching leading-whitespace width
+/// between the `.skip`/`.fixme` open line and its own closing `});` line —
+/// playwright-bdd's generator always indents a block's open and close lines
+/// identically, so this never requires full JS parsing or brace-balancing.
 ///
 /// Deliberately excludes `.only` — a `.only`-suffixed suite genuinely
 /// executes its wrapped tests (Playwright restricts execution TO it, it does
-/// not skip it), so treating it as unbound would be a false positive.
+/// not skip it), so treating it (or anything nested inside it) as unbound
+/// would be a false positive.
 pub fn scan_skip_or_fixme_describe_titles(spec_js: &str) -> Vec<String> {
-    skip_or_fixme_describe_re()
-        .captures_iter(spec_js)
-        .map(|caps| captured_title(&caps))
-        .collect()
+    let lines: Vec<&str> = spec_js.lines().collect();
+    let mut result = Vec::new();
+    for (i, line) in lines.iter().enumerate() {
+        let Some(caps) = skip_or_fixme_describe_re().captures(line) else {
+            continue;
+        };
+        result.push(captured_title(&caps));
+        // A `.skip`/`.fixme` block with zero children collapses onto a
+        // single line (`test.describe.skip('title', () => {});`) — its
+        // body is trivially empty, so there is nothing nested to recurse
+        // into.
+        if line.trim_end().ends_with("{});") {
+            continue;
+        }
+        let indent = leading_whitespace_len(line);
+        let body: Vec<&str> = lines[i + 1..]
+            .iter()
+            .copied()
+            .take_while(|candidate| {
+                !(candidate.trim() == "});" && leading_whitespace_len(candidate) == indent)
+            })
+            .collect();
+        let body_text = body.join("\n");
+        // Every plain, unsuffixed `test(...)` leaf call nested anywhere in
+        // the block's span (a directly-declared Scenario) and every plain
+        // `test.describe(...)` block nested anywhere in its span (a nested
+        // Rule or Scenario Outline) is effectively unbound too — see this
+        // function's own doc comment for why the Outline-Examples-row case
+        // stays harmless.
+        result.extend(
+            bound_test_title_re()
+                .captures_iter(&body_text)
+                .map(|caps| captured_title(&caps)),
+        );
+        result.extend(
+            describe_re()
+                .captures_iter(&body_text)
+                .map(|caps| captured_title(&caps)),
+        );
+    }
+    result
 }
 
 /// Scans playwright-bdd generated `.spec.js` source for EVERY title it
@@ -617,6 +679,21 @@ test.describe('Outline title', () => {
     /// `@skip`-tagged Outline was silently treated as covered. This function
     /// closes that gap by recognising the `.skip`/`.fixme` suffix specifically
     /// (never `.only`, which genuinely does execute its wrapped tests).
+    ///
+    /// Asserts the fuller exact `Vec` (AC-4 guard, post-DD-1
+    /// generalization) rather than a looser `contains` check: the
+    /// Rule/Feature-level fix in [`scan_skip_or_fixme_describe_titles`] now
+    /// also surfaces nested `test(...)`/`test.describe(...)` titles found
+    /// within a `.skip`/`.fixme` block's span (needed so a Scenario nested
+    /// under a skipped Rule/Feature is correctly reported) — for THIS
+    /// Outline fixture that deterministically adds the Examples-row's own
+    /// auto-generated `Example #1` title AFTER the outline's own wrapping
+    /// title (the implementation pushes the wrapping title first, then
+    /// walks the block's body left-to-right for nested `test(...)`/
+    /// `test.describe(...)` matches — see the doc comment on
+    /// [`scan_skip_or_fixme_describe_titles`] itself). Keeping this exact
+    /// documents the new behavior precisely rather than merely asserting a
+    /// subset.
     #[test]
     fn scan_skip_or_fixme_describe_titles_detects_skip_suffixed_outline() {
         let spec_js = "\
@@ -628,17 +705,25 @@ test.describe.skip('Outline title', () => {
 
         let titles = scan_skip_or_fixme_describe_titles(spec_js);
 
-        assert_eq!(titles, vec!["Outline title".to_string()]);
+        assert_eq!(
+            titles,
+            vec!["Outline title".to_string(), "Example #1".to_string()]
+        );
     }
 
-    /// `.fixme` counterpart of the `.skip` case above.
+    /// `.fixme` counterpart of the `.skip` case above. See the exact-`Vec`
+    /// rationale on
+    /// [`scan_skip_or_fixme_describe_titles_detects_skip_suffixed_outline`].
     #[test]
     fn scan_skip_or_fixme_describe_titles_detects_fixme_suffixed_outline() {
         let spec_js = "test.describe.fixme('Outline title', () => {\n  test('Example #1', async ({ page }) => {\n  });\n});\n";
 
         let titles = scan_skip_or_fixme_describe_titles(spec_js);
 
-        assert_eq!(titles, vec!["Outline title".to_string()]);
+        assert_eq!(
+            titles,
+            vec!["Outline title".to_string(), "Example #1".to_string()]
+        );
     }
 
     /// Negative counterpart: `.only` genuinely executes its wrapped tests
@@ -647,6 +732,77 @@ test.describe.skip('Outline title', () => {
     #[test]
     fn scan_skip_or_fixme_describe_titles_ignores_only_suffixed_outline() {
         let spec_js = "test.describe.only('Outline title', () => {\n  test('Example #1', async ({ page }) => {\n  });\n});\n";
+
+        let titles = scan_skip_or_fixme_describe_titles(spec_js);
+
+        assert!(titles.is_empty());
+    }
+
+    /// Generalization of the cycle-5 MEDIUM fix above (AC-1): playwright-bdd's
+    /// `renderDescribe` is the SAME shared rendering path for a `Rule:` node
+    /// as it is for a `Scenario Outline` (see `renderChild`'s direct
+    /// recursion into `renderDescribe` for a `Rule` child) — a Rule-level
+    /// `@skip` tag therefore produces the identical wrapping-`.skip`-suffix
+    /// shape. Unlike an Outline (where the wrapping title itself IS the
+    /// declared entity), a `Rule`'s nested content is a directly-declared
+    /// `Scenario` whose own `test(...)` call title never equals the
+    /// wrapping Rule's own title — so the scanner must also surface the
+    /// nested scenario's own title as unbound for it to be correctly
+    /// flagged by the command layer's `is_unbound_or_absent`.
+    // @covers specs/apps/rhino/behavior/rhino-cli/gherkin/specs/e2e-coverage.feature:A Rule-level @skip tag is detected as unbound
+    #[test]
+    fn scan_skip_or_fixme_describe_titles_detects_skip_suffixed_rule() {
+        let spec_js = "\
+test.describe.skip('Some rule', () => {
+  test('Scenario in the rule', async ({ page }) => {
+  });
+});
+";
+
+        let titles = scan_skip_or_fixme_describe_titles(spec_js);
+
+        assert!(
+            titles.contains(&"Scenario in the rule".to_string()),
+            "expected the Rule's nested scenario title to be reported as \
+             unbound, got: {titles:?}"
+        );
+    }
+
+    /// `.fixme` counterpart of the Rule-level case above (AC-2), wrapping a
+    /// top-level `Feature:` instead — `renderRootSuite` calls the exact same
+    /// `renderDescribe` for the `Feature` node, so a Feature-level `@fixme`
+    /// tag produces the identical shape one level further out.
+    // @covers specs/apps/rhino/behavior/rhino-cli/gherkin/specs/e2e-coverage.feature:A Feature-level @fixme tag is detected as unbound
+    #[test]
+    fn scan_skip_or_fixme_describe_titles_detects_fixme_suffixed_feature() {
+        let spec_js = "\
+test.describe.fixme('Example feature', () => {
+  test('Scenario in the feature', async ({ page }) => {
+  });
+});
+";
+
+        let titles = scan_skip_or_fixme_describe_titles(spec_js);
+
+        assert!(
+            titles.contains(&"Scenario in the feature".to_string()),
+            "expected the Feature's nested scenario title to be reported as \
+             unbound, got: {titles:?}"
+        );
+    }
+
+    /// `.only`-suffix guard at the Rule level (AC-3) — mirrors
+    /// [`scan_skip_or_fixme_describe_titles_ignores_only_suffixed_outline`]:
+    /// `.only` genuinely executes its wrapped tests, so a `.only`-suffixed
+    /// Rule must never be reported as unbound.
+    #[test]
+    fn scan_skip_or_fixme_describe_titles_ignores_only_suffixed_rule() {
+        let spec_js = "\
+test.describe.only('Some rule', () => {
+  test('Scenario in the rule', async ({ page }) => {
+  });
+});
+";
 
         let titles = scan_skip_or_fixme_describe_titles(spec_js);
 

--- a/apps/rhino-cli/src/application/e2e_coverage/parser.rs
+++ b/apps/rhino-cli/src/application/e2e_coverage/parser.rs
@@ -689,8 +689,9 @@ test.describe('Outline title', () => {
     /// Outline fixture that deterministically adds the Examples-row's own
     /// auto-generated `Example #1` title AFTER the outline's own wrapping
     /// title (the implementation pushes the wrapping title first, then
-    /// walks the block's body left-to-right for nested `test(...)`/
-    /// `test.describe(...)` matches — see the doc comment on
+    /// collects the block's nested `test(...)` titles followed by its nested
+    /// `test.describe(...)` titles — two ordered passes, not a single
+    /// interleaved left-to-right walk — see the doc comment on
     /// [`scan_skip_or_fixme_describe_titles`] itself). Keeping this exact
     /// documents the new behavior precisely rather than merely asserting a
     /// subset.

--- a/apps/rhino-cli/src/application/e2e_coverage/parser.rs
+++ b/apps/rhino-cli/src/application/e2e_coverage/parser.rs
@@ -791,6 +791,62 @@ test.describe.fixme('Example feature', () => {
         );
     }
 
+    /// Depth-guard: a top-level `Feature:` `@skip` that wraps a `Rule:` which
+    /// in turn wraps the `Scenario` produces a two-level nesting
+    /// (`test.describe.skip` > `test.describe` > `test`). The scanner's block
+    /// scan recurses through the intermediate `Rule` describe and must still
+    /// surface the depth-2 scenario title as unbound. This locks the "collected
+    /// at any depth" claim in [`scan_skip_or_fixme_describe_titles`]'s doc and
+    /// DD-1's `renderDescribe`-recursion rationale so a future single-level-only
+    /// refactor cannot silently reintroduce a false PASS while all the
+    /// one-level fixtures still pass.
+    #[test]
+    fn scan_skip_or_fixme_describe_titles_detects_scenario_nested_two_levels() {
+        let spec_js = "\
+test.describe.skip('Example feature', () => {
+  test.describe('Some rule', () => {
+    test('Scenario in the rule', async ({ page }) => {
+    });
+  });
+});
+";
+
+        let titles = scan_skip_or_fixme_describe_titles(spec_js);
+
+        assert!(
+            titles.contains(&"Scenario in the rule".to_string()),
+            "expected the depth-2 (Feature > Rule > Scenario) scenario title to \
+             be reported as unbound, got: {titles:?}"
+        );
+    }
+
+    /// Mixed-tag guard: a single spec file carrying both a `.skip` block and a
+    /// `.fixme` block must surface the nested scenario title from BOTH — the
+    /// two suffixes are handled by the same `skip_or_fixme_describe_re`
+    /// alternation, so neither block shadows the other.
+    #[test]
+    fn scan_skip_or_fixme_describe_titles_detects_mixed_skip_and_fixme() {
+        let spec_js = "\
+test.describe.skip('Skipped feature', () => {
+  test('Skipped scenario', async ({ page }) => {
+  });
+});
+test.describe.fixme('Fixme feature', () => {
+  test('Fixme scenario', async ({ page }) => {
+  });
+});
+";
+
+        let titles = scan_skip_or_fixme_describe_titles(spec_js);
+
+        assert!(
+            titles.contains(&"Skipped scenario".to_string())
+                && titles.contains(&"Fixme scenario".to_string()),
+            "expected both the .skip and .fixme nested scenario titles to be \
+             reported as unbound, got: {titles:?}"
+        );
+    }
+
     /// `.only`-suffix guard at the Rule level (AC-3) — mirrors
     /// [`scan_skip_or_fixme_describe_titles_ignores_only_suffixed_outline`]:
     /// `.only` genuinely executes its wrapped tests, so a `.only`-suffixed

--- a/apps/rhino-cli/tests/specs_tree.rs
+++ b/apps/rhino-cli/tests/specs_tree.rs
@@ -353,6 +353,46 @@ impl SpecsTreeWorld {
             combined_output(&out)
         );
     }
+
+    /// Writes the `.feature`/`.spec.js` fixture pair for the Rule-level
+    /// `@skip` scenario: a top-level `Feature:` wrapping a `Rule:` block
+    /// tagged `@skip` (playwright-bdd's `renderDescribe` is the SAME shared
+    /// rendering path for a `Rule:` node as a `Feature:` node — see
+    /// `application::e2e_coverage::parser::scan_skip_or_fixme_describe_titles`'s
+    /// doc comment) — the Rule contains exactly one `@e2e` Scenario
+    /// ([`EC_RULE_SCENARIO_TITLE`]), rendered as a plain, unsuffixed nested
+    /// `test(...)` inside a `test.describe.skip(...)` block.
+    ///
+    /// `with_other_content` additionally writes [`EC_RULE_OTHER_SCENARIO_TITLE`]
+    /// as an ordinary top-level bound Scenario alongside the skipped Rule —
+    /// proving the file still generates real, unrelated output (AC-1's
+    /// Gherkin "the file also has other, non-skipped content so it still
+    /// generates" clause) and that ONLY the Rule-nested scenario is reported
+    /// as a gap, never this sibling.
+    fn ec_write_rule_skip_fixture(&self, with_other_content: bool) {
+        let mut feature = format!(
+            "Feature: fixture\n\n  @skip\n  Rule: {EC_RULE_TITLE}\n\n    @e2e\n    Scenario: {EC_RULE_SCENARIO_TITLE}\n      Given a step\n"
+        );
+        let mut spec_js = format!(
+            "test.describe('fixture', () => {{\n  test.describe.skip('{EC_RULE_TITLE}', () => {{\n    test('{EC_RULE_SCENARIO_TITLE}', async ({{ page }}) => {{\n    }});\n  }});\n"
+        );
+        if with_other_content {
+            let _ = writeln!(
+                feature,
+                "\n  @e2e\n  Scenario: {EC_RULE_OTHER_SCENARIO_TITLE}\n    Given a step"
+            );
+            let _ = writeln!(
+                spec_js,
+                "  test('{EC_RULE_OTHER_SCENARIO_TITLE}', async ({{ page }}) => {{\n  }});"
+            );
+        }
+        spec_js.push_str("});\n");
+        self.write(&format!("{EC_FEATURES_DIR}/{EC_FEATURE_FILE}"), &feature);
+        self.write(
+            &format!("{EC_FEATURES_GEN_DIR}/{EC_SPEC_JS_FILE}"),
+            &spec_js,
+        );
+    }
 }
 
 /// Runs `git` with `args` inside `dir`, using a fixed synthetic identity.
@@ -1813,6 +1853,100 @@ fn then_ec_reports_missing_features_gen(w: &mut SpecsTreeWorld) {
     let text = combined_output(out);
     assert!(text.contains(".features-gen"), "got: {text}");
     assert!(text.contains("bddgen"), "got: {text}");
+}
+
+/// Declared title of the `Rule:` block [`given_ec_rule_skip_tagged`] writes
+/// — shared with [`ec_write_rule_skip_fixture`](SpecsTreeWorld::ec_write_rule_skip_fixture).
+const EC_RULE_TITLE: &str = "A rule under test";
+/// Declared title of the `@e2e` Scenario nested under [`EC_RULE_TITLE`]'s
+/// `@skip`-tagged Rule — the scenario AC-1 asserts is reported as unbound.
+const EC_RULE_SCENARIO_TITLE: &str = "Scenario nested under the skipped rule";
+/// Declared title of the ordinary, fully-bound top-level Scenario
+/// [`given_ec_rule_has_other_content`] adds alongside the skipped Rule —
+/// AC-1's "the file also has other, non-skipped content" clause, and the
+/// negative half of [`then_ec_rule_nested_scenario_is_new_gap`]'s assertion
+/// (this sibling must never be reported as a gap).
+const EC_RULE_OTHER_SCENARIO_TITLE: &str = "An ordinary bound scenario outside the rule";
+
+#[given(r#"a .feature file with a "Rule:" block tagged "@skip""#)]
+fn given_ec_rule_skip_tagged(w: &mut SpecsTreeWorld) {
+    w.ec_write_rule_skip_fixture(false);
+}
+
+#[given("the Rule contains at least one Scenario")]
+fn given_ec_rule_has_scenario(_w: &mut SpecsTreeWorld) {
+    // No-op: `given_ec_rule_skip_tagged` already wrote exactly one @e2e
+    // Scenario nested under the Rule — this Gherkin clause elaborates on
+    // that same fixture rather than performing a further action.
+}
+
+#[given("the file also has other, non-skipped content so it still generates")]
+fn given_ec_rule_has_other_content(w: &mut SpecsTreeWorld) {
+    w.ec_write_rule_skip_fixture(true);
+}
+
+#[then("every scenario nested under the skipped Rule is reported as unbound")]
+fn then_ec_rule_nested_scenario_is_new_gap(w: &mut SpecsTreeWorld) {
+    let out = w.output.as_ref().expect("ran");
+    let text = combined_output(out);
+    assert!(!out.status.success(), "expected failure, got: {text}");
+    assert!(
+        text.contains("1 new unbound scenario(s) found"),
+        "got: {text}"
+    );
+    assert!(text.contains(EC_RULE_SCENARIO_TITLE), "got: {text}");
+    let sibling_marker = format!("\"{EC_RULE_OTHER_SCENARIO_TITLE}\"");
+    assert!(
+        !text.contains(&sibling_marker),
+        "the non-skipped sibling scenario outside the Rule must not be \
+         reported as a gap, got: {text}"
+    );
+}
+
+/// Declared title of the first `@e2e` Scenario
+/// [`given_ec_feature_fixme_tagged`] writes directly under the
+/// `@fixme`-tagged top-level `Feature:`.
+const EC_FEATURE_FIXME_TITLE_1: &str = "First scenario in the fixme-tagged feature";
+/// Declared title of the second `@e2e` Scenario
+/// [`given_ec_feature_fixme_tagged`] writes directly under the
+/// `@fixme`-tagged top-level `Feature:` — proves AC-2's "every scenario in
+/// the file" holds for more than a single scenario.
+const EC_FEATURE_FIXME_TITLE_2: &str = "Second scenario in the fixme-tagged feature";
+
+#[given(r#"a .feature file whose top-level "Feature:" is tagged "@fixme""#)]
+fn given_ec_feature_fixme_tagged(w: &mut SpecsTreeWorld) {
+    // playwright-bdd's `renderRootSuite` calls the exact same `renderDescribe`
+    // for the top-level `Feature:` node as it does for a nested `Rule:` node
+    // — a Feature-level `@fixme` first-class special tag therefore wraps
+    // EVERY nested scenario in one `test.describe.fixme(...)` block, each
+    // rendered as a plain, unsuffixed nested `test(...)` call — see
+    // `application::e2e_coverage::parser::scan_skip_or_fixme_describe_titles`'s
+    // doc comment.
+    w.write(
+        &format!("{EC_FEATURES_DIR}/{EC_FEATURE_FILE}"),
+        &format!(
+            "@fixme\nFeature: fixture\n\n  @e2e\n  Scenario: {EC_FEATURE_FIXME_TITLE_1}\n    Given a step\n\n  @e2e\n  Scenario: {EC_FEATURE_FIXME_TITLE_2}\n    Given a step\n"
+        ),
+    );
+    w.write(
+        &format!("{EC_FEATURES_GEN_DIR}/{EC_SPEC_JS_FILE}"),
+        &format!(
+            "test.describe.fixme('fixture', () => {{\n  test('{EC_FEATURE_FIXME_TITLE_1}', async ({{ page }}) => {{\n  }});\n  test('{EC_FEATURE_FIXME_TITLE_2}', async ({{ page }}) => {{\n  }});\n}});\n"
+        ),
+    );
+}
+
+#[then("every scenario in the file is reported as unbound")]
+fn then_ec_feature_fixme_all_scenarios_new_gap(w: &mut SpecsTreeWorld) {
+    let out = w.output.as_ref().expect("ran");
+    let text = combined_output(out);
+    assert!(!out.status.success(), "expected failure, got: {text}");
+    assert!(
+        text.contains("2 new unbound scenario(s) found"),
+        "got: {text}"
+    );
+    assert!(text.contains(EC_FEATURE_FIXME_TITLE_1), "got: {text}");
+    assert!(text.contains(EC_FEATURE_FIXME_TITLE_2), "got: {text}");
 }
 
 // ===========================================================================

--- a/plans/in-progress/e2e-coverage-rule-feature-skip-fixme-gap/learnings.md
+++ b/plans/in-progress/e2e-coverage-rule-feature-skip-fixme-gap/learnings.md
@@ -1,0 +1,14 @@
+<!-- Knowledge Capture running log — append entries during execution. -->
+<!-- Triage every entry (or record the explicit "none" escape) before archival. -->
+
+# Learnings: e2e-coverage-rule-feature-skip-fixme-gap
+
+<!--
+Entry shape:
+
+## Learning: <one-line summary>
+
+- **Context**: what was being done when this surfaced
+- **Observation**: what was noticed (sanitized — real $HOME paths reduced to $HOME)
+- **Why it might generalize**: the litmus reasoning
+-->

--- a/specs/apps/rhino/behavior/rhino-cli/gherkin/specs/e2e-coverage.feature
+++ b/specs/apps/rhino/behavior/rhino-cli/gherkin/specs/e2e-coverage.feature
@@ -64,6 +64,20 @@ Feature: specs e2e-coverage validate
     And it reports exactly one new unbound scenario for the zero-row outline
 
   @unit
+  Scenario: A Rule-level @skip tag is detected as unbound
+    Given a .feature file with a "Rule:" block tagged "@skip"
+    And the Rule contains at least one Scenario
+    And the file also has other, non-skipped content so it still generates
+    When rhino-cli specs e2e-coverage validate runs for that project
+    Then every scenario nested under the skipped Rule is reported as unbound
+
+  @unit
+  Scenario: A Feature-level @fixme tag is detected as unbound
+    Given a .feature file whose top-level "Feature:" is tagged "@fixme"
+    When rhino-cli specs e2e-coverage validate runs for that project
+    Then every scenario in the file is reported as unbound
+
+  @unit
   Scenario: A test.fixme title contains an escaped apostrophe
     Given an @e2e scenario titled with an apostrophe that appears as test.fixme using playwright-bdd's escaped single-quote convention
     And a baseline manifest that lists no allowed unbound scenarios


### PR DESCRIPTION
## What

Extends the rhino-cli e2e-coverage gap detector so `@skip`/`@fixme` special tags are detected at **`Rule:`** and top-level **`Feature:`** level, not only at `Scenario Outline` level.

## Why

`scan_skip_or_fixme_describe_titles` returned only the wrapping `.skip`/`.fixme` describe block's own title. Scenarios nested under a skipped Rule/Feature render as ordinary plain `test(...)` calls whose titles never equal the wrapper's name, so they were silently treated as bound — a **false PASS** in the coverage gate.

## How

- Generalize the scan from a flat regex to a line-indexed block scan that finds each `.skip`/`.fixme` block's extent (indentation-matching, mirroring `scan_unbound_describe_titles`) and recursively collects every nested `test(...)`/`test.describe(...)` title.
- AC-1 (Rule `@skip`) and AC-2 (Feature `@fixme`) now correctly report nested scenarios as unbound. AC-3 (`.only` guard) and AC-4 (existing Outline behavior) preserved; Outline positive tests assert the fuller exact title vector the recursion now returns.
- Companion Gherkin: two `@unit` scenarios in `e2e-coverage.feature`, wired to genuine cucumber-rs step bindings in `specs_tree.rs` (real CLI-subprocess fixtures) and `@covers`-linked from the parser unit tests.

## Verification

- `nx run rhino-cli:test:quick` green — test:unit 1211 passed/0 failed; `specs:behavior:coverage` 58 specs / 330 scenarios / 1380 steps all covered.
- Real cucumber-rs e2e run (`specs_tree`): 44 scenarios passed.
- `clippy -D warnings` clean; `fmt --check` clean.

Plan: `plans/in-progress/e2e-coverage-rule-feature-skip-fixme-gap/`. TDD RED→GREEN→REFACTOR (RED proof: the two new tests failed pre-fix). Delivery Mode: `worktree-to-pr`. rhino-cli boundary changes will be propagated byte-identically to ose-primer + ose-infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)