### PR TITLE
fix(ayokoding-www): route Callout warning type to the accessible Alert variant

### DIFF
--- a/apps/ayokoding-www/src/app/globals-css-color-primary.unit.test.ts
+++ b/apps/ayokoding-www/src/app/globals-css-color-primary.unit.test.ts
@@ -5,20 +5,24 @@ import { describe, expect, it } from "vitest";
 // Regression guard for swe-ui audit b06d32 Finding 2 (re-validated FALSE_POSITIVE, not fixed):
 // the audit assumed `--color-primary` resolves to the honey/amber `--hue-honey` token from
 // `@open-sharia-enterprise/web-ui-token/src/ayokoding.css`, computing `prose-a:text-primary`
-// (markdown-renderer.tsx) and the `text-primary` meta link (section-card.tsx) at 2.13:1 —
-// below the 4.5:1 WCAG AA minimum. In the LIVE app this is not what renders: this file
-// declares its own local `@theme` block (light) and `.dark` block (dark), both AFTER the
-// `ayokoding.css` import, which redeclare `--color-primary` to blue
-// (`hsl(221.2 83.2% 53.3%)` light / `hsl(217.2 91.2% 59.8%)` dark). Because `@import` is
+// (markdown-renderer.tsx) and the `text-primary` meta link (section-card.tsx) at ~2.13:1-3.85:1
+// depending on methodology — either way below the 4.5:1 WCAG AA minimum. In the LIVE app this
+// is not what renders: this file declares its own local `@theme` block (light) and `.dark`
+// block (dark), both AFTER the `ayokoding.css` import, which redeclare `--color-primary` to
+// blue (`hsl(221.2 83.2% 53.3%)` light / `hsl(217.2 91.2% 59.8%)` dark). Because `@import` is
 // inlined before subsequent same-file rules and CSS custom properties cascade "last
-// declaration for a matching selector wins," this local override — not the honey token —
-// is what `text-primary` actually resolves to. Verified against the compiled Tailwind
-// output (`--color-primary: #2563eb` in `:root`, `#3b82f6` in the winning `.dark` block)
-// and WCAG luminance math: ~5.04:1 (light) / ~5.44:1 (dark) against `--color-background`,
-// both clearing the 4.5:1 AA bar.
+// declaration for a matching selector wins," this local override — not the honey token — is
+// what `text-primary` actually resolves to. THIS OVERRIDE IS LOAD-BEARING FOR ACCESSIBILITY:
+// it is not obvious from reading either file alone that ayokoding.css's honey token is dead
+// code for `--color-primary` specifically. Verified against the compiled Tailwind output
+// (`--color-primary: #2563eb` in `:root`, `#3b82f6` in the winning `.dark` block) and WCAG
+// luminance math (independently cross-checked twice, gamma/sRGB-transfer-function applied
+// both times): ~4.85-5.04:1 (light) / ~5.44:1 (dark) against `--color-background`, both
+// clearing the 4.5:1 AA bar with real margin — versus ~3.85:1 (fails) for the honey token
+// this override shadows.
 //
 // This test pins the override's presence and its position AFTER the import. If either is
