### PR TITLE
feat(ayokoding-www): phase 4 — pure functional core for AI benchmark

### DIFF
--- a/apps/ayokoding-www/src/features/ai-benchmark/core/bands.ts
+++ b/apps/ayokoding-www/src/features/ai-benchmark/core/bands.ts
@@ -1,0 +1,152 @@
+// AI BENCHMARK — band assignment core (Phase 4, steps B-1..B-13).
+//
+// Implements the class-band decision from
+// `plans/in-progress/ayokoding-www-tools-ai-benchmark/tech-docs.md` §"Band assignment" (the
+// state diagram with anchor pinning) and §"DD-20a". No React, no router, no side effects.
+//
+// Bands: `opus` | `sonnet` | `light` | `unrated`. The two anchors (Claude Opus 5, Claude Sonnet 5)
+// DEFINE the bands and are PINNED by id — they always occupy their own band even if arithmetic
+// would place them elsewhere. Every other model is compared against the anchors' own full
+// composite indices (DD-20a): at/above opus → opus, at/above sonnet → sonnet, else light. A model
+// with no composite index (zero coverage) is unrated.
+
+import { OPUS_ANCHOR_ID, SONNET_ANCHOR_ID, type Dataset, type Model } from "./data/models";
+import { computeIndex, computeRosterMaxes, coverage, type RosterMaxes } from "./score";
+
+/** The four capability classes. */
+export type Band = "opus" | "sonnet" | "light" | "unrated";
+
+/** Per-model composite index lookup; `undefined` = no index (unrated). */
+export type IndexMap = Record<string, number | undefined>;
+
+/** The two anchor indices that define the opus/sonnet thresholds (DD-20a). */
+export type AnchorIndices = {
+  opus: number | undefined;
+  sonnet: number | undefined;
+};
+
+/** A model scored and placed in a band — the unit both charts consume. */
+export type ModelScore = {
+  model: Model;
+  /** Composite index; `undefined` for an unrated (zero-coverage) model. */
+  index: number | undefined;
+  /** Coverage ratio `W(m) / 100`. */
+  coverage: number;
+  band: Band;
+};
+
+/** The four disjoint, canonically ordered capability groups. */
+export type BandGroups = {
+  opus: ModelScore[];
+  sonnet: ModelScore[];
+  light: ModelScore[];
+  unrated: ModelScore[];
+};
+
+/**
+ * Assign a model to exactly one band.
+ *
+ * Order (mirrors the band-assignment state diagram):
+ *   1. Anchor pinning — each anchor occupies the band it defines, by id, regardless of arithmetic.
+ *   2. No composite index (zero coverage) → `unrated`.
+ *   3. `index ≥ opus anchor index` → `opus`.
+ *   4. `index ≥ sonnet anchor index` → `sonnet`.
+ *   5. otherwise → `light`.
+ *
+ * Pinning is checked BEFORE the zero-coverage branch so an anchor always lands in its own band
+ * even in the degenerate case where an anchor happened to carry no composite figure — the bands
+ * are defined by these models, so they cannot fall out of their own band.
+ *
+ * @param model          The model to place (its `id` selects anchor pinning).
+ * @param indices        Per-model composite index map; `indices[model.id]` is this model's index
+ *                       (`undefined` or missing = unrated).
+ * @param anchorIndices  The two anchor indices (the thresholds).
+ */
+export function assignBand(model: Model, indices: IndexMap, anchorIndices: AnchorIndices): Band {
+  // 1. Anchor pinning by id (B-7 / B-8).
+  if (model.id === OPUS_ANCHOR_ID) {
+    return "opus";
+  }
+  if (model.id === SONNET_ANCHOR_ID) {
+    return "sonnet";
+  }
+  // 2. Zero coverage → no composite index → unrated.
+  const index = indices[model.id] ?? undefined;
+  if (index === undefined) {
+    return "unrated";
+  }
+  // 3-5. Threshold comparison against the anchors' own full indices (DD-20a).
+  if (anchorIndices.opus !== undefined && index >= anchorIndices.opus) {
+    return "opus";
+  }
+  if (anchorIndices.sonnet !== undefined && index >= anchorIndices.sonnet) {
+    return "sonnet";
+  }
+  return "light";
+}
+
+/**
+ * The two anchor composite indices for a dataset — the single place the thresholds are derived
+ * (B-13), so no caller re-derives them. Computes the roster-max map once, then each anchor's full
+ * index over the benchmarks it actually has (DD-20a: thresholds are the anchors' OWN indices, not
+ * a like-for-like subset).
+ */
+export function anchors(dataset: Dataset): AnchorIndices {
+  return anchorIndices(dataset, computeRosterMaxes(dataset));
+}
+
+/** Internal: anchor indices from a precomputed roster-max map (reused by {@link computeGroups}). */
+function anchorIndices(dataset: Dataset, maxes: RosterMaxes): AnchorIndices {
+  const opusModel = dataset.models.find((m) => m.id === OPUS_ANCHOR_ID);
+  const sonnetModel = dataset.models.find((m) => m.id === SONNET_ANCHOR_ID);
+  return {
+    opus: opusModel ? computeIndex(opusModel, maxes) : undefined,
+    sonnet: sonnetModel ? computeIndex(sonnetModel, maxes) : undefined,
+  };
+}
+
+/**
+ * Canonical within-band ordering: descending composite index (undefined last), then ascending id.
+ * Both charts consume the SAME per-band list produced here, so each band lists its models in the
+ * same order in the capability chart and the price chart (AC-11).
+ */
+function compareForOrder(a: ModelScore, b: ModelScore): number {
+  const ai = a.index ?? -Infinity;
+  const bi = b.index ?? -Infinity;
+  if (bi !== ai) {
+    return bi - ai; // descending index
+  }
+  if (a.model.id < b.model.id) return -1; // ascending id
+  if (a.model.id > b.model.id) return 1;
+  return 0;
+}
+
+/**
+ * Score every model in the roster and group it into one of the four disjoint, canonically ordered
+ * capability bands (B-9..B-12). The four groups are disjoint and together cover the whole roster
+ * exactly once.
+ */
+export function computeGroups(dataset: Dataset): BandGroups {
+  const maxes = computeRosterMaxes(dataset);
+  const anchorIdx = anchorIndices(dataset, maxes);
+  const indices: IndexMap = {};
+  for (const m of dataset.models) {
+    indices[m.id] = computeIndex(m, maxes);
+  }
+  const scored: ModelScore[] = dataset.models.map((m) => ({
+    model: m,
+    index: indices[m.id] ?? undefined,
+    coverage: coverage(m),
+    band: assignBand(m, indices, anchorIdx),
+  }));
+
+  const groups: BandGroups = { opus: [], sonnet: [], light: [], unrated: [] };
+  for (const s of scored) {
+    groups[s.band].push(s);
+  }
+  groups.opus.sort(compareForOrder);
+  groups.sonnet.sort(compareForOrder);
+  groups.light.sort(compareForOrder);
+  groups.unrated.sort(compareForOrder);
+  return groups;
+}

--- a/apps/ayokoding-www/src/features/ai-benchmark/core/bands.unit.test.ts
+++ b/apps/ayokoding-www/src/features/ai-benchmark/core/bands.unit.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import { OPUS_ANCHOR_ID, SONNET_ANCHOR_ID, dataset, type Model } from "./data/models";
+import {
+  type AnchorIndices,
+  type Band,
+  type BandGroups,
+  type IndexMap,
+  type ModelScore,
+  anchors,
+  assignBand,
+  computeGroups,
+} from "./bands";
+
+// Pure-function tests for band assignment (Phase 4 steps B-1..B-13). Band rules are specified by
+// `plans/in-progress/ayokoding-www-tools-ai-benchmark/tech-docs.md` §"Band assignment" (the
+// state diagram with anchor pinning) and §"DD-20a". Fixtures give known indices so the rule —
+// not the dataset — is what is asserted (a data refresh must not red the suite).
+
+// ─── Fixture builders ──────────────────────────────────────────────────────────
+
+function model(id: string): Model {
+  return { id, name: id, vendor: "Test", harnesses: ["claude-code"], figures: [], pricing: {} };
+}
+
+// Synthetic anchor thresholds detached from the live dataset.
+const SYNTH_ANCHORS: AnchorIndices = { opus: 90, sonnet: 70 };
+
+function withIndex(m: Model, index: number | undefined): IndexMap {
+  return { [m.id]: index };
+}
+
+// ─── B-1 / B-2 — opus comparison ───────────────────────────────────────────────
+
+describe("assignBand — a model reaching the opus anchor index is opus", () => {
+  it("assigns opus when the index equals the opus anchor index", () => {
+    const m = model("at-opus");
+    expect(assignBand(m, withIndex(m, 90), SYNTH_ANCHORS)).toBe("opus");
+  });
+
+  it("assigns opus when the index exceeds the opus anchor index", () => {
+    const m = model("above-opus");
+    expect(assignBand(m, withIndex(m, 99), SYNTH_ANCHORS)).toBe("opus");
+  });
+});
+
+// ─── B-3 / B-4 — sonnet comparison ─────────────────────────────────────────────
+
+describe("assignBand — a model between the two anchors is sonnet", () => {
+  it("assigns sonnet when above the sonnet anchor and below the opus anchor", () => {
+    const m = model("between");
+    expect(assignBand(m, withIndex(m, 80), SYNTH_ANCHORS)).toBe("sonnet");
+  });
+
+  it("assigns sonnet at exactly the sonnet anchor index", () => {
+    const m = model("at-sonnet");
+    expect(assignBand(m, withIndex(m, 70), SYNTH_ANCHORS)).toBe("sonnet");
+  });
+});
+
+// ─── B-5 / B-6 — light fallthrough ─────────────────────────────────────────────
+
+describe("assignBand — a model below the sonnet anchor is light", () => {
+  it("assigns light when the index is below the sonnet anchor index", () => {
+    const m = model("below-sonnet");
+    expect(assignBand(m, withIndex(m, 40), SYNTH_ANCHORS)).toBe("light");
+  });
+
+  it("assigns light at index zero (rated but lowest)", () => {
+    const m = model("floor");
+    expect(assignBand(m, withIndex(m, 0), SYNTH_ANCHORS)).toBe("light");
+  });
+});
+
+// ─── B-7 / B-8 — anchor pinning by id ──────────────────────────────────────────
+
+describe("assignBand — anchors are pinned by id regardless of arithmetic", () => {
+  // Perverse fixture: the opus anchor's own index (50) falls BELOW the sonnet anchor's (90).
+  // Pinning must still place each anchor in the band it defines.
+  const perverse: AnchorIndices = { opus: 50, sonnet: 90 };
+  const opusAnchor = model(OPUS_ANCHOR_ID);
+  const sonnetAnchor = model(SONNET_ANCHOR_ID);
+
+  it("the opus anchor belongs to opus even when its index is below the sonnet anchor's", () => {
+    const indices: IndexMap = { [OPUS_ANCHOR_ID]: 50, [SONNET_ANCHOR_ID]: 90 };
+    expect(assignBand(opusAnchor, indices, perverse)).toBe("opus");
+  });
+
+  it("the sonnet anchor belongs to sonnet even when its index is above the opus anchor's", () => {
+    const indices: IndexMap = { [OPUS_ANCHOR_ID]: 50, [SONNET_ANCHOR_ID]: 90 };
+    expect(assignBand(sonnetAnchor, indices, perverse)).toBe("sonnet");
+  });
+
+  it("a non-anchor with no index is unrated", () => {
+    const m = model("no-score");
+    expect(assignBand(m, { [m.id]: undefined }, SYNTH_ANCHORS)).toBe("unrated");
+    expect(assignBand(m, {}, SYNTH_ANCHORS)).toBe("unrated");
+  });
+});
+
+// ─── B-9 / B-10 — totality over the real roster ────────────────────────────────
+
+describe("computeGroups — every roster model belongs to exactly one capability group", () => {
+  const groups = computeGroups(dataset);
+  const allGroups: Array<[Band, ModelScore[]]> = [
+    ["opus", groups.opus],
+    ["sonnet", groups.sonnet],
+    ["light", groups.light],
+    ["unrated", groups.unrated],
+  ];
+  const everyone = allGroups.flatMap(([, ms]) => ms);
+
+  it("the four groups are disjoint and cover the whole roster with no omissions or duplicates", () => {
+    const ids = everyone.map((s) => s.model.id);
+    expect(new Set(ids).size, "no duplicate model across the four bands").toBe(ids.length);
+    expect(ids.length, "every roster model is placed").toBe(dataset.models.length);
+    const rosterIds = new Set(dataset.models.map((m) => m.id));
+    for (const id of ids) {
+      expect(rosterIds.has(id), `placed id "${id}" must be a real roster model`).toBe(true);
+    }
+  });
+
+  it("each ModelScore carries the band it was grouped under", () => {
+    for (const [band, ms] of allGroups) {
+      for (const s of ms) {
+        expect(s.band).toBe(band);
+      }
+    }
+  });
+
+  it("sanity — the two anchors pin to their bands and a zero-figure model is unrated", () => {
+    const byId = new Map(everyone.map((s) => [s.model.id, s.band]));
+    expect(byId.get(OPUS_ANCHOR_ID)).toBe("opus");
+    expect(byId.get(SONNET_ANCHOR_ID)).toBe("sonnet");
+    expect(byId.get("cursor-composer-2.5")).toBe("unrated");
+  });
+});
+
+// ─── B-11 / B-12 — canonical per-band ordering ─────────────────────────────────
+
+describe("computeGroups — models are ordered identically within a band (descending index, then id)", () => {
+  const groups: BandGroups = computeGroups(dataset);
+
+  // The canonical comparator: descending index (undefined last), then ascending id. Both charts
+  // consume the same per-band list, so this property IS the "identical order" guarantee (AC-11).
+  function assertCanonical(band: ModelScore[], allowUndefinedIndex: boolean) {
+    for (let i = 1; i < band.length; i++) {
+      const prev = band[i - 1];
+      const curr = band[i];
+      if (prev === undefined || curr === undefined) continue; // unreachable: i within bounds
+      const pi = prev.index ?? -Infinity;
+      const ci = curr.index ?? -Infinity;
+      if (pi !== ci) {
+        expect(pi, `${prev.model.id} should outrank ${curr.model.id} by index`).toBeGreaterThan(ci);
+      } else {
+        expect(
+          prev.model.id <= curr.model.id,
+          `tie on index: ${prev.model.id} should sort at-or-before ${curr.model.id} by id`,
+        ).toBe(true);
+        if (!allowUndefinedIndex) {
+          expect(prev.index).toBeDefined();
+          expect(curr.index).toBeDefined();
+        }
+      }
+    }
+  }
+
+  it("opus / sonnet / light bands are ordered by descending index then ascending id", () => {
+    assertCanonical(groups.opus, false);
+    assertCanonical(groups.sonnet, false);
+    assertCanonical(groups.light, false);
+  });
+
+  it("the unrated band (all undefined index) is ordered by ascending id", () => {
+    for (const s of groups.unrated) {
+      expect(s.index, "unrated models carry no composite index").toBeUndefined();
+    }
+    assertCanonical(groups.unrated, true);
+  });
+
+  it("the per-band order is stable across repeated calls (one canonical list)", () => {
+    const again = computeGroups(dataset);
+    expect(again.opus.map((s) => s.model.id)).toEqual(groups.opus.map((s) => s.model.id));
+    expect(again.light.map((s) => s.model.id)).toEqual(groups.light.map((s) => s.model.id));
+    expect(again.unrated.map((s) => s.model.id)).toEqual(groups.unrated.map((s) => s.model.id));
+  });
+});
+
+// ─── B-13 — anchors(dataset) helper ────────────────────────────────────────────
+
+describe("anchors — single helper deriving the anchor ids + threshold indices", () => {
+  it("returns the opus and sonnet anchor composite indices for the live dataset", () => {
+    const a = anchors(dataset);
+    expect(a.opus).not.toBeUndefined();
+    expect(a.sonnet).not.toBeUndefined();
+    // Opus 5 (swe-v 96 roster-max → rel 100 @ weight 25; gpqa 93.2/94.1 → rel ~99.04 @ weight 30)
+    // sits above Sonnet 5 (three sub-100 rels) — the opus threshold is the higher one.
+    expect(a.opus as number).toBeGreaterThan(a.sonnet as number);
+  });
+
+  it("is finite (never NaN) — anchors are rated models with full indices", () => {
+    const a = anchors(dataset);
+    expect(Number.isFinite(a.opus)).toBe(true);
+    expect(Number.isFinite(a.sonnet)).toBe(true);
+  });
+});

