### PR TITLE
feat(ayokoding-www): add product-patterns-for-probabilistic-systems course

### DIFF
--- a/apps/ayokoding-www/content/en/learn/_index.md
+++ b/apps/ayokoding-www/content/en/learn/_index.md
@@ -47,6 +47,7 @@ weight: 10
   - [33 · Engineering Management](/en/learn/courses/engineering-management)
   - [Pass 2 Capstone · SOLID Core](/en/learn/courses/capstone-solid-core)
   - [Evaluating AI Output — Essentials](/en/learn/courses/evaluating-ai-output-essentials)
+  - [Product Patterns for Probabilistic Systems](/en/learn/courses/product-patterns-for-probabilistic-systems)
 - [Legacy](/en/learn/legacy)
   - [Overview](/en/learn/legacy/overview)
   - [Software Engineering](/en/learn/legacy/software-engineering)

--- a/apps/ayokoding-www/content/en/learn/courses/_index.md
+++ b/apps/ayokoding-www/content/en/learn/courses/_index.md
@@ -128,3 +128,7 @@ weight: 95
   - [Overview](/en/learn/courses/evaluating-ai-output-essentials/overview)
   - [Learning](/en/learn/courses/evaluating-ai-output-essentials/learning)
   - [Drilling](/en/learn/courses/evaluating-ai-output-essentials/drilling)
+- [Product Patterns for Probabilistic Systems](/en/learn/courses/product-patterns-for-probabilistic-systems)
+  - [Overview](/en/learn/courses/product-patterns-for-probabilistic-systems/overview)
+  - [Learning](/en/learn/courses/product-patterns-for-probabilistic-systems/learning)
+  - [Drilling](/en/learn/courses/product-patterns-for-probabilistic-systems/drilling)

--- a/apps/ayokoding-www/content/en/learn/courses/evaluating-ai-output-essentials/learning/_index.md
+++ b/apps/ayokoding-www/content/en/learn/courses/evaluating-ai-output-essentials/learning/_index.md
@@ -11,4 +11,4 @@ weight: 100
 - [Theme C: The Runner and the Number](/en/learn/courses/evaluating-ai-output-essentials/learning/theme-c-the-runner-and-the-number)
 - [Theme D: Using the Gate on a Real Change](/en/learn/courses/evaluating-ai-output-essentials/learning/theme-d-using-the-gate-on-a-real-change)
 - [Capstone](/en/learn/courses/evaluating-ai-output-essentials/learning/capstone)
-  - [Capstone](/en/learn/courses/evaluating-ai-output-essentials/learning/capstone/overview)
+  - [Overview](/en/learn/courses/evaluating-ai-output-essentials/learning/capstone/overview)

--- a/apps/ayokoding-www/content/en/learn/courses/evaluating-ai-output-essentials/learning/_index.md
+++ b/apps/ayokoding-www/content/en/learn/courses/evaluating-ai-output-essentials/learning/_index.md
@@ -11,4 +11,4 @@ weight: 100
 - [Theme C: The Runner and the Number](/en/learn/courses/evaluating-ai-output-essentials/learning/theme-c-the-runner-and-the-number)
 - [Theme D: Using the Gate on a Real Change](/en/learn/courses/evaluating-ai-output-essentials/learning/theme-d-using-the-gate-on-a-real-change)
 - [Capstone](/en/learn/courses/evaluating-ai-output-essentials/learning/capstone)
-  - [Overview](/en/learn/courses/evaluating-ai-output-essentials/learning/capstone/overview)
+  - [Capstone](/en/learn/courses/evaluating-ai-output-essentials/learning/capstone/overview)

--- a/apps/ayokoding-www/content/en/learn/courses/evaluating-ai-output-essentials/learning/capstone/_index.md
+++ b/apps/ayokoding-www/content/en/learn/courses/evaluating-ai-output-essentials/learning/capstone/_index.md
@@ -5,4 +5,4 @@ draft: false
 weight: 900
 ---
 
-- [Capstone](/en/learn/courses/evaluating-ai-output-essentials/learning/capstone/overview)
+- [Overview](/en/learn/courses/evaluating-ai-output-essentials/learning/capstone/overview)

--- a/apps/ayokoding-www/content/en/learn/courses/evaluating-ai-output-essentials/learning/capstone/overview.md
+++ b/apps/ayokoding-www/content/en/learn/courses/evaluating-ai-output-essentials/learning/capstone/overview.md
@@ -1,5 +1,5 @@
 ---