-// ever removed, the honey token becomes live again and silently reintroduces the 2.13:1
+// ever removed, the honey token becomes live again and silently reintroduces the sub-4.5:1
 // contrast failure without any other test catching it (jsdom does not resolve Tailwind
 // `@theme`/CSS-custom-property cascade, so no component-level test can observe this).
 describe("ayokoding-www globals.css — --color-primary override (WCAG AA guard)", () => {

--- a/apps/ayokoding-www/src/app/globals-css-color-primary.unit.test.ts
+++ b/apps/ayokoding-www/src/app/globals-css-color-primary.unit.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Regression guard for swe-ui audit b06d32 Finding 2 (re-validated FALSE_POSITIVE, not fixed):
+// the audit assumed `--color-primary` resolves to the honey/amber `--hue-honey` token from
+// `@open-sharia-enterprise/web-ui-token/src/ayokoding.css`, computing `prose-a:text-primary`
+// (markdown-renderer.tsx) and the `text-primary` meta link (section-card.tsx) at 2.13:1 —
+// below the 4.5:1 WCAG AA minimum. In the LIVE app this is not what renders: this file
+// declares its own local `@theme` block (light) and `.dark` block (dark), both AFTER the
+// `ayokoding.css` import, which redeclare `--color-primary` to blue
+// (`hsl(221.2 83.2% 53.3%)` light / `hsl(217.2 91.2% 59.8%)` dark). Because `@import` is
+// inlined before subsequent same-file rules and CSS custom properties cascade "last
+// declaration for a matching selector wins," this local override — not the honey token —
+// is what `text-primary` actually resolves to. Verified against the compiled Tailwind
+// output (`--color-primary: #2563eb` in `:root`, `#3b82f6` in the winning `.dark` block)
+// and WCAG luminance math: ~5.04:1 (light) / ~5.44:1 (dark) against `--color-background`,
+// both clearing the 4.5:1 AA bar.
+//
+// This test pins the override's presence and its position AFTER the import. If either is
+// ever removed, the honey token becomes live again and silently reintroduces the 2.13:1
+// contrast failure without any other test catching it (jsdom does not resolve Tailwind
+// `@theme`/CSS-custom-property cascade, so no component-level test can observe this).
+describe("ayokoding-www globals.css — --color-primary override (WCAG AA guard)", () => {
+  const css = readFileSync(join(__dirname, "globals.css"), "utf8");
+
+  it("imports ayokoding.css (the source of the honey --color-primary token)", () => {
+    expect(css).toContain('@import "@open-sharia-enterprise/web-ui-token/src/ayokoding.css"');
+  });
+
+  it("redeclares --color-primary to blue in a local @theme block, positioned after the import", () => {
+    const importIndex = css.indexOf('@import "@open-sharia-enterprise/web-ui-token/src/ayokoding.css"');
+    const lightOverrideIndex = css.indexOf("--color-primary: hsl(221.2 83.2% 53.3%)");
+
+    expect(importIndex).toBeGreaterThan(-1);
+    expect(lightOverrideIndex).toBeGreaterThan(-1);
+    expect(lightOverrideIndex).toBeGreaterThan(importIndex);
+  });
+
+  it("redeclares --color-primary to blue in a local .dark block, positioned after the import", () => {
+    const importIndex = css.indexOf('@import "@open-sharia-enterprise/web-ui-token/src/ayokoding.css"');
+    const darkOverrideIndex = css.indexOf("--color-primary: hsl(217.2 91.2% 59.8%)");
+
+    expect(importIndex).toBeGreaterThan(-1);
+    expect(darkOverrideIndex).toBeGreaterThan(-1);
+    expect(darkOverrideIndex).toBeGreaterThan(importIndex);
+  });
+});

--- a/apps/ayokoding-www/src/features/content/shell/callout.test.tsx
+++ b/apps/ayokoding-www/src/features/content/shell/callout.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Callout } from "./callout";
+
+afterEach(cleanup);
+
+describe("Callout", () => {
+  it("maps type='warning' to the Alert warning variant, not destructive — HIGH-3 fix (contrast)", () => {
+    // Regression for swe-ui audit b06d32 Finding 3: `warning` previously mapped to
+    // `variant="destructive"` (3.05:1 contrast), instead of the dedicated `warning`
+    // variant (6.90:1). Assert on the resolved `data-variant` token, not a screenshot.
+    render(<Callout type="warning">Watch out.</Callout>);
+    const alert = screen.getByRole("alert");
+    expect(alert.getAttribute("data-variant")).toBe("warning");
+  });
+
+  it("maps type='info' to the Alert info variant", () => {
+    render(<Callout type="info">FYI.</Callout>);
+    const alert = screen.getByRole("alert");
+    expect(alert.getAttribute("data-variant")).toBe("info");
+  });
+
+  it("maps type='tip' to the default variant", () => {
+    render(<Callout type="tip">Pro tip.</Callout>);
+    const alert = screen.getByRole("alert");
+    expect(alert.getAttribute("data-variant")).toBe("default");
+  });
+
+  it("unknown types fall back to the default variant", () => {
+    render(<Callout type="unknown">Fallback.</Callout>);
+    const alert = screen.getByRole("alert");
+    expect(alert.getAttribute("data-variant")).toBe("default");
+  });
+
+  it.each(["warning", "info", "tip"])(
+    "renders the '%s' type icon as decorative (aria-hidden), locking in the current contract",
+    (type) => {
+      // swe-ui audit b06d32 Finding 4 flagged iconMap icons as missing an explicit
+      // aria-hidden="true" prop (unlike hero.tsx/tools-teaser.tsx, which pass it
+      // explicitly). Re-validated as FALSE_POSITIVE: lucide-react's Icon primitive
+      // (node_modules/lucide-react/dist/esm/Icon.js) already defaults to
+      // aria-hidden="true" whenever no children/aria-*/role/title prop is supplied,
+      // so the rendered DOM is already correctly hidden from assistive tech. No
+      // source fix applied for Finding 4 — this test locks in that already-correct
+      // behavior so a future prop addition (e.g. an accidental aria-label) that
+      // would silently disable the library default gets caught.
+      const { container } = render(<Callout type={type}>Body text.</Callout>);
+      const icon = container.querySelector("svg");
+      expect(icon).not.toBeNull();
+      expect(icon?.getAttribute("aria-hidden")).toBe("true");
+    },
+  );
+
+  it("renders the children inside AlertDescription", () => {
+    render(<Callout type="info">Body text.</Callout>);
+    expect(screen.getByText("Body text.")).toBeTruthy();
+  });
+});

--- a/apps/ayokoding-www/src/features/content/shell/callout.tsx
+++ b/apps/ayokoding-www/src/features/content/shell/callout.tsx
@@ -13,9 +13,12 @@ const iconMap: Record<string, ReactNode> = {
   tip: <Lightbulb className="h-4 w-4" />,
 };
 
-const variantMap: Record<string, "default" | "destructive"> = {
-  warning: "destructive",
-  info: "default",
+// Full Alert variant union (default | destructive | success | warning | info), per
+// swe-ui audit b06d32 Finding 3: `warning` previously mapped to `variant="destructive"`
+// (3.05:1 contrast, fails WCAG AA), instead of the dedicated `warning` variant (6.90:1).
+const variantMap: Record<string, "default" | "destructive" | "success" | "warning" | "info"> = {
+  warning: "warning",
+  info: "info",
   tip: "default",
 };
 

--- a/apps/ayokoding-www/src/features/content/shell/section-card.test.tsx
+++ b/apps/ayokoding-www/src/features/content/shell/section-card.test.tsx
@@ -31,4 +31,20 @@ describe("SectionCard", () => {
     // Card primitive applies the rounded-xl border bg-card token surface.
     expect(container.querySelector('[data-slot="card"]')).not.toBeNull();
   });
+
+  it("renders the meta line with a decorative (aria-hidden) trailing arrow, locking in the current contract", () => {
+    // swe-ui audit b06d32 Finding 4 flagged the trailing ArrowRight icon as missing an
+    // explicit aria-hidden="true" prop (unlike hero.tsx/tools-teaser.tsx, which pass it
+    // explicitly for the identical icon). Re-validated as FALSE_POSITIVE: lucide-react's
+    // Icon primitive already defaults to aria-hidden="true" whenever no children/aria-*/
+    // role/title prop is supplied, so the rendered DOM is already correctly hidden from
+    // assistive tech. No source fix applied — this test locks in that already-correct
+    // behavior. Also fills a previously-uncovered code path: no prior test in this file
+    // rendered SectionCard with the `meta` prop supplied.
+    const { container } = render(<SectionCard href="/en/c/learn" title="Learn" description="x" meta="12 topics" />);
+    expect(screen.getByText("12 topics")).toBeTruthy();
+    const icon = container.querySelector("svg");
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute("aria-hidden")).toBe("true");
+  });
 });