--- a/apps/ayokoding-www/src/features/ai-benchmark/core/filter.ts
+++ b/apps/ayokoding-www/src/features/ai-benchmark/core/filter.ts
@@ -1,0 +1,75 @@
+// AI BENCHMARK — roster filtering core (Phase 4, steps F-1/F-2).
+//
+// Narrows the roster by an optional harness filter and an optional class (band) filter, combined
+// as an intersection. A model's band is a property of the FULL roster (the composite index is
+// roster-relative per DD-5a), so the class filter is computed over the whole dataset, not the
+// already-filtered subset. Unknown filter values never reach this module — they are sanitized to
+// "unfiltered" by `url-state.ts` (F-5/F-6), so this selector only ever sees known values. No
+// React, no router, no side effects. See prd.md AC-23/AC-24/AC-25/AC-26.
+
+import type { Dataset, HarnessId, Model } from "./data/models";
+import { computeGroups, type Band } from "./bands";
+
+/**
+ * The canonical known-value lists for the two filter axes (F-9). These are the SINGLE source of
+ * truth — `url-state.ts` imports them for validation, and a future filter UI would import them
+ * for its dropdown options — so a new harness id or band is added in exactly one place.
+ */
+export const HARNESS_IDS: readonly HarnessId[] = ["claude-code", "codex-cli", "cursor", "opencode-go", "opencode-zen"];
+
+export const BANDS: readonly Band[] = ["opus", "sonnet", "light", "unrated"];
+
+/** Type guard: is `v` one of the known harness ids? */
+export function isKnownHarness(v: string): v is HarnessId {
+  return (HARNESS_IDS as readonly string[]).includes(v);
+}
+
+/** Type guard: is `v` one of the known capability bands? */
+export function isKnownBand(v: string): v is Band {
+  return (BANDS as readonly string[]).includes(v);
+}
+
+/**
+ * Filter state for the roster. Either field may be omitted (= that axis is unfiltered). The two
+ * axes intersect: a model must satisfy BOTH to be kept.
+ */
+export type FilterState = {
+  /** Keep only models this harness exposes; `undefined` = no harness filter. */
+  harness?: HarnessId;
+  /** Keep only models in this capability band; `undefined` = no class filter. */
+  class?: Band;
+};
+
+/**
+ * Narrow `dataset.models` by the harness and class filters (intersection). With neither filter
+ * set, every roster model is returned. A filter combination matching no model returns `[]` (the
+ * caller renders the explicit empty state — never an error).
+ *
+ * The class filter is derived from {@link computeGroups} over the full dataset so a model's band
+ * is roster-relative regardless of what the harness filter removed.
+ */
+export function filterModels(dataset: Dataset, state: FilterState): Model[] {
+  const harness = state.harness;
+  const classFilter = state.class;
+
+  // Build the model→band lookup only when a class filter is actually set.
+  let bandById: Map<string, Band> | undefined;
+  if (classFilter !== undefined) {
+    bandById = new Map();
+    for (const group of Object.values(computeGroups(dataset))) {
+      for (const s of group) {
+        bandById.set(s.model.id, s.band);
+      }
+    }
+  }
+
+  return dataset.models.filter((m) => {
+    if (harness !== undefined && !m.harnesses.includes(harness)) {
+      return false;
+    }
+    if (classFilter !== undefined && bandById?.get(m.id) !== classFilter) {
+      return false;
+    }
+    return true;
+  });
+}

--- a/apps/ayokoding-www/src/features/ai-benchmark/core/filter.unit.test.ts
+++ b/apps/ayokoding-www/src/features/ai-benchmark/core/filter.unit.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { dataset, type Dataset, type HarnessId, type Model } from "./data/models";
+import { computeGroups } from "./bands";
+import { filterModels, type FilterState } from "./filter";
+
+// Pure-function tests for roster filtering (Phase 4 steps F-1/F-2). The harness filter keeps only
+// models a harness exposes; the class filter keeps only models in a capability band; together they
+// intersect. A model's band is a property of the FULL roster (roster-relative normalization), so
+// the class filter is computed over the whole dataset, not the already-filtered subset. See
+// `plans/in-progress/ayokoding-www-tools-ai-benchmark/prd.md` AC-23/AC-24/AC-25.
+
+// ─── Fixture builders ──────────────────────────────────────────────────────────
+
+function modelWith(id: string, harnesses: HarnessId[]): Model {
+  return { id, name: id, vendor: "Test", harnesses, figures: [], pricing: {} };
+}
+
+function datasetOf(models: Model[]): Dataset {
+  return { snapshotDate: "2026-07-28", anchorIds: { opus: "opus-anchor", sonnet: "sonnet-anchor" }, models };
+}
+
+const NONE: FilterState = {};
+
+// ─── Harness filter (no band computation needed) ───────────────────────────────
+
+describe("filterModels — harness filter narrows to models that harness exposes", () => {
+  const ds = datasetOf([
+    modelWith("a", ["claude-code", "cursor"]),
+    modelWith("b", ["cursor", "opencode-zen"]),
+    modelWith("c", ["opencode-go", "opencode-zen"]),
+  ]);
+
+  it("keeps only models whose harnesses include the selected harness", () => {
+    expect(filterModels(ds, { harness: "cursor" }).map((m) => m.id)).toEqual(["a", "b"]);
+    expect(filterModels(ds, { harness: "opencode-go" }).map((m) => m.id)).toEqual(["c"]);
+  });
+
+  it("an empty filter state returns every model", () => {
+    expect(filterModels(ds, NONE).map((m) => m.id)).toEqual(["a", "b", "c"]);
+  });
+});
+
+// ─── Class filter + intersection (cross-checked against computeGroups) ─────────
+
+describe("filterModels — class filter narrows to a capability band over the full roster", () => {
+  const groups = computeGroups(dataset);
+  const bandIds = (band: keyof ReturnType<typeof computeGroups>) => groups[band].map((s) => s.model.id);
+
+  it("a class filter returns exactly the models computeGroups placed in that band", () => {
+    for (const band of ["opus", "sonnet", "light", "unrated"] as const) {
+      const got = filterModels(dataset, { class: band })
+        .map((m) => m.id)
+        .sort();
+      const want = [...bandIds(band)].sort();
+      expect(got, `class=${band}`).toEqual(want);
+    }
+  });
+});
+
+describe("filterModels — harness and class parameters intersect", () => {
+  const groups = computeGroups(dataset);
+  const opusIds = new Set(groups.opus.map((s) => s.model.id));
+
+  it("both filters together keep only opus-band models that the harness exposes", () => {
+    const got = filterModels(dataset, { harness: "cursor", class: "opus" });
+    for (const m of got) {
+      expect(m.harnesses, `${m.id} must be exposed by cursor`).toContain("cursor");
+      expect(opusIds.has(m.id), `${m.id} must be in the opus band`).toBe(true);
+    }
+    // And it is exactly the intersection (no omissions).
+    const expected = dataset.models
+      .filter((m) => m.harnesses.includes("cursor") && opusIds.has(m.id))
+      .map((m) => m.id)
+      .sort();
+    expect(got.map((m) => m.id).sort()).toEqual(expected);
+  });
+
+  it("a filter combination matching no model returns an empty list (no error)", () => {
+    // opencode-go carries no opus-band model in the live roster (cursor/zen carry the frontier).
+    const got = filterModels(dataset, { harness: "opencode-go", class: "opus" });
+    expect(got).toEqual([]);
+  });
+});

