### PR TITLE
fix(ayokoding-www): allow forward-declared course prerequisites in rehome test

### DIFF
--- a/apps/ayokoding-www/test/unit/fe-steps/course-rehome-redirects.steps.tsx
+++ b/apps/ayokoding-www/test/unit/fe-steps/course-rehome-redirects.steps.tsx
@@ -21,17 +21,142 @@ const feature = await loadFeature(
 const COURSES_DIR = resolve(process.cwd(), "content/en/learn/courses");
 
 // The full planned course-ID catalog (ayokoding-learning-path-02-schema-and-prerequisite-dag's
-// syllabus), used ONLY to accept a prerequisite that names a course not yet authored into
-// COURSES_DIR. ayokoding-learning-path-04-course-authoring lands ~90 courses incrementally, and a
+// syllabus), frozen here so this suite never depends on a `plans/` path that gets archived to
+// `plans/done/` once the plan closes — mirroring
+// apps/ayokoding-www/src/redirects/course-rehome.unit.test.ts's EXPECTED_SLUGS precedent verbatim.
+// Regenerate ONLY if the (closed) syllabus plan's corpus itself changes, by listing *.md basenames
+// (excluding README.md), sorted, under
+// plans/done/2026-07-24__ayokoding-learning-path-02-schema-and-prerequisite-dag/syllabus/courses/.
+// Used ONLY to accept a prerequisite that names a course not yet authored into COURSES_DIR.
+// ayokoding-learning-path-04-course-authoring lands ~90 courses incrementally, and a
 // syllabus-declared prerequisite legitimately crosses band boundaries (e.g.
 // evaluating-ai-output-essentials -> creating-ai-powered-apps, authored in a later phase) — the
 // live site already renders this safely (course-path-nav.ts's resolveCoursePathRenderData omits an
 // unresolved prerequisite link rather than 404ing), so this is purely a typo/invalid-ID guard, not
 // a same-directory membership requirement.
-const SYLLABUS_COURSES_DIR = resolve(
-  process.cwd(),
-  "../../plans/done/2026-07-24__ayokoding-learning-path-02-schema-and-prerequisite-dag/syllabus/courses",
-);
+const SYLLABUS_COURSE_IDS: readonly string[] = [
+  "actor-model-concurrency",
+  "advanced-algorithms",
+  "advanced-frontend",
+  "advanced-networking",
+  "advanced-sql-and-query-performance",
+  "agent-context-and-memory",
+  "agent-orchestration-subagents-and-observability",
+  "agent-permissions-and-sandboxing",
+  "agent-tools-and-mcp",
+  "agentic-ai",
+  "agentic-coding",
+  "analytics-and-experimentation",
+  "android-app-development",
+  "api-design",
+  "async-python-and-fastapi-services",
+  "backend-at-scale",
+  "backend-essentials",
+  "bare-metal-virtualization",
+  "behavioral-and-leadership-interviews",
+  "browser-automation-with-cdp",
+  "build-automation-and-task-runners",
+  "build-your-own-database",
+  "build-your-own-git",
+  "build-your-own-orm-and-query-builder",
+  "build-your-own-raft",
+  "build-your-own-reactive-ui",
+  "build-your-own-web-framework",
+  "building-production-cli-tools",
+  "capstone-build-your-own-coding-agent",
+  "capstone-build-your-own-pentest-engine",
+  "capstone-first-working-software",
+  "capstone-forge-ready",
+  "capstone-full-stack-app",
+  "capstone-interview-loop",
+  "cicd-and-release-engineering",
+  "cloud-and-iac",
+  "coding-interview",
+  "compilers-parsers-and-transpilers",
+  "computer-architecture",
+  "computer-science-foundations",
+  "concurrency-and-parallelism",
+  "containers-and-orchestration",
+  "creating-ai-powered-apps",
+  "csp-style-concurrency",
+  "data-access-orms-and-query-builders",
+  "data-engineering",
+  "data-structures-and-algorithms-essentials",
+  "database-internals-and-storage-engines",
+  "debugging-and-profiling",
+  "defensive-security",
+  "detection-engineering-and-siem-operations",
+  "distributed-systems",
+  "domain-driven-design",
+  "engineering-management",
+  "enterprise-java-and-the-jvm",
+  "evaluating-ai-output-essentials",
+  "evaluating-ai-systems-in-depth",
+  "event-driven-architecture",
+  "extending-neovim",
+  "fine-tuning-and-adaptation",
+  "frontend-essentials",
+  "functional-programming",
+  "graph-databases",
+  "hybrid-app-development",
+  "inference-serving-and-model-deployment",
+  "information-architecture-and-seo",
+  "ios-app-development",
+  "it-and-application-security",
+  "it-governance-grc",
+  "just-enough-bash",
+  "just-enough-c",
+  "just-enough-cpp",
+  "just-enough-csharp",
+  "just-enough-dart",
+  "just-enough-elixir",
+  "just-enough-fsharp",
+  "just-enough-go",
+  "just-enough-java",
+  "just-enough-kotlin",
+  "just-enough-lua",
+  "just-enough-nvim",
+  "just-enough-python",
+  "just-enough-rust",
+  "just-enough-swift",
+  "just-enough-typescript",
+  "linux-app-development",
+  "linux-os",
+  "lisp",
+  "modern-system-programming",
+  "networking-essentials",
+  "nosql-databases",
+  "object-oriented-design-and-patterns",
+  "object-oriented-programming-essentials",
+  "offensive-security",
+  "platform-engineering-and-devex",
+  "product-patterns-for-probabilistic-systems",
+  "programming-paradigms",
+  "project-management",
+  "search-and-information-retrieval",
+  "security-essentials",
+  "self-hosting-essentials",
+  "self-managed-kubernetes-and-gitops",
+  "site-reliability-engineering",
+  "software-architecture",
+  "software-engineering-practices",
+  "software-product-engineering",
+  "software-testing",
+  "sql-essentials",
+  "statistics-for-evaluation",
+  "surgery",
+  "system-design",
+  "system-design-interview",
+  "system-programming",
+  "take-home-and-live-coding",
+  "technical-communication",
+  "the-agent-loop",
+  "type-systems",
+  "version-control-and-git",
+  "vulnerability-management-and-assessment",
+  "windows-app-development",
+  "windows-os",
+];
 
 function courseSlugs(): string[] {
   return readdirSync(COURSES_DIR, { withFileTypes: true })
@@ -41,11 +166,17 @@ function courseSlugs(): string[] {
 }
 
 function plannedCourseIds(): Set<string> {
-  return new Set(
-    readdirSync(SYLLABUS_COURSES_DIR, { withFileTypes: true })
-      .filter((entry) => entry.isFile() && entry.name.endsWith(".md") && entry.name !== "README.md")
-      .map((entry) => entry.name.slice(0, -".md".length)),
-  );
+  return new Set(SYLLABUS_COURSE_IDS);
+}
+
+// Shared membership predicate: a prerequisite resolves if it is authored (COURSES_DIR) or declared
+// on the syllabus roadmap (SYLLABUS_COURSE_IDS) — the union is required because at least one legacy
+// course (capstone-solid-core) exists in COURSES_DIR without a syllabus entry, so the syllabus set
+// alone is not a superset. Extracted so both the data-driven prerequisite scenario below and the
+// fixture-driven oracle scenario exercise the identical union — a future simplification back to
+// courseSlugs()-only breaks both, not just one.
+function knownCourseIdSet(): Set<string> {
+  return new Set([...courseSlugs(), ...plannedCourseIds()]);
 }
 
 function readPrerequisites(slug: string): unknown {
@@ -117,50 +248,74 @@ describeFeature(feature, ({ Scenario, ScenarioOutline, Background }) => {
     });
 
     // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/course-rehome-redirects.feature:Every re-homed course declares its prerequisites
-    And("every named prerequisite resolves to another course in the library", () => {
-      const slugs = courseSlugs();
-      // Union, not courseSlugs() alone: a prerequisite is valid if it is either already authored
-      // (COURSES_DIR) or a real course on the syllabus roadmap not yet authored (SYLLABUS_COURSES_DIR)
-      // — the union is required because at least one legacy course (capstone-solid-core) exists in
-      // COURSES_DIR without a syllabus entry, so the syllabus set alone is not a superset.
-      const slugSet = new Set([...slugs, ...plannedCourseIds()]);
-      const unresolved: string[] = [];
-      const selfRefs: string[] = [];
-      for (const slug of slugs) {
-        const prereqs = readPrerequisites(slug) as string[];
-        if (prereqs.includes(slug)) selfRefs.push(slug);
-        for (const prereq of prereqs) {
-          if (!slugSet.has(prereq)) unresolved.push(`${slug} -> ${prereq}`);
+    And(
+      "every named prerequisite resolves to another course already in the library or declared on the syllabus roadmap",
+      () => {
+        const slugs = courseSlugs();
+        const slugSet = knownCourseIdSet();
+        const unresolved: string[] = [];
+        const selfRefs: string[] = [];
+        for (const slug of slugs) {
+          const prereqs = readPrerequisites(slug) as string[];
+          if (prereqs.includes(slug)) selfRefs.push(slug);
+          for (const prereq of prereqs) {
+            if (!slugSet.has(prereq)) unresolved.push(`${slug} -> ${prereq}`);
+          }
         }
-      }
-      expect(unresolved, `unresolved prerequisites: ${unresolved.join(", ")}`).toEqual([]);
-      expect(selfRefs, `self-referencing courses: ${selfRefs.join(", ")}`).toEqual([]);
+        expect(unresolved, `unresolved prerequisites: ${unresolved.join(", ")}`).toEqual([]);
+        expect(selfRefs, `self-referencing courses: ${selfRefs.join(", ")}`).toEqual([]);
 
-      // REFACTOR (delivery.md §2.3): the declared edges must also form an acyclic graph — a
-      // data-shape guard on these 37 rows, not the full DAG resolver (that belongs to the sibling
-      // ayokoding-learning-path-02-schema-and-prerequisite-dag plan).
-      const edges = new Map<string, string[]>(slugs.map((s) => [s, readPrerequisites(s) as string[]]));
-      const visiting = new Set<string>();
-      const visited = new Set<string>();
-      let cyclePath: string[] = [];
-      function hasCycle(node: string, path: string[]): boolean {
-        if (visited.has(node)) return false;
-        if (visiting.has(node)) {
-          cyclePath = [...path, node];
-          return true;
+        // REFACTOR (delivery.md §2.3): the declared edges must also form an acyclic graph — a
+        // data-shape guard on these 37 rows, not the full DAG resolver (that belongs to the sibling
+        // ayokoding-learning-path-02-schema-and-prerequisite-dag plan).
+        const edges = new Map<string, string[]>(slugs.map((s) => [s, readPrerequisites(s) as string[]]));
+        const visiting = new Set<string>();
+        const visited = new Set<string>();
+        let cyclePath: string[] = [];
+        function hasCycle(node: string, path: string[]): boolean {
+          if (visited.has(node)) return false;
+          if (visiting.has(node)) {
+            cyclePath = [...path, node];
+            return true;
+          }
+          visiting.add(node);
+          for (const dep of edges.get(node) ?? []) {
+            if (hasCycle(dep, [...path, node])) return true;
+          }
+          visiting.delete(node);
+          visited.add(node);
+          return false;
         }
-        visiting.add(node);
-        for (const dep of edges.get(node) ?? []) {
-          if (hasCycle(dep, [...path, node])) return true;
-        }
-        visiting.delete(node);
-        visited.add(node);
-        return false;
-      }
-      const cyclic = slugs.some((slug) => hasCycle(slug, []));
-      expect(cyclic, `cycle detected: ${cyclePath.join(" -> ")}`).toBe(false);
-    });
+        const cyclic = slugs.some((slug) => hasCycle(slug, []));
+        expect(cyclic, `cycle detected: ${cyclePath.join(" -> ")}`).toBe(false);
+      },
+    );
   });
+
+  Scenario(
+    "A prerequisite naming a syllabus-declared but not-yet-authored course still resolves",
+    ({ Given, Then, And }) => {
+      Given(
+        '"creating-ai-powered-apps" is declared on the syllabus roadmap but not yet authored into the course library',
+        () => {
+          expect(SYLLABUS_COURSE_IDS).toContain("creating-ai-powered-apps");
+          expect(courseSlugs()).not.toContain("creating-ai-powered-apps");
+        },
+      );
+
+      Then(
+        'a prerequisite naming "creating-ai-powered-apps" resolves against the union of the course library and the syllabus roadmap',
+        () => {
+          expect(knownCourseIdSet().has("creating-ai-powered-apps")).toBe(true);
+        },
+      );
+
+      // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/course-rehome-redirects.feature:A prerequisite naming a syllabus-declared but not-yet-authored course still resolves
+      And("a prerequisite naming an unrecognized course ID still does not resolve", () => {
+        expect(knownCourseIdSet().has("not-a-real-course-id-xyz")).toBe(false);
+      });
+    },
+  );
 
   ScenarioOutline(
     "The retired fundamentally-strong browse roots permanently redirect to the course library",

--- a/apps/ayokoding-www/test/unit/fe-steps/course-rehome-redirects.steps.tsx
+++ b/apps/ayokoding-www/test/unit/fe-steps/course-rehome-redirects.steps.tsx
@@ -179,6 +179,21 @@ function knownCourseIdSet(): Set<string> {
   return new Set([...courseSlugs(), ...plannedCourseIds()]);
 }
 
+// Picks a syllabus-declared course ID that is not yet authored into COURSES_DIR, for the "still
+// resolves" scenario below. Deliberately dynamic rather than a hardcoded literal: pinning a specific
+// real ID (e.g. "creating-ai-powered-apps") would make this scenario's Given precondition fail the
+// moment ayokoding-learning-path-04-course-authoring authors that course, red-CI-ing an unrelated
+// future PR with no explanation — precisely the class of defect this PR exists to remove. Recomputing
+// independently in each step (rather than sharing state across Given/Then/And) is safe because
+// courseSlugs() reads a stable directory listing for the duration of one test run, so
+// SYLLABUS_COURSE_IDS.find(...) is deterministic and yields the same ID every call.
+function pickNotYetAuthoredSyllabusId(): string {
+  const authored = courseSlugs();
+  const candidate = SYLLABUS_COURSE_IDS.find((id) => !authored.includes(id));
+  expect(candidate, "no unauthored syllabus course remains — this scenario is obsolete, retire it").toBeDefined();
+  return candidate as string;
+}
+
 function readPrerequisites(slug: string): unknown {
   const raw = readFileSync(resolve(COURSES_DIR, slug, "_index.md"), "utf-8");
   return matter(raw).data.prerequisites;
@@ -295,18 +310,17 @@ describeFeature(feature, ({ Scenario, ScenarioOutline, Background }) => {
   Scenario(
     "A prerequisite naming a syllabus-declared but not-yet-authored course still resolves",
     ({ Given, Then, And }) => {
-      Given(
-        '"creating-ai-powered-apps" is declared on the syllabus roadmap but not yet authored into the course library',
-        () => {
-          expect(SYLLABUS_COURSE_IDS).toContain("creating-ai-powered-apps");
-          expect(courseSlugs()).not.toContain("creating-ai-powered-apps");
-        },
-      );
+      Given("a course is declared on the syllabus roadmap but not yet authored into the course library", () => {
+        const id = pickNotYetAuthoredSyllabusId();
+        expect(SYLLABUS_COURSE_IDS).toContain(id);
+        expect(courseSlugs()).not.toContain(id);
+      });
 
       Then(
-        'a prerequisite naming "creating-ai-powered-apps" resolves against the union of the course library and the syllabus roadmap',
+        "a prerequisite naming that course resolves against the union of the course library and the syllabus roadmap",
         () => {
-          expect(knownCourseIdSet().has("creating-ai-powered-apps")).toBe(true);
+          const id = pickNotYetAuthoredSyllabusId();
+          expect(knownCourseIdSet().has(id)).toBe(true);
         },
       );
 

--- a/apps/ayokoding-www/test/unit/fe-steps/course-rehome-redirects.steps.tsx
+++ b/apps/ayokoding-www/test/unit/fe-steps/course-rehome-redirects.steps.tsx
@@ -20,11 +20,32 @@ const feature = await loadFeature(
 // rewrite superseded it).
 const COURSES_DIR = resolve(process.cwd(), "content/en/learn/courses");
 
+// The full planned course-ID catalog (ayokoding-learning-path-02-schema-and-prerequisite-dag's
+// syllabus), used ONLY to accept a prerequisite that names a course not yet authored into
+// COURSES_DIR. ayokoding-learning-path-04-course-authoring lands ~90 courses incrementally, and a
+// syllabus-declared prerequisite legitimately crosses band boundaries (e.g.
+// evaluating-ai-output-essentials -> creating-ai-powered-apps, authored in a later phase) — the
+// live site already renders this safely (course-path-nav.ts's resolveCoursePathRenderData omits an
+// unresolved prerequisite link rather than 404ing), so this is purely a typo/invalid-ID guard, not
+// a same-directory membership requirement.
+const SYLLABUS_COURSES_DIR = resolve(
+  process.cwd(),
+  "../../plans/done/2026-07-24__ayokoding-learning-path-02-schema-and-prerequisite-dag/syllabus/courses",
+);
+
 function courseSlugs(): string[] {
   return readdirSync(COURSES_DIR, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name)
     .sort();
+}
+
+function plannedCourseIds(): Set<string> {
+  return new Set(
+    readdirSync(SYLLABUS_COURSES_DIR, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".md") && entry.name !== "README.md")
+      .map((entry) => entry.name.slice(0, -".md".length)),
+  );
 }
 
 function readPrerequisites(slug: string): unknown {
@@ -74,7 +95,9 @@ describeFeature(feature, ({ Scenario, ScenarioOutline, Background }) => {
 
   Scenario("Every re-homed course declares its prerequisites", ({ Given, When, Then, And }) => {
     Given("the thirty-seven shipped topics and existing capstones have been re-homed into the course library", () => {
-      expect(courseSlugs().length).toBe(37);
+      // >= not ===: ayokoding-learning-path-04-course-authoring adds courses on top of this
+      // re-homed baseline over time, so the library only ever grows from here.
+      expect(courseSlugs().length).toBeGreaterThanOrEqual(37);
     });
 
     When("each re-homed course's canonical metadata is inspected", () => {
@@ -96,7 +119,11 @@ describeFeature(feature, ({ Scenario, ScenarioOutline, Background }) => {
     // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/course-rehome-redirects.feature:Every re-homed course declares its prerequisites
     And("every named prerequisite resolves to another course in the library", () => {
       const slugs = courseSlugs();
-      const slugSet = new Set(slugs);
+      // Union, not courseSlugs() alone: a prerequisite is valid if it is either already authored
+      // (COURSES_DIR) or a real course on the syllabus roadmap not yet authored (SYLLABUS_COURSES_DIR)
+      // — the union is required because at least one legacy course (capstone-solid-core) exists in
+      // COURSES_DIR without a syllabus entry, so the syllabus set alone is not a superset.
+      const slugSet = new Set([...slugs, ...plannedCourseIds()]);
       const unresolved: string[] = [];
       const selfRefs: string[] = [];
       for (const slug of slugs) {

--- a/apps/ayokoding-www/test/unit/fe-steps/course-rehome-redirects.steps.tsx
+++ b/apps/ayokoding-www/test/unit/fe-steps/course-rehome-redirects.steps.tsx
@@ -170,11 +170,13 @@ function plannedCourseIds(): Set<string> {
 }
 
 // Shared membership predicate: a prerequisite resolves if it is authored (COURSES_DIR) or declared
-// on the syllabus roadmap (SYLLABUS_COURSE_IDS) — the union is required because at least one legacy
-// course (capstone-solid-core) exists in COURSES_DIR without a syllabus entry, so the syllabus set
-// alone is not a superset. Extracted so both the data-driven prerequisite scenario below and the
-// fixture-driven oracle scenario exercise the identical union — a future simplification back to
-// courseSlugs()-only breaks both, not just one.
+// on the syllabus roadmap (SYLLABUS_COURSE_IDS). Both arms of this union are pinned by dedicated
+// scenarios below, not merely asserted in this comment: "A prerequisite naming a syllabus-declared
+// but not-yet-authored course still resolves" exercises the syllabus-only arm, and "A prerequisite
+// naming an authored course absent from the syllabus roadmap still resolves" exercises the
+// authored-only arm (currently satisfied by capstone-solid-core, the sole authored course with no
+// syllabus entry) — so a future simplification back to courseSlugs()-only or SYLLABUS_COURSE_IDS-only
+// fails one of the two scenarios instead of passing silently.
 function knownCourseIdSet(): Set<string> {
   return new Set([...courseSlugs(), ...plannedCourseIds()]);
 }
@@ -191,6 +193,23 @@ function pickNotYetAuthoredSyllabusId(): string {
   const authored = courseSlugs();
   const candidate = SYLLABUS_COURSE_IDS.find((id) => !authored.includes(id));
   expect(candidate, "no unauthored syllabus course remains — this scenario is obsolete, retire it").toBeDefined();
+  return candidate as string;
+}
+
+// Picks an authored course ID that is NOT declared on the syllabus roadmap, for the "legacy course
+// still resolves" scenario below — this pins the union's other arm. Deliberately dynamic, mirroring
+// pickNotYetAuthoredSyllabusId() above, rather than hardcoding a specific ID (e.g.
+// "capstone-solid-core"): pinning a literal would silently stop exercising this arm the moment that
+// course is ever back-filled onto the syllabus roadmap, instead of failing loud and telling a future
+// reader what to do. Currently exactly one authored course (capstone-solid-core) is off the syllabus
+// roadmap, but this stays correct for however many exist.
+function pickAuthoredNonSyllabusId(): string {
+  const planned = plannedCourseIds();
+  const candidate = courseSlugs().find((id) => !planned.has(id));
+  expect(
+    candidate,
+    "every authored course is now on the syllabus roadmap — this scenario is obsolete, retire it",
+  ).toBeDefined();
   return candidate as string;
 }
 
@@ -328,6 +347,26 @@ describeFeature(feature, ({ Scenario, ScenarioOutline, Background }) => {
       And("a prerequisite naming an unrecognized course ID still does not resolve", () => {
         expect(knownCourseIdSet().has("not-a-real-course-id-xyz")).toBe(false);
       });
+    },
+  );
+
+  Scenario(
+    "A prerequisite naming an authored course absent from the syllabus roadmap still resolves",
+    ({ Given, Then }) => {
+      Given("a course is authored into the course library but not declared on the syllabus roadmap", () => {
+        const id = pickAuthoredNonSyllabusId();
+        expect(courseSlugs()).toContain(id);
+        expect(plannedCourseIds().has(id)).toBe(false);
+      });
+
+      // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/course-rehome-redirects.feature:A prerequisite naming an authored course absent from the syllabus roadmap still resolves
+      Then(
+        "a prerequisite naming that course resolves against the union of the course library and the syllabus roadmap",
+        () => {
+          const id = pickAuthoredNonSyllabusId();
+          expect(knownCourseIdSet().has(id)).toBe(true);
+        },
+      );
     },
   );
 

--- a/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/course-rehome-redirects.feature
+++ b/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/course-rehome-redirects.feature
@@ -29,7 +29,13 @@ Feature: Course re-home redirects and prerequisites
     When each re-homed course's canonical metadata is inspected
     Then every one declares a prerequisites list of course IDs
     And an empty list is accepted only for a course with no library prerequisite
-    And every named prerequisite resolves to another course in the library
+    And every named prerequisite resolves to another course already in the library or declared on the syllabus roadmap
+
+  @unit
+  Scenario: A prerequisite naming a syllabus-declared but not-yet-authored course still resolves
+    Given "creating-ai-powered-apps" is declared on the syllabus roadmap but not yet authored into the course library
+    Then a prerequisite naming "creating-ai-powered-apps" resolves against the union of the course library and the syllabus roadmap
+    And a prerequisite naming an unrecognized course ID still does not resolve
 
   # Q-E=C override (RESOLVED 2026-07-23): the three fundamentally-strong browse roots are
   # deleted and their old URLs 308 to the course library landing, a narrow exception to the

--- a/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/course-rehome-redirects.feature
+++ b/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/course-rehome-redirects.feature
@@ -33,8 +33,8 @@ Feature: Course re-home redirects and prerequisites
 
   @unit
   Scenario: A prerequisite naming a syllabus-declared but not-yet-authored course still resolves
-    Given "creating-ai-powered-apps" is declared on the syllabus roadmap but not yet authored into the course library
-    Then a prerequisite naming "creating-ai-powered-apps" resolves against the union of the course library and the syllabus roadmap
+    Given a course is declared on the syllabus roadmap but not yet authored into the course library
+    Then a prerequisite naming that course resolves against the union of the course library and the syllabus roadmap
     And a prerequisite naming an unrecognized course ID still does not resolve
 
   # Q-E=C override (RESOLVED 2026-07-23): the three fundamentally-strong browse roots are

--- a/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/course-rehome-redirects.feature
+++ b/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/navigation/course-rehome-redirects.feature
@@ -37,6 +37,11 @@ Feature: Course re-home redirects and prerequisites
     Then a prerequisite naming that course resolves against the union of the course library and the syllabus roadmap
     And a prerequisite naming an unrecognized course ID still does not resolve
 
+  @unit
+  Scenario: A prerequisite naming an authored course absent from the syllabus roadmap still resolves
+    Given a course is authored into the course library but not declared on the syllabus roadmap
+    Then a prerequisite naming that course resolves against the union of the course library and the syllabus roadmap
+
   # Q-E=C override (RESOLVED 2026-07-23): the three fundamentally-strong browse roots are
   # deleted and their old URLs 308 to the course library landing, a narrow exception to the
   # rest of the legacy `_index.md` tree's "updated, never deleted" rule.


### PR DESCRIPTION
## Summary

- `course-rehome-redirects.steps.tsx` hardcoded `courseSlugs().length` to exactly `37` and required every declared course prerequisite to already exist in `content/en/learn/courses` on disk.
- `ayokoding-learning-path-04-course-authoring` lands ~90 courses incrementally from a pre-designed syllabus DAG, so a course's declared prerequisite legitimately names a course from a later authoring phase before that phase lands (e.g. `evaluating-ai-output-essentials` -> `creating-ai-powered-apps`).
- The live site already handles this gracefully — `course-path-nav.ts`'s `resolveCoursePathRenderData` omits an unresolved prerequisite link instead of rendering a dead link — so this was a test-only over-strictness bug blocking every course-authoring PR whose prerequisite crosses a band boundary.

## Changes

- Count assertion loosened from `toBe(37)` to `toBeGreaterThanOrEqual(37)` — the library only grows under this plan.
- The "every named prerequisite resolves" check's oracle widened to `knownCourseIdSet()`, the union of `courseSlugs()` (the currently-authored course directory) and a checked-in `SYLLABUS_COURSE_IDS` constant (121 course IDs) — a genuine typo/invalid ID is still caught while a legitimate not-yet-authored syllabus course is not.
- `SYLLABUS_COURSE_IDS` is a **frozen, checked-in array**, not a live filesystem read of `plans/done/2026-07-24__ayokoding-learning-path-02-schema-and-prerequisite-dag/syllabus/courses/*.md` — the suite never depends on that `plans/` path at runtime, so its `archive-with-plan` disposition stays valid. This mirrors the existing `EXPECTED_SLUGS` precedent in `apps/ayokoding-www/src/redirects/course-rehome.unit.test.ts`, which freezes course slugs for the identical reason (a `plans/` corpus that archives once its plan closes). Regenerating the constant, if the closed syllabus plan's corpus ever changes, is documented in a code comment above it.
- Both arms of the union now have dedicated Gherkin coverage instead of being asserted only implicitly by the data-driven prerequisites scenario:
  - **"A prerequisite naming a syllabus-declared but not-yet-authored course still resolves"** — pins the forward-reference arm (`SYLLABUS_COURSE_IDS`). Uses a dynamically picked syllabus ID (`pickNotYetAuthoredSyllabusId()`) rather than a hardcoded course name, so the scenario doesn't red unrelated future PRs the moment `ayokoding-learning-path-04-course-authoring` authors that specific course.
  - **"A prerequisite naming an authored course absent from the syllabus roadmap still resolves"** — pins the legacy arm (`courseSlugs()`), covering the case of an authored course with no syllabus entry (currently `capstone-solid-core`). Uses a symmetric dynamic picker, `pickAuthoredNonSyllabusId()`.
- New helper functions backing the above: `plannedCourseIds()`, `knownCourseIdSet()`, `pickNotYetAuthoredSyllabusId()`, `pickAuthoredNonSyllabusId()`.

## Test plan

- [x] `npx vitest run --project unit-fe test/unit/fe-steps/course-rehome-redirects.steps.tsx` → 37/37 passed.
- [x] Both new regression scenarios verified red-then-green: each fails deterministically when its corresponding oracle arm is dropped (`knownCourseIdSet()` narrowed to `plannedCourseIds()`-only, then to `courseSlugs()`-only), and passes with the real union restored.
- [x] `npx nx run ayokoding-www:typecheck` passes.
- [x] `npx nx run ayokoding-www:lint` passes (no new warnings).
- [x] `npx nx run ayokoding-www:specs:behavior:coverage` → 40 specs / 284 scenarios / 1028 steps, all covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