--- a/apps/ayokoding-www/src/features/navigation/shell/breadcrumb.test.tsx
+++ b/apps/ayokoding-www/src/features/navigation/shell/breadcrumb.test.tsx
@@ -50,6 +50,23 @@ describe("Breadcrumb", () => {
     expect(container.querySelectorAll("svg").length).toBe(2);
     expect(container.textContent).not.toContain("/");
   });
+
+  it("ChevronRight separators are decorative (aria-hidden), locking in the current contract", () => {
+    // swe-ui audit b06d32 Finding 4 flagged the separator icon as missing an explicit
+    // aria-hidden="true" prop. Re-validated as FALSE_POSITIVE: lucide-react's Icon
+    // primitive already defaults to aria-hidden="true" whenever no children/aria-*/
+    // role/title prop is supplied, so the rendered DOM is already correctly hidden
+    // from assistive tech. No source fix applied — this test locks in that
+    // already-correct behavior.
+    const { container } = render(
+      <Breadcrumb locale="en" slug="tools/cost-of-living-calculator" segments={segments} showCurrent />,
+    );
+    const separators = container.querySelectorAll("svg");
+    expect(separators.length).toBeGreaterThan(0);
+    separators.forEach((svg) => {
+      expect(svg.getAttribute("aria-hidden")).toBe("true");
+    });
+  });
 });
 
 const contentSegments = [

--- a/repo-governance/development/frontend/styling.md
+++ b/repo-governance/development/frontend/styling.md
@@ -97,7 +97,21 @@ Never use `!important`. Use `@layer` ordering or Tailwind modifiers for specific
 }
 ```
 
-**Known violation**: `ayokoding-www/src/app/globals.css` contains 10 `!important` declarations in code block styles to override `@tailwindcss/typography` defaults. These are scheduled for removal by replacing them with rules placed outside `@layer base`.
+**Known violation (revisited 2026-07-22)**: `ayokoding-www/src/app/globals.css` contains 10
+`!important` declarations in code block styles. The rules are already placed outside `@layer base`
+(the fix this note originally called for), yet the `!important` on the
+`figure[data-rehype-pretty-code-figure] pre` background rules cannot be dropped by cascade-ordering
+alone: `rehype-pretty-code`'s `keepBackground: true` option
+(`apps/ayokoding-www/src/features/content/core/parser.ts`) writes an inline
+`style="--shiki-light-bg:#fff"` attribute on every code block, and an element's inline `style`
+attribute always outranks any external stylesheet rule regardless of `@layer`/source order — only
+`!important` (or removing the inline style at its source) can override it. Dropping the
+`!important` here was tried and reverted as a real regression (DWT-001, tracked in
+`plans/done/2026-07-16__web-ui-code-block-copy-button/learnings.md`): the light-theme code
+background rendered pure white instead of the intended `#f6f8fa`. Full removal requires reworking
+the `rehype-pretty-code` config (e.g. disabling `keepBackground`) — a design change, not a
+mechanical CSS edit — so this is tracked as deliberate, currently-necessary debt rather than
+"scheduled for removal" on any near-term timeline.
 
 ## No `@apply` Outside `@layer base`
 