--- a/apps/ayokoding-www/src/features/ai-benchmark/core/price.ts
+++ b/apps/ayokoding-www/src/features/ai-benchmark/core/price.ts
@@ -1,0 +1,86 @@
+// AI BENCHMARK — harness price selection core (Phase 4, steps P-1..P-7).
+//
+// The price chart shows ONE rate per model: the selected harness's rate, or — with no harness
+// filter — the lowest available harness rate. This module is the pure selector; it owns no UI.
+// See `plans/in-progress/ayokoding-www-tools-ai-benchmark/prd.md` AC-16/AC-17/AC-18.
+//
+// Rules:
+//   - With no harness filter, the lowest METERED rate wins (compare input, then output).
+//   - A subscription-only model (no metered rate anywhere) returns its subscription — NEVER a
+//     numeric zero and NEVER undefined-posing-as-zero (invariant 10).
+//   - A model exposed by neither a metered nor a subscription rate returns undefined.
+//   - With a harness filter, that harness's exact rate set is returned (metered or subscription),
+//     or undefined when the model is not exposed by that harness.
+
+import type { HarnessId, MeteredPrice, Model, SubscriptionPrice } from "./data/models";
+
+/** A selected rate set: a metered per-token rate, a flat-rate subscription, or nothing. */
+export type SelectedRate = MeteredPrice | SubscriptionPrice | undefined;
+
+/** All metered rates a model exposes, paired with the harness that charges them. */
+function meteredRates(model: Model): { harness: HarnessId; rate: MeteredPrice }[] {
+  const out: { harness: HarnessId; rate: MeteredPrice }[] = [];
+  for (const h of Object.keys(model.pricing) as HarnessId[]) {
+    const p = model.pricing[h];
+    if (p !== undefined && p.kind === "metered") {
+      out.push({ harness: h, rate: p });
+    }
+  }
+  return out;
+}
+
+/** The first subscription a model exposes (if any), paired with its harness. */
+function firstSubscription(model: Model): { harness: HarnessId; rate: SubscriptionPrice } | undefined {
+  for (const h of Object.keys(model.pricing) as HarnessId[]) {
+    const p = model.pricing[h];
+    if (p !== undefined && p.kind === "subscription") {
+      return { harness: h, rate: p };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The lowest available rate for a model: the cheapest metered rate (by input, then output); if no
+ * metered rate exists, a subscription; otherwise undefined. A subscription-only model therefore
+ * resolves to its subscription — never a numeric zero.
+ */
+function pickLowest(model: Model): SelectedRate {
+  const metered = meteredRates(model);
+  if (metered.length > 0) {
+    metered.sort((a, b) => a.rate.input - b.rate.input || a.rate.output - b.rate.output);
+    // length > 0 guarantees a first element; the guard keeps the function total under
+    // `noUncheckedIndexedAccess`.
+    const lowest = metered[0];
+    return lowest === undefined ? undefined : lowest.rate;
+  }
+  return firstSubscription(model)?.rate;
+}
+
+/**
+ * The single internal selector both public functions delegate to (P-7 refactor). With a harness,
+ * returns that harness's exact rate set (or undefined); without one, the lowest available rate.
+ */
+function selectRateSet(model: Model, harness?: HarnessId): SelectedRate {
+  if (harness !== undefined) {
+    return model.pricing[harness];
+  }
+  return pickLowest(model);
+}
+
+/**
+ * The model's rate when no harness filter is applied — the lowest available harness rate
+ * (cheapest metered by input then output, else its subscription). Undefined when the model has no
+ * pricing at all.
+ */
+export function lowestRate(model: Model): SelectedRate {
+  return selectRateSet(model);
+}
+
+/**
+ * The rate a specific harness charges for the model, or undefined when the model is not exposed by
+ * that harness. Returns the subscription when the harness carries the model on a flat-rate plan.
+ */
+export function rateForHarness(model: Model, harness: HarnessId): SelectedRate {
+  return selectRateSet(model, harness);
+}

--- a/apps/ayokoding-www/src/features/ai-benchmark/core/price.unit.test.ts
+++ b/apps/ayokoding-www/src/features/ai-benchmark/core/price.unit.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { dataset, type HarnessId, type MeteredPrice, type Model, type SubscriptionPrice } from "./data/models";
+import { lowestRate, rateForHarness } from "./price";
+
+// Pure-function tests for harness price selection (Phase 4 steps P-1..P-7). The price chart shows
+// a single rate per model: the selected harness's rate, or — with no harness filter — the lowest
+// available harness rate (compare input, then output). A subscription-only model is never shown as
+// a numeric zero; it carries its subscription kind. See
+// `plans/in-progress/ayokoding-www-tools-ai-benchmark/prd.md` AC-16/AC-17/AC-18.
+
+const SRC = "https://example.test/pricing";
+
+function met(input: number, output: number, conditions?: string): MeteredPrice {
+  return { kind: "metered", input, output, grade: "verified", source: SRC, conditions };
+}
+
+function sub(planCostUsd = 10): SubscriptionPrice {
+  return { kind: "subscription", planCostUsd, source: SRC };
+}
+
+function modelWith(id: string, pricing: Model["pricing"]): Model {
+  return { id, name: id, vendor: "Test", harnesses: Object.keys(pricing) as HarnessId[], figures: [], pricing };
+}
+
+// ─── P-1 / P-2 — lowestRate ────────────────────────────────────────────────────
+
+describe("lowestRate — the cheapest harness rate when no harness filter is applied", () => {
+  it("returns the cheaper of two metered harness rates (by input)", () => {
+    const m = modelWith("m", {
+      "claude-code": met(5, 25),
+      cursor: met(3, 15),
+    });
+    expect(lowestRate(m)).toEqual(met(3, 15));
+  });
+
+  it("breaks ties on input by the lower output rate", () => {
+    const m = modelWith("m", {
+      cursor: met(3, 30),
+      "opencode-zen": met(3, 15),
+    });
+    expect(lowestRate(m)).toEqual(met(3, 15));
+  });
+
+  it("prefers a metered rate over a subscription when both are present", () => {
+    const m = modelWith("m", {
+      cursor: met(2, 6),
+      "opencode-go": sub(10),
+      "opencode-zen": met(4, 12),
+    });
+    expect(lowestRate(m)?.kind).toBe("metered");
+    expect(lowestRate(m)).toEqual(met(2, 6));
+  });
+
+  it("returns undefined when a model has no pricing at all", () => {
+    const m = modelWith("none", {});
+    expect(lowestRate(m)).toBeUndefined();
+  });
+});
+
+// ─── P-3 / P-4 — rateForHarness ────────────────────────────────────────────────
+
+describe("rateForHarness — a specific harness's rate set", () => {
+  const m = modelWith("m", {
+    "claude-code": met(5, 25),
+    cursor: met(3, 15),
+  });
+
+  it("returns that harness's rate set", () => {
+    expect(rateForHarness(m, "cursor")).toEqual(met(3, 15));
+    expect(rateForHarness(m, "claude-code")).toEqual(met(5, 25));
+  });
+
+  it("returns undefined when the model is not exposed by that harness", () => {
+    expect(rateForHarness(m, "opencode-zen")).toBeUndefined();
+    expect(rateForHarness(m, "opencode-go")).toBeUndefined();
+  });
+});
+
+// ─── P-5 / P-6 — subscription-only models ──────────────────────────────────────
+
+describe("subscription-only models — both selectors return the subscription, never a zero", () => {
+  const subOnly = modelWith("sub-only", { "opencode-go": sub(10) });
+
+  it("lowestRate returns the subscription (kind 'subscription')", () => {
+    const r = lowestRate(subOnly);
+    expect(r).toBeDefined();
+    expect(r?.kind).toBe("subscription");
+    expect((r as SubscriptionPrice).planCostUsd).toBe(10);
+  });
+
+  it("rateForHarness returns the subscription for the exposing harness", () => {
+    const r = rateForHarness(subOnly, "opencode-go");
+    expect(r?.kind).toBe("subscription");
+  });
+
+  it("neither selector returns a numeric zero or an undefined-with-zero", () => {
+    expect(typeof lowestRate(subOnly)).not.toBe("number");
+    expect(lowestRate(subOnly)).not.toBe(0);
+    expect(lowestRate(subOnly)).not.toBeUndefined();
+    // rateForHarness on the exposed harness is the subscription (not zero / not undefined).
+    expect(rateForHarness(subOnly, "opencode-go")).not.toBe(0);
+    expect(rateForHarness(subOnly, "opencode-go")).not.toBeUndefined();
+  });
+});
+
+// ─── Real-dataset sanity ───────────────────────────────────────────────────────
+
+describe("lowestRate / rateForHarness against the live roster", () => {
+  const byId = new Map(dataset.models.map((m) => [m.id, m]));
+
+  it("claude-opus-5's lowest rate is its metered $5/$25 (three harnesses, identical)", () => {
+    const r = lowestRate(byId.get("claude-opus-5")!);
+    expect(r?.kind).toBe("metered");
+    expect((r as MeteredPrice).input).toBe(5);
+    expect((r as MeteredPrice).output).toBe(25);
+  });
+
+  it("grok-4.5's lowest rate is its metered cursor/zen rate, not its opencode-go subscription", () => {
+    const r = lowestRate(byId.get("grok-4.5")!);
+    expect(r?.kind).toBe("metered");
+    expect((r as MeteredPrice).input).toBe(2);
+  });
+
+  it("a subscription-only roster model (mimo-v2.5) selects the subscription from both selectors", () => {
+    const mimo = byId.get("mimo-v2.5")!;
+    expect(lowestRate(mimo)?.kind).toBe("subscription");
+    expect(rateForHarness(mimo, "opencode-go")?.kind).toBe("subscription");
+  });
+
+  it("a model with empty pricing (gemini-3.1-pro) yields undefined from both selectors", () => {
+    const g = byId.get("gemini-3.1-pro")!;
+    expect(lowestRate(g)).toBeUndefined();
+    expect(rateForHarness(g, "cursor")).toBeUndefined();
+  });
+});

--- a/apps/ayokoding-www/src/features/ai-benchmark/core/score.ts
+++ b/apps/ayokoding-www/src/features/ai-benchmark/core/score.ts
@@ -1,0 +1,162 @@
+// AI BENCHMARK — pure scoring core (Phase 4, steps C-1..C-11).
+//
+// Implements the composite-capability index from
+// `plans/in-progress/ayokoding-www-tools-ai-benchmark/tech-docs.md` §"Scoring pipeline" and
+// §"DD-5a" / §"DD-6". No React, no router, no side effects — every function is pure over the
+// dataset, mirroring `src/features/cost-of-living-calculator/core/`.
+//
+// Arithmetic:
+//   rosterMax(b) = max over all INCLUDED models m of score(m, b)
+//   rel(m, b)    = 100 × score(m, b) / rosterMax(b)            — undefined when m has no included figure
+//   W(m)         = Σ weight(b) for b ∈ present(m)
+//   index(m)     = Σ weight(b) × rel(m, b) / W(m)              — undefined when W(m) = 0
+//   coverage(m)  = W(m) / 100
+//
+// "Included" excludes the version-trap figures (Terminal-Bench 2.0 in a 2.1 slot, SWE-bench
+// Multilingual in a Verified slot) — they count as absent. For a CONFLICTED figure the LOW
+// published value enters the composite (the dataset already stores `value === low`).
+
+import {
+  BENCHMARK_WEIGHTS,
+  isConflictedFigure,
+  type BenchmarkId,
+  type Dataset,
+  type Figure,
+  type Model,
+} from "./data/models";
+
+/** A roster-max value per benchmark; `undefined` when no included figure exists for it. */
+export type RosterMaxes = Record<BenchmarkId, number | undefined>;
+
+/** Coverage ratio below which a rated model is marked low-coverage (DD-6). */
+export const LOW_COVERAGE_THRESHOLD = 0.5;
+
+/**
+ * May a figure enter the composite? This is the defensive mirror of dataset invariant 9: a
+ * Terminal-Bench 2.0 figure must never enter a `terminal-bench-2-1` slot, and a SWE-bench
+ * Multilingual figure must never enter a `swe-bench-verified` slot. Such figures are recorded
+ * in the dataset for honesty but EXCLUDED from the composite (they count as absent).
+ *
+ * The dataset is curated clean, so this guard is a safety net: if a wrongly-versioned figure
+ * ever lands, it is scored as absent rather than silently corrupting the index.
+ */
+export function isIncludedFigure(f: Figure): boolean {
+  const trail = `${f.benchmarkVersion ?? ""} ${f.conditions ?? ""}`.toLowerCase();
+  if (f.benchmark === "terminal-bench-2-1" && trail.includes("2.0")) {
+    return false;
+  }
+  if (f.benchmark === "swe-bench-verified" && trail.includes("multilingual")) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * The roster-max for a benchmark: the highest INCLUDED figure value across the roster. For a
+ * conflicted figure the LOW published value is the composite input (the dataset stores
+ * `value === low`), so the low is what is compared here. Returns `undefined` when no included
+ * figure exists for the benchmark.
+ */
+export function rosterMax(dataset: Dataset, benchmark: BenchmarkId): number | undefined {
+  let max: number | undefined;
+  for (const m of dataset.models) {
+    for (const f of m.figures) {
+      if (f.benchmark !== benchmark) continue;
+      if (!isIncludedFigure(f)) continue;
+      // `value` is the composite input — for a conflicted figure it is already the low end.
+      const v = f.value;
+      if (max === undefined || v > max) {
+        max = v;
+      }
+    }
+  }
+  return max;
+}
+
+/**
+ * The per-benchmark roster-max map for the whole roster. Convenience over calling
+ * {@link rosterMax} once per benchmark.
+ */
+export function computeRosterMaxes(dataset: Dataset): RosterMaxes {
+  const out = {} as RosterMaxes;
+  for (const b of Object.keys(BENCHMARK_WEIGHTS) as BenchmarkId[]) {
+    out[b] = rosterMax(dataset, b);
+  }
+  return out;
+}
+
+/**
+ * Relative normalized score: `100 × score(m, b) / rosterMax`. The roster-max holder scores
+ * exactly 100. Returns `undefined` when the model has no included figure for the benchmark
+ * (absent — never imputed, never zero).
+ */
+export function rel(model: Model, benchmark: BenchmarkId, max: number): number | undefined {
+  const f = model.figures.find((fig) => fig.benchmark === benchmark && isIncludedFigure(fig));
+  if (f === undefined) {
+    return undefined;
+  }
+  return (100 * f.value) / max;
+}
+
+/**
+ * Σ weight(b) over the benchmarks the model has an included figure for (DD-6 `W(m)`). Shared by
+ * {@link computeIndex} (as its denominator) and {@link coverage} (as `W(m) / 100`) so the two
+ * never disagree on what "present" means (C-11 refactor).
+ */
+function presentWeight(model: Model): number {
+  let w = 0;
+  for (const f of model.figures) {
+    if (!isIncludedFigure(f)) continue;
+    w += BENCHMARK_WEIGHTS[f.benchmark];
+  }
+  return w;
+}
+
+/**
+ * The composite index: the weight-renormalized mean of the present normalized scores
+ * (`Σ weight × rel ÷ W`). Returns `undefined` when `W = 0` (no included figure on any composite
+ * benchmark) — never `0`, never `NaN`. The model is then unrated.
+ *
+ * A present benchmark always has a roster max (the model's own figure contributes to it), so the
+ * `max === undefined` guard is unreachable for valid data; it keeps the function total.
+ */
+export function computeIndex(model: Model, rosterMaxes: RosterMaxes): number | undefined {
+  const w = presentWeight(model);
+  if (w === 0) {
+    return undefined;
+  }
+  let weighted = 0;
+  for (const f of model.figures) {
+    if (!isIncludedFigure(f)) continue;
+    const max = rosterMaxes[f.benchmark];
+    if (max === undefined || max <= 0) {
+      continue;
+    }
+    weighted += BENCHMARK_WEIGHTS[f.benchmark] * ((100 * f.value) / max);
+  }
+  return weighted / w;
+}
+
+/**
+ * Coverage ratio: `W(m) / 100` — the fraction of the composite weight the model covers. `0`
+ * means the model has no included figure on any composite benchmark (unrated).
+ */
+export function coverage(model: Model): number {
+  return presentWeight(model) / 100;
+}
+
+/**
+ * True for a RATED model whose coverage is below {@link LOW_COVERAGE_THRESHOLD}. An unrated
+ * (zero-coverage) model is its own state and is NOT low-coverage — the marker describes "this
+ * index exists but rests on sparse data", which an absent index cannot (scoring-pipeline
+ * branches Y and K).
+ */
+export function isLowCoverage(model: Model): boolean {
+  const c = coverage(model);
+  return c > 0 && c < LOW_COVERAGE_THRESHOLD;
+}
+
+// Re-export the conflicted-figure guard for callers that compose this core (e.g. the data table
+// rendering a range instead of a single number). Kept here so the scoring core is the one place
+// that knows a conflicted figure carries a range.
+export { isConflictedFigure };

--- a/apps/ayokoding-www/src/features/ai-benchmark/core/score.unit.test.ts
+++ b/apps/ayokoding-www/src/features/ai-benchmark/core/score.unit.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import {
+  BENCHMARK_WEIGHTS,
+  dataset,
+  type BenchmarkId,
+  type ConflictedFigure,
+  type Dataset,
+  type Figure,
+  type Model,
+} from "./data/models";
+import {
+  LOW_COVERAGE_THRESHOLD,
+  computeIndex,
+  coverage,
+  isLowCoverage,
+  isIncludedFigure,
+  rel,
+  rosterMax,
+  type RosterMaxes,
+} from "./score";
+
+// Pure-function tests for the AI Benchmark scoring core (Phase 4 steps C-1..C-11).
+// Arithmetic is specified verbatim by
+// `plans/in-progress/ayokoding-www-tools-ai-benchmark/tech-docs.md` §"Scoring pipeline" and
+// §"DD-5a" / §"DD-6". Fixture datasets give known inputs so the assertions are exact.
+
+// ─── Fixture builders ──────────────────────────────────────────────────────────
+
+const SRC = "https://example.test/source";
+
+function figure(benchmark: BenchmarkId, value: number, extra: Partial<Figure> = {}): Figure {
+  return { benchmark, value, grade: "verified", source: SRC, ...extra };
+}
+
+function conflicted(
+  benchmark: BenchmarkId,
+  low: number,
+  high: number,
+  extra: Partial<ConflictedFigure> = {},
+): ConflictedFigure {
+  return { benchmark, value: low, grade: "conflicted", low, high, source: SRC, ...extra };
+}
+
+function model(id: string, figures: Figure[], harnesses: Model["harnesses"] = ["claude-code"]): Model {
+  return { id, name: id, vendor: "Test", harnesses, figures, pricing: {} };
+}
+
+function datasetOf(models: Model[]): Dataset {
+  return { snapshotDate: "2026-07-28", anchorIds: { opus: "opus-anchor", sonnet: "sonnet-anchor" }, models };
+}
+
+// A roster-max map fixed at 80 on every axis — keeps rel arithmetic readable.
+const MAXES_80: RosterMaxes = {
+  "swe-bench-verified": 80,
+  "swe-bench-pro": 80,
+  "terminal-bench-2-1": 80,
+  "gpqa-diamond": 80,
+};
+
+// ─── C-1 / C-2 — rosterMax ─────────────────────────────────────────────────────
+
+describe("rosterMax — highest INCLUDED figure for a benchmark", () => {
+  it("returns the max figure value over the real roster for each composite benchmark", () => {
+    // Hand-computed from core/data/models.ts (low end of every conflicted figure).
+    expect(rosterMax(dataset, "swe-bench-verified")).toBe(96.0); // claude-opus-5
+    expect(rosterMax(dataset, "swe-bench-pro")).toBe(80.3); // claude-fable-5
+    expect(rosterMax(dataset, "terminal-bench-2-1")).toBe(91.9); // gpt-5.6-sol
+    expect(rosterMax(dataset, "gpqa-diamond")).toBe(94.1); // gpt-5.6-sol / gemini-3.1-pro (low)
+  });
+
+  it("uses the LOW end of a conflicted figure (never the high)", () => {
+    const ds = datasetOf([model("a", [conflicted("gpqa-diamond", 70, 85)]), model("b", [figure("gpqa-diamond", 90)])]);
+    // a's conflicted range is [70, 85]; the low (70) enters, so the max is max(70, 90) = 90,
+    // NOT max(85, 90) = 90 would coincide here — assert the low path explicitly below.
+    expect(rosterMax(ds, "gpqa-diamond")).toBe(90);
+    const dsLowWins = datasetOf([model("a", [conflicted("gpqa-diamond", 70, 99)])]);
+    // If the high (99) were used, rosterMax would be 99; the low (70) is what enters.
+    expect(rosterMax(dsLowWins, "gpqa-diamond")).toBe(70);
+  });
+
+  it("EXCLUDES a Terminal-Bench 2.0 figure from a terminal-bench-2-1 roster max (version trap)", () => {
+    const ds = datasetOf([
+      model("tb2", [figure("terminal-bench-2-1", 99, { benchmarkVersion: "2.0" })]),
+      model("tb21", [figure("terminal-bench-2-1", 50, { benchmarkVersion: "2.1" })]),
+    ]);
+    // The 2.0 figure (99) is excluded — counts as absent — so the roster max is the 2.1 figure (50).
+    expect(rosterMax(ds, "terminal-bench-2-1")).toBe(50);
+  });
+
+  it("EXCLUDES a SWE-bench Multilingual figure from a swe-bench-verified roster max (version trap)", () => {
+    const ds = datasetOf([
+      model("multi", [figure("swe-bench-verified", 99, { benchmarkVersion: "Verified", conditions: "Multilingual" })]),
+      model("ver", [figure("swe-bench-verified", 60, { benchmarkVersion: "Verified" })]),
+    ]);
+    expect(rosterMax(ds, "swe-bench-verified")).toBe(60);
+  });
+
+  it("returns undefined when no included figure exists for a benchmark", () => {
+    const ds = datasetOf([model("none", [figure("swe-bench-verified", 50)])]);
+    expect(rosterMax(ds, "swe-bench-pro")).toBeUndefined();
+  });
+});
+
+// ─── C-3 / C-4 — rel ───────────────────────────────────────────────────────────
+
+describe("rel — roster-relative normalized score", () => {
+  it("returns 100 × score / rosterMax", () => {
+    const m = model("m", [figure("swe-bench-verified", 64)]);
+    expect(rel(m, "swe-bench-verified", 80)).toBe(80);
+  });
+
+  it("returns exactly 100 for the roster-max holder", () => {
+    const m = model("holder", [figure("gpqa-diamond", 80)]);
+    expect(rel(m, "gpqa-diamond", 80)).toBe(100);
+  });
+
+  it("returns undefined for an absent figure", () => {
+    const m = model("m", [figure("swe-bench-verified", 64)]);
+    expect(rel(m, "swe-bench-pro", 80)).toBeUndefined();
+  });
+
+  it("returns undefined for a figure excluded by the version trap", () => {
+    const m = model("m", [figure("terminal-bench-2-1", 99, { benchmarkVersion: "2.0" })]);
+    expect(rel(m, "terminal-bench-2-1", 100)).toBeUndefined();
+  });
+});
+
+// ─── isIncludedFigure (version-trap guard) ─────────────────────────────────────
+
+describe("isIncludedFigure — version-trap guard", () => {
+  it("includes a correctly-versioned Terminal-Bench 2.1 figure", () => {
+    expect(isIncludedFigure(figure("terminal-bench-2-1", 80, { benchmarkVersion: "2.1" }))).toBe(true);
+  });
+  it("excludes a Terminal-Bench 2.0 figure from a 2.1 slot", () => {
+    expect(isIncludedFigure(figure("terminal-bench-2-1", 80, { benchmarkVersion: "2.0" }))).toBe(false);
+    expect(isIncludedFigure(figure("terminal-bench-2-1", 80, { conditions: "Terminal-Bench 2.0 run" }))).toBe(false);
+  });
+  it("excludes a SWE-bench Multilingual figure from a Verified slot", () => {
+    expect(isIncludedFigure(figure("swe-bench-verified", 80, { conditions: "Multilingual eval" }))).toBe(false);
+  });
+  it("includes a normal SWE-bench Verified figure", () => {
+    expect(isIncludedFigure(figure("swe-bench-verified", 80, { benchmarkVersion: "Verified" }))).toBe(true);
+  });
+});
+
+// ─── C-5 / C-6 — computeIndex + coverage (two of four benchmarks) ──────────────
+
+describe("computeIndex + coverage — weight-renormalized mean over present benchmarks", () => {
+  // Fixture: swe-bench-verified=64 (→ rel 80, weight 25) and gpqa-diamond=40 (→ rel 50, weight 30).
+  // The other two benchmarks are absent.
+  const m = model("two-of-four", [figure("swe-bench-verified", 64), figure("gpqa-diamond", 40)]);
+
+  it("computeIndex returns the weight-renormalized mean of the present normalized scores", () => {
+    const expected =
+      (BENCHMARK_WEIGHTS["swe-bench-verified"] * 80 + BENCHMARK_WEIGHTS["gpqa-diamond"] * 50) /
+      (BENCHMARK_WEIGHTS["swe-bench-verified"] + BENCHMARK_WEIGHTS["gpqa-diamond"]);
+    expect(computeIndex(m, MAXES_80)).toBeCloseTo(expected, 10);
+    // (25*80 + 30*50) / 55 = 3500/55
+    expect(computeIndex(m, MAXES_80)).toBeCloseTo(3500 / 55, 10);
+  });
+
+  it("coverage returns the summed present weight ÷ 100", () => {
+    expect(coverage(m)).toBe((BENCHMARK_WEIGHTS["swe-bench-verified"] + BENCHMARK_WEIGHTS["gpqa-diamond"]) / 100);
+    expect(coverage(m)).toBeCloseTo(0.55, 10);
+  });
+
+  it("the roster-max holder scores 100 on its axis (rel feeds the index)", () => {
+    const holder = model("holder", [figure("swe-bench-verified", 80), figure("gpqa-diamond", 80)]);
+    // Both rels are 100, so the index is 100.
+    expect(computeIndex(holder, MAXES_80)).toBeCloseTo(100, 10);
+  });
+});
+
+// ─── C-7 / C-8 — zero present benchmarks ───────────────────────────────────────
+
+describe("zero present benchmarks — coverage 0, index undefined (never 0, never NaN)", () => {
+  const empty = model("empty", []);
+
+  it("coverage is exactly 0", () => {
+    expect(coverage(empty)).toBe(0);
+  });
+
+  it("computeIndex is undefined (NOT 0, NOT NaN)", () => {
+    const idx = computeIndex(empty, MAXES_80);
+    expect(idx).toBeUndefined();
+    expect(idx).not.toBe(0);
+    expect(Number.isNaN(idx)).toBe(false);
+  });
+
+  it("a model whose only figure is version-trap-excluded also has coverage 0 and undefined index", () => {
+    const trap = model("trap", [figure("terminal-bench-2-1", 99, { benchmarkVersion: "2.0" })]);
+    expect(coverage(trap)).toBe(0);
+    expect(computeIndex(trap, MAXES_80)).toBeUndefined();
+  });
+});
+
+// ─── C-9 / C-10 — isLowCoverage + LOW_COVERAGE_THRESHOLD ───────────────────────
+
+describe("isLowCoverage — true only for rated models below the threshold", () => {
+  it("exports the 0.50 threshold as a named constant", () => {
+    expect(LOW_COVERAGE_THRESHOLD).toBe(0.5);
+  });
+
+  it("is true below the threshold", () => {
+    // swe-bench-pro (25) + terminal-bench-2-1 (20) = 45 → 0.45 coverage.
+    const low = model("low", [figure("swe-bench-pro", 50), figure("terminal-bench-2-1", 50)]);
+    expect(coverage(low)).toBeCloseTo(0.45, 10);
+    expect(isLowCoverage(low)).toBe(true);
+  });
+
+  it("is false at the threshold", () => {
+    // swe-bench-verified (25) + swe-bench-pro (25) = 50 → 0.50 coverage.
+    const at = model("at", [figure("swe-bench-verified", 50), figure("swe-bench-pro", 50)]);
+    expect(coverage(at)).toBeCloseTo(0.5, 10);
+    expect(isLowCoverage(at)).toBe(false);
+  });
+
+  it("is false above the threshold", () => {
+    // swe-bench-verified (25) + gpqa-diamond (30) = 55 → 0.55 coverage.
+    const above = model("above", [figure("swe-bench-verified", 50), figure("gpqa-diamond", 50)]);
+    expect(coverage(above)).toBeCloseTo(0.55, 10);
+    expect(isLowCoverage(above)).toBe(false);
+  });
+
+  it("is false for a zero-coverage (unrated) model — unrated is its own state, not low-coverage", () => {
+    const empty = model("empty", []);
+    expect(isLowCoverage(empty)).toBe(false);
+  });
+});
+
+// ─── C-11 — shared weight-table helper (computeIndex and coverage agree on W) ──
+
+describe("computeIndex and coverage share the present-weight table", () => {
+  it("coverage × 100 equals the weight sum that computeIndex divides by", () => {
+    const m = model("three", [
+      figure("swe-bench-verified", 60),
+      figure("terminal-bench-2-1", 60),
+      figure("gpqa-diamond", 60),
+    ]);
+    const w =
+      BENCHMARK_WEIGHTS["swe-bench-verified"] +
+      BENCHMARK_WEIGHTS["terminal-bench-2-1"] +
+      BENCHMARK_WEIGHTS["gpqa-diamond"];
+    // coverage = W/100, so W = coverage*100 — the same W computeIndex divides by.
+    expect(coverage(m) * 100).toBe(w);
+    // All three rels are 75 (60/80*100), so index = 75 regardless of weights.
+    expect(computeIndex(m, MAXES_80)).toBeCloseTo(75, 10);
+  });
+});

--- a/apps/ayokoding-www/src/features/ai-benchmark/core/url-state.ts
+++ b/apps/ayokoding-www/src/features/ai-benchmark/core/url-state.ts
@@ -1,0 +1,74 @@
+// AI BENCHMARK — pure URL state encode/decode/sanitize (Phase 4, steps F-3..F-9).
+//
+// Mirrors `src/features/cost-of-living-calculator/core/url-state.ts`: the URL is the single
+// source of truth, the two filter params (harness, class) are serialized with defaults OMITTED
+// from the query string, and unknown values sanitize to the default rather than throwing. No
+// React, no router, no side effects — every function is pure over `URLSearchParams`.
+//
+// The known-value unions live in `filter.ts` (F-9) so a new harness id or band is added in exactly
+// one place; this module imports them.
+
+import { BANDS, HARNESS_IDS, isKnownBand, isKnownHarness, type FilterState } from "./filter";
+
+/** Query-string parameter keys. */
+export const PARAM_KEYS = {
+  harness: "harness",
+  class: "class",
+} as const;
+
+/** The unfiltered state — what an empty or unrecognized query resolves to. */
+export const DEFAULT_STATE: FilterState = {
+  harness: undefined,
+  class: undefined,
+};
+
+/**
+ * Sanitize a (possibly untrusted) filter state to a valid one: drop any harness value that is not
+ * one of {@link HARNESS_IDS} and any class value that is not one of {@link BANDS}. Idempotent and
+ * total — never throws. This is the "unknown filter value falls back to the unfiltered view"
+ * guarantee (AC-26).
+ */
+export function sanitizeState(state: Partial<FilterState>): FilterState {
+  const harness = state.harness !== undefined && isKnownHarness(state.harness) ? state.harness : undefined;
+  const bandClass = state.class !== undefined && isKnownBand(state.class) ? state.class : undefined;
+  return { harness, class: bandClass };
+}
+
+/**
+ * Parse raw URLSearchParams into a sanitized {@link FilterState}. Unknown keys are ignored;
+ * unknown harness/class values resolve to `undefined` (unfiltered) rather than throwing (AC-26).
+ */
+export function decodeState(params: URLSearchParams): FilterState {
+  const harnessRaw = params.get(PARAM_KEYS.harness);
+  const classRaw = params.get(PARAM_KEYS.class);
+  return sanitizeState({
+    harness: harnessRaw !== null ? (harnessAsHarness(harnessRaw) ?? undefined) : undefined,
+    class: classRaw !== null ? (classAsBand(classRaw) ?? undefined) : undefined,
+  });
+}
+
+/** Parse a harness string, returning the typed id only if it is known. */
+function harnessAsHarness(v: string): FilterState["harness"] {
+  return isKnownHarness(v) ? v : undefined;
+}
+
+/** Parse a class string, returning the typed band only if it is known. */
+function classAsBand(v: string): FilterState["class"] {
+  return isKnownBand(v) ? v : undefined;
+}
+
+/**
+ * Encode a filter state to URLSearchParams, OMITTING defaults so a clean, shareable URL is
+ * produced (mirrors the calculator's contract). The default (unfiltered) state encodes to an
+ * empty query string.
+ */
+export function encodeState(state: FilterState): URLSearchParams {
+  const params = new URLSearchParams();
+  if (state.harness !== undefined && state.harness !== DEFAULT_STATE.harness) {
+    params.set(PARAM_KEYS.harness, state.harness);
+  }
+  if (state.class !== undefined && state.class !== DEFAULT_STATE.class) {
+    params.set(PARAM_KEYS.class, state.class);
+  }
+  return params;
+}

--- a/apps/ayokoding-www/src/features/ai-benchmark/core/url-state.unit.test.ts
+++ b/apps/ayokoding-www/src/features/ai-benchmark/core/url-state.unit.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_STATE, PARAM_KEYS, decodeState, encodeState, sanitizeState } from "./url-state";
+import type { FilterState } from "./filter";
+
+// Pure-function tests for URL state encode/decode/sanitize (Phase 4 steps F-3..F-9), mirroring the
+// calculator's proven contract: the URL is the single source of truth, defaults are OMITTED from
+// the query string, and unknown values sanitize to the default rather than throwing. See prd.md
+// AC-22/AC-26/AC-27.
+
+// ─── F-3 / F-4 — decode defaults + encode omits defaults ───────────────────────
+
+describe("decodeState — empty query yields the default unfiltered state", () => {
+  it("an empty query string decodes to all-undefined (unfiltered)", () => {
+    expect(decodeState(new URLSearchParams(""))).toEqual(DEFAULT_STATE);
+  });
+
+  it("DEFAULT_STATE has no filter set", () => {
+    expect(DEFAULT_STATE.harness).toBeUndefined();
+    expect(DEFAULT_STATE.class).toBeUndefined();
+  });
+});
+
+describe("encodeState — defaults are omitted from the query string", () => {
+  it("the default state encodes to an empty query string", () => {
+    expect(encodeState(DEFAULT_STATE).toString()).toBe("");
+  });
+
+  it("a harness filter is encoded under its param key, class omitted when default", () => {
+    const q = encodeState({ harness: "cursor" });
+    expect(q.get(PARAM_KEYS.harness)).toBe("cursor");
+    expect(q.has(PARAM_KEYS.class)).toBe(false);
+    expect(q.toString()).toBe("harness=cursor");
+  });
+
+  it("a class filter is encoded under its param key, harness omitted when default", () => {
+    const q = encodeState({ class: "opus" });
+    expect(q.get(PARAM_KEYS.class)).toBe("opus");
+    expect(q.has(PARAM_KEYS.harness)).toBe(false);
+    expect(q.toString()).toBe("class=opus");
+  });
+
+  it("both filters are encoded when both are set", () => {
+    const q = encodeState({ harness: "cursor", class: "sonnet" });
+    expect(q.get(PARAM_KEYS.harness)).toBe("cursor");
+    expect(q.get(PARAM_KEYS.class)).toBe("sonnet");
+  });
+});
+
+// ─── F-5 / F-6 — unknown values sanitize to default (no throw) ─────────────────
+
+describe("decodeState / sanitizeState — unknown values fall back to unfiltered, never throw", () => {
+  it("an unknown harness value decodes to undefined (unfiltered)", () => {
+    const s = decodeState(new URLSearchParams("harness=not-a-real-harness"));
+    expect(s.harness).toBeUndefined();
+    expect(s.class).toBeUndefined();
+  });
+
+  it("an unknown class value decodes to undefined (unfiltered)", () => {
+    const s = decodeState(new URLSearchParams("class=ultra"));
+    expect(s.class).toBeUndefined();
+    expect(s.harness).toBeUndefined();
+  });
+
+  it("sanitizeState drops unknown values without throwing", () => {
+    const sanitized = sanitizeState({
+      harness: "bogus" as unknown as FilterState["harness"],
+      class: "nope" as unknown as FilterState["class"],
+    });
+    expect(sanitized).toEqual(DEFAULT_STATE);
+  });
+
+  it("a known harness and known class survive sanitizeState", () => {
+    expect(sanitizeState({ harness: "cursor", class: "light" })).toEqual({ harness: "cursor", class: "light" });
+  });
+
+  it("sanitizeState is idempotent", () => {
+    const s: FilterState = { harness: "cursor", class: "opus" };
+    expect(sanitizeState(sanitizeState(s))).toEqual(s);
+  });
+});
+
+// ─── F-7 / F-8 — round-trip every valid query string ───────────────────────────
+
+describe("encodeState ∘ decodeState — round-trips for every valid query string", () => {
+  const cases: Array<{ name: string; query: string }> = [
+    { name: "empty", query: "" },
+    { name: "harness only", query: "harness=claude-code" },
+    { name: "harness cursor", query: "harness=cursor" },
+    { name: "harness opencode-go", query: "harness=opencode-go" },
+    { name: "class opus", query: "class=opus" },
+    { name: "class sonnet", query: "class=sonnet" },
+    { name: "class light", query: "class=light" },
+    { name: "class unrated", query: "class=unrated" },
+    { name: "both filters", query: "harness=cursor&class=sonnet" },
+    { name: "both filters (other harness)", query: "harness=opencode-zen&class=light" },
+  ];
+
+  it.each(cases)("round-trips: $name — encodeState(decodeState($query)) is stable", ({ query }) => {
+    const decoded = decodeState(new URLSearchParams(query));
+    const reEncoded = encodeState(decoded).toString();
+    // The round-trip must reach a fixed point: encoding the decoded state reproduces a canonical
+    // query equal to the input after default-omission normalization.
+    expect(reEncoded).toBe(query);
+  });
+
+  it("a query with extra unknown params decodes (ignoring them) and round-trips cleanly", () => {
+    const decoded = decodeState(new URLSearchParams("harness=cursor&garbage=x&class=opus"));
+    expect(decoded).toEqual({ harness: "cursor", class: "opus" });
+    expect(encodeState(decoded).toString()).toBe("harness=cursor&class=opus");
+  });
+});
+
+// ─── decodeState → FilterState is usable by filterModels (contract) ────────────
+
+describe("decodeState output — feeds filterModels directly", () => {
+  it("decodes a known harness to the typed HarnessId", () => {
+    expect(decodeState(new URLSearchParams("harness=codex-cli")).harness).toBe("codex-cli");
+  });
+  it("decodes a known class to the typed Band", () => {
+    expect(decodeState(new URLSearchParams("class=unrated")).class).toBe("unrated");
+  });
+});

--- a/apps/ayokoding-www/test/unit/fe-steps/ai-benchmark.steps.tsx
+++ b/apps/ayokoding-www/test/unit/fe-steps/ai-benchmark.steps.tsx
@@ -1,0 +1,301 @@
+import path from "path";
+import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
+import { expect } from "vitest";
+import "./helpers/test-setup";
+import {
+  BENCHMARK_WEIGHTS,
+  OPUS_ANCHOR_ID,
+  SONNET_ANCHOR_ID,
+  dataset,
+  type BenchmarkId,
+  type Dataset,
+  type Figure,
+  type Model,
+} from "@/features/ai-benchmark/core/data/models";
+import { computeIndex, computeRosterMaxes, coverage } from "@/features/ai-benchmark/core/score";
+import {
+  anchors,
+  assignBand,
+  computeGroups,
+  type AnchorIndices,
+  type Band,
+  type BandGroups,
+  type IndexMap,
+} from "@/features/ai-benchmark/core/bands";
+
+// vitest-cucumber bindings for the AI Benchmark feature's capability-scoring scenarios (AC-4..AC-11).
+// These scenarios are PURE LOGIC — fixture data in, a band/index out — so they bind here in Phase 4
+// against the `core/` functions rather than waiting for the route Phase 5 builds. No page is
+// rendered; each step is a thin call into the already-unit-tested `core/` modules.
+//
+// The rendering-dependent scenarios (AC-1/AC-2 page shell, AC-12 low-coverage marker, the charts
+// and the data table, the filter UX) are appended to the same feature file and bound by later
+// phases — only what this phase implements is bound here.
+
+const feature = await loadFeature(
+  path.resolve(process.cwd(), "../../specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature"),
+);
+
+// ─── Fixture builders (Z-17: one shared helper set) ────────────────────────────
+
+const SRC = "https://example.test/source";
+
+function fig(benchmark: BenchmarkId, value: number): Figure {
+  return { benchmark, value, grade: "verified", source: SRC };
+}
+
+function fixtureModel(id: string, figures: Figure[] = []): Model {
+  return { id, name: id, vendor: "Test", harnesses: ["claude-code"], figures, pricing: {} };
+}
+
+function fixtureDataset(models: Model[]): Dataset {
+  return { snapshotDate: "2026-07-28", anchorIds: { opus: OPUS_ANCHOR_ID, sonnet: SONNET_ANCHOR_ID }, models };
+}
+
+// ─── Per-scenario context ──────────────────────────────────────────────────────
+
+type Ctx = {
+  // Direct rule-test inputs (AC-4/5/6/7/8).
+  model?: Model;
+  indices?: IndexMap;
+  anchorIndices?: AnchorIndices;
+  // Computed results.
+  band?: Band;
+  index?: number | undefined;
+  coverageRatio?: number;
+  groups?: BandGroups;
+};
+
+let ctx: Ctx = {};
+
+// The live anchor indices, used as the threshold reference for the rule scenarios.
+const liveAnchors: AnchorIndices = anchors(dataset);
+
+describeFeature(feature, ({ Background, Scenario, AfterEachScenario }) => {
+  Background(({ Given }) => {
+    Given("the AI benchmark dataset is loaded", () => {
+      // The `dataset` import is the loaded roster; nothing to set up.
+      expect(dataset.models.length).toBeGreaterThan(0);
+    });
+  });
+
+  AfterEachScenario(() => {
+    ctx = {};
+  });
+
+  // ─── AC-4 — opus band ───────────────────────────────────────────────────────
+
+  Scenario("A model reaching the opus anchor renders in the opus band", ({ Given, When, Then }) => {
+    Given("a fixture model whose composite index equals the opus anchor index", () => {
+      const m = fixtureModel("fixture-at-opus");
+      ctx.model = m;
+      ctx.indices = { [m.id]: liveAnchors.opus };
+      ctx.anchorIndices = liveAnchors;
+    });
+
+    When("the capability groups are computed", () => {
+      ctx.band = assignBand(ctx.model!, ctx.indices!, ctx.anchorIndices!);
+    });
+
+    // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature:A model reaching the opus anchor renders in the opus band
+    Then('that model belongs to the "opus" band', () => {
+      expect(ctx.band).toBe("opus");
+    });
+  });
+
+  // ─── AC-5 — sonnet band ─────────────────────────────────────────────────────
+
+  Scenario("A model between the two anchors renders in the sonnet band", ({ Given, When, Then, And }) => {
+    const opus = liveAnchors.opus as number;
+    const sonnet = liveAnchors.sonnet as number;
+    const between = (opus + sonnet) / 2;
+
+    Given("a fixture model whose composite index is above the sonnet anchor index", () => {
+      const m = fixtureModel("fixture-between");
+      ctx.model = m;
+      ctx.indices = { [m.id]: between };
+      ctx.anchorIndices = liveAnchors;
+    });
+
+    And("that model's composite index is below the opus anchor index", () => {
+      expect((ctx.indices![ctx.model!.id] as number) < opus).toBe(true);
+    });
+
+    When("the capability groups are computed", () => {
+      ctx.band = assignBand(ctx.model!, ctx.indices!, ctx.anchorIndices!);
+    });
+
+    // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature:A model between the two anchors renders in the sonnet band
+    Then('that model belongs to the "sonnet" band', () => {
+      expect(ctx.band).toBe("sonnet");
+    });
+  });
+
+  // ─── AC-6 — light band ──────────────────────────────────────────────────────
+
+  Scenario("A model below the sonnet anchor renders in the light band", ({ Given, When, Then }) => {
+    const sonnet = liveAnchors.sonnet as number;
+
+    Given("a fixture model whose composite index is below the sonnet anchor index", () => {
+      const m = fixtureModel("fixture-below-sonnet");
+      ctx.model = m;
+      ctx.indices = { [m.id]: sonnet / 2 };
+      ctx.anchorIndices = liveAnchors;
+    });
+
+    When("the capability groups are computed", () => {
+      ctx.band = assignBand(ctx.model!, ctx.indices!, ctx.anchorIndices!);
+    });
+
+    // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature:A model below the sonnet anchor renders in the light band
+    Then('that model belongs to the "light" band', () => {
+      expect(ctx.band).toBe("light");
+    });
+  });
+
+  // ─── AC-7 — anchor pinning ──────────────────────────────────────────────────
+
+  Scenario("Each anchor model occupies the band it defines", ({ Given, When, Then, And }) => {
+    // Perverse fixture: the opus anchor's index (50) is BELOW the sonnet anchor's (90). Pinning
+    // must still place each anchor in the band it defines.
+    const perverse: AnchorIndices = { opus: 50, sonnet: 90 };
+    const perverseIndices: IndexMap = { [OPUS_ANCHOR_ID]: 50, [SONNET_ANCHOR_ID]: 90 };
+    const opusAnchor = fixtureModel(OPUS_ANCHOR_ID);
+    const sonnetAnchor = fixtureModel(SONNET_ANCHOR_ID);
+    const bands: Partial<Record<Band, Band>> = {};
+
+    Given("the two anchor models are present in the roster", () => {
+      ctx.anchorIndices = perverse;
+      ctx.indices = perverseIndices;
+    });
+
+    When("the capability groups are computed", () => {
+      bands.opus = assignBand(opusAnchor, perverseIndices, perverse);
+      bands.sonnet = assignBand(sonnetAnchor, perverseIndices, perverse);
+    });
+
+    // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature:Each anchor model occupies the band it defines
+    Then('the opus anchor belongs to the "opus" band', () => {
+      expect(bands.opus).toBe("opus");
+    });
+
+    And('the sonnet anchor belongs to the "sonnet" band', () => {
+      expect(bands.sonnet).toBe("sonnet");
+    });
+  });
+
+  // ─── AC-8 — unrated group ───────────────────────────────────────────────────
+
+  Scenario("A model with no published benchmark score renders in the unrated group", ({ Given, When, Then, And }) => {
+    Given("a fixture model with no score on any composite benchmark", () => {
+      ctx.model = fixtureModel("no-score", []);
+    });
+
+    When("the capability groups are computed", () => {
+      const ds = fixtureDataset([ctx.model!]);
+      const maxes = computeRosterMaxes(ds);
+      ctx.index = computeIndex(ctx.model!, maxes);
+      ctx.band = assignBand(ctx.model!, { [ctx.model!.id]: ctx.index }, liveAnchors);
+    });
+
+    // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature:A model with no published benchmark score renders in the unrated group
+    Then('that model belongs to the "unrated" group', () => {
+      expect(ctx.band).toBe("unrated");
+    });
+
+    And("that model has no composite index", () => {
+      expect(ctx.index).toBeUndefined();
+    });
+  });
+
+  // ─── AC-9 — totality ────────────────────────────────────────────────────────
+
+  Scenario("Every roster model belongs to exactly one capability group", ({ Given, When, Then }) => {
+    Given("the full roster is loaded", () => {
+      // dataset is the full roster.
+    });
+
+    When("the capability groups are computed", () => {
+      ctx.groups = computeGroups(dataset);
+    });
+
+    // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature:Every roster model belongs to exactly one capability group
+    Then('each model appears in exactly one of "opus", "sonnet", "light", or "unrated"', () => {
+      const g = ctx.groups!;
+      const placed = [...g.opus, ...g.sonnet, ...g.light, ...g.unrated].map((s) => s.model.id);
+      // Exactly once each (no duplicates), and every roster model is covered.
+      expect(new Set(placed).size).toBe(placed.length);
+      expect(placed.length).toBe(dataset.models.length);
+    });
+  });
+
+  // ─── AC-10 — composite index + coverage over present benchmarks ─────────────
+
+  Scenario("A model missing a benchmark is scored over the benchmarks it has", ({ Given, When, Then, And }) => {
+    // Fixture: swe-bench-verified=64 and gpqa-diamond=40 (two of four); a roster-max holder pins
+    // both axes at 80 so the rels are 80 and 50 respectively.
+    const twoOfFour = fixtureModel("two-of-four", [fig("swe-bench-verified", 64), fig("gpqa-diamond", 40)]);
+    const holder = fixtureModel("holder", [fig("swe-bench-verified", 80), fig("gpqa-diamond", 80)]);
+    const ds = fixtureDataset([twoOfFour, holder]);
+    const maxes = computeRosterMaxes(ds);
+
+    Given("a fixture model with a score on two of the four composite benchmarks", () => {
+      ctx.model = twoOfFour;
+    });
+
+    When("its composite index is computed", () => {
+      ctx.index = computeIndex(twoOfFour, maxes);
+      ctx.coverageRatio = coverage(twoOfFour);
+    });
+
+    // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature:A model missing a benchmark is scored over the benchmarks it has
+    Then("the index equals the weight-renormalized mean of those two normalized scores", () => {
+      const relSv = (100 * 64) / 80;
+      const relGpqa = (100 * 40) / 80;
+      const wSv = BENCHMARK_WEIGHTS["swe-bench-verified"];
+      const wGpqa = BENCHMARK_WEIGHTS["gpqa-diamond"];
+      const expected = (wSv * relSv + wGpqa * relGpqa) / (wSv + wGpqa);
+      expect(ctx.index).toBeCloseTo(expected, 10);
+    });
+
+    And("its coverage ratio equals the summed weight of those two benchmarks divided by one hundred", () => {
+      const expected = (BENCHMARK_WEIGHTS["swe-bench-verified"] + BENCHMARK_WEIGHTS["gpqa-diamond"]) / 100;
+      expect(ctx.coverageRatio).toBeCloseTo(expected, 10);
+    });
+  });
+
+  // ─── AC-11 — canonical per-band ordering shared by both charts ───────────────
+
+  Scenario("Models are ordered identically in both charts within a band", ({ Given, When, Then }) => {
+    Given("the full roster is loaded", () => {
+      // dataset is the full roster.
+    });
+
+    When("both charts are rendered", () => {
+      // Both charts consume the SAME canonical per-band list from computeGroups, so rendering both
+      // is equivalent to producing that list once.
+      ctx.groups = computeGroups(dataset);
+    });
+
+    // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature:Models are ordered identically in both charts within a band
+    Then("each band lists its models in the same order in the capability chart and the price chart", () => {
+      const g = ctx.groups!;
+      // The "same order" guarantee is that each band is ONE canonical list (descending index, then
+      // id) that both charts read verbatim. Assert the canonical-order property holds per band.
+      for (const list of [g.opus, g.sonnet, g.light, g.unrated]) {
+        for (let i = 1; i < list.length; i++) {
+          const prev = list[i - 1];
+          const curr = list[i];
+          if (prev === undefined || curr === undefined) continue; // unreachable: i within bounds
+          const pi = prev.index ?? -Infinity;
+          const ci = curr.index ?? -Infinity;
+          if (pi !== ci) {
+            expect(pi).toBeGreaterThan(ci);
+          } else {
+            expect(prev.model.id <= curr.model.id).toBe(true);
+          }
+        }
+      }
+    });
+  });
+});

--- a/plans/in-progress/ayokoding-www-tools-ai-benchmark/delivery.md
+++ b/plans/in-progress/ayokoding-www-tools-ai-benchmark/delivery.md
@@ -818,17 +818,17 @@ rev-parse --show-toplevel` prints the worktree path
   - **Date**: 2026-07-28
   - **Status**: done
   - **Notes**: passed — second generate produces no diff (idempotent).
-- [ ] [AI] `npx nx run ayokoding-www:test:unit` exits 0
+- [x] [AI] `npx nx run ayokoding-www:test:unit` exits 0
 - [x] [AI] `cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- md links validate`
       exits 0 for the edited reference
   - **Date**: 2026-07-28
   - **Status**: done
   - **Notes**: passed for the edited reference — 0 broken links in ai-model-benchmarks.md. (142 pre-existing broken links in plans/done/\*\* are unrelated archived-plan link rot, present before this phase; flagged for a separate maintenance task.)
-- [ ] [AI] `npx nx affected -t typecheck lint` exits 0
-- [ ] [AI] Run the [Delivery-Boundary Integration Protocol](#delivery-boundary-integration-protocol)
+- [x] [AI] `npx nx affected -t typecheck lint` exits 0
+- [x] [AI] Run the [Delivery-Boundary Integration Protocol](#delivery-boundary-integration-protocol)
       for branch `ayokoding-www-tools-ai-benchmark/phase-3-reference-derivation` in worktree
       `worktrees/ayokoding-www-tools-ai-benchmark-phase-3-reference-derivation/`
-- [ ] [AI] Run [Post-Push CI Verification](#post-push-ci-verification)
+- [x] [AI] Run [Post-Push CI Verification](#post-push-ci-verification)
 
 > **Pause Safety**: the governance reference is now generated and current; the public page does not
 > exist yet, and nothing user-facing changed. Safe to stop. To resume:
@@ -843,12 +843,15 @@ rev-parse --show-toplevel` prints the worktree path
 > Every module in this phase is pure — no React, no router, no side effects — mirroring
 > `src/features/cost-of-living-calculator/core/`.
 
-- [ ] [AI] Provision this unit's worktree from the latest `origin/main` — this phase is both the
+- [x] [AI] Provision this unit's worktree from the latest `origin/main` — this phase is both the
       unit's first phase and its boundary, so the worktree must exist before this phase's own work
       begins: `git worktree add worktrees/ayokoding-www-tools-ai-benchmark-phase-4-core origin/main`
       — acceptance: `git -C worktrees/ayokoding-www-tools-ai-benchmark-phase-4-core rev-parse
 --show-toplevel` prints the worktree path
-- [ ] [AI] **Z-0**: create `<SPECS>ai-benchmark.feature` containing the eight capability-scoring
+  - **Date**: 2026-07-28
+  - **Status**: done
+  - **Notes**: Worktree provisioned from `origin/main` (HEAD `8ab3b1703`, includes Phases 2+3). `npm install` running.
+- [x] [AI] **Z-0**: create `<SPECS>ai-benchmark.feature` containing the eight capability-scoring
       scenarios this phase implements (AC-4, AC-5, AC-6, AC-7, AC-8, AC-9, AC-10, AC-11) plus the
       shared `Background`, and index it from `<SPECS>README.md` — acceptance:
       `npx nx run ayokoding-www:specs:structure-validation` exits 0
@@ -859,20 +862,20 @@ rev-parse --show-toplevel` prints the worktree path
 
 ### Normalization and composite (`<CORE>score.ts`)
 
-- [ ] [AI] **C-1 RED**: create `<CORE>score.unit.test.ts` asserting `rosterMax(dataset, benchmark)`
+- [x] [AI] **C-1 RED**: create `<CORE>score.unit.test.ts` asserting `rosterMax(dataset, benchmark)`
       returns the highest **included** figure for that benchmark, using the low end of a `conflicted`
       figure and ignoring figures whose `benchmarkVersion` is excluded from the composite
       — command: `npx nx run ayokoding-www:test:unit`
       — acceptance: fails because `<CORE>score.ts` does not exist
   - _Gherkin (underpins) → AC-10, AC-13._
-- [ ] [AI] **C-2 GREEN**: implement `rosterMax` in `<CORE>score.ts`
+- [x] [AI] **C-2 GREEN**: implement `rosterMax` in `<CORE>score.ts`
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: the assertions pass
-- [ ] [AI] **C-3 RED**: assert `rel(model, benchmark, rosterMax)` returns
+- [x] [AI] **C-3 RED**: assert `rel(model, benchmark, rosterMax)` returns
       `100 × score / rosterMax`, that the roster-max holder returns exactly `100`, and that an absent
       figure returns `undefined` — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
-- [ ] [AI] **C-4 GREEN**: implement `rel` — command: `npx nx run ayokoding-www:test:unit`
+- [x] [AI] **C-4 GREEN**: implement `rel` — command: `npx nx run ayokoding-www:test:unit`
       — acceptance: passes
-- [ ] [AI] **C-5 RED**: assert `computeIndex(model, rosterMaxes)` returns the weight-renormalized mean
+- [x] [AI] **C-5 RED**: assert `computeIndex(model, rosterMaxes)` returns the weight-renormalized mean
       over present benchmarks, and `coverage(model)` returns summed present weight ÷ 100, for a
       fixture with exactly two of four benchmarks
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
@@ -886,9 +889,9 @@ rev-parse --show-toplevel` prints the worktree path
       And its coverage ratio equals the summed weight of those two benchmarks divided by one hundred
     ```
 
-- [ ] [AI] **C-6 GREEN**: implement `computeIndex` and `coverage`
+- [x] [AI] **C-6 GREEN**: implement `computeIndex` and `coverage`
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: passes
-- [ ] [AI] **C-7 RED**: assert a model with **zero** present benchmarks returns `coverage === 0` and
+- [x] [AI] **C-7 RED**: assert a model with **zero** present benchmarks returns `coverage === 0` and
       `index === undefined` (never `0`, never `NaN`)
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-8 "A model with no published benchmark score renders in the unrated group"_
@@ -901,21 +904,21 @@ rev-parse --show-toplevel` prints the worktree path
       And that model has no composite index
     ```
 
-- [ ] [AI] **C-8 GREEN**: handle the zero-coverage case explicitly
+- [x] [AI] **C-8 GREEN**: handle the zero-coverage case explicitly
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: passes
-- [ ] [AI] **C-9 RED**: assert `isLowCoverage(model)` is true below the 0.50 threshold and false at
+- [x] [AI] **C-9 RED**: assert `isLowCoverage(model)` is true below the 0.50 threshold and false at
       or above it, with the threshold exported as a named constant
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (underpins) → AC-12._
-- [ ] [AI] **C-10 GREEN**: implement `isLowCoverage` and export `LOW_COVERAGE_THRESHOLD`
+- [x] [AI] **C-10 GREEN**: implement `isLowCoverage` and export `LOW_COVERAGE_THRESHOLD`
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: passes
-- [ ] [AI] **C-11 REFACTOR**: extract the weight table lookup into one helper used by both
+- [x] [AI] **C-11 REFACTOR**: extract the weight table lookup into one helper used by both
       `computeIndex` and `coverage`, removing the duplicated summation
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: all tests still pass
 
 ### Band assignment (`<CORE>bands.ts`)
 
-- [ ] [AI] **B-1 RED**: create `<CORE>bands.unit.test.ts` asserting a fixture model whose index equals
+- [x] [AI] **B-1 RED**: create `<CORE>bands.unit.test.ts` asserting a fixture model whose index equals
       the opus anchor's index is assigned `"opus"`
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-4 "A model reaching the opus anchor renders in the opus band"_
@@ -927,9 +930,9 @@ rev-parse --show-toplevel` prints the worktree path
       Then that model belongs to the "opus" band
     ```
 
-- [ ] [AI] **B-2 GREEN**: implement `assignBand` in `<CORE>bands.ts` with the opus comparison
+- [x] [AI] **B-2 GREEN**: implement `assignBand` in `<CORE>bands.ts` with the opus comparison
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: passes
-- [ ] [AI] **B-3 RED**: assert a fixture model between the anchors is assigned `"sonnet"`
+- [x] [AI] **B-3 RED**: assert a fixture model between the anchors is assigned `"sonnet"`
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-5 "A model between the two anchors renders in the sonnet band"_
 
@@ -941,9 +944,9 @@ rev-parse --show-toplevel` prints the worktree path
       Then that model belongs to the "sonnet" band
     ```
 
-- [ ] [AI] **B-4 GREEN**: add the sonnet comparison
+- [x] [AI] **B-4 GREEN**: add the sonnet comparison
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: passes
-- [ ] [AI] **B-5 RED**: assert a fixture model below the sonnet anchor is assigned `"light"`
+- [x] [AI] **B-5 RED**: assert a fixture model below the sonnet anchor is assigned `"light"`
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-6 "A model below the sonnet anchor renders in the light band"_
 
@@ -954,9 +957,9 @@ rev-parse --show-toplevel` prints the worktree path
       Then that model belongs to the "light" band
     ```
 
-- [ ] [AI] **B-6 GREEN**: add the light fallthrough
+- [x] [AI] **B-6 GREEN**: add the light fallthrough
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: passes
-- [ ] [AI] **B-7 RED**: assert **anchor pinning** — with a deliberately perverse fixture in which the
+- [x] [AI] **B-7 RED**: assert **anchor pinning** — with a deliberately perverse fixture in which the
       opus anchor's own index falls below the sonnet anchor's, both anchors still resolve to their
       own bands — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-7 "Each anchor model occupies the band it defines"_
@@ -969,9 +972,9 @@ rev-parse --show-toplevel` prints the worktree path
       And the sonnet anchor belongs to the "sonnet" band
     ```
 
-- [ ] [AI] **B-8 GREEN**: short-circuit `assignBand` on the two anchor ids before any comparison
+- [x] [AI] **B-8 GREEN**: short-circuit `assignBand` on the two anchor ids before any comparison
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: passes
-- [ ] [AI] **B-9 RED**: assert **totality** over the real dataset — every model resolves to exactly
+- [x] [AI] **B-9 RED**: assert **totality** over the real dataset — every model resolves to exactly
       one of `opus` / `sonnet` / `light` / `unrated`, with no duplicates and no omissions
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-9 "Every roster model belongs to exactly one capability group"_
@@ -983,9 +986,9 @@ rev-parse --show-toplevel` prints the worktree path
       Then each model appears in exactly one of "opus", "sonnet", "light", or "unrated"
     ```
 
-- [ ] [AI] **B-10 GREEN**: implement `groupByBand(dataset)` returning the four disjoint groups
+- [x] [AI] **B-10 GREEN**: implement `groupByBand(dataset)` returning the four disjoint groups
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: passes
-- [ ] [AI] **B-11 RED**: assert `groupByBand` orders models **identically within a band** whichever
+- [x] [AI] **B-11 RED**: assert `groupByBand` orders models **identically within a band** whichever
       chart consumes it — i.e. it returns one canonical ordered list per band, sorted by descending
       index then by id — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-11 "Models are ordered identically in both charts within a band"_
@@ -997,9 +1000,9 @@ rev-parse --show-toplevel` prints the worktree path
       Then each band lists its models in the same order in the capability chart and the price chart
     ```
 
-- [ ] [AI] **B-12 GREEN**: make the ordering canonical and stable
+- [x] [AI] **B-12 GREEN**: make the ordering canonical and stable
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: passes
-- [ ] [AI] **B-13 REFACTOR**: move the anchor ids and threshold derivation into one exported
+- [x] [AI] **B-13 REFACTOR**: move the anchor ids and threshold derivation into one exported
       `anchors(dataset)` helper so no caller re-derives them
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: all tests still pass
 
@@ -1010,7 +1013,7 @@ rev-parse --show-toplevel` prints the worktree path
 > waiting for the route Phase 5 builds. `<USTEPS>ai-benchmark.steps.tsx` is created here at `Z-1` and
 > extended by Phase 5's `W-1a` for the rendering-dependent scenarios.
 
-- [ ] [AI] **Z-1 RED**: create `<USTEPS>ai-benchmark.steps.tsx` binding AC-4, loading
+- [x] [AI] **Z-1 RED**: create `<USTEPS>ai-benchmark.steps.tsx` binding AC-4, loading
       `<SPECS>ai-benchmark.feature` and calling `assignBand` from `<CORE>bands.ts` against a fixture
       dataset (no page render — this scenario is pure-logic)
       — command: `npx nx run ayokoding-www:test:unit`
@@ -1025,9 +1028,9 @@ rev-parse --show-toplevel` prints the worktree path
       Then that model belongs to the "opus" band
     ```
 
-- [ ] [AI] **Z-2 GREEN**: wire `assignBand`'s opus comparison into the AC-4 step definition
+- [x] [AI] **Z-2 GREEN**: wire `assignBand`'s opus comparison into the AC-4 step definition
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: AC-4 passes
-- [ ] [AI] **Z-3 RED**: extend `<USTEPS>ai-benchmark.steps.tsx` binding AC-5
+- [x] [AI] **Z-3 RED**: extend `<USTEPS>ai-benchmark.steps.tsx` binding AC-5
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-5 "A model between the two anchors renders in the sonnet band" — same
     scenario as B-3 above, now bound at the vitest-cucumber layer._
@@ -1040,9 +1043,9 @@ rev-parse --show-toplevel` prints the worktree path
       Then that model belongs to the "sonnet" band
     ```
 
-- [ ] [AI] **Z-4 GREEN**: wire `assignBand`'s sonnet comparison into the AC-5 step definition
+- [x] [AI] **Z-4 GREEN**: wire `assignBand`'s sonnet comparison into the AC-5 step definition
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: AC-5 passes
-- [ ] [AI] **Z-5 RED**: extend `<USTEPS>ai-benchmark.steps.tsx` binding AC-6
+- [x] [AI] **Z-5 RED**: extend `<USTEPS>ai-benchmark.steps.tsx` binding AC-6
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-6 "A model below the sonnet anchor renders in the light band" — same
     scenario as B-5 above, now bound at the vitest-cucumber layer._
@@ -1054,9 +1057,9 @@ rev-parse --show-toplevel` prints the worktree path
       Then that model belongs to the "light" band
     ```
 
-- [ ] [AI] **Z-6 GREEN**: wire `assignBand`'s light fallthrough into the AC-6 step definition
+- [x] [AI] **Z-6 GREEN**: wire `assignBand`'s light fallthrough into the AC-6 step definition
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: AC-6 passes
-- [ ] [AI] **Z-7 RED**: extend `<USTEPS>ai-benchmark.steps.tsx` binding AC-7
+- [x] [AI] **Z-7 RED**: extend `<USTEPS>ai-benchmark.steps.tsx` binding AC-7
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-7 "Each anchor model occupies the band it defines" — same scenario as
     B-7 above, now bound at the vitest-cucumber layer._
@@ -1069,9 +1072,9 @@ rev-parse --show-toplevel` prints the worktree path
       And the sonnet anchor belongs to the "sonnet" band
     ```
 
-- [ ] [AI] **Z-8 GREEN**: wire the anchor-pinning short-circuit into the AC-7 step definition
+- [x] [AI] **Z-8 GREEN**: wire the anchor-pinning short-circuit into the AC-7 step definition
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: AC-7 passes
-- [ ] [AI] **Z-9 RED**: extend `<USTEPS>ai-benchmark.steps.tsx` binding AC-8
+- [x] [AI] **Z-9 RED**: extend `<USTEPS>ai-benchmark.steps.tsx` binding AC-8
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-8 "A model with no published benchmark score renders in the unrated
     group" — same scenario as C-7 above, now bound at the vitest-cucumber layer._
@@ -1084,9 +1087,9 @@ rev-parse --show-toplevel` prints the worktree path
       And that model has no composite index
     ```
 
-- [ ] [AI] **Z-10 GREEN**: wire the zero-coverage case from `<CORE>score.ts` into the AC-8 step
+- [x] [AI] **Z-10 GREEN**: wire the zero-coverage case from `<CORE>score.ts` into the AC-8 step
       definition — command: `npx nx run ayokoding-www:test:unit` — acceptance: AC-8 passes
-- [ ] [AI] **Z-11 RED**: extend `<USTEPS>ai-benchmark.steps.tsx` binding AC-9
+- [x] [AI] **Z-11 RED**: extend `<USTEPS>ai-benchmark.steps.tsx` binding AC-9
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-9 "Every roster model belongs to exactly one capability group" — same
     scenario as B-9 above, now bound at the vitest-cucumber layer._
@@ -1098,9 +1101,9 @@ rev-parse --show-toplevel` prints the worktree path
       Then each model appears in exactly one of "opus", "sonnet", "light", or "unrated"
     ```
 
-- [ ] [AI] **Z-12 GREEN**: wire `groupByBand(dataset)` over the full roster into the AC-9 step
+- [x] [AI] **Z-12 GREEN**: wire `groupByBand(dataset)` over the full roster into the AC-9 step
       definition — command: `npx nx run ayokoding-www:test:unit` — acceptance: AC-9 passes
-- [ ] [AI] **Z-13 RED**: extend `<USTEPS>ai-benchmark.steps.tsx` binding AC-10
+- [x] [AI] **Z-13 RED**: extend `<USTEPS>ai-benchmark.steps.tsx` binding AC-10
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-10 "A model missing a benchmark is scored over the benchmarks it has" —
     same scenario as C-5 above, now bound at the vitest-cucumber layer._
@@ -1113,9 +1116,9 @@ rev-parse --show-toplevel` prints the worktree path
       And its coverage ratio equals the summed weight of those two benchmarks divided by one hundred
     ```
 
-- [ ] [AI] **Z-14 GREEN**: wire `computeIndex`/`coverage` from `<CORE>score.ts` into the AC-10 step
+- [x] [AI] **Z-14 GREEN**: wire `computeIndex`/`coverage` from `<CORE>score.ts` into the AC-10 step
       definition — command: `npx nx run ayokoding-www:test:unit` — acceptance: AC-10 passes
-- [ ] [AI] **Z-15 RED**: extend `<USTEPS>ai-benchmark.steps.tsx` binding AC-11
+- [x] [AI] **Z-15 RED**: extend `<USTEPS>ai-benchmark.steps.tsx` binding AC-11
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-11 "Models are ordered identically in both charts within a band" — same
     scenario as B-11 above, now bound at the vitest-cucumber layer._
@@ -1127,16 +1130,16 @@ rev-parse --show-toplevel` prints the worktree path
       Then each band lists its models in the same order in the capability chart and the price chart
     ```
 
-- [ ] [AI] **Z-16 GREEN**: wire `groupByBand`'s canonical per-band ordering into the AC-11 step
+- [x] [AI] **Z-16 GREEN**: wire `groupByBand`'s canonical per-band ordering into the AC-11 step
       definition — command: `npx nx run ayokoding-www:test:unit` — acceptance: AC-11 passes
-- [ ] [AI] **Z-17 REFACTOR**: extract the fixture-dataset builder shared by Z-1…Z-16 into one helper
+- [x] [AI] **Z-17 REFACTOR**: extract the fixture-dataset builder shared by Z-1…Z-16 into one helper
       in `<USTEPS>ai-benchmark.steps.tsx`, so each step definition stays a thin call into the
       already-tested `<CORE>` functions — command: `npx nx run ayokoding-www:test:unit`
       — acceptance: all tests still pass
 
 ### Harness price selection (`<CORE>price.ts`)
 
-- [ ] [AI] **P-1 RED**: create `<CORE>price.unit.test.ts` asserting `lowestRate(model)` returns the
+- [x] [AI] **P-1 RED**: create `<CORE>price.unit.test.ts` asserting `lowestRate(model)` returns the
       cheaper of two harness rate sets when no harness filter is applied
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-17 "An unfiltered price chart shows the lowest harness rate"_
@@ -1149,15 +1152,15 @@ rev-parse --show-toplevel` prints the worktree path
       And the chart states that it shows the lowest available harness rate
     ```
 
-- [ ] [AI] **P-2 GREEN**: implement `lowestRate` in `<CORE>price.ts`, comparing on input rate then
+- [x] [AI] **P-2 GREEN**: implement `lowestRate` in `<CORE>price.ts`, comparing on input rate then
       output rate — command: `npx nx run ayokoding-www:test:unit` — acceptance: passes
-- [ ] [AI] **P-3 RED**: assert `rateFor(model, harnessId)` returns that harness's rate set and
+- [x] [AI] **P-3 RED**: assert `rateFor(model, harnessId)` returns that harness's rate set and
       `undefined` when the model is not exposed by that harness
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (underpins) → AC-18._
-- [ ] [AI] **P-4 GREEN**: implement `rateFor`
+- [x] [AI] **P-4 GREEN**: implement `rateFor`
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: passes
-- [ ] [AI] **P-5 RED**: assert a subscription-only model returns `{ kind: "subscription" }` from both
+- [x] [AI] **P-5 RED**: assert a subscription-only model returns `{ kind: "subscription" }` from both
       selectors and **never** a numeric zero
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-16 "A subscription-only model renders in the subscription group"_
@@ -1170,15 +1173,15 @@ rev-parse --show-toplevel` prints the worktree path
       But that model renders no per-token bar and no zero value
     ```
 
-- [ ] [AI] **P-6 GREEN**: handle the subscription discriminant explicitly in both selectors
+- [x] [AI] **P-6 GREEN**: handle the subscription discriminant explicitly in both selectors
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: passes
-- [ ] [AI] **P-7 REFACTOR**: collapse `lowestRate` and `rateFor` onto one internal
+- [x] [AI] **P-7 REFACTOR**: collapse `lowestRate` and `rateFor` onto one internal
       `selectRateSet(model, harnessId?)` — command: `npx nx run ayokoding-www:test:unit`
       — acceptance: all tests still pass
 
 ### Filtering (`<CORE>filter.ts`) and URL state (`<CORE>url-state.ts`)
 
-- [ ] [AI] **F-1 RED**: create `<CORE>filter.unit.test.ts` asserting `filterModels(dataset, state)`
+- [x] [AI] **F-1 RED**: create `<CORE>filter.unit.test.ts` asserting `filterModels(dataset, state)`
       narrows by harness, narrows by class, and intersects both
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (binds) → AC-25 "Harness and class parameters intersect"_
@@ -1190,9 +1193,9 @@ rev-parse --show-toplevel` prints the worktree path
       Then only models satisfying both filters are shown
     ```
 
-- [ ] [AI] **F-2 GREEN**: implement `filterModels` — command: `npx nx run ayokoding-www:test:unit`
+- [x] [AI] **F-2 GREEN**: implement `filterModels` — command: `npx nx run ayokoding-www:test:unit`
       — acceptance: passes
-- [ ] [AI] **F-3 RED**: create `<CORE>url-state.unit.test.ts` asserting `decodeState` returns the
+- [x] [AI] **F-3 RED**: create `<CORE>url-state.unit.test.ts` asserting `decodeState` returns the
       default unfiltered state for an empty query string, and `encodeState` **omits** defaults from
       the query string — mirroring the calculator's proven contract
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
@@ -1205,9 +1208,9 @@ rev-parse --show-toplevel` prints the worktree path
       Then every roster model is shown in the data table
     ```
 
-- [ ] [AI] **F-4 GREEN**: implement `PARAM_KEYS`, `DEFAULT_STATE`, `decodeState`, `encodeState` in
+- [x] [AI] **F-4 GREEN**: implement `PARAM_KEYS`, `DEFAULT_STATE`, `decodeState`, `encodeState` in
       `<CORE>url-state.ts` — command: `npx nx run ayokoding-www:test:unit` — acceptance: passes
-- [ ] [AI] **F-5 RED**: assert an unknown harness value and an unknown class value each sanitize to
+- [x] [AI] **F-5 RED**: assert an unknown harness value and an unknown class value each sanitize to
       the default rather than throwing — command: `npx nx run ayokoding-www:test:unit`
       — acceptance: fails
   - _Gherkin (binds) → AC-26 "An unrecognized filter value falls back to the unfiltered view"_
@@ -1220,32 +1223,43 @@ rev-parse --show-toplevel` prints the worktree path
       But no error is surfaced to the reader
     ```
 
-- [ ] [AI] **F-6 GREEN**: sanitize both params against their known-value unions
+- [x] [AI] **F-6 GREEN**: sanitize both params against their known-value unions
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: passes
-- [ ] [AI] **F-7 RED**: assert `encodeState(decodeState(q))` round-trips for every valid query string
+- [x] [AI] **F-7 RED**: assert `encodeState(decodeState(q))` round-trips for every valid query string
       in a table-driven fixture — command: `npx nx run ayokoding-www:test:unit` — acceptance: fails
   - _Gherkin (underpins) → AC-27._
-- [ ] [AI] **F-8 GREEN**: make the round-trip hold
+- [x] [AI] **F-8 GREEN**: make the round-trip hold
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: passes
-- [ ] [AI] **F-9 REFACTOR**: extract the known-value unions into shared constants imported by both
+- [x] [AI] **F-9 REFACTOR**: extract the known-value unions into shared constants imported by both
       `filter.ts` and `url-state.ts`, so a new harness id is added in exactly one place
       — command: `npx nx run ayokoding-www:test:unit` — acceptance: all tests still pass
+
+> **Phase 4 implementation evidence (2026-07-28)**: all step boxes above ticked. Single cohesive TDD pass by swe-typescript-dev. - **Date**: 2026-07-28
+
+- **Status**: done
+- **Files**: `core/score.ts`, `core/bands.ts`, `core/price.ts`, `core/filter.ts`, `core/url-state.ts` (+ `.unit.test.ts` each), `test/unit/fe-steps/ai-benchmark.steps.tsx`, `specs/.../tools/ai-benchmark.feature`
+- **Notes**: implemented per the TDD step (RED/GREEN/REFACTOR). 386 core tests pass; specs:behavior:coverage valid (AC-4..AC-11 bound); Opus5→opus, Sonnet5→sonnet (pinned), Cursor Composer 2.5→unrated; groups opus2/sonnet11/light7/unrated18.
 
 ### Phase 4 Gate
 
 > All checks below must pass before starting Phase 5. This is a **boundary** phase.
 
-- [ ] [AI] `npx nx run ayokoding-www:test:unit` exits 0
-- [ ] [AI] `npx nx run ayokoding-www:specs:behavior:coverage` exits 0 — AC-4 through AC-11 (the only
-      scenarios currently in `<SPECS>ai-benchmark.feature`) each have a `@covers`-annotated step
-- [ ] [AI] Every module under `<CORE>` is free of React and router imports — acceptance:
-      `grep -rn "from \"react\"\|next/navigation\|next/router" <CORE>` prints nothing
-- [ ] [AI] `npx nx run ayokoding-www:test:coverage` meets the project's configured threshold
-- [ ] [AI] `npx nx affected -t typecheck lint` exits 0
-- [ ] [AI] Run the [Delivery-Boundary Integration Protocol](#delivery-boundary-integration-protocol)
+- [x] [AI] `npx nx run ayokoding-www:test:unit` exits 0
+  - **Date**: 2026-07-28 — **Status**: done — **Notes**: passed — 136 files / 2891 tests (cached; min-role timeout fix stable).
+- [x] [AI] `npx nx run ayokoding-www:specs:behavior:coverage` exits 0 — AC-4 through AC-11 (the only
+  - **Date**: 2026-07-28 — **Status**: done — **Notes**: passed — 42 specs, 299 scenarios, 1070 steps all covered; AC-4..AC-11 bound.
+    scenarios currently in `<SPECS>ai-benchmark.feature`) each have a `@covers`-annotated step
+- [x] [AI] Every module under `<CORE>` is free of React and router imports — acceptance:
+  - **Date**: 2026-07-28 — **Status**: done — **Notes**: passed — grep for react/next-navigation/next-router in core/ prints nothing.
+    `grep -rn "from \"react\"\|next/navigation\|next/router" <CORE>` prints nothing
+- [x] [AI] `npx nx run ayokoding-www:test:coverage` meets the project's configured threshold
+  - **Date**: 2026-07-28 — **Status**: done — **Notes**: passed — 88.26% lines (threshold 82).
+- [x] [AI] `npx nx affected -t typecheck lint` exits 0
+  - **Date**: 2026-07-28 — **Status**: done — **Notes**: passed — 56/56 tasks.
+- [x] [AI] Run the [Delivery-Boundary Integration Protocol](#delivery-boundary-integration-protocol)
       for branch `ayokoding-www-tools-ai-benchmark/phase-4-core` in worktree
       `worktrees/ayokoding-www-tools-ai-benchmark-phase-4-core/`
-- [ ] [AI] Run [Post-Push CI Verification](#post-push-ci-verification)
+- [x] [AI] Run [Post-Push CI Verification](#post-push-ci-verification)
 
 > **Pause Safety**: the whole computation layer is implemented and unit-tested with no UI consuming
 > it; no route exists and no rendered surface changed. Safe to stop. To resume:

--- a/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/README.md
+++ b/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/README.md
@@ -6,6 +6,8 @@ Interactive calculator tools at `/[locale]/tools/`.
 
 - [cost-of-living-calculator.feature](./cost-of-living-calculator.feature) — Cost of living, savings,
   and minimum software-engineering role calculator at `/[locale]/tools/cost-of-living-calculator`.
+- [ai-benchmark.feature](./ai-benchmark.feature) — AI model benchmark tool (capability bands,
+  composite index, harness price chart) at `/[locale]/tools/ai-benchmark`.
 
 ## Bounded context
 

--- a/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature
+++ b/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature
@@ -1,0 +1,64 @@
+Feature: AI model benchmark tool
+
+  Background:
+    Given the AI benchmark dataset is loaded
+
+  # AC-4
+  @unit
+  Scenario: A model reaching the opus anchor renders in the opus band
+    Given a fixture model whose composite index equals the opus anchor index
+    When the capability groups are computed
+    Then that model belongs to the "opus" band
+
+  # AC-5
+  @unit
+  Scenario: A model between the two anchors renders in the sonnet band
+    Given a fixture model whose composite index is above the sonnet anchor index
+    And that model's composite index is below the opus anchor index
+    When the capability groups are computed
+    Then that model belongs to the "sonnet" band
+
+  # AC-6
+  @unit
+  Scenario: A model below the sonnet anchor renders in the light band
+    Given a fixture model whose composite index is below the sonnet anchor index
+    When the capability groups are computed
+    Then that model belongs to the "light" band
+
+  # AC-7
+  @unit
+  Scenario: Each anchor model occupies the band it defines
+    Given the two anchor models are present in the roster
+    When the capability groups are computed
+    Then the opus anchor belongs to the "opus" band
+    And the sonnet anchor belongs to the "sonnet" band
+
+  # AC-8
+  @unit
+  Scenario: A model with no published benchmark score renders in the unrated group
+    Given a fixture model with no score on any composite benchmark
+    When the capability groups are computed
+    Then that model belongs to the "unrated" group
+    And that model has no composite index
+
+  # AC-9
+  @unit
+  Scenario: Every roster model belongs to exactly one capability group
+    Given the full roster is loaded
+    When the capability groups are computed
+    Then each model appears in exactly one of "opus", "sonnet", "light", or "unrated"
+
+  # AC-10
+  @unit
+  Scenario: A model missing a benchmark is scored over the benchmarks it has
+    Given a fixture model with a score on two of the four composite benchmarks
+    When its composite index is computed
+    Then the index equals the weight-renormalized mean of those two normalized scores
+    And its coverage ratio equals the summed weight of those two benchmarks divided by one hundred
+
+  # AC-11
+  @unit
+  Scenario: Models are ordered identically in both charts within a band
+    Given the full roster is loaded
+    When both charts are rendered
+    Then each band lists its models in the same order in the capability chart and the price chart


### PR DESCRIPTION
Phase 4 of [ayokoding-www-tools-ai-benchmark](../blob/main/plans/in-progress/ayokoding-www-tools-ai-benchmark/README.md).

## Scope — five pure modules under `core/` (no React, no router, no side effects)
- `score.ts` — rosterMax, rel (roster-relative normalization), computeIndex (coverage-renormalized composite), coverage, isLowCoverage (LOW_COVERAGE_THRESHOLD 0.50)
- `bands.ts` — anchor-pinned opus/sonnet/light/unrated assignment + groupByBand (canonical per-band ordering)
- `price.ts` — per-harness rate selection (lowestRate, rateFor), subscription discriminant
- `filter.ts` — harness ∩ class intersection
- `url-state.ts` — pure encode/decode/sanitize (defaults omitted from query string)
- Plus `ai-benchmark.feature` (AC-4..AC-11) + vitest-cucumber step bindings.

## Verification
- 386 core tests pass; `test:unit` green (136 files/2891 tests); coverage 88.26% (threshold 82).
- `specs:behavior:coverage` valid (42 specs, 299 scenarios, 1070 steps); structure-validation clean.
- Sanity: Opus5→opus (idx 99.48, pinned), Sonnet5→sonnet (idx 84.80, pinned), Cursor Composer 2.5→unrated (no composite figures), gpt-5.6-sol→opus@100 (roster max on both its benchmarks). Groups: opus2/sonnet11/light7/unrated18 = 38.
- Conflicted figures use LOW value; version trap excludes TB-2.0/Multilingual; zero-coverage → index undefined → unrated.