### PR TITLE
docs(governance): land the Phase 4/5 bare-repo-landing-method frictions

### DIFF
--- a/repo-governance/development/workflow/bare-repo-landing-method.md
+++ b/repo-governance/development/workflow/bare-repo-landing-method.md
@@ -115,9 +115,16 @@ question, not as a corroborating reference.
 5. **Run local quality gates** in the worktree — typecheck, lint, `test:quick`, `specs:coverage`, and
    the markdown gates where the change touches markdown.
 6. `git push origin HEAD:main` — push the worktree's branch tip directly onto the remote `main` ref.
+   This is the **direct-push** landing path. When the unit of work instead lands through a branch and
+   a pull request, this step becomes the PR's own push-and-merge, and step 7 needs the branch cleanup
+   below before it runs.
 7. `git worktree remove <path>` — remove the worktree non-destructively, never with `--force` and
    never `rm -rf`, per the
-   [No Destructive Git Operations Convention](./no-destructive-git-operations.md).
+   [No Destructive Git Operations Convention](./no-destructive-git-operations.md). If step 6 was a
+   branch-and-pull-request landing rather than a direct push, delete the merged remote branch
+   **before** running this step — see
+   [Remote-Branch Cleanup in a Bare Repository](#remote-branch-cleanup-in-a-bare-repository). This
+   step's worktree removal is exactly what triggers the ordering trap that section closes.
 8. **Reconcile local `main`** — the step most often missing in practice. See
    [Terminal Reconcile](#terminal-reconcile) for the exact command, keyed by topology.
 
@@ -223,9 +230,20 @@ $ git -C ose-infra rev-list --left-right --count origin/main...main
 
 The first reading and the last are byte-identical, and only one of them means what it appears to
 mean. **Always refresh the remote-tracking ref before measuring** — either with a preceding
-`git fetch origin`, or by reading the count only after the reconcile command itself has run, since
-`git fetch origin main:main` updates both refs. Treat any left-right count taken before a fetch as
-no evidence at all.
+`git fetch origin`, or by reading the count only after the reconcile command itself has run. (This
+transcript demonstrates the false-clean problem, not the claim below on its own: the plain
+`git fetch origin` shown above already refreshed `origin/main` before `git fetch origin main:main`
+ran, so the final `0 0` here is equally consistent with `main:main` having updated only `main`, which
+was already caught up.)
+
+Separately, as a documented git behavior rather than something this transcript isolates:
+`git fetch origin main:main` does update both `main` and `refs/remotes/origin/main` — but the
+`origin/main` half is git's **opportunistic remote-tracking update**, which fires only when the
+remote's standard `remote.origin.fetch` refspec is configured, as it is for every repository this
+document addresses. That update is not intrinsic to the `main:main` refspec itself: a bare repository
+cloned without that standard refspec (for example, a plain `git clone --bare`) has no `origin/main`
+ref at all, and the same command then fails loudly — `fatal: ambiguous argument 'origin/main...main'`
+— rather than silently. Treat any left-right count taken before a fetch as no evidence at all.
 
 ## Remote-Branch Cleanup in a Bare Repository
 
@@ -267,26 +285,40 @@ needs permission; both routes above avoid that.
 
 This method is frequently used to propagate a change across sibling repositories, which means
 reading a file out of one repository while standing in another. Address it by **git ref, never by
-working-tree path**:
+working-tree path**, and fetch immediately before the read:
 
 ```console
+git -C <other-repo> fetch origin
 git -C <other-repo> show origin/main:<path>
 ```
 
 A working-tree path such as `<other-repo>/<path>` resolves against whatever that checkout happens to
 contain right now. On a shared machine that is not a safe assumption: another session may have left
 its local `main` behind `origin/main` — the very defect this document exists to close — in which case
-the file may be stale, or may not exist at all. The ref form reads from the remote-tracking ref
-directly and is correct regardless of any checkout's sync state, including when the source repository
-is bare and has no working tree to path into.
+the file may be stale, or may not exist at all. The ref form fixes exactly that problem: it does not
+depend on a working tree being reconciled at all, and it is the only form that works when the source
+repository is bare and has no working tree to path into.
+
+What the ref form does **not** fix is staleness of the remote-tracking ref itself. `origin/main` —
+`refs/remotes/origin/main` — is a purely local ref, the same class of ref
+[Measure after fetching, never before](#measure-after-fetching-never-before) above warns about:
+`git show origin/main:<path>` performs no network access, so it returns whatever `<other-repo>` last
+fetched, silently, with no error if that content is stale or the change is entirely missing from it.
+The drift is not always the direction that section's example shows, either — it can just as easily be
+that another session pushed to the shared remote and `<other-repo>`'s own `origin/main` has not caught
+up yet, rather than `<other-repo>`'s local `main` lagging behind its own `origin/main`. Treat this read
+under the same discipline as that section's `rev-list` measurement: **always fetch in `<other-repo>`
+immediately before the `show`**, as the two-line recipe above does, never rely on a ref that was
+fetched at some earlier, unknown time. This is why the read across sibling repositories for a
+byte-identity check must be a fetch-then-show pair, not the `show` alone.
 
 ## One Landing Path Per Unit Of Work
 
-Choose exactly one landing path for a given unit of work: through the worktree described above, **or**
-through an already-reconciled local `main`. **Never both.** Applying the same delta through both paths
-produces a duplicate, stale-base commit — the second landing carries a parent that the first landing's
-push has already superseded, and the two histories then diverge instead of one simply following the
-other.
+Choose exactly one landing path for a given unit of work: through the worktree described above — step
+6's direct push, or its branch-and-pull-request variant — **or** through an already-reconciled local
+`main`. **Never both.** Applying the same delta through both paths produces a duplicate, stale-base
+commit — the second landing carries a parent that the first landing's push has already superseded, and
+the two histories then diverge instead of one simply following the other.
 
 The duplicate-commit failure is the sharper-edged sibling of the silent-lag defect the worked example
 above shows: that example left local `main` two commits behind with no divergence, because nothing

--- a/repo-governance/development/workflow/bare-repo-landing-method.md
+++ b/repo-governance/development/workflow/bare-repo-landing-method.md
@@ -198,6 +198,88 @@ No command failed and nothing warned during the original landings — the lag wa
 is exactly why step 8 is a fixed part of the numbered method rather than a step performed only when
 something looks wrong.
 
+### Measure after fetching, never before
+
+`git rev-list --left-right --count origin/main...main` compares two **local** refs: `main` and the
+remote-tracking ref `refs/remotes/origin/main`. It performs no network access. Run before any fetch,
+it therefore reports the relationship between two refs that may both be equally stale, and the
+answer it gives is `0 0` — indistinguishable from a genuinely reconciled repository.
+
+That false clean is not hypothetical. Immediately after a merge landed on the remote, this sequence
+was observed in a bare sibling:
+
+```console
+$ git -C ose-infra rev-list --left-right --count origin/main...main
+0 0
+
+$ git -C ose-infra fetch origin
+$ git -C ose-infra rev-list --left-right --count origin/main...main
+1 0
+
+$ git -C ose-infra fetch origin main:main
+$ git -C ose-infra rev-list --left-right --count origin/main...main
+0 0
+```
+
+The first reading and the last are byte-identical, and only one of them means what it appears to
+mean. **Always refresh the remote-tracking ref before measuring** — either with a preceding
+`git fetch origin`, or by reading the count only after the reconcile command itself has run, since
+`git fetch origin main:main` updates both refs. Treat any left-right count taken before a fetch as
+no evidence at all.
+
+## Remote-Branch Cleanup in a Bare Repository
+
+When a unit of work lands through a branch and a pull request rather than through this document's
+direct `git push origin HEAD:main`, the merged remote branch still has to be deleted. In a bare
+repository the obvious command does not work, and the reason has nothing to do with the branch:
+
+```console
+$ git -C ose-primer push origin --delete <branch>
+NX  Command failed: git diff --name-only --no-renames --relative HEAD .
+fatal: this operation must be run in a work tree
+husky - pre-push script failed (code 1)
+error: failed to push some refs
+```
+
+The `pre-push` hook runs `nx affected`, which shells out to a work-tree operation. A bare repository
+has none, so **every** push originating from it fails — including a pure ref deletion that carries
+no content and could not fail a quality gate even in principle.
+
+Two routes work. Either delete the branch **from inside the linked worktree, before removing it**,
+while a work tree still exists for the hook to run in; or delete the ref through the forge's API
+after the worktree is gone:
+
+```console
+gh api -X DELETE /repos/<owner>/<repo>/git/refs/heads/<branch>
+```
+
+That API call is the same path `gh pr merge --delete-branch` takes natively, so no hook is bypassed
+and nothing is force-pushed. Note the ordering trap: this document's own step order removes the
+worktree before cleanup would typically happen, which leaves the bare repository — the one actor
+that cannot push — as the only one remaining.
+
+**`--no-verify` is not the sanctioned answer here.** It is the obvious workaround, and the
+[Git Push Safety Convention](./git-push-safety.md) requires explicit per-instance user approval for
+it. A rule that is unexecutable as written pushes its reader toward exactly the escape hatch that
+needs permission; both routes above avoid that.
+
+## Reading a File From Another Repository
+
+This method is frequently used to propagate a change across sibling repositories, which means
+reading a file out of one repository while standing in another. Address it by **git ref, never by
+working-tree path**:
+
+```console
+git -C <other-repo> show origin/main:<path>
+```
+
+A working-tree path such as `<other-repo>/<path>` resolves against whatever that checkout happens to
+contain right now. On a shared machine that is not a safe assumption: another session may have left
+its local `main` behind `origin/main` — the very defect this document exists to close — in which case
+the file may be stale, or may not exist at all. The ref form reads from the remote-tracking ref
+directly and is correct regardless of any checkout's sync state, including when the source repository
+is bare and has no working tree to path into.
+
 ## One Landing Path Per Unit Of Work
 
 Choose exactly one landing path for a given unit of work: through the worktree described above, **or**

--- a/repo-governance/development/workflow/bare-repo-landing-method.md
+++ b/repo-governance/development/workflow/bare-repo-landing-method.md
@@ -233,8 +233,8 @@ mean. **Always refresh the remote-tracking ref before measuring** — either wit
 `git fetch origin`, or by reading the count only after the reconcile command itself has run. (This
 transcript demonstrates the false-clean problem, not the claim below on its own: the plain
 `git fetch origin` shown above already refreshed `origin/main` before `git fetch origin main:main`
-ran, so the final `0 0` here is equally consistent with `main:main` having updated only `main`, which
-was already caught up.)
+ran, so the final `0 0` here is equally consistent with `main:main` having updated only `main` — the
+ref that was actually behind — and leaving the already-current `origin/main` untouched.)
 
 Separately, as a documented git behavior rather than something this transcript isolates:
 `git fetch origin main:main` does update both `main` and `refs/remotes/origin/main` — but the
@@ -242,8 +242,11 @@ Separately, as a documented git behavior rather than something this transcript i
 remote's standard `remote.origin.fetch` refspec is configured, as it is for every repository this
 document addresses. That update is not intrinsic to the `main:main` refspec itself: a bare repository
 cloned without that standard refspec (for example, a plain `git clone --bare`) has no `origin/main`
-ref at all, and the same command then fails loudly — `fatal: ambiguous argument 'origin/main...main'`
-— rather than silently. Treat any left-right count taken before a fetch as no evidence at all.
+ref at all. There, the fetch still **succeeds** — it updates `main` and prints an ordinary update
+line — and it is the measurement afterwards that fails loudly, with
+`fatal: ambiguous argument 'origin/main...main'`. That failure is the good case: it is the one shape
+of this problem that cannot pass silently. Treat any left-right count taken before a fetch as no
+evidence at all.
 
 ## Remote-Branch Cleanup in a Bare Repository
 


### PR DESCRIPTION
Phase 6 (Knowledge Capture) of the `bare-repo-governance-hardening` plan, routing three
`learnings.md` entries back into the document they are defects in.

`repo-governance/development/workflow/bare-repo-landing-method.md` documents a procedure that
Phases 4 and 5 then executed live, against `ose-primer` and `ose-infra`. Each of the three gaps
below was hit during that execution; none is theoretical.

## 1. Measure after fetching, never before

`git rev-list --left-right --count origin/main...main` compares two **local** refs and performs no
network access. Run before a fetch it reports `0 0` whether or not the repository is reconciled.
Observed live, immediately after a merge landed on the remote:

- `0 0` before any fetch — a false clean
- `1 0` after `git fetch origin` — the true state
- `0 0` after `git fetch origin main:main` — genuinely reconciled

The first and last readings are byte-identical and only one of them means what it appears to mean.
An agent that ran the acceptance command once, saw `0 0`, and moved on would have recorded a pass
with local `main` a commit behind.

## 2. Remote-branch cleanup in a bare repository

The `pre-push` hook runs `nx affected`, which shells out to a work-tree operation, so **every** push
originating from a bare repository fails — including a pure ref deletion that carries no content and
could not fail a quality gate even in principle. This document's own step order removes the worktree
first, leaving the bare repository as the only remaining actor.

Both working routes are now documented: delete the branch from inside the linked worktree before
removing it, or delete the ref through the forge API afterwards (the same path
`gh pr merge --delete-branch` takes natively). The section also states plainly that `--no-verify` is
**not** the sanctioned answer — it is the obvious workaround and needs per-instance approval under
the Git Push Safety Convention, so a rule that is unexecutable as written pushes its reader straight
at the one escape hatch requiring permission.

## 3. Reading a file from another repository

Cross-repo propagation means reading a file out of one repository while standing in another. Address
it by git ref (`git -C <other-repo> show origin/main:<path>`), never by working-tree path: on a
shared machine another session's local `main` may lag `origin/main` — this document's own motivating
defect — so the path may be stale or absent, and a bare source repository has no path to read at all.
This was hit at Phase 4, where the plan's own copy step named a working-tree path that did not exist.

## Scope

Docs-only, one file, 82 insertions, no deletions. No `apps/` or `libs/` change, so no specs/Gherkin
companion is owed. Tester gates (web triad, API exploratory) are exempt — no UI and no API surface.

After this merges, the corrected file propagates verbatim to `ose-primer` and `ose-infra`, which are
required to stay byte-identical to this copy.

Generated with [Claude Code](https://claude.com/claude-code)