### PR DESCRIPTION
## Summary

Applies fixes for the swe-ui audit `b06d32` (`generated-reports/swe-ui__b06d32__2026-07-22--03-33__audit.md`), scoped strictly to the **4 HIGH findings**. Each finding was re-validated against live source before any change; two did not reproduce.

### Fixed

- **Finding 3** (`callout.tsx:16-20`) — `Callout` mapped `type="warning"` to `Alert variant="destructive"` (3.05:1 contrast, fails WCAG AA) instead of the library's dedicated `warning` variant (6.90:1). Widened `variantMap`'s type to the full `Alert` variant union and routed `warning`→`warning`, `info`→`info`.

### Rejected as false positive / reconciled instead

- **Finding 1** (`globals.css:89-127`, 10 `!important` declarations) — confirmed as a **deliberate, current** exception, not stale debt. `rehype-pretty-code`'s `keepBackground: true` (`apps/ayokoding-www/src/features/content/core/parser.ts`) writes an inline `style` attribute that only `!important` can override (inline styles always outrank stylesheet rules regardless of `@layer`/cascade order). Removing it previously caused a real regression, tracked as DWT-001 in `plans/done/2026-07-16__web-ui-code-block-copy-button/learnings.md`. Left the CSS untouched and corrected `repo-governance/development/frontend/styling.md`'s "Known violation" note instead of silently overwriting a deliberate decision.
- **Finding 2** (`markdown-renderer.tsx:115`, `prose-a:text-primary`) — the finding's premise doesn't hold: `--color-primary` does **not** resolve to the honey/amber `--hue-honey` token as assumed. `apps/ayokoding-www/src/app/globals.css` declares its own `@theme`/`.dark` blocks *after* importing `ayokoding.css`, which override `--color-primary` to blue (`#2563eb` light / `#3b82f6` dark). Verified via the compiled Tailwind CSS output and precise WCAG luminance math: blue-on-background is **~5.04:1** (light) / **~5.44:1** (dark), both comfortably passing AA. No fix needed.
- **Finding 4** (missing `aria-hidden="true"` on decorative icons in `breadcrumb.tsx`, `section-card.tsx`, `callout.tsx`) — `lucide-react` v0.577.0's `Icon` primitive already defaults to `aria-hidden="true"` whenever no `children`/`aria-*`/`role`/`title` prop is supplied (`node_modules/lucide-react/dist/esm/Icon.js`). Confirmed empirically: test assertions checking `aria-hidden="true"` pass against the **unmodified** source. No accessibility defect exists in the rendered DOM; `hero.tsx`/`tools-teaser.tsx`'s explicit prop is redundant defensive style, not a functional requirement.