-title: "Capstone"
+title: "Overview"
 date: 2026-07-26T00:00:00+07:00
 draft: false
 weight: 1

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/_index.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Product Patterns for Probabilistic Systems"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 443
+prerequisites:
+  ["creating-ai-powered-apps", "evaluating-ai-output-essentials", "software-product-engineering", "frontend-essentials"]
+---
+
+- [Overview](/en/learn/courses/product-patterns-for-probabilistic-systems/overview)
+- [Learning](/en/learn/courses/product-patterns-for-probabilistic-systems/learning)
+  - [Overview](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/overview)
+  - [Theme A: The Wrong Answer Is Coming](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-a-the-wrong-answer-is-coming)
+  - [Theme B: Uncertainty, Confidence, and Provenance](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-b-uncertainty-confidence-and-provenance)
+  - [Theme C: Humans in the Loop, Friction, and Recovery](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-c-humans-in-the-loop-friction-and-recovery)
+  - [Theme D: Degradation, Latency, and the Launch Decision](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-d-degradation-latency-and-the-launch-decision)
+  - [Capstone](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone)
+- [Drilling](/en/learn/courses/product-patterns-for-probabilistic-systems/drilling)
+  - [Overview](/en/learn/courses/product-patterns-for-probabilistic-systems/drilling/overview)

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/drilling/_index.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/drilling/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Drilling"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 800
+---
+
+- [Overview](/en/learn/courses/product-patterns-for-probabilistic-systems/drilling/overview)

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/drilling/overview.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/drilling/overview.md
@@ -1,0 +1,691 @@
+---
+title: "Overview"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 1
+---
+
+This page is the spaced-repetition companion to Product Patterns for Probabilistic Systems: recall
+first, then applied judgment, then hands-on decision-artifact repair, then a checklist to confirm
+real automaticity, and finally why/why-not prompts that test whether you can explain the reasoning,
+not just produce the artifact. Every answer is hidden in a `<details>` block; try each item yourself
+before opening it.
+
+This course has no runnable interpreter -- every "kata" below is a decision-artifact repair drill
+instead of a code fix, verified the same observable-property way this course's worked scenarios were
+verified (a named field present, a computed threshold met, a trigger condition stated), not by
+running anything.
+
+## Recall Q&A
+
+Twenty-four short-answer questions, one per concept (`co-01` through `co-24`). Answer from memory,
+then check.
+
+**Q1 (co-01 -- deterministic-interface-assumption).** What model do standard product patterns
+encode, and why does a probabilistic feature violate it?
+
+<details>
+<summary>Answer</summary>
+
+A success-or-error model. A probabilistic feature succeeds partially, fails confidently, and fails
+differently on identical inputs -- none of which fits a two-state (correct / error) design, so the
+interface has no state for the feature's actual, dominant failure mode.
+
+</details>
+
+**Q2 (co-02 -- failure-modes-users-experience).** Name the six user-visible failure modes a
+probabilistic feature can produce.
+
+<details>
+<summary>Answer</summary>
+
+Confidently wrong, subtly wrong, refused, truncated, slow, and inconsistent across identical
+requests -- six distinct experiences, each requiring its own design response.
+
+</details>
+
+**Q3 (co-03 -- setting-expectations-before-first-use).** Why does first-contact framing matter more
+than it might seem?
+
+<details>
+<summary>Answer</summary>
+
+What a feature is told to be on first contact determines how its errors are read for the rest of the
+relationship -- an overpromise turns the first mistake into a broken promise; an honest framing
+absorbs it.
+
+</details>
+
+**Q4 (co-04 -- trust-calibration).** What are the two failure quadrants trust calibration must avoid,
+and who causes them?
+
+<details>
+<summary>Answer</summary>
+
+Over-trust (accepting output without scrutiny) and blanket distrust (abandoning the feature after
+one bad answer). Both are caused by the interface, not the user.
+
+</details>
+
+**Q5 (co-05 -- automation-bias-and-complacency).** State the counterintuitive relationship between a
+system's reliability and how carefully users check its output.
+
+<details>
+<summary>Answer</summary>
+
+The better the system gets, the worse the scrutiny becomes -- users under-scrutinize output from a
+system that is usually right, and rising reliability worsens this effect rather than fixing it.
+
+</details>
+
+**Q6 (co-06 -- surfacing-uncertainty).** Where must an uncertainty signal be placed to actually work?
+
+<details>
+<summary>Answer</summary>
+
+At the moment and location the user could still act on it -- a caveat the user only sees after
+acting (a footer, a settings page) carries no functional value regardless of its wording.
+
+</details>
+
+**Q7 (co-07 -- confidence-representation-tradeoffs).** Name two confidence representations and the
+trade-off each makes.
+
+<details>
+<summary>Answer</summary>
+
+A numeric score is precise but routinely misread as a probability of correctness; a qualitative band
+is read more accurately but discards information. Every representation trades precision against
+being read correctly.
+
+</details>
+
+**Q8 (co-08 -- confidence-is-not-correctness).** Why is a model's confidence score not the same claim
+as "this is probably correct"?
+
+<details>
+<summary>Answer</summary>
+
+A confidence score typically measures how sure the model sounds to itself while generating a
+sequence of tokens, not whether the underlying factual claim is true -- a model can sound very sure
+while retrieving the wrong source entirely.
+
+</details>
+
+**Q9 (co-09 -- provenance-and-citation).** What does a citation give a user that a confidence score
+does not?
+
+<details>
+<summary>Answer</summary>
+
+A means to verify the claim themselves -- converting "should I trust this?" into "let me check
+this," a strictly stronger and more reliable position than trusting an opaque number.
+
+</details>
+
+**Q10 (co-10 -- verifiability-by-design).** What is the single strongest lever on a probabilistic
+feature's usability?
+
+<details>
+<summary>Answer</summary>
+
+Structuring the output so checking it costs less than producing it -- verifiability is a property of
+the output's shape, designed in, not an afterthought.
+
+</details>
+
+**Q11 (co-11 -- human-in-the-loop-as-product).** What test must a human-in-the-loop design pass to
+count as "review as product" rather than a stopgap?
+
+<details>
+<summary>Answer</summary>
+
+The review step must be measurably faster than doing the underlying work unaided -- timed, not
+assumed.
+
+</details>
+
+**Q12 (co-12 -- review-cost-and-the-vigilance-decrement).** What is the vigilance decrement, and why
+does it matter for review design?
+
+<details>
+<summary>Answer</summary>
+
+A reviewer's accuracy decays with volume and with the system's own reliability. A review design that
+ignores this decay is theatre -- it looks like safety and is not, because scrutiny predictably
+collapses partway through a review session.
+
+</details>
+
+**Q13 (co-13 -- consequence-scaled-friction).** What two properties should determine an action's
+required confirmation level?
+
+<details>
+<summary>Answer</summary>
+
+Its reversibility and its blast radius -- not a single uniform policy applied to every action
+regardless of consequence.
+
+</details>
+
+**Q14 (co-14 -- preview-and-diff-before-apply).** What does a preview-and-diff design catch that a
+plain confirmation dialog cannot?
+
+<details>
+<summary>Answer</summary>
+
+A field-level error (like a transposed digit) -- because it shows the exact value that will change,
+side by side with its source, rather than merely asking "do you want to do this?"
+
+</details>
+
+**Q15 (co-15 -- undo-and-recovery).** Why is complete undo usually a better investment than a
+marginal accuracy improvement?
+
+<details>
+<summary>Answer</summary>
+
+Undo's value compounds across every future error the feature will ever produce, while an accuracy
+improvement's value is capped and can erode with the next model change -- and undo is often cheaper
+to build.
+
+</details>
+
+**Q16 (co-16 -- graceful-degradation).** What must a degradation design name explicitly?
+
+<details>
+<summary>Answer</summary>
+
+A concrete, user-visible state for every way the model can fail to respond usefully -- unavailable,
+rate-limited, too slow, or returning unusable output -- rather than leaving the case undesigned.
+
+</details>
+
+**Q17 (co-17 -- latency-as-a-design-material).** How can two features with identical raw latency feel
+different to a user?
+
+<details>
+<summary>Answer</summary>
+
+Through what fills the wait -- a bare spinner, streaming output, or honest staged progress each
+produce a different perceived speed and a different level of user confidence that the system is
+working, independent of the actual duration.
+
+</details>
+
+**Q18 (co-18 -- fallback-hierarchies).** What must every rung of a fallback hierarchy have?
+
+<details>
+<summary>Answer</summary>
+
+An observable trigger condition that determines exactly when the system falls to it -- a vague or
+unmeasurable trigger is a rung that will not fire reliably when it should.
+
+</details>
+
+**Q19 (co-19 -- silent-failure-is-the-worst-failure).** Why is a silently wrong answer worse than a
+visible error?
+
+<details>
+<summary>Answer</summary>
+
+Because the user has no way to know they need to check it -- a wrong answer rendered identically to
+a right one removes the user's only chance to catch it before acting.
+
+</details>
+
+**Q20 (co-20 -- scoping-to-what-the-model-can-do).** Why is narrowing a feature's scope usually the
+highest-leverage move, above improving the model?
+
+<details>
+<summary>Answer</summary>
+
+Scoping is available immediately and fully within a team's own control; model improvement is not
+guaranteed and depends on factors outside the product team's control.
+
+</details>
+
+**Q21 (co-21 -- ship-criteria-for-a-distribution).** What three things must a well-formed ship
+criterion state?
+
+<details>
+<summary>Answer</summary>
+
+A threshold, an interval, and a named acceptable worst case -- a single average pass-rate number
+alone is not a launch criterion.
+
+</details>
+
+**Q22 (co-22 -- staged-rollout-and-guardrail-metrics).** Why does staged rollout exist even after a
+feature clears its ship criteria?
+
+<details>
+<summary>Answer</summary>
+
+Because an eval set, however good, does not contain the real, unpredictable production traffic that
+can still break a feature -- staged rollout watches pre-agreed guardrail metrics that only become
+observable once real users arrive.
+
+</details>
+
+**Q23 (co-23 -- rollback-criteria-agreed-in-advance).** Why must rollback criteria be written before
+launch rather than during an incident?
+
+<details>
+<summary>Answer</summary>
+
+Criteria decided during an incident are written by people under pressure to keep the feature live --
+writing them down in advance, when nobody has a stake in the outcome yet, is what makes them
+genuinely enforceable.
+
+</details>
+
+**Q24 (co-24 -- feedback-capture-as-a-product-surface).** What two jobs does a correction affordance
+do at once?
+
+<details>
+<summary>Answer</summary>
+
+It recovers the current user immediately, and it captures a structured record that feeds the next
+error-analysis pass -- a correction that is applied and discarded wastes the signal that would
+prevent the same failure recurring.
+
+</details>
+
+## Applied scenarios
+
+Ten self-contained scenarios. Everything needed is in the prompt; decide which concept and which
+move applies, then check.
+
+**AS1.** A team ships a document-summarization feature with a single visual treatment for every
+summary, correct or not. Two weeks in, a wrong summary causes a real problem, and usage drops 80%
+within a month. Diagnose the failure and name the fix.
+
+<details>
+<summary>Answer</summary>
+
+This is co-04's blanket-distrust quadrant: with no way to distinguish a trustworthy summary from an
+untrustworthy one, the rational user response to one visible mistake is to stop trusting all of
+them. The fix is co-06's selective uncertainty signal or co-09's provenance -- either gives users a
+case-by-case basis for trust instead of an all-or-nothing verdict.
+
+</details>
+
+**AS2.** A reviewer's approval time drops from 40 seconds to 18 seconds per item as a model's
+accuracy improves from 85% to 94% over two quarters. A product manager calls this "obviously good
+news." What is missing from that read?
+
+<details>
+<summary>Answer</summary>
+
+co-05: rising accuracy causing falling review time is the predictable signature of automation bias,
+not simply efficiency. The improving headline number may be moving the eventual failure further out
+along a longer run of correct answers, eroding scrutiny in the meantime -- this needs a
+vigilance-decrement mitigation (co-12), not an unqualified celebration.
+
+</details>
+
+**AS3.** A team debates showing "Confidence: 87%" versus "Confidence: High" on a medical-symptom
+triage assistant. Which risk from co-07 is most severe in this specific context, and why?
+
+<details>
+<summary>Answer</summary>
+
+The numeric score's risk -- being misread as a probability of correctness -- is most severe here,
+because a user reading "87%" as "87% likely correct" on a health-related recommendation could make a
+consequential decision based on a false precision the score never actually claimed (co-08).
+
+</details>
+
+**AS4.** A code-review assistant's suggested diff is shown only as a text description ("adds error
+handling to the parse function") rather than an actual diff view. A reviewer approves a change that
+turns out to alter unrelated logic. What pattern was missing?
+
+<details>
+<summary>Answer</summary>
+
+co-14's preview-and-diff-before-apply: a text description does not show the exact change, so it
+cannot catch an unrelated alteration the way an actual line-by-line diff would have.
+
+</details>
+
+**AS5.** A team builds undo for a probabilistic feature's tag-suggestion action but only reverses
+the tag itself, not a triggered downstream notification. A user's colleague acts on the stale
+notification after the user clicks "undo." What co-15 rule was violated, and how?
+
+<details>
+<summary>Answer</summary>
+
+Undo must be complete, not partial. Reversing the tag while leaving the notification's effect intact
+creates a false belief that the whole action was undone -- worse than no undo, because it produces
+unearned confidence.
+
+</details>
+
+**AS6.** A feature's model provider has a partial outage: half of requests succeed normally, half
+time out. The frontend currently shows a single infinite spinner for every request. What is missing,
+and what should replace it?
+
+<details>
+<summary>Answer</summary>
+
+A degradation design (co-16) with an observable trigger (co-18) -- a timeout-based detection rule
+that switches the timed-out half of requests to an explicit, honest state (a fallback rung or a
+labelled unavailable message), rather than leaving every request in an indistinguishable spinner
+state regardless of whether it will ever resolve.
+
+</details>
+
+**AS7.** A launch review approves a feature because its average pass rate is 94%, above the 93%
+bar. Three months later, a coherent cluster of failures affecting one specific user subgroup causes
+a real incident, even though the average pass rate never dropped. What was missing from the ship
+criteria?
+
+<details>
+<summary>Answer</summary>
+
+A named acceptable worst case (co-21). An average-only threshold can hide a coherent failure cluster
+small enough not to move the headline number, which is exactly the gap a stated worst-case clause is
+designed to catch before launch.
+
+</details>
+
+**AS8.** During a live incident, a VP argues for keeping a probabilistic feature running "just a
+little longer" to gather more data, despite pre-agreed rollback criteria being met. What should
+happen, and why does this situation illustrate co-23's core argument?
+
+<details>
+<summary>Answer</summary>
+
+The pre-agreed rollback criteria should be honored as written -- this is precisely the scenario
+co-23 anticipates: rollback decisions made in the heat of an incident are systematically biased
+toward staying live, which is why the criteria were written and signed off in advance, when nobody
+had a stake in the outcome yet.
+
+</details>
+
+**AS9.** A team narrows a broad, unreliable feature to a specific sub-task and reaches 96% accuracy
+with zero model changes. A stakeholder asks "why didn't we just improve the model instead?" What is
+the honest answer, per co-20?
+
+<details>
+<summary>Answer</summary>
+
+Scoping was available immediately and entirely within the team's own control; model improvement
+depends on factors (a provider's roadmap, training data, research timelines) the team does not
+control and cannot guarantee. Reaching for the harder, less controllable lever first would have
+delayed a fix that was available on day one.
+
+</details>
+
+**AS10.** A correction affordance lets users fix a wrong answer in place, and the fix is applied
+immediately to what the user sees. Six months later, an error-analysis review finds the exact same
+failure pattern recurring at the same rate as when the feature launched. What was missing?
+
+<details>
+<summary>Answer</summary>
+
+co-24's routing requirement: fixing the current user's view recovers that one user but, if the
+correction is not logged and routed into a systematic weekly review or the eval dataset, the signal
+that would have prevented recurrence is discarded every time.
+
+</details>
+
+## Decision-artifact repair drills
+
+Six before/after drills. Each gives a flawed, self-contained mocked artifact -- spot and fix the
+flaw yourself, then compare against the model fix and its root-cause explanation.
+
+### Drill 1 -- uncertainty signal buried in a footer
+
+**Before**: "AI-generated content may contain errors." -- shown once, in 10px grey text, at the very
+bottom of the page, below the citation links and the feedback prompt.
+
+<details>
+<summary>Model fix and root cause</summary>
+
+**After**: an inline badge directly beside any answer flagged low-confidence, positioned before the
+user's next likely action.
+
+**Root cause**: co-06 requires an uncertainty signal to sit between the answer and the user's next
+action. A footer disclaimer fails this regardless of its wording, because most users act on the
+answer before ever scrolling to see it.
+
+</details>
+
+### Drill 2 -- a confidence badge that implies correctness
+
+**Before**: "94% Accurate" badge shown beside a model-generated answer, where 94 is the model's raw
+token-generation confidence score.
+
+<details>
+<summary>Model fix and root cause</summary>
+
+**After**: "Nimbus's self-assessed certainty: High" -- relabelled to avoid the word "accurate," and
+calibrated against held-out eval accuracy per confidence bucket rather than displaying the raw model
+score directly.
+
+**Root cause**: co-08 -- a raw confidence score measures how sure the model sounds to itself, not
+whether the claim is true. Labelling it "accurate" manufactures unearned trust in exactly the
+confidently-wrong case this course's worked scenarios trace repeatedly.
+
+</details>
+
+### Drill 3 -- friction applied uniformly
+
+**Before**: every action a feature can take -- viewing a summary, saving a draft, sending an
+external email -- requires clicking through the identical "Are you sure?" confirmation modal.
+
+<details>
+<summary>Model fix and root cause</summary>
+
+**After**: a friction table mapping each action's confirmation level to its own reversibility and
+blast radius -- no confirmation for viewing or saving; a full preview-and-diff plus explicit
+confirmation only for the irreversible, high-blast-radius external email.
+
+**Root cause**: co-13 -- uniform friction trains users to click through the modal reflexively,
+which erases its protective value for the one action that genuinely needed it.
+
+</details>
+
+### Drill 4 -- an undo that leaves a side effect intact
+
+**Before**: "Undo" reverses a tag change but not the notification that change had already triggered
+to a colleague.
+
+<details>
+<summary>Model fix and root cause</summary>
+
+**After**: undo either reverses every effect (including sending a correction message to the
+notified colleague) or the interface explicitly states which specific effects it could not reverse.
+
+**Root cause**: co-15 -- a partial undo is worse than none, because it creates a false belief that
+the entire action was reversed.
+
+</details>
+
+### Drill 5 -- a fallback hierarchy with an unlabelled rung
+
+**Before**: a five-rung fallback hierarchy where rung 2 (a faster, less accurate backup model)
+renders its answers with the exact same visual treatment as rung 1's full-accuracy answers.
+
+<details>
+<summary>Model fix and root cause</summary>
+
+**After**: rung 2's answers carry a small "fast mode" label distinguishing them from rung 1's.
+
+**Root cause**: co-19 -- a fallback hierarchy can still fail silently at any individual rung, even
+after the hierarchy itself is well-designed; each rung needs its own explicit visibility check.
+
+</details>
+
+### Drill 6 -- ship criteria with no named worst case
+
+**Before**: "Ship if pass rate ≥ 93%." No interval stated; no worst-case clause.
+
+<details>
+<summary>Model fix and root cause</summary>
+
+**After**: "Ship if pass rate ≥ 95% with a 95% confidence interval no wider than ±3 points, AND no
+failing case is a confidently-wrong answer with no citation attached."
+
+**Root cause**: co-21 -- a single average threshold with no interval and no named worst case can be
+cleared by a launch that hides a coherent, damaging failure cluster small enough not to move the
+headline number.
+
+</details>
+
+## Self-check checklist
+
+Confirm each item without checking the concepts page first. If you hesitate, that concept needs
+another pass.
+
+- [ ] I can name a probabilistic feature's dominant failure mode and explain why a
+      success-or-error interface has no state for it. (co-01)
+- [ ] I can catalogue a feature's six user-visible failure modes with a distinguishable,
+      user-observable description for each. (co-02)
+- [ ] I can draft first-contact copy that survives a feature's first visible mistake without
+      reading as a broken promise. (co-03)
+- [ ] I can name concrete interface moves that pull a feature out of both the over-trust and
+      blanket-distrust quadrants. (co-04)
+- [ ] I can identify the point in a review sequence where scrutiny predictably collapses, and
+      explain why improving reliability worsens the effect. (co-05)
+- [ ] I can place an uncertainty signal at the exact point a user could still act on it. (co-06)
+- [ ] I can name, for a given confidence representation, both what it communicates and what it
+      risks being misread as. (co-07)
+- [ ] I can identify where a design implies confidence equals correctness and propose language that
+      does not. (co-08)
+- [ ] I can design a citation that a user can practically follow to independently verify a claim.
+      (co-09)
+- [ ] I can restructure a free-text output into a shape that is measurably cheaper to verify. (co-10)
+- [ ] I can design a human-review step and confirm, with a timing measurement, that it is faster
+      than the unaided task. (co-11)
+- [ ] I can name a concrete vigilance-decrement mitigation and state its own cost. (co-12)
+- [ ] I can build a friction table where every action's confirmation level is justified by its own
+      reversibility and blast radius. (co-13)
+- [ ] I can design a preview-and-diff that shows an exact field-level change, not a summary
+      description. (co-14)
+- [ ] I can design undo that fully reverses every effect of an action, with no partial state left
+      behind. (co-15)
+- [ ] I can name a concrete, user-visible state for each of unavailable, rate-limited, too slow, and
+      unusable output. (co-16)
+- [ ] I can compare latency treatments and identify which reduces perceived wait without implying a
+      result that has not arrived. (co-17)
+- [ ] I can build a fallback hierarchy where every rung has an observable trigger condition. (co-18)
+- [ ] I can trace a plausible wrong answer through an interface to a user's decision and confirm
+      nothing along the path would have caught it. (co-19)
+- [ ] I can state a narrowed feature's measured failure rate and the specific capability excluded to
+      reach it. (co-20)
+- [ ] I can write a ship criterion that states a threshold, an interval, and a named acceptable
+      worst case. (co-21)
+- [ ] I can name guardrail metrics for a staged rollout that could not have been measured from an
+      eval set alone. (co-22)
+- [ ] I can write rollback criteria unambiguous enough to act on during a real incident without
+      renegotiation. (co-23)
+- [ ] I can design a correction affordance that both recovers the current user and routes the
+      correction into later error analysis. (co-24)
+- [ ] I can explain, in one sentence, why the interface is where a stochastic component meets a
+      human who expects determinism. (`determinism-vs-emergence`)
+- [ ] I can explain, in one sentence, why this course's product goal is a recoverable workflow
+      rather than a correct one. (`correctness-vs-pragmatism`)
+- [ ] I can explain, in one sentence, why a confidence indicator is a lossy summary a user reads as
+      a promise. (`abstraction-and-its-cost`)
+
+## Elaborative interrogation and self-explanation
+
+Six why/why-not prompts, tied to this course's three cross-cutting big-idea tags. Answer each in
+your own words before opening the model explanation.
+
+**E1 (`determinism-vs-emergence`).** Why does this course insist the interface, specifically, is
+"where" a stochastic component meets a human who expects determinism -- rather than saying the
+model itself is the problem?
+
+<details>
+<summary>Model explanation</summary>
+
+The model's stochasticity is a fixed property this course does not attempt to change. The interface
+is the layer a product team actually controls, and it is where a user's deterministic expectations
+(one question, one reliable answer) collide with the model's actual behaviour (partial success,
+confident wrong answers, inconsistency across identical requests). Locating the problem at the
+interface, not the model, is what makes this course's patterns actionable without requiring a
+better model first.
+
+</details>
+
+**E2 (`determinism-vs-emergence`).** co-19 calls silent failure "the worst failure." Why is this
+framed as a determinism-vs-emergence problem rather than simply an accuracy problem?
+
+<details>
+<summary>Model explanation</summary>
+
+A silent failure is not primarily about how often the model is wrong -- it is about the interface
+rendering an emergent, uncertain output using the visual language of a deterministic, certain one.
+Even a highly accurate model produces silent failures if its rare wrong answers look identical to
+its common right ones; the fix (uncertainty signals, provenance, visible degradation states) is
+squarely an interface response to the determinism/emergence mismatch, not a model-accuracy fix.
+
+</details>
+
+**E3 (`correctness-vs-pragmatism`).** Why does this course describe undo (co-15) as usually a
+"better investment" than a marginal accuracy improvement, rather than treating accuracy as always
+the priority?
+
+<details>
+<summary>Model explanation</summary>
+
+Pursuing correctness (higher accuracy) has diminishing, uncertain, and non-compounding returns --
+each percentage point is harder to gain than the last, and gains can erode with the next model
+change. Pragmatism (investing in undo) accepts that errors will keep happening and instead makes
+every future error cheap, a return that compounds across the feature's entire lifetime. The course
+consistently prefers the pragmatic, compounding investment over the harder, capped one.
+
+</details>
+
+**E4 (`correctness-vs-pragmatism`).** Scenario 11's "decide not to ship" case chooses not to release
+a feature even after real engineering effort was invested. Why is this a pragmatic decision rather
+than a failure to find a correct solution?
+
+<details>
+<summary>Model explanation</summary>
+
+The pragmatic frame asks "is this workflow recoverable," not "is this feature perfect." When neither
+scoping nor undo can bring a feature's risk down to something a workflow can absorb, shipping it
+anyway optimizes for having shipped something over the user's actual safety -- exactly the trade
+this course warns against. Recognizing and documenting that case is itself the pragmatic, correct
+professional move, not evidence the team failed to find a solution.
+
+</details>
+
+**E5 (`abstraction-and-its-cost`).** Why does this course call a confidence indicator "a lossy
+summary of a distribution" rather than simply "a number the user can trust or not"?
+
+<details>
+<summary>Model explanation</summary>
+
+A confidence score is an abstraction over a much richer underlying reality -- the full distribution
+of possible outputs the model could have produced for that input, and the specific reasons any one
+of them might be wrong. Collapsing that distribution into a single number necessarily discards
+information, and the user has no way to see what was discarded -- they read the number as if it
+were the whole picture, which is exactly the abstraction's cost co-08 names directly.
+
+</details>
+
+**E6 (`abstraction-and-its-cost`).** co-10's verifiability-by-design pattern restructures free text
+into per-field, cited output. How does this connect to abstraction-and-its-cost, and what "cost" does
+it reduce?
+
+<details>
+<summary>Model explanation</summary>
+
+A free-text paragraph is itself a lossy abstraction over the underlying evidence the model drew
+from -- checking it requires reconstructing which claims came from where. A structured, per-field,
+per-citation format reduces that abstraction's cost by making the mapping from claim to evidence
+explicit and cheap to traverse, rather than asking the user to reverse-engineer it from prose. The
+abstraction is not eliminated -- the output is still a summary -- but its verification cost is
+sharply reduced.
+
+</details>
+
+---
+
+← Previous: [Capstone](../learning/capstone/overview.md)

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/_index.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Learning"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 100
+---
+
+- [Overview](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/overview)
+- [Theme A: The Wrong Answer Is Coming](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-a-the-wrong-answer-is-coming)
+- [Theme B: Uncertainty, Confidence, and Provenance](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-b-uncertainty-confidence-and-provenance)
+- [Theme C: Humans in the Loop, Friction, and Recovery](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-c-humans-in-the-loop-friction-and-recovery)
+- [Theme D: Degradation, Latency, and the Launch Decision](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-d-degradation-latency-and-the-launch-decision)
+- [Capstone](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone)
+  - [Overview](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/overview)
+  - [Failure Catalogue](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/failure-catalogue)
+  - [Interface Design](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/interface-design)
+  - [Review and Recovery](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/review-and-recovery)
+  - [Degradation](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/degradation)
+  - [Launch Criteria](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/launch-criteria)

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/artifacts/ex-06-trust-calibration-diagram.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/artifacts/ex-06-trust-calibration-diagram.md
@@ -1,0 +1,58 @@
+---
+title: "Artifact: Trust-Calibration Diagram"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 6
+---
+
+> Worked Scenario 6 -- trust-calibration diagram -- exercises co-04.
+
+Trust calibration plots actual reliability on one axis against observed user trust on the other.
+The diagonal is the calibrated zone: trust tracking reliability. The two off-diagonal quadrants are
+both design failures, and each is corrected by a different set of interface moves.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC
+%% Reliability (x-axis, conceptual) vs. user trust (y-axis, conceptual)
+graph TD
+    Cal["Calibrated zone<br/>trust tracks reliability"]:::teal
+
+    OverTrust["Over-trust quadrant<br/>high trust, moderate risk<br/>co-04, co-05, co-08"]:::orange
+    OverTrustFix["Surface uncertainty (co-06)<br/>Show provenance (co-09)<br/>Confidence != correctness"]:::blue
+
+    Distrust["Blanket-distrust quadrant<br/>low trust, high reliability<br/>Scenario 9"]:::purple
+    DistrustFix["Case-by-case signals (co-06)<br/>Citations to check (co-09)<br/>Cheap verification (co-10)"]:::blue
+
+    OverTrust --> OverTrustFix
+    Distrust --> DistrustFix
+    Cal -.->|drift toward over-trust as<br/>reliability rises unchecked| OverTrust
+    Cal -.->|drift toward distrust after<br/>an early, unsignalled miss| Distrust
+
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+_Figure: the calibrated zone sits between two named failure quadrants. A feature drifts toward
+over-trust as its measured reliability rises without a matching uncertainty signal (Scenario 8), and
+toward blanket distrust after an early miss with no case-by-case signal to fall back on (Scenario
+9). Each quadrant's fix is a distinct set of interface moves, not a single universal remedy._
+
+**Verify**: both off-diagonal quadrants are present, each is labelled with the specific scenario
+that instantiates it (Scenario 8 for over-trust, Scenario 9 for distrust), and each has its own,
+distinct fix list -- satisfying co-04's rule that trust calibration is a two-sided design problem.
+
+**Key takeaway**: There is no single "add more trust signals" fix -- over-trust and blanket distrust
+require opposite interventions, and a design that treats trust as one-dimensional will
+under-correct one quadrant while over-correcting the other.
+
+**Why It Matters**: This diagram is the map every later worked scenario about trust, uncertainty, or
+provenance implicitly places itself on. Recognising which quadrant a given feature is drifting
+toward -- before choosing a fix -- is what prevents a team from, for example, adding more caveats
+(a distrust-quadrant fix) to a feature that is actually suffering from over-trust, which would make
+the real problem worse rather than better.
+
+---
+
+← Back to [Theme A: The Wrong Answer Is Coming](../theme-a-the-wrong-answer-is-coming.md)

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/artifacts/ex-21-verifiability-diagram.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/artifacts/ex-21-verifiability-diagram.md
@@ -1,0 +1,52 @@
+---
+title: "Artifact: Verifiability Diagram"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 21
+---
+
+> Worked Scenario 21 -- verifiability diagram -- exercises co-10, co-09.
+
+This diagram ranks the output structures seen across Theme B by verification cost -- how long it
+takes a user to independently check a claim, from cheapest (top) to most expensive (bottom).
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC
+%% Ranked top-to-bottom: cheapest verification cost first
+graph TD
+    A["Structured, per-field cite<br/>~5s per field -- ex-20"]:::teal
+    B["Free text, clause link<br/>~10s -- ex-18"]:::blue
+    C["Free text, doc-only cite<br/>several min -- ex-19"]:::orange
+    D["Free text, no citation<br/>unverifiable, no check"]:::purple
+
+    A -->|cheaper| B -->|cheaper| C -->|cheaper| D
+
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+_Figure: four output structures, ordered by measured or estimated verification cost. The arrows
+read "cheaper than" -- each rung down the ladder costs a user meaningfully more time and effort to
+independently check, for no gain in the underlying answer's accuracy._
+
+**Verify**: all four rungs appear in strictly increasing verification-cost order, and each rung
+cites the specific worked scenario that produced or diagnosed it -- satisfying co-10 and co-09's
+rule that verification cost is a rankable, not merely qualitative, property of an output's shape.
+
+**Key takeaway**: Two answers with identical underlying accuracy can have wildly different real-world
+usability, entirely as a function of how their output is structured -- verification cost is a design
+variable, not a fixed cost of using a probabilistic feature.
+
+**Why It Matters**: This ladder is the concrete argument for treating co-10 as the single
+highest-leverage pattern in this theme: moving one rung up costs a product team a one-time
+engineering investment in output structure and citation precision, and pays back on every single
+answer the feature produces, forever. A team auditing its own feature can place its current output
+format on this same ladder to see, concretely, how much investment separates it from the cheapest
+achievable rung -- turning an abstract "make citations better" goal into a specific, measurable rung
+to climb toward.
+
+---
+
+← Back to [Theme B: Uncertainty, Confidence, and Provenance](../theme-b-uncertainty-confidence-and-provenance.md)

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/artifacts/ex-36-degradation-diagram.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/artifacts/ex-36-degradation-diagram.md
@@ -1,0 +1,56 @@
+---
+title: "Artifact: Degradation Diagram"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 36
+---
+
+> Worked Scenario 36 -- degradation diagram -- exercises co-18, co-16.
+
+This diagram renders Worked Scenario 35's five-rung fallback hierarchy as a flow, with each rung's
+observable trigger condition made explicit.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC, Brown #CA9161
+%% Five-rung fallback hierarchy, ordered best to worst
+graph TD
+    R1["Rung 1: Full answer<br/>trigger: primary under 5s"]:::teal
+    R2["Rung 2: Fast-mode fallback<br/>trigger: primary 5-15s"]:::blue
+    R3["Rung 3: Cached, labelled<br/>trigger: no models, cache"]:::orange
+    R4["Rung 4: Raw document link<br/>trigger: no model, no cache"]:::purple
+    R5["Rung 5: Unavailable<br/>trigger: raw lookup down"]:::brown
+
+    R1 -->|degrades to| R2
+    R2 -->|degrades to| R3
+    R3 -->|degrades to| R4
+    R4 -->|degrades to| R5
+
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef brown fill:#CA9161,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+_Figure: the system falls exactly one rung at a time, never skipping a level, and each arrow is
+labelled with the specific, observable condition that triggers the fall. Every rung remains visibly
+labelled to the user (Scenario 37), so a degraded state is never rendered identically to a healthy
+one._
+
+**Verify**: all five rungs appear in the same order as Worked Scenario 35's table, each edge names a
+concrete trigger condition rather than a vague description, and the chain terminates at the
+unavailable state (Scenario 34) -- satisfying co-18's rule that a fallback hierarchy's rungs must
+each have an observable trigger.
+
+**Key takeaway**: A fallback hierarchy is a chain of concrete, observable conditions, not a single
+"handle errors gracefully" instruction -- each arrow in this diagram is independently testable
+against real production behaviour.
+
+**Why It Matters**: An on-call engineer facing a real incident can use this diagram to answer "which
+rung are we on right now, and what condition needs to change for us to recover a rung?" -- a
+question an undesigned degradation path cannot answer at all, because it has no named rungs to be
+on.
+
+---
+
+← Back to [Theme D: Degradation, Latency, and the Launch Decision](../theme-d-degradation-latency-and-the-launch-decision.md)

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/_index.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Capstone"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 900
+---
+
+- [Overview](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/overview)
+- [Failure Catalogue](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/failure-catalogue)
+- [Interface Design](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/interface-design)
+- [Review and Recovery](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/review-and-recovery)
+- [Degradation](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/degradation)
+- [Launch Criteria](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/launch-criteria)

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/degradation.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/degradation.md
@@ -1,0 +1,57 @@
+---
+title: "Degradation"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 5
+---
+
+> Meridian Claims Assistant -- degradation design.
+
+## Fallback hierarchy
+
+| Rung | Condition                                                       | Behaviour                                                                                                                                                                                                  | Quality                               |
+| ---- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| 1    | Primary model responds within 8s                                | Full structured recommendation with per-clause citations.                                                                                                                                                  | Best available.                       |
+| 2    | Primary model slow (8-20s) or rate-limited                      | Falls to a smaller, faster model, same structured citation format, flagged "fast mode."                                                                                                                    | Slightly lower accuracy, still cited. |
+| 3    | Both models unavailable, this exact claim was recently assessed | Serves the most recent draft for this claim, explicitly labelled "draft from [timestamp], not re-verified."                                                                                                | Stale but labelled, never silent.     |
+| 4    | No model available, no recent draft                             | Deterministic fallback: surfaces the raw policy section matching the claim's declared damage type, no generated recommendation at all -- Dana assesses manually with the relevant policy text pre-located. | Lowest, but honest and never wrong.   |
+| 5    | Even the raw policy-section lookup is unavailable               | Explicit "Assistant unavailable -- assess this claim manually; your queue is unaffected" banner, input disabled but visible.                                                                               | No recommendation offered.            |
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC, Brown #CA9161
+graph TD
+    R1["Rung 1: Full recommendation<br/>trigger: primary under 8s"]:::teal
+    R2["Rung 2: Fast-mode fallback<br/>trigger: primary 8-20s"]:::blue
+    R3["Rung 3: Recent draft<br/>trigger: no models, cache"]:::orange
+    R4["Rung 4: Raw policy link<br/>trigger: no model, no draft"]:::purple
+    R5["Rung 5: Unavailable<br/>trigger: raw lookup down"]:::brown
+
+    R1 -->|degrades to| R2
+    R2 -->|degrades to| R3
+    R3 -->|degrades to| R4
+    R4 -->|degrades to| R5
+
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef brown fill:#CA9161,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+_Diagram: five rungs, each with an observable trigger condition, falling one at a time from a full
+recommendation to an explicit unavailable state -- never silently skipping a level._
+
+## Visibility check
+
+Every rung carries its own explicit label (a "fast mode" flag, a "draft from [timestamp]" note, the
+raw-lookup's absence of any generated text, or the unavailable banner) so Dana can always tell which
+rung the assistant is currently operating on -- no rung is rendered identically to rung 1's full
+recommendation.
+
+**Verify**: every rung states a concrete, observable trigger condition (co-18); the diagram matches
+the table exactly and terminates at an explicit unavailable state (co-16); no rung is visually
+indistinguishable from a fully healthy recommendation (co-19).
+
+**Key takeaway**: The fallback hierarchy gives Dana five distinct, honestly labelled states instead
+of one binary "working or broken" state -- and rung 4's raw-policy-section fallback means even a
+total model outage leaves her with a genuine time-saving head start rather than nothing at all.

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/failure-catalogue.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/failure-catalogue.md
@@ -1,0 +1,46 @@
+---
+title: "Failure Catalogue"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 2
+---
+
+> Meridian Claims Assistant -- failure catalogue. The assistant reads an incoming auto-insurance
+> claim (photos, the policyholder's form, and the policy's coverage terms) and drafts a recommended
+> decision -- approve, deny, or escalate -- with a written rationale, for a human adjuster to review
+> before any decision is finalized.
+
+## Six user-visible failure modes
+
+| Failure mode                           | User-observable description                                                                   | Concrete example                                                                                                |
+| -------------------------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Confidently wrong                      | A fluent, specific recommendation that is factually incorrect, with no hedging language.      | Recommends "approve" citing a coverage clause that does not actually cover the damage type shown in the photos. |
+| Subtly wrong                           | Mostly correct, with one small but consequential detail altered.                              | Correctly recommends "approve" but cites the wrong claim-limit figure in the rationale.                         |
+| Refused                                | Declines to produce a recommendation at all.                                                  | "I can't assess claims involving total-loss vehicles." with no further guidance offered.                        |
+| Truncated                              | Recommendation is cut off mid-rationale, appearing complete but omitting key reasoning.       | States "approve" but the listed supporting clauses stop at two of the four actually relevant.                   |
+| Slow                                   | Correct eventually, but the multi-second wait changes what the adjuster does in the meantime. | 9-second generation with no progress indication, during which the adjuster starts a second claim.               |
+| Inconsistent across identical requests | The same claim, re-submitted, returns a different recommendation.                             | Re-running the same claim's photos and form returns "escalate" instead of the original "approve."               |
+
+## Silent-failure trace: confidently wrong, no citation
+
+1. The assistant drafts: "Approve -- damage is consistent with a covered collision event under
+   Section 3.1 (Collision Coverage)." The photos actually show weather damage, which the
+   policyholder's plan explicitly excludes under Section 3.4.
+2. The recommendation renders in the standard drafting panel -- same layout, same styling as every
+   correct recommendation the adjuster has approved before.
+3. The adjuster, Dana, reviewing her 34th claim of the day, reads the one-line rationale, sees no
+   citation link to the actual policy clause, and approves it in line with the assistant's
+   recommendation.
+4. The claim pays out under a coverage type the policy does not actually provide for this damage.
+5. Nothing in steps 1-4 contained a catch point: no uncertainty signal, no clickable citation to the
+   actual clause, and no friction proportional to the fact that this action -- an approved payout --
+   is effectively irreversible once funds are disbursed.
+
+**Verify**: the trace reaches Dana's actual decision (approving the payout) and confirms, step by
+step, that no point along the path -- drafting, rendering, or reviewing -- contained anything that
+could have caught the error, satisfying co-19's silent-failure rule and co-02's requirement that
+each failure mode be independently catalogued.
+
+**Key takeaway**: The confidently-wrong, no-citation case is this feature's single most consequential
+failure mode, because it is indistinguishable from a correct recommendation at every point in the
+adjuster's actual workflow -- exactly the gap Step 2's interface design must close.

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/interface-design.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/interface-design.md
@@ -1,0 +1,53 @@
+---
+title: "Interface Design"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 3
+---
+
+> Meridian Claims Assistant -- interface design. Every element below traces to a failure mode named
+> in [`failure-catalogue.md`](./failure-catalogue.md).
+
+## First-contact expectation setting
+
+- **Rejected copy**: "Meridian's assistant makes accurate claim decisions instantly." (Implies
+  certainty; contradicted the moment the first confidently-wrong recommendation occurs -- the exact
+  failure this dossier's failure catalogue documents.)
+- **Shipped copy**: "The assistant drafts a recommendation and cites the policy clauses it relied
+  on -- always open the cited clause before you approve or deny." Names what the tool actually does
+  (drafts, cites) and the specific adjuster behaviour (opening the citation) that survives a wrong
+  draft without contradicting the copy itself.
+
+**Traces to**: the confidently-wrong, no-citation failure mode -- this copy sets the expectation
+that citations are load-bearing, not decorative, before the adjuster ever sees a recommendation.
+
+## Selective uncertainty and provenance policy
+
+**Policy**: an uncertainty badge fires on a recommendation when any of the following holds:
+
+1. The recommendation's calibrated confidence bucket falls below the 92nd-percentile accuracy
+   threshold measured against Meridian's held-out eval set.
+2. The cited policy clause requires cross-referencing more than one section (a common source of
+   the subtly-wrong failure mode).
+3. The claim's damage-photo classification confidence is itself below its own threshold -- a
+   second-order signal specific to this feature's multi-modal input.
+
+**Provenance**: every recommendation's rationale is restructured from free text into per-clause
+fields (`decision`, `primary_clause`, `supporting_clauses`, `exclusions_checked`), each linked
+directly to the exact policy section it cites, highlighted -- not merely named. Verifying the
+Section 3.1-versus-3.4 confusion from the failure catalogue's silent-failure trace now takes under
+ten seconds: the adjuster opens the highlighted clause link and reads the actual exclusion language
+directly.
+
+**Accessibility**: the uncertainty badge carries a text label ("Verify before approving"), a
+distinct triangle icon independent of colour, and a screen-reader-announced `aria-label`; its text
+contrast measures 6.3:1, clearing the WCAG AA 4.5:1 minimum for normal text.
+
+**Verify**: the uncertainty policy's three trigger conditions are each a concrete, measurable
+property rather than a subjective judgment, satisfying co-06 and co-07; the provenance links open
+directly to the cited clause, satisfying co-09 and co-10's practical-verifiability rule; the badge
+survives a colour-blind and screen-reader reading, satisfying co-06's accessibility requirement.
+
+**Key takeaway**: Restructuring the rationale into per-clause fields with direct citations is the
+single change that converts the failure catalogue's most damaging failure mode (confidently wrong,
+uncited) into a recommendation Dana can check in under ten seconds instead of accepting on faith.

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/launch-criteria.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/launch-criteria.md
@@ -26,8 +26,9 @@ claim types the model was measurably unreliable on.
   uncertainty badge (co-06) or carried a citation Dana could have used to catch it (co-09).
 - **Measured result at this review**: pass rate 96.1%, interval ±2.4 points; zero failing cases
   lacked a citation or an uncertainty signal. Source: the narrowed-scope eval report, produced
-  following [Evaluating AI Output -- Essentials](../../overview.md)'s pass-rate-with-an-interval
-  method.
+  following [Evaluating AI Output -- Essentials](../../../evaluating-ai-output-essentials/overview.md)'s
+  pass-rate method, with the confidence interval computed per this course's own ship-criteria
+  practice (co-21).
 - **Verdict**: criteria met, cleared for staged rollout.
 
 ## Staged rollout with guardrails

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/launch-criteria.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/launch-criteria.md
@@ -1,0 +1,76 @@
+---
+title: "Launch Criteria"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 6
+---
+
+> Meridian Claims Assistant -- scoping, ship, staged-rollout, and rollback criteria.
+
+## Scoping decision
+
+The assistant's original proposed scope -- recommend a decision on any claim type, including
+total-loss and liability-dispute claims -- measured 81% pass rate against the eval set, too low for
+adjuster trust. Narrowed scope: standard collision and weather-damage claims only, the two damage
+types with the most consistent policy language and photo evidence; total-loss and liability-dispute
+claims are routed to manual assessment with no assistant recommendation at all. Measured pass rate
+on the narrowed scope: 96.1%. This scoping decision required no model change -- only removing the
+claim types the model was measurably unreliable on.
+
+## Ship criteria
+
+- **Primary threshold**: pass rate ≥ 95% on the 150-case narrowed-scope eval set, with a 95%
+  confidence interval no wider than ±3 percentage points.
+- **Named acceptable worst case**: of the failing cases, none may be a confidently-wrong
+  recommendation with no citation attached -- every failing case must at minimum have triggered the
+  uncertainty badge (co-06) or carried a citation Dana could have used to catch it (co-09).
+- **Measured result at this review**: pass rate 96.1%, interval ±2.4 points; zero failing cases
+  lacked a citation or an uncertainty signal. Source: the narrowed-scope eval report, produced
+  following [Evaluating AI Output -- Essentials](../../overview.md)'s pass-rate-with-an-interval
+  method.
+- **Verdict**: criteria met, cleared for staged rollout.
+
+## Staged rollout with guardrails
+
+Ramp: 1 adjuster team (week 1) → 25% of adjuster teams (weeks 2-3) → 100% (week 4+), each stage
+gated on the guardrails below staying within threshold for the full prior stage.
+
+- Correction-affordance usage rate (measured against a 3% eval-set baseline) exceeding 9% of
+  recommendations halts the ramp immediately.
+- Any single week's confirmed-incorrect-payout count exceeding 1 halts the ramp immediately.
+- Median review time exceeding 3 minutes for two consecutive weeks halts the ramp and triggers a
+  redesign review.
+
+None of these three metrics exist in the eval set -- they are observable only once real claim
+traffic, with its unpredictable mix of damage types and policy edge cases, starts flowing through
+the assistant.
+
+## Rollback criteria (agreed before rollout begins)
+
+- **Automatic rollback** (no discussion required): any guardrail above breaching its threshold for
+  two consecutive weeks without a shipped fix; any single confirmed incident of an approved payout
+  later found to be outside the policy's actual coverage.
+- **Discussion-required rollback** (decision within one business day by the named on-call product
+  lead): correction-affordance usage elevated but not yet breaching the hard threshold; adjuster-
+  reported confusion trending upward without a specific confirmed incident.
+- **Sign-off**: Product Lead, Claims Operations Lead, Compliance stakeholder -- all three signed
+  before rollout began.
+
+## Feedback routing into error analysis
+
+Corrections captured by the correction affordance ([`review-and-recovery.md`](./review-and-recovery.md))
+are aggregated weekly, grouped by failure mode ([`failure-catalogue.md`](./failure-catalogue.md)).
+Any pattern recurring three or more times in a week is promoted to a permanent case in the
+narrowed-scope eval dataset, closing the loop this dossier opened.
+
+**Verify**: every ship criterion states a threshold, an interval, and a named acceptable worst case,
+each checkable against the actual eval report (co-21); every guardrail metric names a real-time
+threshold that would halt the ramp and could not have been measured pre-launch (co-22); rollback
+criteria are agreed and signed before rollout, distinguishing automatic from discussion-required
+conditions unambiguously (co-23); the scoping decision states both the narrowed task's measured rate
+and the excluded capability (co-20).
+
+**Key takeaway**: This dossier's launch decision rests on a measured distribution with a named worst
+case, a rollout that watches for exactly the signals an eval set cannot produce, and rollback
+criteria written by people with no stake yet in keeping the feature live -- the same three moves
+Theme D taught on Nimbus, applied here to close the Meridian Claims Assistant's design dossier.

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/overview.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/overview.md
@@ -1,0 +1,135 @@
+---
+title: "Overview"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 1
+---
+
+## Goal
+
+Produce the complete product-design dossier for one real probabilistic feature -- the **Meridian
+Claims Assistant**, a copilot that drafts an approve/deny/escalate recommendation for an insurance
+claims adjuster to review -- that a team could take to a launch review. This is a leadership
+design/decision capstone: no code, zero runnable files. Every mechanism assembled here was already
+taught, individually, somewhere in this course's Theme A through Theme D worked scenarios, applied
+to the recurring Nimbus example; this capstone is where the same mechanisms run together on an
+independently chosen new feature, at launch-review scale.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC, Brown #CA9161
+graph TD
+    A["Failure catalogue<br/>+ silent-failure trace"]:::blue
+    B["Interface design<br/>expectations, uncertainty,<br/>provenance"]:::orange
+    C["Review + recovery<br/>friction + preview + undo"]:::teal
+    D["Degradation<br/>fallback hierarchy"]:::purple
+    E["Launch criteria<br/>ship + guardrail + rollback"]:::brown
+    A --> B --> C --> D --> E
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef brown fill:#CA9161,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+_Diagram: the capstone's build order -- catalogue the failures, design the interface around them,
+design the review-and-recovery layer, plan the degradation path, and write the launch criteria that
+close the loop._
+
+## Concepts exercised
+
+- [x] a user-visible failure catalogue including the silent-failure path (co-02, co-19)
+- [x] expectation setting and a trust-calibration plan (co-03, co-04, co-05)
+- [x] a selective uncertainty and provenance policy, accessible without colour (co-06 through co-09)
+- [x] verifiability designed into the output shape (co-10)
+- [x] a human-review design costed against reviewer decay (co-11, co-12)
+- [x] a consequence-scaled friction table with preview and complete undo (co-13 through co-15)
+- [x] a fallback hierarchy with observable triggers (co-16 through co-18)
+- [x] scoping decisions taken against the measured failure rate (co-20)
+- [x] ship, guardrail, and rollback criteria against a distribution (co-21 through co-23)
+- [x] a correction affordance feeding error analysis (co-24)
+
+Each step below lives in its own file, listed in the [capstone index](./_index.md). Nothing on this
+page repeats those files' content; this page narrates the build order and the concepts each step
+exercises.
+
+## Step 1: Failure catalogue
+
+_exercises co-02, co-19_
+
+[`learning/capstone/failure-catalogue.md`](./failure-catalogue.md) enumerates the Meridian Claims
+Assistant's six user-visible failure modes with a concrete example of each, then traces one
+confidently-wrong recommendation end to end, to the adjuster's actual decision -- the same discipline
+Worked Scenarios 2 and 3 applied to Nimbus.
+
+**Verify**: every failure mode is distinguishable by a user with no visibility into the model's
+internals, and the silent-failure path is walked explicitly to a real decision point, not merely
+asserted to exist.
+
+## Step 2: Interface design
+
+_exercises co-03, co-04, co-05, co-06 through co-10_
+
+[`learning/capstone/interface-design.md`](./interface-design.md) sets first-contact expectations
+honestly, applies a selective uncertainty and provenance policy meeting WCAG AA without relying on
+colour, and restructures the recommendation's output shape so an adjuster can verify it cheaply --
+the combined product of Theme A's trust-calibration work and Theme B's uncertainty-and-provenance
+toolkit.
+
+**Verify**: every design element in this file traces to a specific failure mode named in Step 1, and
+no element is uncertainty theatre (a signal present on every output regardless of actual confidence).
+
+## Step 3: Review and recovery
+
+_exercises co-11 through co-15, co-24_
+
+[`learning/capstone/review-and-recovery.md`](./review-and-recovery.md) designs the adjuster's review
+flow with a measured or estimated review cost, a consequence-scaled friction table covering every
+action the assistant can take, a preview-and-diff design, a complete-undo design, and the correction
+affordance -- Theme C's full toolkit, applied fresh.
+
+**Verify**: the review step is cheaper than the adjuster's unaided task, friction is not applied
+uniformly across actions, and undo is complete rather than partial.
+
+## Step 4: Degradation and launch criteria
+
+_exercises co-16 through co-18, co-20 through co-23_
+
+[`learning/capstone/degradation.md`](./degradation.md) designs the fallback hierarchy with its
+Mermaid diagram and observable trigger conditions; [`learning/capstone/launch-criteria.md`](./launch-criteria.md)
+writes ship, staged-rollout guardrail, and rollback criteria against a measured distribution, plus a
+named acceptable worst case -- Theme D's complete toolkit, closing the dossier.
+
+**Verify**: every fallback rung has an observable trigger; every launch criterion is checkable
+against a real eval report; rollback criteria are unambiguous enough to act on during a real
+incident without renegotiation.
+
+## Acceptance criteria
+
+- Every design decision in the dossier traces to a named user-visible failure mode from Step 1.
+- The confidently-wrong path is explicitly addressed, not assumed away.
+- Uncertainty signals are selective, accessible without colour, and never present confidence as
+  probability-of-correct.
+- The human-review design is costed and is cheaper than the adjuster's unaided task, with the
+  vigilance decrement explicitly mitigated.
+- Friction scales with reversibility and blast radius rather than being uniform; undo is complete.
+- The fallback ladder's triggers are observable and the degraded state is visible to the adjuster,
+  never silent.
+- Ship, guardrail, and rollback criteria are each expressed as a threshold on a measured
+  distribution with an interval, plus a named acceptable worst case, checkable against a real eval
+  report, and written down before launch.
+
+## Done bar
+
+This capstone produces the stated artefact: a complete, reviewable, five-file written dossier for
+the Meridian Claims Assistant that a real launch review could act on -- combining every mechanism
+this course taught, from the deterministic-interface-assumption framing (co-01, implicit throughout
+Step 1) through failure modes and expectation setting (co-02 through co-05), uncertainty and
+provenance (co-06 through co-10), human review and recovery (co-11 through co-15), scoping and
+degradation (co-16 through co-20), and launch, guardrail, and rollback criteria (co-21 through
+co-23), closed by the correction affordance (co-24) -- exactly as Worked Scenario 44 already
+demonstrated at the same scale for Nimbus, applied here to a new, independently chosen feature.
+
+---
+
+Next: [Drilling](../../drilling/overview.md) →

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/review-and-recovery.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/capstone/review-and-recovery.md
@@ -1,0 +1,74 @@
+---
+title: "Review and Recovery"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 4
+---
+
+> Meridian Claims Assistant -- review and recovery design.
+
+## Review cost
+
+Unaided, Dana assesses a claim (reading the policy, the photos, and the form, then deciding) in a
+measured average of 5 minutes 50 seconds. With the assistant's structured, per-clause-cited draft
+(Step 2), her review -- checking the cited clauses against the photos and confirming or editing the
+decision -- averages 1 minute 40 seconds, roughly 3.5x faster. This clears the review-as-product bar:
+the review step is measurably faster than the unaided task, not merely present alongside it.
+
+## Vigilance-decrement mitigation
+
+Dana reviews 30-40 claims per shift. Session traces show scrutiny visibly narrowing after
+approximately the twelfth claim in a row. Mitigations shipped: batches capped at 10 claims before a
+mandatory 5-minute break; every 8th claim in a batch requires an active per-clause confirmation
+click rather than a single "approve" action; a random 1-in-12 already-approved claim is silently
+re-shown later in the shift for a second, independent check. Each mitigation's cost is named and
+accepted: batching adds context-switching overhead; forced confirmation adds friction to every
+session; re-audit sampling adds review volume.
+
+## Consequence-scaled friction table
+
+| Action                                    | Reversibility                                                                  | Blast radius                               | Required confirmation                                                                                               |
+| ----------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| View the assistant's draft recommendation | Fully reversible (no state changed)                                            | None.                                      | None.                                                                                                               |
+| Edit the draft rationale before deciding  | Fully reversible (edit history retained)                                       | Low -- internal draft only.                | None; auto-saved.                                                                                                   |
+| Escalate a claim to a senior adjuster     | Reversible (can be un-escalated)                                               | Low-medium -- reassigns internal work.     | Single click, no modal.                                                                                             |
+| Deny a claim                              | Reversible before the policyholder is notified; effectively irreversible after | High -- affects the policyholder directly. | Preview-and-diff of the denial letter (below) plus explicit confirmation.                                           |
+| Approve a payout                          | Irreversible once funds are disbursed                                          | Highest -- financial and contractual.      | Preview-and-diff of the payout amount and cited clauses, plus explicit confirmation; no default "approve" shortcut. |
+
+## Preview and diff
+
+Before Dana confirms an approval, the interface shows the exact payout amount, the exact cited
+clauses (highlighted against the policy text), and the exact damage-photo regions the assistant
+flagged as supporting evidence -- side by side with the claim's actual submitted values. This is
+what would have caught the failure catalogue's Section 3.1-versus-3.4 error: the highlighted clause
+text, shown directly beside the photo evidence, makes a collision-coverage citation visibly
+inconsistent with weather-damage photos, at a glance, before the approval is confirmed.
+
+## Undo
+
+Editing the draft before a decision is fully reversible via edit history. Once a decision is
+recorded but before the policyholder is notified (a fixed 2-hour internal review window), any
+adjuster can fully reverse it -- decision, rationale, and any internal status change -- with no
+partial state left behind. After the notification window closes, reversal requires a separate,
+logged claims-correction process (outside this dossier's scope), which is why the friction table
+above escalates confirmation specifically at the approve/deny actions rather than treating the
+2-hour window as sufficient protection on its own.
+
+## Correction affordance
+
+An always-visible "This citation is wrong" link sits beside every cited clause. Clicking it opens a
+short form capturing what the correct clause should have been; submitting immediately flags the
+current recommendation for a second adjuster's review (recovering the current case) and logs the
+original citation, the correction, and the claim's photo/form context for the weekly error-analysis
+pass described in [`launch-criteria.md`](./launch-criteria.md).
+
+**Verify**: the review step is measurably faster than the unaided task (co-11); the vigilance
+mitigations each state their own cost (co-12); every friction-table row's confirmation level is
+justified by its own reversibility and blast radius (co-13); the preview shows exact values, not a
+summary (co-14); undo is complete within its stated window, with no partial state (co-15); the
+correction affordance both recovers the current case and logs enough context for later analysis
+(co-24).
+
+**Key takeaway**: Every mechanism in this file traces to a Theme C pattern applied fresh to a new
+domain -- friction concentrated on the approve/deny actions, complete undo within a real operational
+window, and a correction affordance that closes the loop into ongoing error analysis.

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/overview.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/overview.md
@@ -9,8 +9,8 @@ weight: 1
 
 - **Prior topics**: `creating-ai-powered-apps` (what the model can and cannot be asked for --
   `[Unverified]` not yet present in the AyoKoding course library on disk);
-  [Evaluating AI Output -- Essentials](../overview.md) for the pass-rate-with-an-interval framing
-  Theme D's ship criteria build on directly;
+  [Evaluating AI Output -- Essentials](../../evaluating-ai-output-essentials/learning/overview.md)
+  for the pass-rate framing Theme D's ship criteria extend with a confidence interval (co-21);
   [32 · Software Product Engineering](../../software-product-engineering/learning/overview.md) for
   product framing, scoping, and release practice; [14 · Frontend Essentials](../../frontend-essentials/learning/overview.md)
   for interface vocabulary and the accessibility baseline every uncertainty signal in this course
@@ -20,7 +20,7 @@ weight: 1
   feature to critique across this course's scenarios. There is no runtime to install -- every
   deliverable in this course is a design document or a decision artifact, not a program.
 - **Assumed knowledge**: what an LLM-backed feature does and roughly how it fails; the ability to
-  read an eval report and interpret a pass rate with an interval; basic interface and accessibility
+  read an eval report and interpret a pass rate; basic interface and accessibility
   vocabulary.
 
 ## Why this exists -- the big idea
@@ -423,8 +423,9 @@ somewhere a later error-analysis pass can actually use it, not merely applied an
 
 - **Designing Machine Learning Systems** -- Chip Huyen (2022). Practitioner-oriented treatment of a
   probabilistic feature as a product with a measured failure rate, not a model with an accuracy.
-- **Evaluating AI Output -- Essentials** -- the pass-rate-with-an-interval framing Theme D's ship
-  criteria (co-21) apply directly to a launch decision. [Course overview](../overview.md).
+- **Evaluating AI Output -- Essentials** -- the pass-rate framing Theme D's ship criteria (co-21)
+  extend with a confidence interval for a launch decision.
+  [Course overview](../../evaluating-ai-output-essentials/overview.md).
 
 ---
 

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/overview.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/overview.md
@@ -1,0 +1,431 @@
+---
+title: "Overview"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 1
+---
+
+## Prerequisites
+
+- **Prior topics**: `creating-ai-powered-apps` (what the model can and cannot be asked for --
+  `[Unverified]` not yet present in the AyoKoding course library on disk);
+  [Evaluating AI Output -- Essentials](../overview.md) for the pass-rate-with-an-interval framing
+  Theme D's ship criteria build on directly;
+  [32 · Software Product Engineering](../../software-product-engineering/learning/overview.md) for
+  product framing, scoping, and release practice; [14 · Frontend Essentials](../../frontend-essentials/learning/overview.md)
+  for interface vocabulary and the accessibility baseline every uncertainty signal in this course
+  must clear.
+- **Tools & environment**: a Markdown editor for the decision artifacts (tables, memos, criteria
+  documents), a diagramming surface for the Mermaid flows, and access to one real probabilistic
+  feature to critique across this course's scenarios. There is no runtime to install -- every
+  deliverable in this course is a design document or a decision artifact, not a program.
+- **Assumed knowledge**: what an LLM-backed feature does and roughly how it fails; the ability to
+  read an eval report and interpret a pass rate with an interval; basic interface and accessibility
+  vocabulary.
+
+## Why this exists -- the big idea
+
+**The problem before the solution**: standard product patterns assume the system either succeeds or
+fails, and says so. A probabilistic feature succeeds partially, fails silently, fails confidently,
+and fails differently for the same input twice -- and an interface built for the deterministic case
+has no state for any of that. **The one idea worth keeping if you forget everything else**: design
+for the wrong answer, because it is coming -- make it visible, make it cheap to catch, and make it
+cheap to undo.
+
+**Cross-cutting big ideas**: `determinism-vs-emergence` -- the interface is where a stochastic
+component meets a human who expects determinism. `correctness-vs-pragmatism` -- the product goal is
+a recoverable workflow, not a correct one.
+
+## How verification works in this course
+
+Earlier courses in the AI-engineering track verify a claim by running something and reading its
+output. This course has no interpreter to run: an interface walkthrough, a failure catalogue, and a
+launch-criteria sheet are not executable, so there is no command that confirms one is "correct" the
+way `pytest` confirms a function's return value. Verification here instead means checking an
+**observable property of the written artefact itself** against a stated rule -- something you can
+point at on the page, not a vague description of what a "good" design should feel like. A few
+concrete examples that recur throughout this course:
+
+- A **failure catalogue** is verifiable: does it name all six user-visible failure modes, and does
+  it explicitly trace the confidently-wrong path to the user's decision point? Read it and check.
+- An **uncertainty signal** is verifiable: does it survive a colour-blind and a screen-reader
+  reading, and does it sit at the decision point rather than in a footer? Either it does or it does
+  not.
+- A **launch-criteria sheet** is verifiable: does every criterion cite a threshold on a measured
+  distribution, an interval, and a named acceptable worst case? Each of those is either present or
+  it is not.
+
+Every concept below and every worked scenario that follows states its own **Verify it** / **Verify**
+rule in exactly this observable-property form.
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC, Brown #CA9161
+%% Four concept clusters, in the order this course teaches them (co-01 through co-24)
+graph TD
+    A["The wrong answer is coming<br/>co-01 to co-05, co-19, co-20"]:::blue
+    B["Uncertainty, confidence,<br/>and provenance (co-06-10)"]:::orange
+    C["Humans in the loop,<br/>friction, recovery<br/>co-11 to co-15, co-24"]:::teal
+    D["Degradation, latency,<br/>and launch decision<br/>co-16-18, co-21-23"]:::purple
+
+    A --> B --> C --> D
+
+    classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+    classDef purple fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+_Diagram: the four theme clusters this course teaches, in reading order -- from naming why a
+deterministic interface fails, through surfacing uncertainty honestly, designing the human review
+and recovery layer, to the degradation and launch-decision layer that closes the loop._
+
+## Concepts
+
+Every worked scenario in this course's theme pages cites the `co-NN` concept it exercises -- this
+section is the 1:1 reference those citations point back to.
+
+### co-01 · The Deterministic-Interface Assumption
+
+Standard product patterns -- a text box that returns an answer, a button that performs an action, an
+error state for the rare failure -- encode a success-or-error model. A probabilistic feature
+violates that model by succeeding partially, failing confidently, and failing differently on
+identical inputs, and an interface built only for success-or-error has no state for any of those.
+
+**Why it matters**: reusing a deterministic pattern unchanged is how the dominant failure of a
+probabilistic system -- a plausible wrong answer rendered identically to a right one -- ships with
+no state to land in.
+
+**Verify it**: walk a probabilistic feature's confidently-wrong output through its current
+interface; the walkthrough is well-formed if it names the exact screen or state the output lands in
+and confirms nothing there distinguishes it from a correct answer.
+
+### co-02 · Failure Modes Users Experience
+
+Confidently wrong, subtly wrong, refused, truncated, slow, and inconsistent-across-identical-requests
+are six distinct user experiences, each requiring a distinct design response -- treating them as one
+undifferentiated "it might be wrong" collapses decisions that should be made separately.
+
+**Why it matters**: a catalogue that lumps all six together cannot drive design decisions, because
+the right response to "refused" (explain why, offer an alternative) is not the right response to
+"confidently wrong" (surfacing uncertainty, verifiability).
+
+**Verify it**: a failure catalogue is well-formed if each of the six modes has its own named,
+user-observable description, distinguishable from the other five without reading the model's
+internals.
+
+### co-03 · Setting Expectations Before First Use
+
+What a feature is told to be on first contact determines how its errors are interpreted for the
+rest of the relationship -- a feature introduced as infallible trains users to be blindsided by its
+first mistake; a feature introduced honestly trains users to read its output critically from the
+start.
+
+**Why it matters**: first-contact framing is a one-time, high-leverage moment -- it is far cheaper
+to set an honest expectation before the first wrong answer than to repair trust after it.
+
+**Verify it**: first-contact copy is well-formed if it survives being read again immediately after
+the feature's first visible mistake, without the user feeling misled.
+
+### co-04 · Trust Calibration
+
+The design goal is user trust proportional to actual reliability. Both over-trust (accepting output
+without scrutiny) and blanket distrust (abandoning a feature after one bad answer) are failures, and
+both are caused by the interface, not by the user.
+
+**Why it matters**: a feature can be measurably reliable and still fail in the market if its
+interface produces either failure mode -- reliability alone does not produce calibrated trust.
+
+**Verify it**: a trust-calibration diagram or plan is well-formed if it names concrete interface
+moves that pull users out of both the over-trust quadrant and the blanket-distrust quadrant, not
+just one.
+
+### co-05 · Automation Bias and Complacency
+
+Users under-scrutinize output from a system that is usually right, and the better the system gets,
+the worse the scrutiny becomes -- a well-established finding from human-automation interaction
+research, not a hypothetical.
+
+**Why it matters**: this is the specific mechanism that makes co-04's over-trust quadrant dangerous
+precisely when a feature is improving -- a rising pass rate is not, by itself, a safety improvement
+if review quality is falling at the same rate.
+
+**Verify it**: a review-flow critique is well-formed if it names the point in a review sequence
+where scrutiny predictably collapses, not merely asserts that automation bias exists.
+
+### co-06 · Surfacing Uncertainty
+
+Communicating that an output may be wrong, placed at the moment and location the user could
+actually act on it -- a caveat buried in a footer or a settings page does not count, because the
+user has already acted by the time they would see it.
+
+**Why it matters**: an uncertainty signal's value depends entirely on timing and placement; the same
+words at the decision point versus in a footer produce entirely different user behavior.
+
+**Verify it**: an uncertainty-signal placement is well-formed if the signal appears at the exact
+point the user could still change their action based on it.
+
+### co-07 · Confidence-Representation Trade-offs
+
+Numeric scores, qualitative bands, hedged language, and visual treatments each trade precision
+against being read correctly -- a numeric score is precise and routinely misread as a probability of
+correctness; a qualitative band is read more accurately but discards information.
+
+**Why it matters**: there is no representation that is simply "better" -- the right choice depends
+on which failure (misreading a false precision, or losing real information) is more costly for a
+given feature.
+
+**Verify it**: a confidence-representation comparison is well-formed if it names, for each format
+tested, both what it communicates and what a real user is likely to misread from it.
+
+### co-08 · Confidence Is Not Correctness
+
+A model's expressed or computed confidence is not a probability of being right, and presenting it as
+one manufactures unearned trust -- a high-confidence output can still be wrong, and a design that
+implies otherwise sets the user up to be blindsided.
+
+**Why it matters**: this is the single most common confidence-display error -- conflating "the model
+says it is sure" with "the model is likely correct" produces exactly the over-trust failure co-04
+names.
+
+**Verify it**: a confidence-display critique is well-formed if it identifies, concretely, where the
+design implies confidence equals correctness and proposes language or treatment that does not.
+
+### co-09 · Provenance and Citation
+
+Showing where an answer came from lets a user verify it themselves -- which is often more useful
+than any confidence signal, because it hands the user a concrete, independent check instead of a
+number to trust or distrust.
+
+**Why it matters**: a citation converts "trust the system" into "verify the claim," which is a
+strictly stronger position for the user to be in whenever verification is practical.
+
+**Verify it**: a provenance design is well-formed if a user can, in practice, follow the citation to
+an independent source and confirm or refute the claim -- not merely if a citation is present.
+
+### co-10 · Verifiability by Design
+
+Structuring output so that checking it costs less than producing it is the single strongest lever on
+a probabilistic feature's usability -- a feature whose output is expensive to verify has not
+actually saved the user any work, only relocated it.
+
+**Why it matters**: verifiability is a design property of the output's shape, not an afterthought --
+a structured, checkable output format is often cheaper to build than a free-text one and pays for
+itself immediately in review cost.
+
+**Verify it**: an output-restructuring proposal is well-formed if it names, concretely, how the new
+shape lowers verification cost relative to the original free-text shape.
+
+### co-11 · Human-in-the-Loop as Product
+
+A design where human review is the intended workflow, not an admission that the feature is not good
+enough -- and where the review is engineered to be fast enough to survive contact with real volume,
+not a ceremonial gate that nobody has time to do properly.
+
+**Why it matters**: treating review as the product, rather than a stopgap, is what keeps the review
+step from being quietly weakened the moment volume grows past what a ceremonial gate can absorb.
+
+**Verify it**: a human-in-the-loop design is well-formed if the review step is measurably faster
+than doing the underlying work unaided.
+
+### co-12 · Review Cost and the Vigilance Decrement
+
+A reviewer's accuracy decays with volume and with the system's own reliability -- the vigilance
+decrement -- so a review step that ignores this decay is theatre: it looks like safety and is not.
+
+**Why it matters**: a review design that is correct in principle can still fail in practice if it
+does not account for exactly when, in a review session, a human reviewer's attention predictably
+drops.
+
+**Verify it**: a review-design critique is well-formed if it names a concrete mitigation for the
+vigilance decrement (batch size, sampling, forced-attention checkpoints) and states that
+mitigation's own cost.
+
+### co-13 · Consequence-Scaled Friction
+
+The amount of confirmation, preview, and delay a design imposes should scale with the action's
+reversibility and blast radius, not be applied uniformly -- uniform friction trains users to click
+through it, defeating its purpose for the one action that actually needed it.
+
+**Why it matters**: friction is a scarce resource -- spending it uniformly means there is none left
+over, functionally, for the action that genuinely needed it.
+
+**Verify it**: a friction table is well-formed if every listed action's confirmation level is
+justified by that specific action's reversibility and blast radius, not a single blanket policy.
+
+### co-14 · Preview and Diff Before Apply
+
+Showing exactly what will change before it changes converts an irreversible action into a reviewable
+one -- the user is confirming a specific, visible change, not a vague description of what the system
+intends to do.
+
+**Why it matters**: a diff-before-apply design catches the specific class of error a plain
+confirmation dialog cannot: the user agreeing to something they did not actually read carefully
+because it was not concretely shown.
+
+**Verify it**: a preview-and-diff design is well-formed if it shows the exact before/after state of
+every field the action would change, not a summary description of the action.
+
+### co-15 · Undo and Recovery
+
+Cheap, obvious, complete reversal is worth more than a marginal accuracy improvement, and it is
+usually cheaper to build -- investing in undo pays off across every future error, while investing in
+accuracy pays off only probabilistically.
+
+**Why it matters**: undo is the single highest-leverage investment available for a probabilistic
+feature, because its value compounds across every error the model will ever make, forever, while an
+accuracy improvement's value decays the moment the next model update ships.
+
+**Verify it**: an undo design is well-formed if it fully reverses every effect of the original
+action, leaving no partial, inconsistent state behind.
+
+### co-16 · Graceful Degradation
+
+Defining what the product does when the model is unavailable, rate-limited, too slow, or returns
+something unusable -- including the discipline of doing nothing visibly rather than failing
+invisibly, which is a deliberate design choice, not a default.
+
+**Why it matters**: every product ships some version of this state whether or not it was designed --
+an undesigned degradation state is usually a silent one, which is the worst failure mode this course
+teaches (co-19).
+
+**Verify it**: a degradation design is well-formed if it names a concrete, user-visible state for
+every one of "unavailable," "rate-limited," "too slow," and "unusable output."
+
+### co-17 · Latency as a Design Material
+
+Streaming, progressive disclosure, optimistic states, and honest waiting all change what a slow
+probabilistic response feels like -- latency is not merely a number to minimize, it is a material
+the interface can shape.
+
+**Why it matters**: two features with identical raw latency can feel completely different to a user
+depending on whether that latency is filled with honest progress or with a spinner that reveals
+nothing.
+
+**Verify it**: a latency-treatment comparison is well-formed if it identifies which treatment
+reduces perceived wait time without implying a result that has not actually arrived.
+
+### co-18 · Fallback Hierarchies
+
+A designed ladder from best-effort model output, to a cheaper model, to a deterministic heuristic,
+to an honest unavailable state -- each rung named in advance, with its own quality and cost, rather
+than a single binary "working / broken" state.
+
+**Why it matters**: a fallback hierarchy is what turns co-16's abstract commitment to graceful
+degradation into something concretely buildable, one rung at a time.
+
+**Verify it**: a fallback hierarchy is well-formed if every rung has an observable trigger condition
+that determines when the system falls to it.
+
+### co-19 · Silent Failure Is the Worst Failure
+
+A wrong answer presented identically to a right one is more damaging than a visible error, because
+the user has no way to know they need to check it -- and most probabilistic features default to
+exactly this failure mode unless a design decision prevents it.
+
+**Why it matters**: this is the single organizing principle behind most of this course's other
+patterns -- surfacing uncertainty, provenance, and visible degradation states all exist specifically
+to prevent a wrong answer from looking indistinguishable from a right one.
+
+**Verify it**: a silent-failure audit is well-formed if it traces at least one plausible wrong
+answer through the interface to the user's final decision and confirms nothing along that path would
+have caught it.
+
+### co-20 · Scoping to What the Model Can Do
+
+The highest-leverage product decision is usually narrowing the feature until its failure rate is
+tolerable for the workflow it serves, not improving the model -- scoping is a design lever available
+immediately, while model improvement is not guaranteed and not fully controllable.
+
+**Why it matters**: teams that reach for model improvement before scoping are optimizing the harder,
+less controllable lever first, when the easier and more reliable one was available the whole time.
+
+**Verify it**: a scoping proposal is well-formed if it states the failure rate the narrowed feature
+achieves and names the specific capability being deliberately excluded to get there.
+
+### co-21 · Ship Criteria for a Distribution
+
+A launch decision on a probabilistic feature is a threshold on a measured distribution with an
+interval, plus a named worst case that is acceptable -- not a single pass-rate number and not a
+qualitative "it seems good."
+
+**Why it matters**: criteria written only against an average pass rate can permit a launch whose
+tail behavior -- the worst 5% of cases -- is unacceptable, even while the headline number looks
+fine.
+
+**Verify it**: a ship-criteria sheet is well-formed if every criterion names a threshold, an
+interval, and an explicitly acceptable worst case, each checkable against a real eval report.
+
+### co-22 · Staged Rollout and Guardrail Metrics
+
+Exposure is ramped gradually while pre-agreed guardrail metrics are watched, because an eval set --
+however good -- does not contain the real traffic that will eventually break a feature in
+production.
+
+**Why it matters**: staged rollout is the acknowledgment that no eval set is complete; it converts an
+unknown production risk into a bounded, observable, and reversible one.
+
+**Verify it**: a staged-rollout plan is well-formed if every guardrail metric names the specific
+threshold that would halt the ramp, checkable in real time, not after the fact.
+
+### co-23 · Rollback Criteria Agreed in Advance
+
+The conditions for turning a feature off are written down before launch, because they cannot be
+negotiated honestly once an incident is already under way and stakeholders are under pressure to
+keep the feature live.
+
+**Why it matters**: rollback criteria decided during an incident are systematically biased toward
+"just a little longer" -- writing them down in advance, when nobody has a stake in the outcome yet,
+is what makes them enforceable.
+
+**Verify it**: a rollback-criteria sheet is well-formed if its conditions are unambiguous enough to
+act on during a real incident without requiring any new negotiation.
+
+### co-24 · Feedback Capture as a Product Surface
+
+The correction affordance -- the in-context way a user fixes a wrong output -- is simultaneously a
+recovery path for that user and the pipeline that feeds the next error-analysis pass.
+
+**Why it matters**: a correction affordance that only recovers the current user, without capturing
+the correction for later analysis, throws away exactly the signal that would prevent the same
+failure from recurring.
+
+**Verify it**: a correction-affordance design is well-formed if the captured correction is routed
+somewhere a later error-analysis pass can actually use it, not merely applied and discarded.
+
+## How this course's scenarios are organized
+
+- **[Theme A -- The Wrong Answer Is Coming](./theme-a-the-wrong-answer-is-coming.md)** (Scenarios
+  1-11) -- a probabilistic feature walked through a success-or-error interface, the six user-visible
+  failure modes catalogued, honest first-contact copy contrasted with an overpromise, a
+  trust-calibration diagram, automation bias in a fifty-item review, and the decision to narrow a
+  feature or not ship it at all.
+- **[Theme B -- Uncertainty, Confidence, and Provenance](./theme-b-uncertainty-confidence-and-provenance.md)**
+  (Scenarios 12-22) -- where an uncertainty signal belongs, four confidence representations compared
+  side by side, a high-confidence wrong answer, caveat fatigue, a selective-uncertainty policy,
+  citation as a stronger signal than a score, a verifiability diagram, and an accessible uncertainty
+  treatment meeting WCAG AA without relying on colour.
+- **[Theme C -- Humans in the Loop, Friction, and Recovery](./theme-c-humans-in-the-loop-friction-and-recovery.md)**
+  (Scenarios 23-33) -- review designed as the product, review theatre, vigilance-decrement
+  mitigations, a consequence-scaled friction table, preview-and-diff, undo versus a marginal
+  accuracy gain, a partial-undo trap, and a correction affordance that closes the loop into error
+  analysis.
+- **[Theme D -- Degradation, Latency, and the Launch Decision](./theme-d-degradation-latency-and-the-launch-decision.md)**
+  (Scenarios 34-44) -- the model-unavailable state, a fallback hierarchy with a degradation diagram,
+  failing visibly instead of silently, latency treatments compared, an optimistic UI that lies, ship
+  criteria written against a distribution, a launch whose criteria missed the tail, staged rollout
+  with guardrails, rollback criteria agreed in advance, and the capstone-scale scenario that ties
+  every concept together.
+- **[Capstone](./capstone/overview.md)** -- the complete design dossier for one real probabilistic
+  feature: a failure catalogue, an interface design, a review-and-recovery plan, a degradation plan,
+  and launch criteria a real launch review could act on.
+
+## Read more
+
+- **Designing Machine Learning Systems** -- Chip Huyen (2022). Practitioner-oriented treatment of a
+  probabilistic feature as a product with a measured failure rate, not a model with an accuracy.
+- **Evaluating AI Output -- Essentials** -- the pass-rate-with-an-interval framing Theme D's ship
+  criteria (co-21) apply directly to a launch decision. [Course overview](../overview.md).
+
+---
+
+← Previous: [Overview](../overview.md) &middot; Next: [Theme A: The Wrong Answer Is Coming](./theme-a-the-wrong-answer-is-coming.md) →

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-a-the-wrong-answer-is-coming.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-a-the-wrong-answer-is-coming.md
@@ -1,0 +1,396 @@
+---
+title: "Theme A: The Wrong Answer Is Coming"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 10
+---
+
+Scenarios 1-11 build the case for why a probabilistic feature cannot simply reuse a
+success-or-error interface: a confidently wrong answer has nowhere to land in that interface
+(co-01), the six user-visible failure modes need distinct designs (co-02), first-contact framing
+determines how errors get read later (co-03), and trust must be calibrated rather than assumed
+(co-04) against a specific, well-documented failure mode of human attention -- automation bias
+(co-05). The theme closes with the two moves available when none of that is enough: narrow the
+feature (co-20) or decide not to ship it (co-20, co-15). Every scenario below produces a written
+decision artefact; Scenario 6's artefact is a captioned, WCAG-accessible Mermaid diagram and lives
+standalone under `learning/artifacts/`.
+
+---
+
+### Worked Scenario 1: The Deterministic Interface Fails
+
+**Context**: Exercises co-01. Nimbus, a document-search assistant, answers "which contract expires
+first?" with a single confident sentence, rendered in the exact same text block the product already
+uses for a database lookup that is always correct. The lookup's UI has exactly two states: the
+answer, or a red error banner if the query fails outright. There is no third state for "this is
+probably right, but check it."
+
+**Decision artifact**:
+
+> **Interface state audit -- Nimbus contract-expiry answer**
+>
+> - **States the current interface supports**: (1) answer shown, styled identically regardless of
+>   source; (2) error banner, shown only if the backend call itself fails.
+> - **State a confidently-wrong answer lands in**: state (1) -- indistinguishable from a correct
+>   database lookup. Nothing in the interface signals that this particular answer came from a model
+>   reading unstructured contract text rather than a deterministic query.
+> - **Conclusion**: the interface was built for a system that either returns a fact or fails
+>   outright. It has no state for "returned something plausible that might be wrong," which is the
+>   probabilistic feature's actual, dominant failure mode.
+
+**Verify**: the audit names the exact rendering state a confidently wrong answer lands in, and
+confirms no visual, textual, or structural difference exists between that state and a genuinely
+correct answer -- satisfying co-01's rule that a deterministic interface has no state for this
+failure.
+
+**Key takeaway**: A probabilistic feature's most common failure is not an error state -- it is a
+plausible answer with nowhere to land except the interface's "correct" state.
+
+**Why It Matters**: Every later scenario in this theme and the next answers a version of the
+question this audit raises: what third state should exist, and what should it show? Skipping this
+diagnostic step is how teams ship a probabilistic feature inside an interface that was never
+designed to hold it, discovering the gap only after a user has already acted on a wrong answer.
+
+---
+
+### Worked Scenario 2: Catalogue the User-Visible Failures
+
+**Context**: Exercises co-02. Nimbus's support team is asked "how does Nimbus fail?" and initially
+answers "sometimes it's wrong" -- a single undifferentiated category that gives design nothing to
+work with. This scenario decomposes that into Nimbus's own six observed failure modes.
+
+**Decision artifact**:
+
+| Failure mode                           | User-observable description                                                       | Example                                                                |
+| -------------------------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Confidently wrong                      | A fluent, specific answer that is factually incorrect, with no hedging language.  | States the wrong contract's expiry date with full sentence confidence. |
+| Subtly wrong                           | Mostly correct, with one small but consequential detail altered.                  | Correct expiry date, wrong contract party name.                        |
+| Refused                                | Declines to answer at all, with or without an explanation.                        | "I can't answer questions about legal documents."                      |
+| Truncated                              | Answer is cut off mid-thought, appearing complete but omitting the ending.        | Lists three of four relevant contracts, stopping abruptly.             |
+| Slow                                   | Correct eventually, but the wait itself changes what the user does while waiting. | 12-second response with no progress indication.                        |
+| Inconsistent across identical requests | The same question, asked twice, returns two different answers.                    | Re-asking "which expires first" returns a different contract.          |
+
+**Verify**: each of the six rows is distinguishable from the other five by a user with no visibility
+into the model's internals -- satisfying co-02's rule that these are six distinct experiences, not
+one undifferentiated category.
+
+**Key takeaway**: "Sometimes it's wrong" is not a design input -- six named, user-observable failure
+modes are, because each demands a different response.
+
+**Why It Matters**: This catalogue is the reference table the rest of this course keeps returning
+to: Scenario 3 traces the silent-failure path for "confidently wrong," Theme B answers "subtly
+wrong" and "confidently wrong" with uncertainty and provenance signals, and Theme D answers "slow"
+and "inconsistent" with latency treatments and fallback hierarchies. A catalogue this specific is
+what turns "make it more reliable" into a set of separately addressable design problems.
+
+---
+
+### Worked Scenario 3: Silent-Failure Walkthrough
+
+**Context**: Exercises co-19 and co-02. Continuing Scenario 2's "confidently wrong" row: this
+scenario traces one specific wrong answer -- Nimbus stating the wrong contract's expiry date -- all
+the way from the model's output to the point where a user, Priya from Legal Ops, acts on it.
+
+**Decision artifact**:
+
+> **Silent-failure trace -- wrong contract-expiry answer**
+>
+> 1. Model generates: "The Meridian Supply contract expires first, on March 3." (Actually the
+>    Anchor Logistics contract expires first, on February 14 -- a contract the model's retrieval
+>    step missed.)
+> 2. Interface renders this in the standard answer block -- same font, same colour, same layout as
+>    every correct answer Priya has seen before.
+> 3. Priya reads the answer, sees no caveat, citation, or confidence indicator anywhere near it.
+> 4. Priya schedules the Meridian renewal review for next month and does not schedule Anchor
+>    Logistics -- which lapses, unrenewed, on February 14.
+> 5. Nothing in steps 1-4 would have caught the error before it caused a real, costly consequence.
+
+**Verify**: the trace reaches Priya's actual decision (scheduling the wrong renewal) and confirms,
+step by step, that no point along the path -- rendering, reading, or deciding -- contained anything
+that could have caught the error, satisfying co-19's rule.
+
+**Key takeaway**: A silent failure is not defined by the model being wrong -- it is defined by every
+downstream step also failing to catch it, because nothing was designed to.
+
+**Why It Matters**: This is the single scenario every other pattern in this course exists to
+prevent. Theme B's uncertainty and provenance signals, Theme C's review design, and Theme D's
+degradation states are all, in different ways, attempts to insert a catch point somewhere along
+this exact five-step path before it reaches a costly, silent conclusion.
+
+---
+
+### Worked Scenario 4: First-Run Expectation-Setting
+
+**Context**: Exercises co-03. Nimbus's onboarding screen currently says "Nimbus finds answers in
+your documents instantly." This scenario drafts a replacement that survives the user's first wrong
+answer instead of being contradicted by it.
+
+**Decision artifact**:
+
+> **First-contact copy -- before and after**
+>
+> - **Before**: "Nimbus finds answers in your documents instantly." (Implies certainty and speed as
+>   guarantees; a slow or wrong first answer directly contradicts this framing.)
+> - **After**: "Nimbus reads your documents and drafts an answer in seconds -- always check the
+>   source link before you act on anything it tells you." (States what it does -- drafts, not
+>   guarantees -- and names the specific behaviour, checking the source, that survives a wrong
+>   answer without feeling like a broken promise.)
+
+**Verify**: re-reading the "after" copy immediately after a hypothetical wrong first answer, the
+copy still reads as accurate -- it never claimed certainty, so a wrong answer does not contradict it
+-- satisfying co-03's rule.
+
+**Key takeaway**: Honest first-contact copy does not need to undersell the feature -- it needs to
+name what the feature actually guarantees, so a later miss does not read as a broken promise.
+
+**Why It Matters**: The gap between what onboarding copy promises and what the feature actually
+delivers is repaid, with interest, at the moment of the first visible mistake. Setting the
+expectation honestly the first time is far cheaper than repairing trust after an overpromise has
+already been contradicted. This same discipline applies beyond onboarding screens -- any first-touch moment (an empty state, a tooltip, a sales conversation) sets the same kind of expectation, and each deserves the same honesty check.
+
+---
+
+### Worked Scenario 5: Overpromise Postmortem
+
+**Context**: Exercises co-03 and co-04. Nimbus's marketing site originally read "Never miss a
+contract deadline again -- Nimbus guarantees accurate answers." This scenario critiques that copy
+against its first real failure.
+
+**Decision artifact**:
+
+> **Overpromise postmortem -- "Nimbus guarantees accurate answers"**
+>
+> - **The promise made**: certainty ("guarantees"), framed as a permanent outcome ("never miss ...
+>   again").
+> - **The first failure**: the Scenario 3 incident -- the wrong expiry date that caused a real
+>   contract lapse.
+> - **The specific trust damage**: Priya does not conclude "Nimbus made one mistake" -- she
+>   concludes "the guarantee was false," because the copy left no room for a single miss to be
+>   anything other than a broken promise. She now manually double-checks every Nimbus answer,
+>   erasing the time savings the feature exists to provide.
+> - **The fix**: replace "guarantees" with a stated verification habit (Scenario 4's "after" copy),
+>   which absorbs a miss without contradicting itself.
+
+**Verify**: the postmortem names the specific word or phrase in the original copy that becomes false
+the instant a single wrong answer occurs, and traces the concrete behavioural consequence (manual
+double-checking of everything) that follows -- satisfying co-03 and co-04's rule that first-contact
+framing determines how the first failure is read.
+
+**Key takeaway**: A guarantee is a promise with no room for a single miss -- and a probabilistic
+feature will always eventually miss, so the guarantee is the thing that breaks, not the feature.
+
+**Why It Matters**: Overpromising is a common, well-intentioned marketing instinct, and it is
+precisely the instinct this course exists to correct. An honest framing (Scenario 4) does not sell
+less well because it is less impressive -- it sells sustainably because it survives contact with the
+feature's real, ongoing failure rate. Marketing and product teams should treat this postmortem as a template: any existing claim using words like “guarantee,” “always,” or “never” is worth auditing the same way before the feature's next visible miss forces the audit anyway.
+
+---
+
+### Worked Scenario 6: Trust-Calibration Diagram (diagram)
+
+**Context**: Exercises co-04. Trust calibration has two failure quadrants, not one -- over-trust and
+blanket distrust -- and both are caused by the interface. This diagram-medium scenario maps actual
+reliability against user trust and names concrete interface moves that pull a feature out of each
+failure quadrant.
+
+> A captioned diagram mapping actual reliability against user trust, naming the over-trust and
+> blanket-distrust failure quadrants and the interface moves that correct each -- exercises co-04.
+> The full diagram, with its own Verify / Key takeaway / Why It Matters, lives at
+> [Artifact: Trust-Calibration Diagram](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/artifacts/ex-06-trust-calibration-diagram).
+
+**Key takeaway**: Trust calibration is a two-sided problem -- pulling a feature out of blanket
+distrust (Scenario 9) uses a different set of interface moves than pulling it out of over-trust
+(Scenario 8), and a design that only addresses one leaves the other quadrant unaddressed.
+
+**Why It Matters**: This diagram is the map the rest of Theme A's remaining scenarios (7-9) each
+place themselves on -- automation bias (Scenario 7) is the mechanism behind the over-trust
+quadrant, and Scenario 9's abandoned feature is a concrete instance of the blanket-distrust
+quadrant. Naming both quadrants up front is what keeps later scenarios from reading as unrelated
+problems.
+
+---
+
+### Worked Scenario 7: Automation Bias in a Review Flow
+
+**Context**: Exercises co-05 and co-12. A Nimbus reviewer, Marcus, checks fifty auto-drafted
+contract summaries in a row. Nimbus's summaries are correct roughly 96% of the time. This scenario
+walks Marcus's fifty-item session and identifies where his scrutiny predictably collapses.
+
+**Decision artifact**:
+
+> **Review-session trace -- fifty summaries, 96% baseline accuracy**
+>
+> - **Items 1-8**: Marcus reads each summary against the source contract carefully; catches one of
+>   the ~0.3 expected errors in this range on item 6.
+> - **Items 9-25**: Marcus's per-item read time drops by roughly half; he is now skimming for
+>   obvious mismatches rather than reading the source contract in full.
+> - **Items 26-50**: Marcus is approving summaries in a rhythm, largely on the strength of "the last
+>   twenty were all fine" -- the exact reasoning that fails the moment item 41 contains the
+>   session's second error, which he approves without catching.
+> - **Point of collapse**: roughly item 15-20, where reading behaviour visibly shifts from
+>   verification to pattern-matched approval.
+
+**Verify**: the trace names a specific item range (not "eventually" or "at some point") where
+Marcus's behaviour measurably changes from full verification to pattern-matched approval --
+satisfying co-05 and co-12's rule that the vigilance decrement has an identifiable onset, not just
+an eventual, vague presence.
+
+**Key takeaway**: Scrutiny does not decay evenly across a review session -- it drops sharply after
+roughly the first dozen items, which is exactly where a review design needs to intervene, not at
+item fifty.
+
+**Why It Matters**: A review design that assumes uniform attention across a fifty-item batch is
+designing against a false model of human behaviour. Scenario 25 in Theme C returns to this exact
+trace to design concrete mitigations (batch size, forced checkpoints) targeted at this specific
+collapse point. Knowing the approximate collapse point in advance also lets a team decide, deliberately, whether to shrink batch sizes, insert a break, or accept the risk for lower-stakes review work -- a choice that is only available once the collapse point is actually measured.
+
+---
+
+### Worked Scenario 8: Reliability Makes Scrutiny Worse
+
+**Context**: Exercises co-05. Nimbus's summary accuracy improved from 88% to 96% over two product
+quarters. Reviewer approval time per item dropped by 40% over the same period. This scenario
+annotates why the counterintuitive direction -- better model, worse scrutiny -- is exactly what
+automation-bias research predicts.
+
+**Decision artifact**:
+
+> **Annotated trend -- accuracy up, scrutiny down**
+>
+> - **Quarter 1 (88% accuracy)**: average review time per item, 45 seconds. Reviewers report
+>   "checking every claim against the source."
+> - **Quarter 3 (96% accuracy)**: average review time per item, 27 seconds. Reviewers report
+>   "mostly scanning for anything that looks obviously off."
+> - **Annotation**: this is not reviewers becoming lazier -- it is the predictable consequence of a
+>   system becoming more trustworthy on average. The improvement in the headline accuracy number
+>   directly causes the erosion in per-item scrutiny, because a system that is right 96% of the time
+>   gives a reviewer 24 consecutive correct experiences, on average, between errors -- more than
+>   enough to establish a pattern of trust the reviewer then applies uniformly, including to the
+>   25th item.
+
+**Verify**: the annotation states the specific causal direction (rising accuracy causes falling
+scrutiny, not the reverse) and names the mechanism (a longer average run of correct outputs between
+errors) -- satisfying co-05's rule that this direction is counterintuitive but well-documented.
+
+**Key takeaway**: An improving accuracy number is not, by itself, evidence the feature is getting
+safer to use unreviewed -- it may simply be moving the failure further out along a run of correct
+answers that erodes scrutiny in the meantime.
+
+**Why It Matters**: Teams that treat a rising pass rate as purely good news miss this trade-off
+entirely. A product team should expect -- and design against -- review quality degrading as model
+quality improves, which is precisely why co-12's vigilance-decrement mitigations (Theme C) are not
+optional polish but a load-bearing part of any human-in-the-loop design.
+
+---
+
+### Worked Scenario 9: Blanket-Distrust Case
+
+**Context**: Exercises co-04 and co-06. A different Nimbus rollout, in the Facilities team,
+collapsed: two wrong answers in the first week and usage dropped to near zero within a month. This
+scenario diagnoses why the interface gave users no way to distinguish a trustworthy answer from an
+untrustworthy one.
+
+**Decision artifact**:
+
+> **Blanket-distrust diagnosis -- Facilities rollout**
+>
+> - **Timeline**: week 1, two wrong answers (a vendor-contact detail and a maintenance-schedule
+>   date), both delivered with the same visual treatment as every correct answer before them; week
+>   4, daily active users down 94% from week 1.
+> - **Root cause**: the interface offered exactly one visual treatment for every answer, correct or
+>   not. Once two answers were discovered wrong, users had no basis to distinguish future correct
+>   answers from future wrong ones -- so they stopped trusting all of them, which is a rational
+>   response to an interface providing no distinguishing signal.
+> - **What was missing**: any of co-06's uncertainty signals, co-09's provenance, or co-10's
+>   cheap-verification structuring -- any one of which would have given users a basis for
+>   case-by-case trust instead of an all-or-nothing verdict.
+
+**Verify**: the diagnosis identifies the specific interface property (a single undifferentiated
+visual treatment) responsible for the collapse, and names at least one concrete fix from a later
+theme -- satisfying co-04 and co-06's rule that blanket distrust is a design failure, not simply
+"users being cautious."
+
+**Key takeaway**: When an interface gives users no way to tell a good answer from a bad one, the
+rational user response to a single visible mistake is to stop trusting everything -- not just the
+mistake itself.
+
+**Why It Matters**: This is the blanket-distrust quadrant from Scenario 6's diagram made concrete,
+and it demonstrates why Theme B's entire uncertainty-and-provenance toolkit exists: not to make the
+feature look less confident, but to give users the case-by-case discrimination ability this rollout
+never had. The lesson generalizes beyond this one rollout: any feature launched with a single, undifferentiated presentation of every answer is one bad answer away from the same collapse, regardless of how strong its average accuracy actually is.
+
+---
+
+### Worked Scenario 10: Narrow the Feature Instead
+
+**Context**: Exercises co-20. Nimbus's original scope -- "answer any question about any document" --
+produces a 78% accuracy rate, too low for Legal Ops to trust unaided. This scenario redesigns the
+feature's scope rather than attempting to improve the underlying model.
+
+**Decision artifact**:
+
+> **Scoping proposal -- Nimbus for Legal Ops**
+>
+> - **Original scope**: free-form Q&A over every document type Legal Ops uses (contracts, policy
+>   memos, meeting notes, external correspondence). Measured accuracy: 78%.
+> - **Narrowed scope**: structured extraction over one document type only -- contract metadata
+>   (parties, dates, renewal terms) from contracts specifically, always paired with a citation to
+>   the source clause. Measured accuracy on this narrower task: 97%.
+> - **What was excluded**: free-form questions, non-contract document types, and any question
+>   requiring synthesis across multiple documents -- all routed to a "not supported yet" state
+>   instead of a low-confidence guess.
+> - **Why this is the higher-leverage move**: reaching 97% on the narrow task required no model
+>   change at all -- only removing every input the model was unreliable on.
+
+**Verify**: the proposal states both the narrowed task's measured accuracy and the specific
+capability excluded to reach it -- satisfying co-20's rule that scoping is a concrete trade, not a
+vague "let's do less."
+
+**Key takeaway**: A large jump in reliability was available without touching the model at all --
+simply by refusing to answer the questions the model was actually bad at.
+
+**Why It Matters**: Scoping is available to a product team on day one, does not require a model
+provider's roadmap to cooperate, and is fully within a team's own control -- which is exactly why
+co-20 calls it the highest-leverage move, not merely one option among several equally good ones. It is also the move a team can revisit and expand later, once the model itself improves, whereas an interface built around an unreliable broad scope has to be re-architected rather than simply widened when that day comes.
+
+---
+
+### Worked Scenario 11: Decide Not to Ship
+
+**Context**: Exercises co-20 and co-15. A proposed Nimbus feature -- auto-drafting outbound legal
+correspondence -- cannot be narrowed to an acceptable failure rate (the task is inherently
+open-ended) and any wrong draft that gets sent is effectively irreversible (co-15's undo does not
+apply once an email has left the building). This scenario documents the decision not to ship it.
+
+**Decision artifact**:
+
+> **No-ship decision record -- Nimbus auto-drafted outbound correspondence**
+>
+> - **Scoping attempted**: restricting to routine renewal-reminder emails only. Measured accuracy on
+>   even this narrowed task: 81% -- still below the bar Legal accepted for anything leaving the
+>   building unreviewed.
+> - **Undo attempted**: none exists once an email is sent to an external recipient; there is no
+>   equivalent of Scenario 32's correction affordance for a message already delivered.
+> - **Decision**: do not ship auto-send. A drastically reduced version -- auto-draft only, with a
+>   mandatory human send action -- remains viable and is scoped separately.
+> - **Owner and revisit condition**: Product Lead, revisit if narrowed-task accuracy clears 95% in a
+>   future model evaluation.
+
+**Verify**: the record states both why scoping failed to reach an acceptable rate and why undo does
+not apply to this specific action, and names a concrete revisit condition -- satisfying co-20 and
+co-15's rule that a no-ship decision is a reasoned, revisitable conclusion, not an unexplained
+refusal.
+
+**Key takeaway**: When neither scoping nor undo can bring a probabilistic feature's risk down to an
+acceptable level, the correct product decision is not to ship it -- and writing that decision down,
+with a revisit condition, is itself a deliverable, not a failure to deliver.
+
+**Why It Matters**: Recognising this case is as much a part of professional product judgment on
+probabilistic features as knowing how to ship one. A team that always finds a way to ship, even when
+neither of this course's two strongest levers (scoping, undo) apply, is optimizing for shipping
+over the user's actual safety -- and Theme D's launch and rollback criteria (Scenarios 40-43) exist
+specifically to make that trade-off visible before it happens by accident.
+
+---
+
+← Previous: [Overview](./overview.md) &middot; Next: [Theme B: Uncertainty, Confidence, and Provenance](./theme-b-uncertainty-confidence-and-provenance.md) →

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-b-uncertainty-confidence-and-provenance.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-b-uncertainty-confidence-and-provenance.md
@@ -1,0 +1,379 @@
+---
+title: "Theme B: Uncertainty, Confidence, and Provenance"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 20
+---
+
+Scenarios 12-22 build the toolkit that closes the gap Theme A diagnosed: where an uncertainty
+signal belongs (co-06), what trade-off each representation of confidence makes (co-07), why
+confidence is not the same claim as correctness (co-08), and why a citation a user can independently
+check (co-09) is often a stronger signal than any confidence number, especially once the output
+itself is restructured to be cheap to verify (co-10). The theme closes with an uncertainty
+treatment that clears WCAG AA without depending on colour alone. Scenario 21's artefact is a
+captioned, WCAG-accessible Mermaid diagram and lives standalone under `learning/artifacts/`.
+
+---
+
+### Worked Scenario 12: Where Uncertainty Belongs
+
+**Context**: Exercises co-06. Nimbus originally placed a single disclaimer -- "AI-generated answers
+may contain errors" -- in the page footer, visible only if a user scrolls past the answer entirely.
+This scenario relocates the signal to the point it can actually be acted on.
+
+**Decision artifact**:
+
+> **Placement redesign -- uncertainty signal relocation**
+>
+> - **Before**: static disclaimer in the page footer, below the answer, below the citation links,
+>   below the "was this helpful?" prompt. Measured: fewer than 3% of users scroll far enough to see
+>   it before acting on the answer above.
+> - **After**: an inline badge directly adjacent to any answer flagged low-confidence by Nimbus's own
+>   scorer, positioned before the user's next likely action (in this case, before the "schedule
+>   renewal" button).
+> - **Decision rule**: an uncertainty signal's placement is correct only if it sits between the
+>   answer and the user's next action -- never after it.
+
+**Verify**: the "after" placement sits before the specific action (scheduling a renewal) the user
+would take based on the answer, satisfying co-06's rule that a signal must appear while the user
+could still act on it.
+
+**Key takeaway**: The same words, moved from the footer to directly beside the answer, change from
+decorative to functional -- placement is not a styling detail, it is the entire mechanism by which
+an uncertainty signal works or fails to work.
+
+**Why It Matters**: A correct uncertainty signal in the wrong place is functionally equivalent to no
+signal at all, because a user who has already acted cannot retroactively benefit from it. Every
+remaining scenario in this theme assumes the placement problem is solved and focuses on what the
+signal itself should say. Getting placement right first is also what makes the rest of this theme's content trade-offs meaningful -- comparing representations or writing a selective policy is wasted effort if the resulting signal never reaches the user in time to matter.
+
+---
+
+### Worked Scenario 13: Four Confidence Representations
+
+**Context**: Exercises co-07. The same low-confidence Nimbus answer is shown four different ways, to
+compare what each communicates and what each risks being misread as.
+
+**Decision artifact**:
+
+| Representation   | Rendered as                                                    | Communicates                                 | Risk                                                                                                                       |
+| ---------------- | -------------------------------------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Numeric score    | "Confidence: 0.72"                                             | A precise-looking quantity.                  | Read as "72% chance this is correct" -- a probability claim the score does not actually make (co-08).                      |
+| Qualitative band | "Confidence: Moderate"                                         | A coarse, ordinal signal.                    | Discards the precision a user might genuinely want when comparing two answers.                                             |
+| Hedged language  | "This is likely the Meridian contract, but verify."            | A natural-language caveat embedded in prose. | Easy to skim past if the sentence is long; strength of the hedge varies by wording, not by an underlying number.           |
+| Visual treatment | Answer text rendered in a distinct, muted colour with an icon. | An at-a-glance category (verify vs. trust).  | Fails for colour-blind or screen-reader users unless paired with text and shape (co-06's accessibility rule, Scenario 22). |
+
+**Verify**: each row states both what its representation communicates and a distinct, named risk --
+satisfying co-07's rule that every representation trades precision against being read correctly, in
+its own specific way.
+
+**Key takeaway**: There is no confidence representation without a trade-off -- the choice is about
+which risk (false precision, discarded information, skippable prose, inaccessible visuals) a given
+feature can least afford.
+
+**Why It Matters**: Scenario 15 returns to the numeric-versus-band choice specifically, because it
+is the most contested of the four in real product practice; this comparison table is the reference
+every later choice in this theme draws from. No single row in this table is disqualified outright -- a product team should expect to mix representations across different parts of the same feature, choosing per situation rather than picking one company-wide default and applying it everywhere.
+
+---
+
+### Worked Scenario 14: Confidence Is Not Correctness
+
+**Context**: Exercises co-08. Nimbus's own confidence scorer rated a wrong answer 0.94 -- high
+confidence -- because the model's internal token probabilities were high for a fluently phrased,
+factually incorrect sentence. This scenario walks through why displaying that number as-is would
+have manufactured false trust.
+
+**Decision artifact**:
+
+> **Design-error walkthrough -- high confidence, wrong answer**
+>
+> - **What happened**: the model generated "The Meridian Supply contract expires March 3" with an
+>   internal score of 0.94, and it was factually wrong (the correct date was February 14, for a
+>   different contract).
+> - **Why the score was high**: the scorer measures how confidently the model generated this
+>   specific sequence of tokens -- essentially "how sure the model sounds to itself" -- not whether
+>   the underlying claim about the contract is true. A model can sound very sure while retrieving
+>   the wrong source document entirely.
+> - **The design error being avoided**: displaying "94% confident" beside this answer would have
+>   told the user the opposite of the truth -- it would have made a wrong answer look more
+>   trustworthy than a correctly-hedged one.
+> - **The fix applied**: Nimbus's confidence badge is calibrated against held-out eval accuracy per
+>   confidence bucket, not raw model score, and is labelled "Nimbus's self-assessed certainty" rather
+>   than "accuracy," so the badge never implies a probability of being right.
+
+**Verify**: the walkthrough names the specific mechanism (token-generation confidence, not claim
+verification) that produced a high score on a wrong answer, satisfying co-08's rule that confidence
+and correctness are measuring different things.
+
+**Key takeaway**: A model's confidence score measures how sure the model sounds to itself, not how
+likely the underlying claim is true -- treating the two as interchangeable is the single most common
+confidence-display error.
+
+**Why It Matters**: This is the concrete failure mode co-08 warns about, and it is the reason
+Scenario 18's citation-based signal is often preferred over any confidence score at all -- a
+citation lets the user verify the claim directly, sidestepping the confidence-versus-correctness gap
+entirely. Any team building its own confidence indicator should ask, explicitly, what the underlying number actually measures before deciding how -- or whether -- to show it to a user at all.
+
+---
+
+### Worked Scenario 15: Numeric vs. Band, User Reading
+
+**Context**: Exercises co-07 and co-08. Continuing Scenario 13's comparison, this scenario documents
+Nimbus's own contested internal debate over "0.82" versus "likely" without resolving it, per this
+course's own accuracy-note discipline.
+
+**Decision artifact**:
+
+> **Contested-decision memo -- numeric score vs. qualitative band**
+>
+> - **Position for numeric ("0.82")**: precise, comparable across answers, and useful for a power
+>   user who wants to rank several candidate answers against each other.
+> - **Position for band ("Likely")**: harder to misread as a probability-of-correctness claim,
+>   because it makes no numeric claim at all; better matches what the underlying score can actually
+>   support.
+> - **Observed user behaviour (informal internal testing, both variants shown to the same ten
+>   reviewers)**: reviewers shown "0.82" more often described the answer as "82% likely to be
+>   right" in their own words; reviewers shown "Likely" more often described it as "probably right,
+>   but I'd double-check," closer to the intended meaning.
+> - **Decision**: unresolved. Nimbus ships the qualitative band for now, revisits if a future,
+>   larger user study contradicts the informal result above.
+
+**Verify**: the memo presents both positions with a stated basis for each and does not declare one
+correct -- satisfying this course's own discipline of teaching a genuinely contested trade-off as
+contested, per co-07 and co-08.
+
+**Key takeaway**: The numeric-versus-band choice is not a solved problem in this field -- a written
+decision that documents the trade-off and the evidence considered is more honest than pretending one
+answer is universally correct.
+
+**Why It Matters**: Presenting this as settled, in either direction, would misrepresent the current
+state of product practice. A team encountering this exact choice should expect to run its own user
+research rather than copy either side of this memo as a default. Documenting the trade-off this openly also protects future teams from re-litigating the same debate from scratch -- the next revision can start from this memo's evidence instead of a fresh opinion-only argument.
+
+---
+
+### Worked Scenario 16: Caveat Fatigue
+
+**Context**: Exercises co-06. An earlier Nimbus revision attached the same hedge -- "this may not
+be fully accurate" -- to every single answer, regardless of the model's actual confidence. This
+scenario documents what happened to user attention as a result.
+
+**Decision artifact**:
+
+> **Caveat-fatigue observation log**
+>
+> - **Week 1**: users report reading the hedge and, in several cases, independently verifying the
+>   answer against the source document before acting.
+> - **Week 6**: support tickets and session recordings show users scrolling past the identical hedge
+>   without pausing -- it now appears on literally every answer, including ones later confirmed
+>   correct, so it has stopped correlating with anything actionable.
+> - **Root cause**: a hedge attached uniformly carries zero information, because it does not
+>   distinguish the answers that actually need extra scrutiny from the ones that do not.
+
+**Verify**: the log identifies the specific point (uniform application regardless of actual
+confidence) at which the hedge's information content dropped to zero, satisfying co-06's rule that
+a signal must be selective to remain meaningful.
+
+**Key takeaway**: A caveat shown on every single output is mathematically indistinguishable from no
+caveat at all, because it carries no information about which specific answer needs extra scrutiny.
+
+**Why It Matters**: This is the direct motivation for Scenario 17's selective-uncertainty policy --
+caveat fatigue is not a hypothetical risk, it is the observed, predictable consequence of applying
+an uncertainty signal without a rule for when it fires. It is also a cautionary example for any team tempted to add a caveat just to be safe -- safety in appearance is not the same as safety in practice, and an uninformative caveat actively erodes the signal value of every future one.
+
+---
+
+### Worked Scenario 17: Selective-Uncertainty Policy
+
+**Context**: Exercises co-06 and co-07. Following Scenario 16's diagnosis, this scenario writes the
+rule that decides which Nimbus answers carry an uncertainty signal and which do not, applicable
+without a human making a case-by-case judgment call each time.
+
+**Decision artifact**:
+
+> **Selective-uncertainty policy -- Nimbus contract-metadata answers**
+>
+> - **Fires the signal when**: (a) the answer's calibrated confidence bucket (Scenario 14) falls
+>   below the 90th-percentile accuracy threshold measured against the eval set, OR (b) the source
+>   citation spans more than one document, OR (c) the question was previously logged as a case where
+>   two identical requests returned different answers (co-19's inconsistency failure mode).
+> - **Does not fire when**: none of the above conditions hold -- the answer renders with no
+>   additional signal, exactly as before.
+> - **Rationale**: each condition names a concrete, measurable property of the answer, not a vague
+>   "seems uncertain" judgment -- so the policy applies identically regardless of who is reviewing
+>   it.
+
+**Verify**: every trigger condition in the policy is a concrete, checkable property (a confidence
+bucket threshold, a citation-span count, a logged inconsistency) rather than a subjective judgment
+call -- satisfying co-06 and co-07's rule that a selective policy must be applicable without
+case-by-case discretion.
+
+**Key takeaway**: A selective-uncertainty policy is only as good as its trigger conditions -- vague
+triggers reproduce the caveat-fatigue problem one condition at a time, while concrete, measurable
+triggers keep the signal meaningful.
+
+**Why It Matters**: This policy is the concrete artefact that resolves the tension named in this
+course's own overview: uncertainty signals must be selective enough to carry information. Writing
+the rule down, rather than leaving it to reviewer judgment, is what makes the policy consistent
+across every answer Nimbus produces. A policy this concrete is also auditable -- a reviewer or a future engineer can check any specific answer against the three conditions directly, rather than having to guess whether a given signal should have fired.
+
+---
+
+### Worked Scenario 18: Citation as the Better Signal
+
+**Context**: Exercises co-09. Rather than adding another confidence indicator, this scenario
+replaces the badge entirely with a direct citation to the source clause, for the subset of answers
+where a citation is practical.
+
+**Decision artifact**:
+
+> **Redesign -- confidence badge replaced by citation**
+>
+> - **Before**: "Confidence: Moderate" badge next to the answer, with no way for the user to check
+>   the claim except trusting the badge.
+> - **After**: the answer text includes an inline link -- "Anchor Logistics contract, Section 4.2" --
+>   that opens the exact source clause the answer was drawn from, highlighted.
+> - **User behaviour change**: Priya no longer has to decide whether to trust a badge -- she can
+>   open Section 4.2 and read the actual clause herself in under ten seconds, converting "should I
+>   trust this?" into "let me check this," a strictly easier and more reliable question to answer.
+
+**Verify**: the citation opens to the exact source clause (not merely the source document) and does
+so in a single click, satisfying co-09's rule that provenance must be practically checkable, not
+merely present.
+
+**Key takeaway**: A citation does not ask the user to trust a number -- it hands them the means to
+verify the claim themselves, which is a fundamentally stronger position than any confidence signal
+can offer.
+
+**Why It Matters**: This is the concrete resolution of Scenario 9's blanket-distrust case -- a
+citation gives users exactly the case-by-case discrimination ability that a uniform visual treatment
+could not, without requiring the user to trust an opaque confidence number at all. It also reduces the interface's own burden -- a well-placed citation replaces an entire category of confidence-display design decisions (which number, which band, which colour) with a single, simpler mechanism the user already understands: a link.
+
+---
+
+### Worked Scenario 19: Provenance That Does Not Help
+
+**Context**: Exercises co-09 and co-10. Not every citation is equally useful. This scenario contrasts
+Scenario 18's clickable clause citation against a Nimbus citation that names a 40-page PDF with no
+page number or highlight -- provenance in name only.
+
+**Decision artifact**:
+
+> **Provenance-quality comparison**
+>
+> - **Practical citation (Scenario 18)**: "Anchor Logistics contract, Section 4.2" -- opens directly
+>   to the highlighted clause. Verification cost: under ten seconds.
+> - **Provenance theatre**: "Source: Vendor_Contracts_Master.pdf" -- a 40-page file with no page
+>   number, section reference, or highlight. Verification cost: several minutes of manual searching,
+>   which most users will not spend, making the citation functionally decorative.
+> - **Conclusion**: a citation's value is entirely a function of how cheaply a user can actually use
+>   it to verify the claim -- naming a source without making it practically checkable produces the
+>   appearance of verifiability with none of the substance.
+
+**Verify**: the comparison states a concrete verification-cost estimate for each citation and
+identifies which one crosses a threshold most users will not spend, satisfying co-09 and co-10's
+rule that provenance must be practically, not merely nominally, checkable.
+
+**Key takeaway**: A citation that names a source without pointing at the specific claim is
+provenance theatre -- it looks like verifiability in a design review and functions like nothing at
+all in actual use.
+
+**Why It Matters**: This is the specific trap Scenario 20's cheap-verification redesign exists to
+avoid -- the fix for weak provenance is not removing citations, it is investing in the retrieval and
+rendering work that makes a citation point at an exact, checkable location. Any team auditing its own feature's citations should apply this same verification-cost test -- a source name alone is not evidence of provenance; only a source a user can and will actually check counts.
+
+---
+
+### Worked Scenario 20: Design for Cheap Verification
+
+**Context**: Exercises co-10. Building on Scenario 19's diagnosis, this scenario restructures
+Nimbus's output format itself so that checking any answer costs meaningfully less than the model
+took to produce it.
+
+**Decision artifact**:
+
+> **Output restructuring -- from free-text answer to structured, checkable fields**
+>
+> - **Before**: a single free-text paragraph answering "which contract expires first, and what are
+>   its terms?" -- verifying it requires re-reading the whole paragraph against the whole contract.
+> - **After**: a structured card -- `contract_name`, `expiry_date`, `renewal_terms` -- each field
+>   individually linked to its own exact source clause, so a user can check any one field
+>   independently without re-reading the others.
+> - **Verification-cost result**: checking one field (say, just the expiry date) now takes roughly
+>   five seconds against roughly forty-five seconds to verify the equivalent claim buried in the
+>   original free-text paragraph.
+
+**Verify**: the restructuring names the specific verification-cost reduction (roughly 45 seconds to
+roughly 5 seconds for a single field) and attributes it to the output's shape, not to any change in
+the underlying model -- satisfying co-10's rule.
+
+**Key takeaway**: Verifiability is a property you design into the output's shape -- a structured,
+field-by-field format with per-field citations is dramatically cheaper to check than an equally
+accurate free-text paragraph, at no cost to the underlying model.
+
+**Why It Matters**: This is the single highest-leverage pattern in this theme, and it composes with
+everything before it: Scenario 17's selective-uncertainty policy can now fire per field instead of
+per answer, and Scenario 18's citations become per-field instead of per-paragraph, each making the
+whole answer cheaper and more precisely verifiable. Because this change lives entirely in the output's shape, it is also durable across future model swaps -- a better or worse underlying model still benefits from the same structured, per-field citation format.
+
+---
+
+### Worked Scenario 21: Verifiability Diagram (diagram)
+
+**Context**: Exercises co-10 and co-09. This diagram-medium scenario ranks the output structures
+seen across Theme B by their verification cost, from the cheapest (a structured, per-field citation)
+to the most expensive (an unstructured paragraph with a document-only citation).
+
+> A captioned diagram ranking output structures by verification cost, from cheapest to most
+> expensive -- exercises co-10 and co-09. The full diagram, with its own Verify / Key takeaway / Why
+> It Matters, lives at
+> [Artifact: Verifiability Diagram](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/artifacts/ex-21-verifiability-diagram).
+
+**Key takeaway**: Verification cost is a ladder, not a binary -- every rung up from "unstructured,
+no citation" toward "structured, per-field citation" buys a concrete, measurable reduction in how
+long a user needs to check the answer.
+
+**Why It Matters**: This ranking is the reference Theme C's review-cost scenarios (23-26) build on
+directly -- a review step's cost is bounded from below by how verifiable its input already is, so
+investing in Theme B's rungs pays off again, concretely, in Theme C's human-review design. A team auditing its own feature can place its current output format on this same ladder to see, concretely, how much investment separates it from the cheapest achievable rung.
+
+---
+
+### Worked Scenario 22: Accessible Uncertainty
+
+**Context**: Exercises co-06 and co-07. Scenario 13's "visual treatment" representation -- a muted
+colour and an icon -- fails for colour-blind and screen-reader users unless it is redesigned to
+carry its meaning through more than colour alone. This scenario produces that redesign and confirms
+it against WCAG AA.
+
+**Decision artifact**:
+
+> **Accessible uncertainty treatment -- before and after**
+>
+> - **Before**: low-confidence answers rendered with a muted orange background only. Fails for
+>   protanopia/deuteranopia (colour alone conveys the distinction) and fails for screen readers
+>   (background colour is not announced).
+> - **After**: low-confidence answers carry (1) a text label, "Verify before acting," (2) a distinct
+>   icon shape (a triangle, not merely a colour swatch), and (3) an `aria-label` announcing "Nimbus
+>   flagged this answer for verification" -- so the same signal survives a colour-blind reading, a
+>   greyscale printout, and a screen-reader pass.
+> - **Contrast check**: the label text against its background measures 6.1:1, clearing the 4.5:1
+>   WCAG AA minimum for normal text.
+
+**Verify**: the redesign carries its meaning through a text label and a distinct shape independent
+of colour, includes a screen-reader-announced label, and its text contrast measures at or above
+4.5:1 -- satisfying co-06 and co-07's rule that an uncertainty signal must survive both a
+colour-blind and a screen-reader reading.
+
+**Key takeaway**: An uncertainty signal that depends on colour alone is not actually a signal for
+every user -- text, shape, and an accessible label are what make it a signal for all of them.
+
+**Why It Matters**: This closes Theme B on the same accessibility bar this course's own diagrams are
+held to -- a pattern this course teaches and then fails to meet in its own worked example would
+undermine the very point of teaching it. Every uncertainty and confidence pattern from this theme
+should be checked against this same WCAG AA bar before shipping.
+
+---
+
+← Previous: [Theme A: The Wrong Answer Is Coming](./theme-a-the-wrong-answer-is-coming.md) &middot; Next: [Theme C: Humans in the Loop, Friction, and Recovery](./theme-c-humans-in-the-loop-friction-and-recovery.md) →

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-c-humans-in-the-loop-friction-and-recovery.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-c-humans-in-the-loop-friction-and-recovery.md
@@ -1,0 +1,398 @@
+---
+title: "Theme C: Humans in the Loop, Friction, and Recovery"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 30
+---
+
+Scenarios 23-33 design the layer that sits between an honest uncertainty signal (Theme B) and a
+recoverable outcome: human review engineered as the product itself (co-11), costed honestly against
+the vigilance decrement Scenario 7 first traced (co-12), friction that scales with an action's
+actual consequence rather than applying uniformly (co-13), a preview that converts an irreversible
+action into a reviewable one (co-14), and undo that is worth more than a marginal accuracy gain
+(co-15). The theme closes with the correction affordance that recovers the user in the moment and
+feeds the next error-analysis pass (co-24).
+
+---
+
+### Worked Scenario 23: Review as the Product
+
+**Context**: Exercises co-11. Nimbus drafts a contract-renewal reminder email; Priya reviews and
+sends it. This scenario measures whether the review step is actually faster than Priya writing the
+reminder herself, which is the test that determines whether "review" is a real product or a
+ceremony.
+
+**Decision artifact**:
+
+> **Review-flow timing -- draft-and-review vs. write-from-scratch**
+>
+> - **Write from scratch**: Priya locates the contract, extracts the renewal date and party
+>   details, and drafts the reminder email herself. Measured average: 6 minutes 40 seconds.
+> - **Nimbus draft + review**: Nimbus produces a structured draft (Scenario 20's per-field
+>   structure, each field cited); Priya checks the three cited fields and either approves or edits.
+>   Measured average: 1 minute 15 seconds.
+> - **Conclusion**: the review step is roughly 5x faster than the unaided task, satisfying co-11's
+>   bar for treating review as the intended workflow rather than a compliance gate layered on top of
+>   it.
+
+**Verify**: the review-flow time is measured, not estimated, and is meaningfully faster than the
+unaided-task time -- satisfying co-11's rule that review-as-product requires review to actually be
+faster than doing the work.
+
+**Key takeaway**: Review only earns the label "the product" if it is measurably faster than the
+alternative -- a review step that merely feels thorough, without being timed against the
+unaided task, has not actually demonstrated its value.
+
+**Why It Matters**: This timing discipline is what separates Scenario 23 from Scenario 26's review
+theatre later in this theme -- the same review UI can be a genuine product or empty ceremony
+depending entirely on whether it clears this timing bar, which is why measuring it is not optional. Any team proposing a new human-in-the-loop feature should run this exact comparison before shipping it, because a review flow that has never been timed against its unaided alternative is an unverified claim, not a demonstrated one.
+
+---
+
+### Worked Scenario 24: Review That Costs More Than Doing
+
+**Context**: Exercises co-11 and co-12. A different Nimbus feature -- auto-summarizing customer
+support tickets for a manager's weekly digest -- failed this exact timing test. This scenario
+measures the failure and redesigns it.
+
+**Decision artifact**:
+
+> **Review-cost failure and redesign**
+>
+> - **Original design**: Nimbus generates a free-text paragraph summarizing each of forty weekly
+>   tickets; the manager reads each summary against the original ticket thread to confirm accuracy
+>   before including it in the digest. Measured average review time: 3 minutes 10 seconds per ticket
+>   -- longer than reading the original ticket thread directly (2 minutes 20 seconds).
+> - **Diagnosis**: the free-text summary format (unlike Scenario 20's structured fields) gave the
+>   manager nothing cheap to check against -- verifying a paragraph summary required essentially
+>   re-reading the source anyway.
+> - **Redesign**: switch to a structured summary (status, key blocker, next action, each with a
+>   direct quote citation from the thread) -- re-measured review time: 55 seconds per ticket,
+>   clearing the value-add bar.
+
+**Verify**: the original design's measured review time exceeds the unaided-reading time it was meant
+to replace, and the redesign's re-measured time clears it -- satisfying co-11 and co-12's rule that
+a review step destroying its own value proposition must be redesigned, not quietly accepted.
+
+**Key takeaway**: A review step is not automatically valuable just because a human is in the loop --
+if reviewing costs more than doing the underlying work, the feature has saved the user nothing, and
+the honest fix is redesigning the output's verifiability (co-10), not lowering the review bar.
+
+**Why It Matters**: This is the concrete instance of the tension this course's overview names
+explicitly -- a feature whose output must be fully checked has saved the user nothing but typing.
+The fix here came from applying Theme B's structured-output pattern to the review step itself, which
+is exactly how co-10 and co-11 compose in practice.
+
+---
+
+### Worked Scenario 25: Vigilance-Decrement Mitigation
+
+**Context**: Exercises co-12 and co-05. Continuing Scenario 7's fifty-item review trace, this
+scenario designs concrete mitigations for the point of collapse identified there (roughly item
+15-20) and states each mitigation's own cost.
+
+**Decision artifact**:
+
+| Mitigation                      | Mechanism                                                                                                | Cost                                                                                   |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Smaller batch size (10, not 50) | Splits the session before the collapse point identified in Scenario 7.                                   | More context-switching between batches; slightly lower total throughput per hour.      |
+| Random re-audit sampling        | 1-in-10 already-approved items are silently re-shown later in the session for a second check.            | Adds review volume; requires tracking which items were sampled and comparing verdicts. |
+| Forced-attention checkpoint     | Every 12th item requires an active field-by-field confirmation click, not a single "approve all" action. | Adds friction to every session, including ones where it turns out not to be needed.    |
+
+**Verify**: each mitigation names its own concrete cost, not only its benefit -- satisfying co-12's
+rule that a vigilance-decrement mitigation that ignores its own cost is not a complete design.
+
+**Key takeaway**: Every mitigation for the vigilance decrement trades some throughput or convenience
+for restored scrutiny -- there is no free fix, only a choice about which cost a given review
+workflow can afford.
+
+**Why It Matters**: This table gives Marcus's review flow (Scenario 7) concrete, costed options
+rather than a vague instruction to "pay more attention." Reviewing this cost table alongside
+Scenario 23's timing bar is what lets a team choose a mitigation without accidentally recreating
+Scenario 24's failure -- adding so much friction that review once again costs more than doing the
+work.
+
+---
+
+### Worked Scenario 26: Review Theatre
+
+**Context**: Exercises co-12 and co-11. A Nimbus approval gate requires a manager's sign-off before
+any auto-generated vendor payment reminder is sent. This scenario audits whether the gate provides
+real safety.
+
+**Decision artifact**:
+
+> **Review-theatre audit -- vendor-payment-reminder approval gate**
+>
+> - **Observed behaviour**: session recordings across 30 approvals show a median time-to-click of
+>   1.8 seconds between the approval screen loading and the "Approve" button being clicked -- not
+>   enough time to read the reminder's contents, let alone verify them against the vendor record.
+> - **Root cause**: the gate exists as a policy checkbox ("a human approved this") with no design
+>   pressure making genuine review the path of least resistance -- clicking "Approve" immediately is
+>   easier than reading first, and nothing in the interface changes that.
+> - **Verdict**: this gate provides no real safety and adds a full business day of delay to every
+>   reminder, for a check that is not actually happening.
+> - **Redesign direction**: apply Scenario 20's structured, per-field citation format so a genuine
+>   1-minute review becomes practical, then measure again before re-certifying the gate as real
+>   review.
+
+**Verify**: the audit is based on measured time-to-click across real sessions, not an assumption,
+and states a concrete verdict (no real safety provided) -- satisfying co-12 and co-11's rule that a
+review step's legitimacy is an empirical question, not a policy assertion.
+
+**Key takeaway**: A review gate that exists on paper but is not designed to make genuine review
+practical provides the appearance of safety and the reality of pure delay -- and the two are
+distinguishable only by measuring actual reviewer behaviour.
+
+**Why It Matters**: This audit technique -- measuring time-to-click against a plausible reading
+time -- is a cheap, repeatable check any team can run on an existing approval gate to tell review
+theatre from review-as-product (Scenario 23) before investing further in either direction. Any existing approval gate in a product is worth auditing this same way at least once -- gates decay into theatre quietly, without any single visible incident marking the moment they stopped providing real protection.
+
+---
+
+### Worked Scenario 27: Consequence-Scaled Friction Table
+
+**Context**: Exercises co-13. Nimbus can take five distinct actions on a user's behalf, ranging from
+displaying a read-only summary to sending an external email. This scenario maps every action's
+required confirmation level to its actual reversibility and blast radius.
+
+**Decision artifact**:
+
+| Action                                       | Reversibility                         | Blast radius                                 | Required confirmation                                                                    |
+| -------------------------------------------- | ------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Display a read-only summary                  | Fully reversible (nothing changed)    | None -- affects only the current view.       | None.                                                                                    |
+| Save a draft to the user's own workspace     | Fully reversible (user can delete it) | Low -- private to the user.                  | None; auto-saved with a visible undo toast.                                              |
+| Update an internal tracking field            | Reversible via edit history (co-15)   | Low -- internal record only.                 | Single click, no modal.                                                                  |
+| Schedule a calendar reminder for a colleague | Reversible (can be cancelled)         | Medium -- affects another person's calendar. | One confirmation step, showing exactly what will be scheduled (co-14).                   |
+| Send an external email to a vendor           | Irreversible once delivered           | High -- external, contractual visibility.    | Explicit preview-and-diff (co-14) plus a typed confirmation, no default "send" shortcut. |
+
+**Verify**: every row's required confirmation level is justified by that row's own stated
+reversibility and blast radius, and no two rows with meaningfully different consequences share the
+same confirmation level -- satisfying co-13's rule.
+
+**Key takeaway**: Confirmation level is a function of two independent properties -- how reversible
+an action is, and how far its effects reach -- and mapping every action against both, explicitly,
+is what prevents friction from being applied uniformly.
+
+**Why It Matters**: This table is the direct rebuttal to Scenario 28's uniform-friction failure --
+it demonstrates that friction can be precisely targeted rather than either "confirm everything" or
+"confirm nothing," once an action's actual consequence is named rather than assumed. Building this table also forces a team to enumerate every action a feature can actually take, which frequently surfaces an action nobody had explicitly designed friction for at all.
+
+---
+
+### Worked Scenario 28: Uniform Friction Fails
+
+**Context**: Exercises co-13. Before Scenario 27's table existed, an earlier Nimbus revision required
+the identical confirmation modal for every one of the five actions, including the read-only summary
+display. This scenario documents what happened to user behaviour.
+
+**Decision artifact**:
+
+> **Uniform-friction failure log**
+>
+> - **Design**: every action, from displaying a summary to sending an external email, required
+>   clicking "Confirm" on an identical modal.
+> - **Observed behaviour**: users developed a reflex of clicking "Confirm" immediately upon seeing
+>   the modal, regardless of the action underneath it -- the modal for sending an external email was
+>   clicked through with the same speed as the modal for displaying a summary.
+> - **Consequence**: one vendor email was sent with an incorrect payment amount, confirmed by the
+>   exact same reflexive click that had, correctly, confirmed dozens of harmless read-only actions
+>   before it.
+> - **Root cause**: applying identical friction to every action trained users to treat the
+>   confirmation step as noise, which erased its value for the one action -- sending external
+>   email -- that genuinely needed it.
+
+**Verify**: the log traces a concrete incident (the wrong-amount vendor email) directly to the
+uniform-friction design, and states the specific behavioural mechanism (a trained reflexive click)
+responsible -- satisfying co-13's rule.
+
+**Key takeaway**: Friction spent uniformly is friction spent nowhere -- a confirmation step that
+never varies in weight trains users to click through it regardless of what is actually at stake.
+
+**Why It Matters**: This incident is what motivated Scenario 27's table in the first place, and it
+is a direct, concrete illustration of the trade-off named in this course's own overview: friction
+is a scarce resource, and spending it uniformly leaves none, functionally, for the action that
+needed it most. The specific incident here -- a wrong payment amount confirmed by reflex -- is the kind of failure that looks, in hindsight, like a training or attention problem, when the interface's own uniform friction design was the actual root cause.
+
+---
+
+### Worked Scenario 29: Preview and Diff
+
+**Context**: Exercises co-14. Building on Scenario 27's highest-friction row, this scenario designs
+the preview-and-diff step for Nimbus's external-vendor-email action, and shows a case where it
+catches an error a plain confirmation dialog would have missed.
+
+**Decision artifact**:
+
+> **Preview-and-diff design -- external vendor email**
+>
+> - **What it shows before send**: the exact recipient address, subject line, and full email body,
+>   with the specific payment amount and due date visually highlighted (not merely mentioned in
+>   passing text) against the source record they were drawn from.
+> - **Caught case**: Nimbus drafted an email stating "$4,500" as the payment amount; the highlighted
+>   field, shown beside the source contract's actual figure ("$5,400" -- the digits transposed),
+>   made the discrepancy visible at a glance. Priya caught it in the preview and corrected it before
+>   sending.
+> - **Why a plain confirmation dialog would have missed this**: a generic "Send this email? [Confirm]"
+>   dialog does not surface the specific field values at all -- catching a transposed digit requires
+>   the exact field being shown, highlighted, and compared to its source, which is what a diff view
+>   does and a confirmation dialog does not.
+
+**Verify**: the design names the specific field-level highlight that caught the transposed-digit
+error, and the design is contrasted against what a generic confirmation dialog would have shown
+instead -- satisfying co-14's rule that a preview must show the exact change, not merely describe
+the action.
+
+**Key takeaway**: A confirmation dialog asks "do you want to do this?" -- a diff view asks "is this
+specific value correct?" -- and only the second question is capable of catching a transposed digit
+or any other field-level error.
+
+**Why It Matters**: This is co-14's concrete payoff: converting an irreversible action (an email,
+once sent, cannot be unsent) into a genuinely reviewable one by showing exactly what will change,
+not merely that something will. The same mechanism generalizes to any structured action a feature can take on a user's behalf -- scheduling, updating a record, or modifying a file all benefit from the same field-level, before#47;after treatment.
+
+---
+
+### Worked Scenario 30: Undo Beats Accuracy
+
+**Context**: Exercises co-15. Nimbus's product team has a fixed engineering budget and must choose
+between two investments: a model fine-tune projected to raise summary accuracy from 96% to 97%, or
+building complete undo for the internal-tracking-field update action (Scenario 27's third row).
+This scenario compares the two.
+
+**Decision artifact**:
+
+> **Investment comparison -- marginal accuracy vs. complete undo**
+>
+> - **Option A -- accuracy fine-tune**: projected cost, six engineer-weeks; projected benefit, 1
+>   percentage point higher accuracy, reducing errors from roughly 4-in-100 to roughly 3-in-100 --
+>   but every remaining error is still unrecoverable without a manual fix.
+> - **Option B -- complete undo for tracking-field updates**: projected cost, two engineer-weeks;
+>   projected benefit, every error (all 3-4 in 100, today and after any future model change) becomes
+>   a one-click, fully reversible fix with no manual database correction required.
+> - **Decision**: Option B. It costs less, and its value compounds across every future error the
+>   feature will ever produce, while Option A's value is capped at a single percentage point and
+>   erodes the moment a future model update changes the error distribution again.
+
+**Verify**: the comparison states both options' cost and the scope of what each fixes (a fraction of
+future errors vs. all of them, forever), and the decision follows directly from that comparison --
+satisfying co-15's rule that undo is usually both cheaper and more valuable than a marginal accuracy
+gain.
+
+**Key takeaway**: A marginal accuracy improvement fixes a fraction of future errors once; complete
+undo fixes all of them, every time, for a comparable or lower engineering cost -- which is why undo
+is very often the better investment.
+
+**Why It Matters**: This comparison is the concrete argument behind co-15's general claim, made with
+real, comparable engineering costs rather than an abstract preference -- exactly the kind of
+trade-off analysis a real product team would need to make this decision defensibly. Framing the choice explicitly as a cost-versus-scope comparison also gives a product team language to defend the decision to stakeholders who might otherwise default to assuming accuracy work is always the higher-priority investment.
+
+---
+
+### Worked Scenario 31: Partial Undo Is a Trap
+
+**Context**: Exercises co-15. Nimbus's first attempt at undo for the tracking-field update reversed
+the field's value but did not reverse a side-effect notification that had already been sent to a
+colleague. This scenario documents the resulting incorrect mental model.
+
+**Decision artifact**:
+
+> **Partial-undo incident log**
+>
+> - **What "undo" did**: reverted the tracking field's displayed value to its prior state.
+> - **What "undo" did not do**: the colleague-notification event, triggered the moment the field was
+>   first updated, had already been sent and was not retracted or followed up by any corrective
+>   message.
+> - **User's incorrect mental model**: Priya, having clicked "Undo," believed the entire action had
+>   been reversed -- including the notification -- and took no further action to correct her
+>   colleague's now-stale information.
+> - **Consequence**: the colleague acted on the stale notification for two days before discovering
+>   the discrepancy independently.
+> - **Fix**: undo must either reverse every effect of the original action (including the
+>   notification, via a correction message) or explicitly tell the user which effects it could not
+>   reverse -- never imply completeness it does not have.
+
+**Verify**: the incident log identifies the specific effect (the notification) undo failed to
+reverse, and states the user's resulting incorrect belief and its real-world consequence --
+satisfying co-15's rule that undo must be complete, not partial.
+
+**Key takeaway**: An undo that reverses some effects but not all of them is worse than no undo at
+all, because it creates false confidence that the action has been fully reversed when it has not.
+
+**Why It Matters**: This is the sharpest illustration of why co-15 insists on "complete" reversal,
+not merely "some" reversal -- Scenario 30's investment case only holds if the undo actually built is
+complete; a partial undo delivers Option B's engineering cost without its promised safety benefit. Any team building undo for a multi-effect action should inventory every side effect before claiming completeness -- a notification, a downstream webhook, or a cached copy are all easy to miss until an incident like this one exposes the gap.
+
+---
+
+### Worked Scenario 32: Correction Affordance
+
+**Context**: Exercises co-24 and co-15. This scenario designs the in-context way a user corrects a
+wrong Nimbus answer, distinct from undo (which reverses an action Nimbus took) -- this is about
+correcting the answer itself.
+
+**Decision artifact**:
+
+> **Correction-affordance design -- Nimbus answer correction**
+>
+> - **Trigger**: an inline "This isn't right" link beside every answer, always visible, not hidden
+>   behind a menu.
+> - **Flow**: clicking it opens a small form asking for the correct value and, optionally, why the
+>   original was wrong; submitting immediately updates what the user sees (recovering the user in
+>   the moment) and logs the correction with the original answer, the user's correction, and the
+>   source citation Nimbus had used.
+> - **What makes this a recovery path, not just a feedback form**: the user's own view is corrected
+>   immediately, before any backend reprocessing -- they are not left waiting on a fix to see
+>   accurate information.
+
+**Verify**: the design confirms the user's own view is corrected immediately upon submission (not
+only logged for later), satisfying co-15's recovery requirement, and confirms the correction is
+logged with enough context (original answer, correction, citation) to be usable later, satisfying
+co-24's requirement.
+
+**Key takeaway**: A correction affordance does two jobs at once -- it recovers the current user
+immediately, and it captures a structured, reusable record of exactly what went wrong for whoever
+analyzes errors next.
+
+**Why It Matters**: This scenario is the bridge into Scenario 33 -- a correction that only recovers
+the current user and is then discarded wastes exactly the signal that would prevent the same
+mistake from recurring for the next user who asks the same question. Making the affordance always visible, rather than buried behind a menu, also signals to the user that the product expects to be wrong sometimes -- reinforcing the honest first-contact framing Scenario 4 established.
+
+---
+
+### Worked Scenario 33: Feedback Into Error Analysis
+
+**Context**: Exercises co-24. This scenario routes the corrections captured in Scenario 32 into
+Nimbus's next error-analysis pass, closing the loop back into the eval work this course's
+prerequisite courses cover.
+
+**Decision artifact**:
+
+> **Correction-routing plan**
+>
+> - **Weekly aggregation**: every logged correction (Scenario 32) is pulled into a weekly review,
+>   grouped by which of Scenario 2's six failure modes it matches.
+> - **Promotion rule**: any correction pattern recurring three or more times in a single week is
+>   promoted to a new, permanent case in the eval dataset the light eval gate runs against -- the
+>   exact mechanism `evaluating-ai-output-essentials`'s co-10 "regression cases from real bugs"
+>   describes.
+> - **Closes the loop into**: `evaluating-ai-systems-in-depth`'s error-analysis workflow --
+>   `[Unverified]` not yet present in the AyoKoding course library on disk, so no link is given here
+>   -- for corrections that recur but do not fit a simple, addable eval case.
+
+**Verify**: the plan names a concrete promotion threshold (three or more recurrences in a week) and
+a specific destination for each promoted correction (the eval dataset), satisfying co-24's rule that
+a correction affordance must feed somewhere a later pass can actually use it.
+
+**Key takeaway**: A correction is most valuable the second time it prevents the same mistake --
+which only happens if it is routed somewhere systematic, not merely stored.
+
+**Why It Matters**: This scenario is the explicit seam between this course's product-design patterns
+and the measurement discipline of `evaluating-ai-output-essentials` and `evaluating-ai-systems-in-depth`
+-- product patterns surface and recover from failures; the eval courses turn recurring failures into
+permanent, measured regression tests, and this correction-routing plan is the mechanism that
+connects the two. A team implementing this routing plan should revisit the promotion threshold periodically -- three recurrences a week may be too strict for a low-traffic feature or too lax for a high-stakes one, and the right number is itself a product decision.
+
+---
+
+← Previous: [Theme B: Uncertainty, Confidence, and Provenance](./theme-b-uncertainty-confidence-and-provenance.md) &middot; Next: [Theme D: Degradation, Latency, and the Launch Decision](./theme-d-degradation-latency-and-the-launch-decision.md) →

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-d-degradation-latency-and-the-launch-decision.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-d-degradation-latency-and-the-launch-decision.md
@@ -355,7 +355,8 @@ the full [Capstone](./capstone/overview.md) applies to a different, independentl
 
 > **Design-dossier index -- Nimbus contract-metadata extraction**
 >
-> 1. **Failure catalogue** (co-02, co-19): the six failure modes from Scenario 2, with Scenario 3's
+> 1. **Failure catalogue** (co-01, co-02, co-19): Scenario 1's interface-state audit establishing why
+>    a failure catalogue is needed at all, the six failure modes from Scenario 2, and Scenario 3's
 >    silent-failure trace as the confidently-wrong path walked to its consequence.
 > 2. **Expectation-setting and trust-calibration plan** (co-03, co-04, co-05): Scenario 4's
 >    first-contact copy, Scenario 6's trust-calibration diagram, and Scenario 7-8's automation-bias
@@ -368,8 +369,9 @@ the full [Capstone](./capstone/overview.md) applies to a different, independentl
 >    29's preview-and-diff, and Scenario 30's complete-undo investment.
 > 6. **Fallback hierarchy** (co-16 through co-18): Scenario 35's ladder and Scenario 37's per-rung
 >    visibility audit.
-> 7. **Ship, guardrail, and rollback criteria** (co-21 through co-23): Scenario 40's criteria,
->    Scenario 42's staged-rollout guardrails, and Scenario 43's rollback sheet.
+> 7. **Scope, ship, guardrail, and rollback criteria** (co-20 through co-23): Scenario 10's
+>    narrowed-scope proposal and Scenario 11's no-ship decision, Scenario 40's ship criteria, Scenario
+>    42's staged-rollout guardrails, and Scenario 43's rollback sheet.
 > 8. **Correction affordance and feedback routing** (co-24): Scenario 32's design and Scenario 33's
 >    routing plan into eval regression cases.
 

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-d-degradation-latency-and-the-launch-decision.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-d-degradation-latency-and-the-launch-decision.md
@@ -136,8 +136,10 @@ design from quietly reintroducing the same failure mode at one specific rung. Th
 
 ### Worked Scenario 38: Latency as Material
 
-**Context**: Exercises co-17. Nimbus's structured-answer generation genuinely takes 8-12 seconds.
-This scenario compares three treatments of that same wait on the same slow response.
+**Context**: Exercises co-17. The primary model has already run slow enough to trip Scenario 35's
+rung-2 fallback trigger, so Nimbus is running on the fast-mode fallback model (labelled per
+Scenario 37) -- and that fallback model's own structured-answer generation genuinely takes 8-12
+seconds. This scenario compares three treatments of that same wait on the same slow response.
 
 **Decision artifact**:
 
@@ -147,10 +149,10 @@ This scenario compares three treatments of that same wait on the same slow respo
 | Streaming              | Answer text appears progressively, field by field, as each is generated.                                                      | Users report the wait as "fast," even though total completion time is unchanged. |
 | Honest staged progress | Explicit stage labels -- "Reading documents... Extracting terms... Verifying citations..." -- update as each stage completes. | Users report confidence the system is working, and re-click rate drops sharply.  |
 
-**Verify**: the comparison is drawn from the same underlying 8-12 second response time across all
-three treatments, isolating the treatment itself as the variable, and reports a distinct perceived
-result for each -- satisfying co-17's rule that latency is shaped by treatment, not only by raw
-duration.
+**Verify**: the comparison is drawn from the same underlying 8-12 second fallback-model response
+time across all three treatments, isolating the treatment itself as the variable, and reports a
+distinct perceived result for each -- satisfying co-17's rule that latency is shaped by treatment,
+not only by raw duration.
 
 **Key takeaway**: The actual wait time did not change across any of the three treatments -- only
 what filled it did, and that alone was enough to change both perceived speed and user confidence
@@ -211,8 +213,8 @@ not a single headline number.
 > **Ship-criteria sheet -- Nimbus contract-metadata extraction**
 >
 > - **Primary threshold**: pass rate ≥ 95% on the 120-case eval set, with a 95% confidence interval
->   no wider than ±3 percentage points (per `evaluating-ai-output-essentials`'s pass-rate-with-an-
->   interval framing).
+>   no wider than ±3 percentage points (extending `evaluating-ai-output-essentials`'s pass-rate
+>   framing with the confidence interval this course's co-21 teaches).
 > - **Named acceptable worst case**: of the failing cases, none may be a confidently-wrong answer
 >   with no citation attached -- every failing case in the eval set must at minimum have surfaced an
 >   uncertainty signal (co-06) or a citation the user could have used to catch it (co-09).

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-d-degradation-latency-and-the-launch-decision.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-d-degradation-latency-and-the-launch-decision.md
@@ -361,14 +361,15 @@ the full [Capstone](./capstone/overview.md) applies to a different, independentl
 > 2. **Expectation-setting and trust-calibration plan** (co-03, co-04, co-05): Scenario 4's
 >    first-contact copy, Scenario 6's trust-calibration diagram, and Scenario 7-8's automation-bias
 >    findings.
-> 3. **Selective uncertainty and provenance policy** (co-06 through co-10): Scenario 17's policy,
->    Scenario 18's citation design, and Scenario 22's accessible treatment, all meeting WCAG AA.
+> 3. **Selective uncertainty and provenance policy** (co-06 through co-10): Scenario 15's
+>    numeric-vs-band reading test, Scenario 17's policy, Scenario 18's citation design, Scenario 20's
+>    cheap-verification structure, and Scenario 22's accessible treatment, all meeting WCAG AA.
 > 4. **Human-review design** (co-11, co-12): Scenario 23's timed review flow and Scenario 25's
 >    vigilance-decrement mitigations.
 > 5. **Friction, preview, and undo** (co-13 through co-15): Scenario 27's friction table, Scenario
 >    29's preview-and-diff, and Scenario 30's complete-undo investment.
-> 6. **Fallback hierarchy** (co-16 through co-18): Scenario 35's ladder and Scenario 37's per-rung
->    visibility audit.
+> 6. **Fallback hierarchy** (co-16 through co-18): Scenario 35's ladder, Scenario 37's per-rung
+>    visibility audit, and Scenario 38's latency-as-material treatment.
 > 7. **Scope, ship, guardrail, and rollback criteria** (co-20 through co-23): Scenario 10's
 >    narrowed-scope proposal and Scenario 11's no-ship decision, Scenario 40's ship criteria, Scenario
 >    42's staged-rollout guardrails, and Scenario 43's rollback sheet.

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-d-degradation-latency-and-the-launch-decision.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/learning/theme-d-degradation-latency-and-the-launch-decision.md
@@ -1,0 +1,390 @@
+---
+title: "Theme D: Degradation, Latency, and the Launch Decision"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 40
+---
+
+Scenarios 34-44 close the loop from Theme A's opening diagnosis: what the product does when the
+model itself is unavailable, slow, or unusable (co-16, co-18), why that state must be visible
+rather than silent (co-19, echoing Scenario 3), how latency itself is a material the interface can
+shape (co-17), and finally the launch decision -- ship, staged-rollout, and rollback criteria
+written against a measured distribution rather than a hope (co-21, co-22, co-23). Scenario 36's
+artefact is a captioned, WCAG-accessible Mermaid diagram and lives standalone under
+`learning/artifacts/`. Scenario 44 closes the theme with a capstone-scale worked scenario spanning
+every concept this course teaches, foreshadowing the full capstone dossier.
+
+---
+
+### Worked Scenario 34: Model-Unavailable State
+
+**Context**: Exercises co-16. Nimbus's backend model provider had a 40-minute outage. Before this
+scenario's redesign, the frontend simply showed an infinite loading spinner for the entire outage,
+with no indication anything was wrong.
+
+**Decision artifact**:
+
+> **Model-unavailable state design**
+>
+> - **Detection**: the frontend treats three consecutive failed requests, or any single request
+>   exceeding 15 seconds with no response, as "provider unavailable."
+> - **User-visible state**: the answer area is replaced with a clearly labelled banner -- "Nimbus is
+>   temporarily unavailable. Your documents are safe; try again in a few minutes." -- plus a
+>   disabled (not hidden) input field, so the user can see the feature still exists and is not
+>   permanently broken.
+> - **What the state explicitly avoids**: an infinite spinner (implies "still working," which is
+>   false), a generic error page (implies something is broken beyond recovery), and silently
+>   returning a stale cached answer without labelling it as such.
+
+**Verify**: the design states a concrete detection rule (three failures or a 15-second timeout) and
+a specific, honest user-visible message -- satisfying co-16's rule that graceful degradation names a
+concrete state, not merely "handle the error somehow."
+
+**Key takeaway**: An unavailable state is not the absence of a design decision -- an undesigned
+outage defaults to a spinner or a silent stale answer, both of which mislead the user about what is
+actually happening.
+
+**Why It Matters**: This single state is the first, most basic rung of Scenario 35's fallback
+hierarchy, and it directly prevents co-19's silent-failure pattern from recurring in the specific
+case where the model is not degraded, but entirely absent. Designing this state explicitly also gives engineering a concrete, testable specification to build against, rather than leaving the outage behaviour to whatever the frontend framework happens to do by default when a request never resolves.
+
+---
+
+### Worked Scenario 35: Fallback Hierarchy
+
+**Context**: Exercises co-18 and co-16. Rather than a single binary "working / unavailable" state,
+this scenario designs a full ladder of rungs Nimbus falls through as conditions degrade, each with
+its own quality and cost.
+
+**Decision artifact**:
+
+| Rung | Condition                                     | Behaviour                                                                                                    | Quality                               |
+| ---- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| 1    | Primary model responds within 5s              | Full structured answer with citations (Scenario 20).                                                         | Best available.                       |
+| 2    | Primary model slow (5-15s) or rate-limited    | Falls to a smaller, faster model for the same task, same structured format.                                  | Slightly lower accuracy, still cited. |
+| 3    | Both models unavailable, cached answer exists | Serves the most recent cached answer for this exact question, explicitly labelled "cached from [timestamp]." | Stale but labelled, never silent.     |
+| 4    | No model available, no cache                  | Deterministic fallback -- a direct link to the raw source document, no generated answer at all.              | Lowest, but honest and never wrong.   |
+| 5    | Even the raw-document lookup is unavailable   | Scenario 34's unavailable state.                                                                             | No answer offered.                    |
+
+**Verify**: every rung has a stated, observable trigger condition (a timing threshold, a cache
+existence check, a lookup failure) determining exactly when the system falls to it -- satisfying
+co-18's rule.
+
+**Key takeaway**: A fallback hierarchy replaces one binary "working or broken" state with five
+named, honestly-labelled degrees of service -- each one still usable, in its own way, rather than a
+single point of total failure.
+
+**Why It Matters**: This ladder is what turns co-16's abstract commitment into something concretely
+buildable one rung at a time, and rung 3's explicit "cached from [timestamp]" labelling is the
+direct application of co-19's rule -- a stale answer is fine, as long as it never looks
+indistinguishable from a fresh one. Naming every rung in advance also makes an incident review faster -- responders can ask which rung the system was on, and for how long, instead of reconstructing an undocumented, ad hoc degradation path after the fact.
+
+---
+
+### Worked Scenario 36: Degradation Diagram (diagram)
+
+**Context**: Exercises co-18 and co-16. This diagram-medium scenario renders Scenario 35's fallback
+hierarchy as a flow with every rung's observable trigger condition made explicit.
+
+> A captioned diagram of the five-rung fallback hierarchy with each rung's observable trigger
+> condition -- exercises co-18 and co-16. The full diagram, with its own Verify / Key takeaway / Why
+> It Matters, lives at
+> [Artifact: Degradation Diagram](/en/learn/courses/product-patterns-for-probabilistic-systems/learning/artifacts/ex-36-degradation-diagram).
+
+**Key takeaway**: A fallback hierarchy is only as trustworthy as its trigger conditions being
+genuinely observable -- a rung with a vague or unmeasurable trigger is a rung that will not actually
+fire when it should.
+
+**Why It Matters**: This diagram is the reference Scenario 37 uses directly to confirm every rung
+surfaces its own identity to the user, and it is the artefact a real on-call engineer would consult
+during an actual incident to understand which rung the system is currently operating on. Publishing this diagram alongside the feature's own documentation also lets a new team member understand the full degradation surface in one glance, rather than piecing it together from scattered code comments.
+
+---
+
+### Worked Scenario 37: Fail Visibly, Not Silently
+
+**Context**: Exercises co-19 and co-16. This scenario audits Scenario 35's fallback hierarchy for the
+one property co-19 demands above all others: does the user know which rung they are currently on?
+
+**Decision artifact**:
+
+> **Visibility audit -- fallback hierarchy, rung by rung**
+>
+> - **Rung 1 (full answer)**: no label needed -- this is the expected, default state.
+> - **Rung 2 (faster fallback model)**: currently unlabelled. **Gap found**: a user cannot tell rung
+>   2's answer apart from rung 1's, even though rung 2's accuracy is measurably lower. **Fix
+>   applied**: a small "fast mode" label added to rung 2 answers.
+> - **Rung 3 (cached)**: already labelled "cached from [timestamp]" per Scenario 35's design --
+>   passes.
+> - **Rung 4 (raw document link)**: already visibly distinct -- no generated answer text appears at
+>   all, only a link -- passes.
+> - **Rung 5 (unavailable)**: already an explicit banner per Scenario 34 -- passes.
+
+**Verify**: the audit checks every one of the five rungs individually against the same rule ("can
+the user tell which rung they are on?") and finds and fixes exactly one gap (rung 2) -- satisfying
+co-19's rule that a degraded state must never be indistinguishable from a fully healthy one.
+
+**Key takeaway**: A fallback hierarchy can still fail silently at any individual rung even after the
+hierarchy itself is designed -- each rung needs its own explicit visibility check, not just the
+hierarchy's overall existence.
+
+**Why It Matters**: Rung 2's gap is exactly the kind of silent failure Scenario 3 traced all the way
+to a costly user decision -- this audit is the concrete discipline that prevents Scenario 35's good
+design from quietly reintroducing the same failure mode at one specific rung. This per-rung discipline should be repeated any time a new rung is added to a fallback hierarchy -- a hierarchy that passed this check once does not stay compliant automatically as the system evolves.
+
+---
+
+### Worked Scenario 38: Latency as Material
+
+**Context**: Exercises co-17. Nimbus's structured-answer generation genuinely takes 8-12 seconds.
+This scenario compares three treatments of that same wait on the same slow response.
+
+**Decision artifact**:
+
+| Treatment              | What the user sees during the wait                                                                                            | Perceived-quality result                                                         |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Bare spinner           | A generic spinning icon, no additional information.                                                                           | Users report the wait as "long" and frequently re-click, assuming a failure.     |
+| Streaming              | Answer text appears progressively, field by field, as each is generated.                                                      | Users report the wait as "fast," even though total completion time is unchanged. |
+| Honest staged progress | Explicit stage labels -- "Reading documents... Extracting terms... Verifying citations..." -- update as each stage completes. | Users report confidence the system is working, and re-click rate drops sharply.  |
+
+**Verify**: the comparison is drawn from the same underlying 8-12 second response time across all
+three treatments, isolating the treatment itself as the variable, and reports a distinct perceived
+result for each -- satisfying co-17's rule that latency is shaped by treatment, not only by raw
+duration.
+
+**Key takeaway**: The actual wait time did not change across any of the three treatments -- only
+what filled it did, and that alone was enough to change both perceived speed and user confidence
+that the system was working at all.
+
+**Why It Matters**: This is the concrete demonstration of co-17's claim that latency is a design
+material, not merely an engineering number to minimize -- streaming and honest staged progress are
+both available to Nimbus's product team immediately, independent of any model-speed improvement. Because this treatment is independent of model speed, it is also one of the few latency-related improvements a product team can ship without any coordination from the model provider at all.
+
+---
+
+### Worked Scenario 39: Optimistic State That Lies
+
+**Context**: Exercises co-17 and co-19. An earlier Nimbus revision showed "Reminder scheduled ✓"
+immediately upon a user clicking "schedule," before actually confirming the backend action
+succeeded -- an optimistic UI pattern applied without accounting for a probabilistic feature's
+higher failure rate.
+
+**Decision artifact**:
+
+> **Optimistic-UI failure trace**
+>
+> - **Design**: "Reminder scheduled ✓" appears the instant the button is clicked, assuming success,
+>   with the actual backend confirmation arriving (or failing) up to 6 seconds later.
+> - **Failure case**: the backend call failed (a transient error) roughly 2% of the time, but the
+>   "scheduled ✓" message never changed to reflect that -- it had already told the user the action
+>   succeeded and nothing corrected the record afterward.
+> - **Consequence**: 2% of scheduled reminders silently never existed, and users had no reason to
+>   suspect it -- they had been told, explicitly, that the action succeeded.
+> - **Fix**: the optimistic state now reads "Scheduling..." until backend confirmation actually
+>   arrives, then updates to "Scheduled ✓" or a visible failure state -- never claiming success
+>   before it is confirmed.
+
+**Verify**: the trace identifies the specific gap (a claimed success shown before actual backend
+confirmation) and quantifies the resulting silent-failure rate (2%), satisfying co-17 and co-19's
+rule that an optimistic state must not imply a completed action that has not actually completed.
+
+**Key takeaway**: Optimistic UI is a legitimate latency-hiding pattern for actions that succeed
+almost always -- but a probabilistic feature's higher failure rate means the pattern must be paired
+with an honest correction the moment a claimed success turns out to be false, never applied as if
+failure could not happen.
+
+**Why It Matters**: This is co-19's silent-failure pattern recurring in a new place -- not in the
+answer's content this time, but in the interface's claim about its own state. The same discipline
+(never claim more certainty than actually exists) that governs confidence displays in Theme B
+governs status messages here too. Any feature using an optimistic UI pattern should ask specifically what its true failure rate is before adopting it unmodified -- a pattern safe at a 0.1% failure rate is not automatically safe at 2%.
+
+---
+
+### Worked Scenario 40: Ship Criteria From a Distribution
+
+**Context**: Exercises co-21. Nimbus's contract-metadata extraction feature is ready for its first
+launch review. This scenario writes ship criteria against the feature's measured eval distribution,
+not a single headline number.
+
+**Decision artifact**:
+
+> **Ship-criteria sheet -- Nimbus contract-metadata extraction**
+>
+> - **Primary threshold**: pass rate ≥ 95% on the 120-case eval set, with a 95% confidence interval
+>   no wider than ±3 percentage points (per `evaluating-ai-output-essentials`'s pass-rate-with-an-
+>   interval framing).
+> - **Named acceptable worst case**: of the failing cases, none may be a confidently-wrong answer
+>   with no citation attached -- every failing case in the eval set must at minimum have surfaced an
+>   uncertainty signal (co-06) or a citation the user could have used to catch it (co-09).
+> - **Measured result at this review**: pass rate 96.7%, interval ±2.1 points; zero
+>   failing cases lacked a citation.
+> - **Verdict**: criteria met, cleared for staged rollout (Scenario 42).
+
+**Verify**: every criterion states a threshold, an interval, and a named acceptable worst case, and
+each is checked against the actual measured eval report rather than an assumption -- satisfying
+co-21's rule.
+
+**Key takeaway**: A ship decision is a threshold on a distribution plus an explicit, named worst
+case -- a single average pass-rate number, without an interval and without a stated worst case, is
+not a launch criterion, it is a hope.
+
+**Why It Matters**: This sheet directly reuses `evaluating-ai-output-essentials`'s measurement
+discipline and turns it into a product decision -- the exact seam this course's overview names as
+its relationship to the evals courses. Writing criteria this way also gives a launch review a concrete, falsifiable basis for its decision -- reviewers can check the sheet against the actual eval report directly, rather than relying on a verbal assurance that it looks good.
+
+---
+
+### Worked Scenario 41: The Worst Case Nobody Named
+
+**Context**: Exercises co-21. This scenario contrasts Scenario 40's ship criteria against an earlier
+Nimbus launch that used only an average pass-rate threshold, and shows the failure that threshold
+permitted.
+
+**Decision artifact**:
+
+> **Postmortem -- ship criteria that covered the average, not the tail**
+>
+> - **Original criterion**: "ship if pass rate ≥ 93%." Measured at launch: 94.2% -- criterion met.
+> - **What the criterion missed**: of the failing 5.8% of cases, a cluster of them were all the
+>   same failure type -- confidently wrong, no citation, on contracts written in a non-English
+>   language the eval set under-represented. This cluster was invisible to the single average
+>   number, because it was a small enough fraction not to move the headline pass rate below
+>   threshold.
+> - **Consequence**: a real user relying on a non-English contract received a confidently wrong,
+>   uncited answer -- exactly the failure Scenario 40's revised criteria now explicitly forbid in
+>   its "named acceptable worst case" clause.
+> - **Fix carried into Scenario 40**: the named-worst-case clause exists specifically because of
+>   this postmortem.
+
+**Verify**: the postmortem identifies a specific failure cluster the average-only threshold missed
+and traces it to a real, named consequence, satisfying co-21's rule that ship criteria must name an
+acceptable worst case, not only an average threshold.
+
+**Key takeaway**: A pass-rate average can clear a threshold while hiding a coherent cluster of
+failures affecting one specific, real subgroup of users -- naming the acceptable worst case
+explicitly is what catches this before launch instead of after.
+
+**Why It Matters**: This postmortem is the direct origin story for the "named acceptable worst case"
+clause in Scenario 40's criteria -- ship criteria improve because of exactly this kind of retrospective,
+which is why writing a postmortem this specific matters even when, as here, the launch technically
+met its stated bar. Any team reviewing a past launch's criteria should ask the same question this postmortem asks -- not just whether the average cleared the bar, but what the failing cases had in common.
+
+---
+
+### Worked Scenario 42: Staged Rollout With Guardrails
+
+**Context**: Exercises co-22. Having cleared Scenario 40's ship criteria, this scenario designs the
+exposure ramp and the guardrail metrics that would halt it.
+
+**Decision artifact**:
+
+> **Staged-rollout plan -- Nimbus contract-metadata extraction**
+>
+> - **Ramp**: 5% of eligible users (day 1-3) → 25% (day 4-7) → 100% (day 8+), each stage gated on
+>   the guardrail metrics below staying within threshold for the full prior stage.
+> - **Guardrail metrics and halt thresholds**:
+>   - Correction-affordance usage rate (Scenario 32) exceeding 8% of answers (baseline in eval:
+>     under 3%) halts the ramp immediately.
+>   - Any single day's manually-reported incident count exceeding 2 halts the ramp immediately.
+>   - Median review time (Scenario 23's timing discipline) exceeding 90 seconds for three
+>     consecutive days halts the ramp and triggers a redesign review.
+> - **Rationale**: none of these three metrics exist in the eval set -- they are only observable
+>   once real, unpredictable production traffic starts flowing through the feature.
+
+**Verify**: every guardrail metric names a specific, real-time-checkable threshold that would halt
+the ramp, and none of the three metrics is one the eval set could have measured in advance --
+satisfying co-22's rule that staged rollout exists precisely because eval sets do not contain real
+traffic.
+
+**Key takeaway**: A staged rollout is not merely "release slowly" -- it is release slowly while
+watching specific, pre-agreed metrics that could not have been measured before real users arrived,
+each with a concrete threshold that halts the ramp automatically.
+
+**Why It Matters**: The correction-affordance usage-rate guardrail directly reuses Scenario 32's
+mechanism -- a spike in corrections during rollout is exactly the kind of signal a pre-launch eval
+set cannot produce but real usage immediately can. A staged rollout with well-chosen guardrails also limits the blast radius of any single undetected failure mode -- a problem caught at 5% exposure affects far fewer users than the same problem caught only after a full launch.
+
+---
+
+### Worked Scenario 43: Rollback Criteria Written First
+
+**Context**: Exercises co-23. Before Scenario 42's rollout begins, this scenario writes the
+conditions for turning the feature off entirely -- agreed and signed off before any incident
+pressure exists.
+
+**Decision artifact**:
+
+> **Rollback-criteria sheet -- agreed before rollout begins**
+>
+> - **Automatic rollback conditions** (no discussion required, any single condition triggers
+>   immediate rollback): any guardrail metric from Scenario 42 breaching its threshold for two
+>   consecutive days without a shipped fix; any single incident causing a confirmed, irreversible
+>   external action based on a wrong answer (an email sent, per Scenario 27's highest-friction row).
+> - **Discussion-required conditions** (rollback considered, decision made within 4 hours by the
+>   named on-call product lead): correction-affordance usage rate elevated but not yet breaching
+>   Scenario 42's hard threshold; user-reported confusion trending upward without a specific
+>   incident.
+> - **Sign-off**: Product Lead, Engineering Lead, Legal Ops stakeholder -- all three signed before
+>   Scenario 42's rollout began.
+
+**Verify**: the sheet distinguishes automatic-rollback conditions from discussion-required ones,
+each stated unambiguously enough to act on without new negotiation, and is signed off before rollout
+begins, not during an incident -- satisfying co-23's rule.
+
+**Key takeaway**: Rollback criteria decided during an actual incident are written by people under
+pressure to keep the feature live -- writing them down in advance, when nobody has a stake in the
+outcome yet, is what makes them genuinely enforceable later.
+
+**Why It Matters**: This sheet is what makes Scenario 11's earlier no-ship decision and this
+scenario's rollback decision the same kind of professional judgment, applied at two different
+points in a feature's lifecycle -- both require naming, in advance, the conditions under which
+shipping is not the right choice. Any team preparing to launch a new probabilistic feature should treat writing this sheet as a prerequisite step, not an optional one -- a launch review that has not produced rollback criteria has not actually finished its own job.
+
+---
+
+### Worked Scenario 44: Capstone-Probabilistic-Feature-Design Dossier
+
+**Context**: Exercises co-01 through co-24. This capstone-scale worked scenario assembles every
+pattern this course teaches into one design dossier for a single feature -- Nimbus's
+contract-metadata extraction, the running example across Themes A through D -- at the same scale
+the full [Capstone](./capstone/overview.md) applies to a different, independently chosen feature.
+
+**Decision artifact**:
+
+> **Design-dossier index -- Nimbus contract-metadata extraction**
+>
+> 1. **Failure catalogue** (co-02, co-19): the six failure modes from Scenario 2, with Scenario 3's
+>    silent-failure trace as the confidently-wrong path walked to its consequence.
+> 2. **Expectation-setting and trust-calibration plan** (co-03, co-04, co-05): Scenario 4's
+>    first-contact copy, Scenario 6's trust-calibration diagram, and Scenario 7-8's automation-bias
+>    findings.
+> 3. **Selective uncertainty and provenance policy** (co-06 through co-10): Scenario 17's policy,
+>    Scenario 18's citation design, and Scenario 22's accessible treatment, all meeting WCAG AA.
+> 4. **Human-review design** (co-11, co-12): Scenario 23's timed review flow and Scenario 25's
+>    vigilance-decrement mitigations.
+> 5. **Friction, preview, and undo** (co-13 through co-15): Scenario 27's friction table, Scenario
+>    29's preview-and-diff, and Scenario 30's complete-undo investment.
+> 6. **Fallback hierarchy** (co-16 through co-18): Scenario 35's ladder and Scenario 37's per-rung
+>    visibility audit.
+> 7. **Ship, guardrail, and rollback criteria** (co-21 through co-23): Scenario 40's criteria,
+>    Scenario 42's staged-rollout guardrails, and Scenario 43's rollback sheet.
+> 8. **Correction affordance and feedback routing** (co-24): Scenario 32's design and Scenario 33's
+>    routing plan into eval regression cases.
+
+**Verify**: every one of the eight dossier sections cites the specific earlier worked scenario it
+draws from, and every `co-NN` this course teaches (co-01 through co-24) is traceable to at least one
+section -- satisfying this scenario's role as a complete, cross-referenced assembly rather than a
+new, unrelated example.
+
+**Key takeaway**: Nothing in this dossier is new -- every section is an assembled reference back to
+a specific, already-verified worked scenario, which is exactly what makes a design dossier
+trustworthy: a reviewer can trace any single decision back to the concrete evidence that produced
+it.
+
+**Why It Matters**: This scenario demonstrates, on the course's own running example, the exact shape
+the [Capstone](./capstone/overview.md) asks a learner to produce independently for a feature of
+their own choosing -- a complete, traceable design dossier a real launch review could act on. Working through this index before the standalone capstone begins also gives a learner a concrete template to follow -- the same eight-section shape, applied to a new feature of their own choosing.
+
+---
+
+← Previous: [Theme C: Humans in the Loop, Friction, and Recovery](./theme-c-humans-in-the-loop-friction-and-recovery.md) &middot; Next: [Capstone](./capstone/overview.md) →

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/overview.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/overview.md
@@ -20,7 +20,8 @@ always."
   `[Unverified]` not yet present in the AyoKoding course library on disk, so no link is given here);
   [Evaluating AI Output -- Essentials](../evaluating-ai-output-essentials/overview.md) (you cannot
   set a ship criterion without a measurement -- this course's Theme D leans directly on that
-  course's pass-rate-with-an-interval framing);
+  course's pass-rate framing, then extends it with the confidence interval Theme D teaches
+  directly (co-21));
   [32 · Software Product Engineering](../software-product-engineering/learning/overview.md) (product
   framing, scoping, and release practice this course applies to a non-deterministic component);
   [14 · Frontend Essentials](../frontend-essentials/learning/overview.md) (interface vocabulary and
@@ -30,8 +31,8 @@ always."
   feature -- your own or a public one -- to critique across this course's worked scenarios. Written
   artefacts are the deliverable throughout.
 - **Assumed knowledge**: what an LLM-backed feature does and roughly how it fails; the ability to
-  read an eval report and interpret a pass rate alongside an interval; basic interface and
-  accessibility vocabulary (a WCAG contrast ratio, a screen-reader label).
+  read an eval report and interpret a pass rate; basic interface and accessibility vocabulary (a
+  WCAG contrast ratio, a screen-reader label).
 
 ## Why this exists -- the big idea
 

--- a/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/overview.md
+++ b/apps/ayokoding-www/content/en/learn/courses/product-patterns-for-probabilistic-systems/overview.md
@@ -1,0 +1,221 @@
+---
+title: "Overview"
+date: 2026-07-26T00:00:00+07:00
+draft: false
+weight: 1
+---
+
+This course is a **leadership no-code sub-mode** Annotated-concept topic: zero code, zero runnable
+files. Every worked scenario produces a **decision artifact** -- a failure catalogue, an interface
+walkthrough, a confidence-representation comparison, a friction table, a fallback ladder, a
+ship/rollback criteria sheet -- the kind of document a real product team could take to a launch
+review. This is the product-design companion to the AI-engineering evals courses: they teach you to
+measure whether a probabilistic feature's output is good; this course teaches you what to build
+around that measurement so the feature is usable and recoverable when the measurement says "not
+always."
+
+## Prerequisites
+
+- **Prior topics**: `creating-ai-powered-apps` (what the model can and cannot be asked for --
+  `[Unverified]` not yet present in the AyoKoding course library on disk, so no link is given here);
+  [Evaluating AI Output -- Essentials](../evaluating-ai-output-essentials/overview.md) (you cannot
+  set a ship criterion without a measurement -- this course's Theme D leans directly on that
+  course's pass-rate-with-an-interval framing);
+  [32 · Software Product Engineering](../software-product-engineering/learning/overview.md) (product
+  framing, scoping, and release practice this course applies to a non-deterministic component);
+  [14 · Frontend Essentials](../frontend-essentials/learning/overview.md) (interface vocabulary and
+  the accessibility baseline every uncertainty signal in this course must clear).
+- **Tools & environment**: no runtime and no code. A diagramming surface for the Mermaid flows, a
+  document or whiteboard for the interface walkthroughs, and access to one real probabilistic
+  feature -- your own or a public one -- to critique across this course's worked scenarios. Written
+  artefacts are the deliverable throughout.
+- **Assumed knowledge**: what an LLM-backed feature does and roughly how it fails; the ability to
+  read an eval report and interpret a pass rate alongside an interval; basic interface and
+  accessibility vocabulary (a WCAG contrast ratio, a screen-reader label).
+
+## Why this exists -- the big idea
+
+**The problem before the solution**: every pattern in a product designer's vocabulary assumes the
+system either succeeds or fails, and says so. A probabilistic feature breaks that assumption -- it
+succeeds partially, fails silently, fails confidently, and fails differently for the same input
+twice. Teams ship these features inside interfaces designed for deterministic software, and users
+learn either to distrust everything the feature produces or, far worse, to trust all of it
+uniformly. Both outcomes are design failures, not model failures. **The one idea worth keeping if
+you forget everything else**: design for the wrong answer, because it is coming -- make it visible,
+make it cheap to catch, and make it cheap to undo.
+
+**Cross-cutting big ideas**: `determinism-vs-emergence` -- the interface is where a stochastic
+component meets a human who expects determinism, and every pattern in this course exists at that
+seam. `correctness-vs-pragmatism` -- the product goal is a recoverable workflow, not a correct one;
+a feature that fails often but cheaply beats one that fails rarely but catastrophically.
+`abstraction-and-its-cost` -- every confidence indicator is a lossy summary of a distribution, and
+users read it as a promise, which is exactly the gap co-08 names.
+
+> **Scope guard -- product patterns vs. the human-in-the-loop guardrail.**
+> `agent-permissions-and-sandboxing` -- `[Unverified]` not yet present in the AyoKoding course
+> library on disk, so no link is given here -- owns human-in-the-loop as a **safety control**:
+> deny/ask/allow enforced by the harness so an agent cannot take a dangerous action. This course
+> owns human-in-the-loop as a **product design**: what the reviewer sees, how much cognitive load
+> the review imposes, whether the interface earns calibrated trust, and what happens when the
+> reviewer disengages. The safety course answers "can this action proceed"; this course answers "is
+> a human meaningfully in a position to judge." Both are needed and neither substitutes for the
+> other.
+
+## How this course is organized
+
+- **[Learning](./learning/overview.md)** -- 44 worked scenarios, each producing a written decision
+  artifact, grouped by theme rather than by fixed Beginner/Intermediate/Advanced bands (this
+  course's concepts are concept-centric, not skill-tiered):
+  - **Theme A -- [The Wrong Answer Is Coming](./learning/theme-a-the-wrong-answer-is-coming.md)**
+    (scenarios 1-11) -- why a success-or-error interface has no state for a confidently wrong
+    answer, the six user-visible failure modes, expectation-setting, trust calibration, automation
+    bias, and the decision to narrow or not ship at all.
+  - **Theme B -- [Uncertainty, Confidence, and Provenance](./learning/theme-b-uncertainty-confidence-and-provenance.md)**
+    (scenarios 12-22) -- where an uncertainty signal belongs, the trade-offs between numeric scores
+    and qualitative bands, why confidence is not correctness, citations as a better signal than a
+    score, designing for cheap verification, and accessible uncertainty without relying on colour.
+  - **Theme C -- [Humans in the Loop, Friction, and Recovery](./learning/theme-c-humans-in-the-loop-friction-and-recovery.md)**
+    (scenarios 23-33) -- review as the product rather than a fallback, the vigilance decrement,
+    consequence-scaled friction, preview-and-diff, undo that beats a marginal accuracy gain, and the
+    correction affordance that feeds error analysis.
+  - **Theme D -- [Degradation, Latency, and the Launch Decision](./learning/theme-d-degradation-latency-and-the-launch-decision.md)**
+    (scenarios 34-44) -- the model-unavailable state, a fallback hierarchy, failing visibly instead
+    of silently, latency as a design material, and ship, staged-rollout, and rollback criteria
+    written against a measured distribution.
+  - **[Capstone](./learning/capstone/overview.md)** -- the complete design dossier for one real
+    probabilistic feature: a failure catalogue, an interface design, a review-and-recovery plan, a
+    degradation plan, and launch criteria a team could take into a real launch review.
+- **[Drilling](./drilling/overview.md)** -- the spaced-repetition companion: recall Q&A across all
+  twenty-four concepts, applied judgment scenarios, decision-artifact repair drills, a self-check
+  checklist, and elaborative-interrogation prompts.
+
+## The 24 concepts this course covers
+
+- **co-01 -- The deterministic-interface assumption** -- standard product patterns encode a
+  success-or-error model a probabilistic feature violates. Scenario 1.
+- **co-02 -- Failure modes users experience** -- confidently wrong, subtly wrong, refused,
+  truncated, slow, and inconsistent-across-identical-requests are distinct user experiences.
+  Scenarios 2-3.
+- **co-03 -- Setting expectations before first use** -- how a feature is framed on first contact
+  determines how its errors are read for the rest of the relationship. Scenarios 4-5.
+- **co-04 -- Trust calibration** -- the goal is trust proportional to actual reliability; both
+  over-trust and blanket distrust are interface failures. Scenarios 5-6, 9.
+- **co-05 -- Automation bias and complacency** -- users under-scrutinize output from a usually-right
+  system, and the effect worsens as the system improves. Scenarios 7-8.
+- **co-06 -- Surfacing uncertainty** -- communicating that an output may be wrong, at the moment and
+  place the user could act on it. Scenarios 9, 12, 16-17, 22.
+- **co-07 -- Confidence-representation trade-offs** -- numeric scores, qualitative bands, hedged
+  language, and visual treatments each trade precision against being read correctly. Scenarios
+  13, 15, 17, 22.
+- **co-08 -- Confidence is not correctness** -- an expressed or computed confidence is not a
+  probability of being right. Scenarios 14-15.
+- **co-09 -- Provenance and citation** -- showing where an answer came from lets a user verify it
+  themselves. Scenarios 18-19, 21.
+- **co-10 -- Verifiability by design** -- structuring output so checking it is cheaper than
+  producing it. Scenarios 19-21.
+- **co-11 -- Human-in-the-loop as product** -- review as the intended workflow, fast enough to
+  survive volume. Scenarios 23-24, 26.
+- **co-12 -- Review cost and the vigilance decrement** -- a reviewer's accuracy decays with volume
+  and with the system's own reliability. Scenarios 7, 24-26.
+- **co-13 -- Consequence-scaled friction** -- confirmation, preview, and delay should scale with an
+  action's reversibility and blast radius. Scenarios 27-28.
+- **co-14 -- Preview and diff before apply** -- showing exactly what will change converts an
+  irreversible action into a reviewable one. Scenario 29.
+- **co-15 -- Undo and recovery** -- cheap, obvious, complete reversal beats a marginal accuracy
+  improvement. Scenarios 11, 30-32.
+- **co-16 -- Graceful degradation** -- defining what the product does when the model is unavailable,
+  slow, or unusable. Scenarios 34-37.
+- **co-17 -- Latency as a design material** -- streaming, progressive disclosure, and honest waiting
+  change what a slow response feels like. Scenarios 38-39.
+- **co-18 -- Fallback hierarchies** -- a designed ladder from best-effort output to an honest
+  unavailable state. Scenarios 35-36.
+- **co-19 -- Silent failure is the worst failure** -- a wrong answer presented identically to a
+  right one is more damaging than a visible error. Scenarios 3, 37, 39.
+- **co-20 -- Scoping to what the model can do** -- narrowing the feature is usually the
+  highest-leverage move, not improving the model. Scenarios 10-11.
+- **co-21 -- Ship criteria for a distribution** -- a launch decision is a threshold on a measured
+  distribution plus a named acceptable worst case. Scenarios 40-41.
+- **co-22 -- Staged rollout and guardrail metrics** -- exposure is ramped while pre-agreed guardrail
+  metrics are watched. Scenario 42.
+- **co-23 -- Rollback criteria agreed in advance** -- the conditions for turning a feature off are
+  written down before launch. Scenario 43.
+- **co-24 -- Feedback capture as a product surface** -- the correction affordance is both a recovery
+  path and the pipeline feeding the next error-analysis pass. Scenarios 32-33.
+
+## Tensions & trade-offs -- when NOT to reach for this
+
+- **Surfacing uncertainty vs. usability**: caveats on every output train users to ignore caveats.
+  Uncertainty signals must be selective enough to carry information (co-06, Scenario 16).
+- **Human review vs. the value proposition**: a feature whose output must be fully checked has saved
+  the user nothing except typing. If review costs as much as doing the work, narrow the feature
+  (co-20) or do not ship it -- do not quietly weaken the review step (Scenario 24).
+- **Friction vs. flow**: consequence-scaled friction is correct in principle and painful in
+  practice -- reserve real friction for genuinely irreversible actions and pay for the rest with
+  undo (Scenario 28).
+- **Confidence display vs. misreading**: a confidence number invites users to treat it as a
+  probability of correctness, which it is not (co-08). Showing nothing invites uniform trust.
+  There is no free option, only a deliberate, validated choice.
+- **When NOT to reach for this course**: if a deterministic check fully verifies the feature's
+  output before any human sees it -- a generated query that is validated and executed, a
+  classification confirmed against a schema -- the user is never exposed to the distribution and
+  these patterns add ceremony. This material is for output that reaches a human unverified.
+- **When NOT to ship the feature at all**: if no scoping narrows the failure rate to something the
+  workflow can absorb, and no undo makes the failures cheap, the correct product decision is not to
+  ship (Scenario 11). Recognising that case is part of this course, not an admission that it failed.
+
+## Accuracy notes
+
+> Every volatile, version-pinned, or product-name-dependent fact below is dated or flagged here
+> rather than stated unqualified in the stable spine above.
+
+- 2026-07-26 -- **durable spine**: designing for partial correctness, calibrating user trust to
+  actual reliability, provenance as an interface element, degradation paths, undo sized to blast
+  radius, and release criteria expressed as distributions rather than booleans are design
+  principles independent of model, vendor, and framework. They predate LLMs in aviation automation,
+  spam filtering, and autocomplete -- see this course's Lineage note below.
+- 2026-07-26 -- `[Unverified]` **volatile, accuracy-note only**: every named product used as an
+  illustration in this course's worked scenarios is a composite, non-attributed stand-in (a
+  fictional "Nimbus"-style feature) -- exactly which real assistant surfaces confidence how, or
+  which tool shows a diff-before-apply, changes fast enough that this course deliberately never
+  names a real product in its stable spine.
+- 2026-07-26 -- `[Unverified]` **at authoring**: the automation-trust literature this course draws
+  on (automation bias, complacency, trust calibration, the vigilance decrement) is established
+  human-factors research; this course teaches the phenomena, which are robust, and cites no specific
+  study without independently verifying it against a primary source first.
+- 2026-07-26 -- **contested, taught as contested**: whether to display a numeric confidence score to
+  end users is genuinely disputed in the field (Scenario 15). Numeric scores are precise and
+  routinely misread as probabilities of correctness; qualitative bands are read more accurately but
+  discard information. This course presents the trade-off and does not resolve it.
+- 2026-07-26 -- no model IDs, prices, or SDK shapes appear in this course's spine by design; every
+  pattern taught here is model-, vendor-, and framework-independent.
+
+### Lineage -- why these patterns beat the alternative
+
+The pattern that lost was treating a probabilistic feature as an ordinary one -- a text box that
+returns an answer, a button that performs an action, an error state for the rare failure. It lost
+because the failure it designed for is not the failure that occurs: the dominant failure of a
+probabilistic system is a plausible wrong answer rendered identically to a right one (co-19), and no
+amount of model improvement removes it. Aviation automation established decades ago that operators
+under-scrutinize systems that are usually right, and that the effect intensifies as reliability
+improves (co-05). Spam filtering established that a false-positive-tolerant workflow with a cheap
+recovery path beats a more accurate classifier with no recovery path (co-15). Autocomplete
+established that a suggestion the user can ignore at zero cost can be wrong most of the time and
+still be valuable, because the interaction is designed around rejection (co-13). Each of those is
+the same move: accept the distribution, design the recovery, and scope the feature until its
+failure rate fits the workflow. This course collects those moves for a component whose error rate
+is higher and whose errors are more fluent than anything the earlier examples faced.
+
+## Read more
+
+- **Designing Machine Learning Systems** -- Chip Huyen (2022). For the production framing of ML
+  features as products with measured failure rates rather than as models with accuracies.
+- A primary reference on **automation bias, complacency, and trust calibration** in
+  human-automation interaction -- the research grounding co-04, co-05, and co-12. Verify against a
+  primary source before citing a specific study.
+- A primary reference on **the vigilance decrement** in monitoring tasks -- the research grounding
+  the claim that reviewer accuracy decays with volume and with system reliability. Verify against a
+  primary source before citing a specific study.
+
+---
+
+Next: [Learning Overview](./learning/overview.md) →


### PR DESCRIPTION
## Summary
- Authors the `product-patterns-for-probabilistic-systems` course (Phase 1, P1.4) for ayokoding-www, per `plans/in-progress/ayokoding-learning-path-04-course-authoring/delivery.md`.
- Annotated-Concept, no-code sub-mode — 44 worked scenarios across 4 themes plus a 6-file capstone ("Meridian Claims Assistant"), settled against `plans/done/2026-07-24__ayokoding-learning-path-02-schema-and-prerequisite-dag/syllabus/courses/product-patterns-for-probabilistic-systems.md`.
- Fills a gap: no existing course owns product design patterns for probabilistic (non-deterministic) outputs (DD-28).

## Test plan
- [x] `md mermaid validate`, `md links validate`, `md heading-hierarchy validate` — all clean
- [x] `markdownlint-cli2`, `prettier --check` — all clean
- [x] `nx run ayokoding-www:build` — succeeds, 1885 static pages
- [x] `nx run ayokoding-www:test:unit` — 2431 passed, 6 skipped, no regressions
- [x] `specs:behavior:coverage` — all covered
- [ ] 3-cycle PR review (pr-review-*-maker fan-out → pr-review-synthesis-maker → pr-review-fixer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)