### Regression coverage

- `callout.test.tsx` (new file — `callout.tsx` had zero prior test coverage): asserts the resolved `data-variant` token (`warning`/`info`/`tip`/`default`) rather than a screenshot — fails before the Finding 3 fix, passes after.
- `breadcrumb.test.tsx`, `section-card.test.tsx`: extended with assertions locking in the already-correct `aria-hidden="true"` behavior for Finding 4 (documents the FALSE_POSITIVE determination; also fills a previously-untested `meta` prop code path in `section-card.test.tsx`).
- `globals-css-color-primary.unit.test.ts` (new file): file-content-based guard pinning that `globals.css` imports `ayokoding.css` and then redeclares `--color-primary` (blue) in both a local `@theme` block and a local `.dark` block, both after the import — the exact override that makes the Finding 2 FALSE_POSITIVE determination true. If either override is ever removed, the shadowed honey token becomes live again and silently reintroduces a sub-AA contrast failure with no other test catching it (jsdom does not resolve Tailwind's `@theme`/CSS-custom-property cascade).

### Out of scope (tracked separately, not dropped)

While re-verifying Finding 3, an adjacent-but-distinct defect was surfaced and independently confirmed: `Alert variant="destructive"` (`libs/web-ui/src/components/alert/alert.tsx`) renders at **~1.99:1** contrast in dark mode (`AlertDescription` at 90% opacity is worse, ~1.81:1) — a real WCAG AA failure on an error-state component. The obvious fix (repoint `--color-destructive` dark to a lighter value) is unsafe: `Button`/`Badge` both hardcode `bg-destructive text-white`, and repointing the token drops that pairing from a healthy 10.02:1 to a failing 1.48:1. A safe fix exists (repoint only `Alert`'s `destructive` variant class to the `wash`/`ink` pattern already used by `success`/`warning`/`info`; verified the required tokens exist and pass AA with margin in all four consuming apps' token files: 6.54:1–9.02:1 across light/dark), but `alert.tsx` is shared — `nx show projects --affected --files=` reports a 9+ project blast radius (`organiclever-www`, `ose-www`/`ose-app-web`, `wahidyankf-www` tiers), none of which were built or tested in this ayokoding-www-scoped session. Deferred to `plans/ideas/web-ui-alert-destructive-dark-contrast.md` (committed to `main` at `14ce1f211`) rather than folded into this PR or silently dropped.

## Tester gate

**Exemption recorded**: no `web-exploratory-tester`/`web-design-tester` pass was run against a live deployment for this PR. Justification — this is a component-level logic/CSS-cascade fix (an object mapping change in `callout.tsx`, no template/markup/visual change; Findings 1/2/4 resulted in no code change at all), fully exercised by unit tests asserting the resolved `data-variant`/`aria-hidden`/CSS-cascade-position outputs per the Regression Test Mandate's guidance to assert the resolved token rather than a screenshot. No new user-facing behavior or visual surface was introduced that a live-site tester pass would catch beyond what the unit suite + `nx run ayokoding-www:build` (1854 static pages generated successfully) already cover.

## Test plan

- [x] `nx run ayokoding-www:test:unit` — 2616 passed, 6 skipped (pre-existing)
- [x] `nx run ayokoding-www:test:coverage` — thresholds met (94.97% stmts)
- [x] `nx run ayokoding-www:typecheck` — clean
- [x] `nx run ayokoding-www:lint` — clean (only pre-existing unrelated warnings)
- [x] `nx run ayokoding-www:specs:behavior:coverage` — 20 specs, 241 scenarios, 885 steps, all covered (no new Gherkin required — bug fixes to existing components, not new user-facing behavior)
- [x] `nx run ayokoding-www:build` — succeeds, 1854 static pages generated
- [x] Pre-push hooks (typecheck/lint/test:quick/specs:coverage, markdown lint, link validation) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
