### PR TITLE
fix(ayokoding-www): contain ai-benchmark table horizontal overflow at lg

### DIFF
--- a/apps/ayokoding-www-fe-e2e/playwright.config.ts
+++ b/apps/ayokoding-www-fe-e2e/playwright.config.ts
@@ -53,6 +53,14 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
+  // Default (30s) is too tight for the handful of scenarios that fan out several
+  // `page.request.get()` calls (with `getResilient`'s single-retry, and per-request timeouts up
+  // to 30s) against the single local production server instance under full-suite parallel load —
+  // see `src/support/resilient-request.ts`. It also has to accommodate the `expect.poll` calls in
+  // `cost-of-living-calculator.steps.ts` (up to 60s each) that wait out a lagging React re-render
+  // under the same contention. 150s gives that combined class of scenario room to retry without
+  // hitting the test's own deadline first.
+  timeout: 150000,
   reporter: [["list"], ["html"], ["junit", { outputFile: "test-results/junit.xml" }]],
   use: {
     baseURL: process.env.BASE_URL || "http://localhost:3101",

--- a/apps/ayokoding-www-fe-e2e/src/steps/ai-benchmark.steps.ts
+++ b/apps/ayokoding-www-fe-e2e/src/steps/ai-benchmark.steps.ts
@@ -1,5 +1,6 @@
 import { createBdd } from "playwright-bdd";
 import { expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 const { Given, When, Then } = createBdd();
 
@@ -320,4 +321,34 @@ Then("every rated band's bar fill meets the WCAG non-text contrast ratio against
       `--chart-band-${band} vs --color-background contrast ratio`,
     ).toBeGreaterThanOrEqual(WCAG_NON_TEXT_MIN_CONTRAST);
   }
+});
+
+// ── Horizontal overflow regression (AC-52 / R5) ───────────────────────────────
+
+// Shared by every viewport-and-locale-parametrized scenario outline against this page (AC-52 here;
+// the later AC-49/AC-50/AC-58 outlines reuse it instead of re-implementing navigation).
+async function navigateAtViewport(page: Page, width: number, locale: string): Promise<void> {
+  await page.setViewportSize({ width, height: 800 });
+  await page.goto(`/${locale}/tools/ai-benchmark`);
+  await page.waitForLoadState("networkidle");
+}
+
+let overflowScrollWidth = 0;
+let overflowClientWidth = 0;
+
+// @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature:The document never scrolls horizontally
+Given(
+  "the AI benchmark page is loaded at a {string} px viewport in the {string} locale",
+  async ({ page }, width: string, locale: string) => {
+    await navigateAtViewport(page, Number(width), locale);
+  },
+);
+
+When("the document's scroll width is compared with its client width", async ({ page }) => {
+  overflowScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+  overflowClientWidth = await page.evaluate(() => document.documentElement.clientWidth);
+});
+
+Then("the document scroll width does not exceed the document client width", async ({}) => {
+  expect(overflowScrollWidth).toBeLessThanOrEqual(overflowClientWidth);
 });

--- a/apps/ayokoding-www-fe-e2e/src/steps/content-namespace.steps.ts
+++ b/apps/ayokoding-www-fe-e2e/src/steps/content-namespace.steps.ts
@@ -1,5 +1,6 @@
 import { createBdd } from "playwright-bdd";
 import { expect } from "@playwright/test";
+import { getResilient } from "../support/resilient-request";
 
 const { When, Then } = createBdd();
 
@@ -11,7 +12,7 @@ When("a raw HTTP GET is made to {string} with redirects disabled", async ({ page
   // Stash the raw response on the page object via evaluate so the Then step
   // can inspect it. We use page.request (the APIRequestContext bound to this
   // browser context) with maxRedirects: 0 so the 308 is captured as-is.
-  const response = await page.request.get(url, { maxRedirects: 0 });
+  const response = await getResilient(page, url, { maxRedirects: 0 });
   // Store status + location in page title attribute via a temp state variable.
   // playwright-bdd shares fixture state across steps in the same scenario,
   // so we piggy-back on page.evaluate to stash in window.__redirectCapture.

--- a/apps/ayokoding-www-fe-e2e/src/steps/cost-of-living-calculator.steps.ts
+++ b/apps/ayokoding-www-fe-e2e/src/steps/cost-of-living-calculator.steps.ts
@@ -894,14 +894,21 @@ When("I view the minimum role result", async ({ page }) => {
 });
 
 Then("the baseline savings bar equals that role's essential savings in Jakarta", async ({ page }) => {
-  const marker = page.locator("[data-testid='minimum-marker']");
-  await expect(marker).toBeVisible();
+  // Several cities can legitimately tie for the lowest qualifying rank (see min-role.tsx's
+  // `isMinEntry` — every tied entry is marked), so this can resolve to more than one element;
+  // `.first()` avoids a strict-mode violation on ties. The controlled reference-role/city
+  // selects commit through a URL round-trip before the ladder re-renders (same class as the
+  // household-composition race elsewhere in this file), so a generous timeout tolerates that
+  // round-trip under full-suite parallel load instead of sampling the DOM once.
+  const marker = page.locator("[data-testid='minimum-marker']").first();
+  await expect(marker).toBeVisible({ timeout: 15000 });
 });
 
 // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/cost-of-living-calculator.feature:Minimum role from a reference city and role
 Then("the marked minimum role reaches at least that essential savings in absolute terms", async ({ page }) => {
-  const marker = page.locator("[data-testid='minimum-marker']");
-  await expect(marker).toBeVisible();
+  // See the comment above — ties are valid, `.first()` avoids a strict-mode violation.
+  const marker = page.locator("[data-testid='minimum-marker']").first();
+  await expect(marker).toBeVisible({ timeout: 15000 });
 });
 
 // ── My salary baseline ────────────────────────────────────────────────────────
@@ -985,9 +992,15 @@ Then(
   async ({ page }, _role: string) => {
     const divider = page.locator("[data-testid='qualifying-divider']");
     const noQual = page.locator("[data-testid='no-qualifier-message']");
-    const hasDivider = await divider.isVisible().catch(() => false);
-    const hasNoQual = await noQual.isVisible().catch(() => false);
-    expect(hasDivider || hasNoQual).toBe(true);
+    // `waitForLoadState("networkidle")` in the preceding step settles network requests, but the
+    // React re-render this triggers can still lag behind under full-suite parallel load — a bare
+    // `.isVisible()` sampled the DOM once and flaked. `expect.poll` retries the predicate until
+    // one of the two elements actually renders, matching Playwright's normal auto-wait behavior.
+    await expect
+      .poll(async () => (await divider.isVisible()) || (await noQual.isVisible()), {
+        timeout: 60000,
+      })
+      .toBe(true);
   },
 );
 
@@ -996,15 +1009,20 @@ Then("a more senior role becomes the marked minimum", async ({ page }) => {
   // The minimum-role marker can render on more than one row when several cities tie at the same
   // minimum-qualifying role rank (see min-role.tsx's RoleRow `isMin` prop — this is correct,
   // expected product behaviour, not a bug). `.isVisible()` on a locator that resolves to more
-  // than one element throws a strict-mode-violation error; the `.catch(() => false)` below was
-  // silently swallowing that error, making `hasMarker` always false whenever more than one role
-  // tied for the minimum — i.e. this assertion could fail regardless of the real DOM state.
-  // `.first()` narrows to Playwright's single-element strict-mode requirement.
+  // than one element throws a strict-mode-violation error; `.first()` narrows to Playwright's
+  // single-element strict-mode requirement. A bare single-sample `.isVisible()` also flaked under
+  // full-suite parallel load (shared-machine contention — same root cause the Phase 0 baseline
+  // fixed elsewhere in this file): the household-composition re-render can lag behind the
+  // preceding step's `networkidle` wait, so neither element is visible yet on the first sample.
+  // `expect.poll` retries the predicate until the re-render catches up, matching the fix already
+  // applied to the sibling assertion above.
   const marker = page.locator("[data-testid='minimum-marker']").first();
   const noQual = page.locator("[data-testid='no-qualifier-message']");
-  const hasMarker = await marker.isVisible().catch(() => false);
-  const hasNoQual = await noQual.isVisible().catch(() => false);
-  expect(hasMarker || hasNoQual).toBe(true);
+  await expect
+    .poll(async () => (await marker.isVisible().catch(() => false)) || (await noQual.isVisible().catch(() => false)), {
+      timeout: 60000,
+    })
+    .toBe(true);
 });
 
 // ── No role can reach the bar ─────────────────────────────────────────────────

--- a/apps/ayokoding-www-fe-e2e/src/steps/course-rehome-redirects.steps.ts
+++ b/apps/ayokoding-www-fe-e2e/src/steps/course-rehome-redirects.steps.ts
@@ -1,5 +1,6 @@
 import { createBdd } from "playwright-bdd";
 import { expect } from "@playwright/test";
+import { getResilient } from "../support/resilient-request";
 
 const { Then } = createBdd();
 
@@ -22,7 +23,10 @@ Then(
 
     await Promise.all(
       [...hrefs].map(async (href) => {
-        const response = await page.request.get(href, { timeout: 10000 });
+        // See `getResilient` — retries once on a load-induced ECONNRESET; the 30s timeout
+        // (vs. the 10s default) additionally tolerates slow-but-successful responses under
+        // full-suite contention. A genuine 404/drained route still fails on the retry.
+        const response = await getResilient(page, href, { timeout: 30000 });
         expect(response.status(), `Course catalog entry ${href} should not be a drained/missing location`).not.toBe(
           404,
         );

--- a/apps/ayokoding-www-fe-e2e/src/steps/ia-navigation-revamp.steps.ts
+++ b/apps/ayokoding-www-fe-e2e/src/steps/ia-navigation-revamp.steps.ts
@@ -1,5 +1,6 @@
 import { createBdd } from "playwright-bdd";
 import { expect } from "@playwright/test";
+import { getResilient } from "../support/resilient-request";
 
 const { Given, When, Then } = createBdd();
 
@@ -72,9 +73,12 @@ Then("every content link resolves directly to its bare URL with status 200", asy
   }
   expect(hrefs.length).toBeGreaterThan(0);
 
+  // See `getResilient` — retries once on a load-induced ECONNRESET; 30s (vs. the 10s
+  // default) additionally tolerates slow-but-successful responses under full-suite
+  // parallel contention on the single local server instance.
   await Promise.all(
     hrefs.map(async (href) => {
-      const response = await page.request.get(href, { maxRedirects: 0, timeout: 10000 });
+      const response = await getResilient(page, href, { maxRedirects: 0, timeout: 30000 });
       expect(response.status(), `${href} should resolve directly, not 404`).not.toBe(404);
     }),
   );
@@ -95,9 +99,12 @@ Then("no internal content link resolves through a 308 redirect", async ({ page }
     hrefs.push(href);
   }
 
+  // See `getResilient` — retries once on a load-induced ECONNRESET; 30s (vs. the 10s
+  // default) additionally tolerates slow-but-successful responses under full-suite
+  // parallel contention on the single local server instance.
   await Promise.all(
     hrefs.map(async (href) => {
-      const response = await page.request.get(href, { maxRedirects: 0, timeout: 10000 });
+      const response = await getResilient(page, href, { maxRedirects: 0, timeout: 30000 });
       expect(response.status(), `Link ${href} should not be a 308 redirect`).not.toBe(308);
     }),
   );
@@ -158,7 +165,8 @@ Then(
 let feedBody = "";
 
 Given("the feed is generated from the content index", async ({ page }) => {
-  const response = await page.request.get("/feed.xml");
+  // See `getResilient` — retries once on a load-induced ECONNRESET.
+  const response = await getResilient(page, "/feed.xml");
   expect(response.status()).toBe(200);
   feedBody = await response.text();
 });

--- a/apps/ayokoding-www-fe-e2e/src/steps/learn-three-bucket.steps.ts
+++ b/apps/ayokoding-www-fe-e2e/src/steps/learn-three-bucket.steps.ts
@@ -1,5 +1,6 @@
 import { createBdd } from "playwright-bdd";
 import { expect } from "@playwright/test";
+import { getResilient } from "../support/resilient-request";
 
 const { Then } = createBdd();
 
@@ -11,6 +12,6 @@ Then("the response status should not be a client or server error", async ({ page
   // Re-fetch whatever URL the browser landed on after following every redirect hop, so this
   // check is independent of how many hops the prior "a visitor navigates to" step's own
   // page.goto() Response object already discarded.
-  const response = await page.request.get(page.url());
+  const response = await getResilient(page, page.url());
   expect(response.status(), `${page.url()} responded ${response.status()}`).toBeLessThan(400);
 });

--- a/apps/ayokoding-www-fe-e2e/src/support/resilient-request.ts
+++ b/apps/ayokoding-www-fe-e2e/src/support/resilient-request.ts
@@ -1,0 +1,25 @@
+import type { APIResponse, Page } from "@playwright/test";
+
+/**
+ * `page.request.get()` wrapped with a single retry.
+ *
+ * Full-suite parallel runs (`fullyParallel: true`, `workers: undefined` locally) open hundreds
+ * of concurrent connections against one local production server instance (`webServer` in
+ * `playwright.config.ts` boots a single `node server.js`). Under that contention the server
+ * occasionally drops a connection mid-handshake (`ECONNRESET`) even though the route itself is
+ * healthy and responds correctly moments later — this is connection-pool/OS-socket pressure, not
+ * an application defect. A genuine failure (a real 404/500, a route that is actually down) fails
+ * identically on the retry, so this never masks a real regression; it only absorbs transient
+ * connection-reset noise from the shared single-server topology.
+ */
+export async function getResilient(
+  page: Page,
+  url: string,
+  options?: Parameters<Page["request"]["get"]>[1],
+): Promise<APIResponse> {
+  try {
+    return await page.request.get(url, options);
+  } catch {
+    return await page.request.get(url, options);
+  }
+}

--- a/apps/ayokoding-www/src/features/ai-benchmark/shell/model-table.test.tsx
+++ b/apps/ayokoding-www/src/features/ai-benchmark/shell/model-table.test.tsx
@@ -107,25 +107,18 @@ describe("ModelTable — fullDataset keeps a harness-filtered model's full-roste
   });
 });
 
-// ─── Regression: the DWT-003 migration to the shared `Table` primitive silently disabled the
-// sticky table header at `lg`+ (pr-review-synthesis-maker HIGH finding, PR #122 cycle 1) — the
-// primitive's own wrapper hardcodes `overflow-x-auto` (forcing `overflow-y` to compute to `auto`
-// too, per MDN's `overflow-x` computed-value rule), making it a scroll container in BOTH axes at
-// every breakpoint. `position: sticky` on `<thead>` resolves against that ancestor and never
-// sticks unless `lg:overflow-visible` restores the bespoke table's original non-scrolling
-// behaviour at `lg`+. jsdom applies no CSS, so this only asserts the class NAME reaches the
-// wrapper div (not the `<table>` element, which the plain `className` prop reaches instead) — a
-// real assertion, since reverting the `wrapperClassName` prop wiring makes this fail.
-describe("ModelTable — sticky header wrapper override survives the DWT-003 shared-primitive migration", () => {
+// ─── Regression: R5 (tech-docs.md §DD-27) — the desktop table bled past the viewport and forced
+// the whole document to scroll horizontally, because the `lg`-breakpoint overflow override
+// restored a BOTH-axes scroll container. A unit-level re-guard for AC-52 (Phase 1 cycle 1.1's
+// e2e-tagged behaviour) against ever re-adding that override — no new behaviour scenario to bind.
+describe("ModelTable — R5 desktop horizontal overflow regression", () => {
   afterEach(() => {
     cleanup();
   });
 
-  it("passes lg:overflow-visible to the table-wrapper div, not the <table> element", () => {
+  it("never restores the lg-breakpoint overflow override on the table wrapper", () => {
     const { container } = render(<ModelTable dataset={dataset} fullDataset={dataset} locale="en" />);
     const wrapper = container.querySelector('[data-testid="model-table-desktop"] [data-slot="table-wrapper"]');
-    expect(wrapper?.className).toContain("lg:overflow-visible");
-    const table = container.querySelector('[data-testid="model-table-desktop"] table');
-    expect(table?.className).not.toContain("lg:overflow-visible");
+    expect(wrapper?.className).not.toContain("lg:overflow-visible");
   });
 });

--- a/apps/ayokoding-www/src/features/ai-benchmark/shell/model-table.test.tsx
+++ b/apps/ayokoding-www/src/features/ai-benchmark/shell/model-table.test.tsx
@@ -109,8 +109,10 @@ describe("ModelTable — fullDataset keeps a harness-filtered model's full-roste
 
 // ─── Regression: R5 (tech-docs.md §DD-27) — the desktop table bled past the viewport and forced
 // the whole document to scroll horizontally, because the `lg`-breakpoint overflow override
-// restored a BOTH-axes scroll container. A unit-level re-guard for AC-52 (Phase 1 cycle 1.1's
-// e2e-tagged behaviour) against ever re-adding that override — no new behaviour scenario to bind.
+// (`lg:overflow-visible`) cancelled the wrapper's scroll container at `lg`, leaving the table
+// uncontained. Removing it lets `overflow-x-auto` hold a BOTH-axes scroll container at every
+// breakpoint. A unit-level re-guard for AC-52 (Phase 1 cycle 1.1's e2e-tagged behaviour) against
+// ever re-adding that override — no new behaviour scenario to bind.
 describe("ModelTable — R5 desktop horizontal overflow regression", () => {
   afterEach(() => {
     cleanup();

--- a/apps/ayokoding-www/src/features/ai-benchmark/shell/model-table.tsx
+++ b/apps/ayokoding-www/src/features/ai-benchmark/shell/model-table.tsx
@@ -258,15 +258,15 @@ export function ModelTable({ dataset = defaultDataset, fullDataset, locale }: Mo
           `TableHead`/`TableCell`/`TableCaption` set `cost-of-living-calculator/shell/min-role.tsx`
           already uses, rather than a bespoke hand-rolled `<table>`. Sticky header/first-column and
           `scope="row"` are preserved via className overrides on top of the shared primitives; the
-          row-hover intensity is now the primitive's own `hover:bg-muted/50` (previously a bespoke,
-          inconsistent `hover:bg-muted/40`). `wrapperClassName="lg:overflow-visible"` restores the
-          bespoke table's original override (pr-review-synthesis-maker HIGH finding, PR #122 cycle
-          1): the primitive's wrapper hardcodes `overflow-x-auto`, which forces `overflow-y` to
-          compute to `auto` too, making it a scroll container in BOTH axes at every breakpoint —
-          `position: sticky` on `<thead>` resolves against that ancestor and never sticks during a
-          page scroll unless this override restores non-scrolling behaviour at `lg`+. ───────────── */}
+          row-hover intensity is the primitive's own `hover:bg-muted/50`. DD-27 (tech-docs.md) fixes
+          R5 — the table bleeding past the viewport and forcing the whole document to scroll
+          horizontally — in two steps: Unit 1 (here) removes the wrapper's `lg`-breakpoint overflow
+          override so `overflow-x-auto` contains the table at every breakpoint, at the cost of the
+          sticky `<thead>` no longer sticking at `lg` (a scroll container in both axes can't have a
+          sticky descendant). Unit 2 restores that override once the column-reduction work shrinks
+          the table below the `lg` viewport, making it safe again (AC-59). ─────────────────────── */}
       <div data-testid="model-table-desktop" className="hidden md:block">
-        <Table wrapperClassName="lg:overflow-visible" className="w-max min-w-full border-collapse lg:w-full">
+        <Table className="w-max min-w-full border-collapse lg:w-full">
           <TableCaption className="sr-only">{t(locale, "aiBenchTableCaption")}</TableCaption>
           <TableHeader className="sticky top-0 z-10 bg-background">
             <TableRow>

--- a/apps/ayokoding-www/test/unit/fe-steps/ai-benchmark.steps.tsx
+++ b/apps/ayokoding-www/test/unit/fe-steps/ai-benchmark.steps.tsx
@@ -2006,4 +2006,26 @@ describeFeature(feature, ({ Background, Scenario, ScenarioOutline, AfterEachScen
       expect(true).toBe(true);
     });
   });
+
+  // ─── AC-52 — the document never scrolls horizontally (R5) ─────────────────────
+  //
+  // jsdom has no real viewport or layout engine, so `document.documentElement.scrollWidth` vs
+  // `clientWidth` cannot be meaningfully compared — the REAL assertion runs at the e2e layer
+  // (`apps/ayokoding-www-fe-e2e/src/steps/ai-benchmark.steps.ts`). Same established
+  // `expect(true).toBe(true)` placeholder convention as the AC-38 binding above, so
+  // `specs:behavior:coverage` finds a `@covers` annotation for this scenario.
+  ScenarioOutline("The document never scrolls horizontally", ({ Given, When, Then }) => {
+    Given('the AI benchmark page is loaded at a "<width>" px viewport in the "<locale>" locale', () => {
+      expect(true).toBe(true);
+    });
+
+    When("the document's scroll width is compared with its client width", () => {
+      expect(true).toBe(true);
+    });
+
+    // @covers specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature:The document never scrolls horizontally
+    Then("the document scroll width does not exceed the document client width", () => {
+      expect(true).toBe(true);
+    });
+  });
 });

--- a/plans/in-progress/ayokoding-www-ai-benchmark-responsive-overhaul/delivery.md
+++ b/plans/in-progress/ayokoding-www-ai-benchmark-responsive-overhaul/delivery.md
@@ -466,12 +466,23 @@ minimum`, same root-cause class Phase 0 fixed elsewhere in this file) — fixed 
 
 ### Commit Guidelines — Phase 1
 
-- [ ] [AI] Commit thematically, Conventional Commits format:
+- [x] [AI] Commit thematically, Conventional Commits format:
       `fix(ayokoding-www): contain ai-benchmark table overflow at lg (R5)` for the source change and
       `test(ayokoding-www): add horizontal-overflow regression coverage` for the tests
       — acceptance: `git log --oneline -2` shows two conventional-format subjects
-- [ ] [AI] Any preexisting fix gets its own separate commit — acceptance: no unrelated change is
+
+  > **Date**: 2026-07-31 **Status**: Done **Notes**: `6f48c13e1 fix(ayokoding-www): contain
+ai-benchmark table overflow at lg (R5)` and `f092cf7e8 test(ayokoding-www): add
+horizontal-overflow regression coverage`, both conventional-format.
+
+- [x] [AI] Any preexisting fix gets its own separate commit — acceptance: no unrelated change is
       bundled into either commit above
+
+  > **Date**: 2026-07-31 **Status**: Done **Notes**: `899978ee4
+fix(ayokoding-www-fe-e2e): harden e2e steps against shared-machine contention` — the Phase 0
+  > flakiness fix plus the Phase 1-discovered cost-of-living-calculator flakiness fix, both bundled
+  > into this one separate preexisting-fix commit (same root-cause class), not into the fix/test
+  > commits above.
 
 ### Integration — Unit 1 boundary
 

--- a/plans/in-progress/ayokoding-www-ai-benchmark-responsive-overhaul/delivery.md
+++ b/plans/in-progress/ayokoding-www-ai-benchmark-responsive-overhaul/delivery.md
@@ -107,64 +107,160 @@ the branch-and-commit part and stops there.
 > branch, runs no PR-Review Maker→Fixer Cycle, and merges nothing — under every Delivery Mode. The
 > earliest phase that may open a PR is Phase 1; any evidence file written here rides that first PR.
 
-- [ ] [AI] Provision the worktree from the repo root:
+- [x] [AI] Provision the worktree from the repo root:
       `git worktree add worktrees/ayokoding-www-ai-benchmark-responsive-overhaul -b ai-benchmark-r5-overflow-containment origin/main`
       — acceptance: `git worktree list | grep -c ai-benchmark-responsive-overhaul` prints `1`
-- [ ] [AI] Install dependencies in the root worktree: `npm install`
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**: none (worktree metadata only)
+  > **Notes**: provisioned via the harness's worktree tool, routed to
+  > `worktrees/ayokoding-www-ai-benchmark-responsive-overhaul/` per this repo's own convention;
+  > branch renamed to `ai-benchmark-r5-overflow-containment` to match this checkbox's target.
+  > `git worktree list | grep -c ai-benchmark-responsive-overhaul` printed `1`.
+
+- [x] [AI] Install dependencies in the root worktree: `npm install`
       — acceptance: exits 0, `node_modules/` synchronized
-- [ ] [AI] Converge the polyglot toolchain in the root worktree: `npm run doctor -- --fix`
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**: `node_modules/` (untracked)
+  > **Notes**: `added 1572 packages, and audited 1596 packages in 2m`, exit 0.
+
+- [x] [AI] Converge the polyglot toolchain in the root worktree: `npm run doctor -- --fix`
       — acceptance: exits 0 with no unresolved drift
-- [ ] [AI] Install the e2e project's own dependencies: `npx nx run ayokoding-www-fe-e2e:install`
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**: none
+  > **Notes**: `Summary: 16/16 tools OK, 0 warning, 0 missing` — `Nothing to fix`, exit 0.
+
+- [x] [AI] Install the e2e project's own dependencies: `npx nx run ayokoding-www-fe-e2e:install`
       — acceptance: exits 0
-- [ ] [AI] Confirm the two claimed no-op targets really are no-ops, so no later acceptance clause
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**: `apps/ayokoding-www-fe-e2e/node_modules/` (untracked)
+  > **Notes**: `NX Successfully ran target install for project ayokoding-www-fe-e2e`, exit 0.
+
+- [x] [AI] Confirm the two claimed no-op targets really are no-ops, so no later acceptance clause
       cites them: `npx nx run ayokoding-www:test:e2e` and `npx nx run ayokoding-www:test:integration`
       — acceptance: both print a line beginning `no-op:` and exit 0. Falsifiable both ways: if
       either ever becomes a real target, its output will not begin `no-op:` and this check fails,
       forcing the plan's gate list to be revisited.
-- [ ] [AI] Confirm the unit-layer step file this plan must extend exists:
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**: none
+  > **Notes**: `test:e2e` → `no-op: target not applicable for this project`, exit 0.
+  > `test:integration` → `no-op: integration tier not used for this content app`, exit 0.
+
+- [x] [AI] Confirm the unit-layer step file this plan must extend exists:
       `test -f apps/ayokoding-www/test/unit/fe-steps/ai-benchmark.steps.tsx && echo PRESENT`
       — acceptance: prints `PRESENT` (a defensive re-check of a path already `[Repo-grounded]` at
       authoring time in `tech-docs.md` §File impact, not the resolution of an open marker — no
       `[Unverified]` marker remains in that table)
-- [ ] [AI] Confirm the e2e-layer step file exists:
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**: none
+  > **Notes**: printed `PRESENT`.
+
+- [x] [AI] Confirm the e2e-layer step file exists:
       `test -f apps/ayokoding-www-fe-e2e/src/steps/ai-benchmark.steps.ts && echo PRESENT`
       — acceptance: prints `PRESENT`
-- [ ] [AI] Create the evidence folder:
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**: none
+  > **Notes**: printed `PRESENT`.
+
+- [x] [AI] Create the evidence folder:
       `mkdir -p plans/in-progress/ayokoding-www-ai-benchmark-responsive-overhaul/evidence`
       — acceptance: the directory exists
-- [ ] [AI] Record the current scenario count in the feature file so Phase 9's audit has a baseline:
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**: `evidence/` (new directory)
+  > **Notes**: directory created and confirmed present.
+
+- [x] [AI] Record the current scenario count in the feature file so Phase 9's audit has a baseline:
       `grep -cE '^\s+Scenario( Outline)?:' specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature`
       — acceptance: the integer is written verbatim into `evidence/phase-0-baseline.txt`
-- [ ] [AI] Record the baseline quality-gate state:
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**: `evidence/phase-0-baseline.txt` (new)
+  > **Notes**: count is `49`, written verbatim into the evidence file.
+
+- [x] [AI] Record the baseline quality-gate state:
       `npx nx run ayokoding-www:test:quick` and `npx nx run ayokoding-www:specs:behavior:coverage`
       — acceptance: both exit 0, or every preexisting failure is documented in
       `evidence/phase-0-baseline.txt`
-- [ ] [AI] Build once so the e2e webServer can boot: `npx nx run ayokoding-www:build`
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**: `evidence/phase-0-baseline.txt`
+  > **Notes**: `test:quick` exit 0 (145 test files, 3196 passed, 6 skipped);
+  > `specs:behavior:coverage` exit 0 (42 specs, 343 scenarios, 1235 steps — all covered). No
+  > failures to document.
+
+- [x] [AI] Build once so the e2e webServer can boot: `npx nx run ayokoding-www:build`
       — acceptance: exits 0 and `apps/ayokoding-www/.next/standalone/` exists
-- [ ] [AI] Record the e2e baseline: `npx nx run ayokoding-www-fe-e2e:test:e2e`
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**: `apps/ayokoding-www/.next/` (build output, gitignored), `apps/ayokoding-www/next-env.d.ts` (auto-regenerated)
+  > **Notes**: exit 0; `.next/standalone/` confirmed present.
+
+- [x] [AI] Record the e2e baseline: `npx nx run ayokoding-www-fe-e2e:test:e2e`
       — acceptance: exits 0, or every preexisting failure is documented in
       `evidence/phase-0-baseline.txt`
-- [ ] [AI] Resolve every preexisting failure before proceeding (Root Cause Orientation — fix, do not
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**: `evidence/phase-0-baseline.txt`
+  > **Notes**: first run: 3 failed / 656 passed / 301 skipped, exit 1 — root cause and fixes
+  > documented in the next item. After fixes: 3 consecutive full-suite runs all green (659
+  > passed, 301 skipped, 0 failed each time).
+
+- [x] [AI] Resolve every preexisting failure before proceeding (Root Cause Orientation — fix, do not
       defer) — acceptance: no unresolved preexisting failure remains
-- [ ] [AI] Create the Knowledge Capture running log at
+
+  > **Date**: 2026-07-31 **Status**: Done
+  > **Files changed**: `apps/ayokoding-www-fe-e2e/playwright.config.ts`,
+  > `apps/ayokoding-www-fe-e2e/src/steps/{content-namespace,cost-of-living-calculator,
+course-rehome-redirects,ia-navigation-revamp,learn-three-bucket}.steps.ts`,
+  > `apps/ayokoding-www-fe-e2e/src/support/resilient-request.ts` (new)
+  > **Notes**: root cause was shared-machine contention against this e2e project's single
+  > production webServer instance under `fullyParallel` load (load average 14-37 observed on a
+  > 12-core box during runs, from other concurrent processes) — a rotating subset of
+  > `course-rehome-redirects`, `ia-navigation-revamp` (network timeout/`ECONNRESET`),
+  > `cost-of-living-calculator` "Household composition" (a bare `.isVisible()` sampled before a
+  > URL-driven re-render caught up), and "Minimum role from a reference city and role" (a
+  > legitimate tied-result strict-mode violation, not an app bug). Fixed via a new
+  > `getResilient()` retry helper wired into every raw request call site, timeouts raised
+  > 10000ms→30000ms, `.isVisible()` replaced with `expect.poll`, tied-result assertions changed
+  > to `.first()` + `toBeVisible({ timeout: 15000 })`, and the project's global Playwright test
+  > timeout raised 30000ms→90000ms. Verified: `tsc --noEmit`, `nx run ayokoding-www-fe-e2e:lint`,
+  > `prettier --check` all exit 0 on every touched file; no `apps/ayokoding-www` app-source
+  > change was needed.
+
+- [x] [AI] Create the Knowledge Capture running log at
       `plans/in-progress/ayokoding-www-ai-benchmark-responsive-overhaul/learnings.md`
       — acceptance: the file exists and its first content line is the H1
       `# Learnings: ayokoding-www-ai-benchmark-responsive-overhaul`
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**: none (already existed from plan authoring)
+  > **Notes**: confirmed present with the exact required H1 as its first content line; not
+  > overwritten.
 
 ### Phase 0 Gate
 
 > All checks below must pass before starting Phase 1.
 
-- [ ] [AI] `npm install` exited 0 and `npm run doctor -- --fix` reports no unresolved drift
-- [ ] [AI] `npx nx run ayokoding-www:test:quick` exits 0 (or every preexisting failure is resolved)
-- [ ] [AI] `npx nx run ayokoding-www-fe-e2e:test:e2e` exits 0 (or every preexisting failure is resolved)
-- [ ] [AI] `evidence/phase-0-baseline.txt` exists and records the scenario count and both baselines
-- [ ] [AI] Nothing was pushed and no PR exists for this branch — run both, reading the printed
+- [x] [AI] `npm install` exited 0 and `npm run doctor -- --fix` reports no unresolved drift
+
+  > **Date**: 2026-07-31 **Status**: Done **Notes**: both confirmed above.
+
+- [x] [AI] `npx nx run ayokoding-www:test:quick` exits 0 (or every preexisting failure is resolved)
+
+  > **Date**: 2026-07-31 **Status**: Done **Notes**: exit 0, confirmed above.
+
+- [x] [AI] `npx nx run ayokoding-www-fe-e2e:test:e2e` exits 0 (or every preexisting failure is resolved)
+
+  > **Date**: 2026-07-31 **Status**: Done **Notes**: exit 0 after fix, 3 consecutive green runs.
+
+- [x] [AI] `evidence/phase-0-baseline.txt` exists and records the scenario count and both baselines
+
+  > **Date**: 2026-07-31 **Status**: Done **Notes**: confirmed present, 77 lines, all facts recorded.
+
+- [x] [AI] Nothing was pushed and no PR exists for this branch — run both, reading the printed
       number (never `&&`-chaining, since `grep -c` exits 1 on a zero count):
       `git ls-remote --heads origin "$(git branch --show-current)" | grep -c .` returns `0`, and
       `gh pr list --head "$(git branch --show-current)" --json number --jq 'length'` returns `0`.
       Falsifiable both ways: pushing the branch makes the first return `1`, and opening a PR for it
       makes the second return `1` — either fails the gate.
+
+  > **Date**: 2026-07-31 **Status**: Done **Notes**: re-verified live on branch
+  > `ai-benchmark-r5-overflow-containment` — `git ls-remote --heads origin ... | grep -c .`
+  > printed `0`; `gh pr list --head ... --json number --jq 'length'` printed `0`. Gate passes.
 
 > **Pause Safety**: only the local toolchain was verified and the baseline recorded — no feature
 > work exists, nothing is pushed, no PR exists. Safe to stop indefinitely. To resume: re-run
@@ -204,7 +300,7 @@ the branch-and-commit part and stops there.
       | 1440  | id     |
 ```
 
-- [ ] [AI] **RED**: add the scenario above verbatim to
+- [x] [AI] **RED**: add the scenario above verbatim to
       `specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature` under an
       `# AC-52` comment, and add its three step bindings to
       `apps/ayokoding-www-fe-e2e/src/steps/ai-benchmark.steps.ts` following the
@@ -216,7 +312,18 @@ the branch-and-commit part and stops there.
       because the wrapper still contains its overflow at those widths). Falsifiable both ways: if
       the desktop rows passed here, R5 would not exist and the fix below would be unnecessary.
   - _Suggested executor: `swe-e2e-dev`_
-- [ ] [AI] **GREEN**: in `apps/ayokoding-www/src/features/ai-benchmark/shell/model-table.tsx`,
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**:
+  > `specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature`,
+  > `apps/ayokoding-www-fe-e2e/src/steps/ai-benchmark.steps.ts`
+  > **Notes**: first insert attempt split the prior scenario's Examples table (caused a gherkin
+  > parse error, "inconsistent cell count") — caught and fixed by moving the new scenario after that
+  > table's `dark` row. RED run: 9 failed exactly on Example #4 (1280, all 3 browsers, actual
+  > 1705px) and Example #5 (1440, all 3 browsers, actual 1785px), plus webkit's Example #7 (1440 id,
+  > actual 1976px); Examples #1/#2/#3/#6 passed. 12 passed / 9 failed, confirming R5 exists exactly
+  > at desktop widths.
+
+- [x] [AI] **GREEN**: in `apps/ayokoding-www/src/features/ai-benchmark/shell/model-table.tsx`,
       change the `<Table>` call's `wrapperClassName="lg:overflow-visible"` (line 269) to remove the
       `lg` override so the wrapper contains its own overflow at every breakpoint, and replace the
       lines 262-267 comment block with one recording DD-27's two-step sequence and the sticky-thead
@@ -226,19 +333,32 @@ the branch-and-commit part and stops there.
       `grep -cF 'lg:overflow-visible' apps/ayokoding-www/src/features/ai-benchmark/shell/model-table.tsx`
       prints `0`
   - _Suggested executor: `swe-typescript-dev`_
-- [ ] [AI] **REFACTOR**: extract the repeated viewport-and-locale navigation into one shared helper
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**:
+  > `apps/ayokoding-www/src/features/ai-benchmark/shell/model-table.tsx`
+  > **Notes**: removed the `wrapperClassName` prop entirely and rewrote the comment block to
+  > describe DD-27's two-step sequence without using the literal string `lg:overflow-visible`
+  > (grep's acceptance clause is literal). All 21 (7 rows × 3 browsers) passed after rebuild; grep
+  > confirmed `0`.
+
+- [x] [AI] **REFACTOR**: extract the repeated viewport-and-locale navigation into one shared helper
       in `apps/ayokoding-www-fe-e2e/src/steps/ai-benchmark.steps.ts` so the later AC-49/AC-50/AC-58
       outlines reuse it instead of re-implementing navigation
       — command: `npx nx run ayokoding-www-fe-e2e:test:e2e`
       — acceptance: all AC-52 rows still pass and
       `npx nx run ayokoding-www-fe-e2e:typecheck` exits 0
 
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**:
+  > `apps/ayokoding-www-fe-e2e/src/steps/ai-benchmark.steps.ts`
+  > **Notes**: extracted `navigateAtViewport(page, width, locale)`; typecheck exits 0; all 21 AC-52
+  > browser/row combinations still pass.
+
 ### TDD cycle 1.2 — a unit-level guard against re-adding the override
 
 **Exempt from Gherkin tagging** — a unit-level regression re-guard for AC-52's already-tagged
 behavior (cycle 1.1); no new behavior scenario to bind.
 
-- [ ] [AI] **RED**: add a test to
+- [x] [AI] **RED**: add a test to
       `apps/ayokoding-www/src/features/ai-benchmark/shell/model-table.test.tsx` asserting the
       rendered `[data-slot="table-wrapper"]` element's `className` does NOT contain
       `lg:overflow-visible`
@@ -246,22 +366,55 @@ behavior (cycle 1.1); no new behavior scenario to bind.
       — acceptance: with the Phase 1 GREEN change reverted locally the test FAILS; note the
       observed failure message in the checklist before restoring the change. This is the both-ways
       falsifiability check for a class-name assertion.
-- [ ] [AI] **GREEN**: restore the Phase 1 GREEN change
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**:
+  > `apps/ayokoding-www/src/features/ai-benchmark/shell/model-table.test.tsx`
+  > **Notes**: the file already had an OUTDATED describe block asserting the OPPOSITE (that the
+  > class WAS present) — a leftover from PR #122. That old assertion failed the moment the Phase 1
+  > GREEN change landed (`expected 'relative w-full overflow-x-auto' to contain
+'lg:overflow-visible'`), which is the both-ways proof this new test needs: the class IS present
+  > before the fix and IS ABSENT after it. Replaced the outdated block with the new
+  > not-`toContain` assertion rather than running a separate revert, since the converse case was
+  > already directly observed.
+
+- [x] [AI] **GREEN**: restore the Phase 1 GREEN change
       — command: `npx nx run ayokoding-www:test:unit`
       — acceptance: the new test passes and no other test in the file breaks
-- [ ] [AI] **REFACTOR**: co-locate the new test under a `describe("R5 — desktop horizontal overflow
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**: none (GREEN change already in place)
+  > **Notes**: `npx nx run ayokoding-www:test:unit` — 145 test files passed, 3224 tests passed, 6
+  > skipped (after also adding the required unit-layer AC-52 placeholder binding — see Specs
+  > section below).
+
+- [x] [AI] **REFACTOR**: co-locate the new test under a `describe("R5 — desktop horizontal overflow
 regression")` block with a comment linking to `tech-docs.md §DD-27`
       — command: `npx nx run ayokoding-www:test:unit`
       — acceptance: all tests still pass
 
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**:
+  > `apps/ayokoding-www/src/features/ai-benchmark/shell/model-table.test.tsx`
+  > **Notes**: co-located under `describe("ModelTable — R5 desktop horizontal overflow
+regression")` with a comment citing `tech-docs.md §DD-27`; full unit suite still green.
+
 ### Specs & Gherkin Delivery (Phase 1)
 
-- [ ] [AI] Verify the new AC-52 scenario has a `@covers` binding at the e2e layer:
+- [x] [AI] Verify the new AC-52 scenario has a `@covers` binding at the e2e layer:
       `npx nx run ayokoding-www-fe-e2e:specs:e2e:coverage`
       — acceptance: exits 0
-- [ ] [AI] Verify the behaviour-coverage scanner is still satisfied for `ayokoding-www`:
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**:
+  > `apps/ayokoding-www/test/unit/fe-steps/ai-benchmark.steps.tsx` (added the required unit-layer
+  > placeholder binding, discovered necessary when `test:unit` first raised `ScenarioNotCalledError`
+  > for the new outline — fixed following the AC-38 `expect(true).toBe(true)` placeholder
+  > convention already established in that file)
+  > **Notes**: `E2E COVERAGE GAP DETECTOR PASSED: 0 new unbound scenario(s) beyond baseline`, exit 0.
+
+- [x] [AI] Verify the behaviour-coverage scanner is still satisfied for `ayokoding-www`:
       `npx nx run ayokoding-www:specs:behavior:coverage`
       — acceptance: exits 0
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**: none
+  > **Notes**: `Spec coverage valid! 42 specs, 344 scenarios, 1238 steps — all covered.`, exit 0.
 
 ### Local Quality Gates (Before Push) — Phase 1
 
@@ -270,12 +423,46 @@ regression")` block with a comment linking to `tech-docs.md §DD-27`
 > encountered during work. Do not defer or skip existing issues. Commit preexisting fixes
 > separately with appropriate conventional commit messages.
 
-- [ ] [AI] `npx nx affected -t typecheck` — exits 0
-- [ ] [AI] `npx nx affected -t lint` — exits 0
-- [ ] [AI] `npx nx affected -t test:quick` — exits 0
-- [ ] [AI] `npx nx affected -t specs:behavior:coverage` — exits 0
-- [ ] [AI] `npx nx run ayokoding-www-fe-e2e:test:e2e` — exits 0
-- [ ] [AI] Re-run every previously failing check to confirm resolution — acceptance: zero failures
+- [x] [AI] `npx nx affected -t typecheck` — exits 0
+
+  > **Date**: 2026-07-31 **Status**: Done **Notes**: 25 affected projects, all exit 0.
+
+- [x] [AI] `npx nx affected -t lint` — exits 0
+
+  > **Date**: 2026-07-31 **Status**: Done **Notes**: 25 affected projects, exit 0 (only pre-existing
+  > non-failing `no-empty-pattern` warnings, matching this project's own documented playwright-bdd
+  > idiom).
+
+- [x] [AI] `npx nx affected -t test:quick` — exits 0
+
+  > **Date**: 2026-07-31 **Status**: Done **Notes**: 25 affected projects and 11 dependency tasks,
+  > exit 0.
+
+- [x] [AI] `npx nx affected -t specs:behavior:coverage` — exits 0
+
+  > **Date**: 2026-07-31 **Status**: Done **Notes**: 25 projects, exit 0.
+
+- [x] [AI] `npx nx run ayokoding-www-fe-e2e:test:e2e` — exits 0
+
+  > **Date**: 2026-07-31 **Status**: Done **Files changed**:
+  > `apps/ayokoding-www-fe-e2e/src/steps/cost-of-living-calculator.steps.ts`,
+  > `apps/ayokoding-www-fe-e2e/playwright.config.ts`
+  > **Notes**: first two full runs (679/680 vs 21) were piped through `tail`, which silently
+  > masked a real nx failure exit code with `tail`'s own exit 0 — caught by re-running without a
+  > pipe. The genuine failure: "Household composition changes the minimum qualifying role" flaked
+  > under contention (a bare single-sample `.isVisible()` in `a more senior role becomes the marked
+minimum`, same root-cause class Phase 0 fixed elsewhere in this file) — fixed with the same
+  > `expect.poll` pattern. A third confirmation run then failed on the SIBLING assertion (the
+  > already-Phase-0-fixed `expect.poll` at line ~1000) exceeding its 30s timeout under measured load
+  > average 61.9 on this 12-core box (5.2x over capacity, worse than Phase 0's observed 14-37) —
+  > raised both `expect.poll` timeouts to 60s and the project's global test timeout 90s→150s to give
+  > headroom. Two further full runs after that (680 passed each, confirmed via direct exit code, no
+  > pipe) were green.
+
+- [x] [AI] Re-run every previously failing check to confirm resolution — acceptance: zero failures
+
+  > **Date**: 2026-07-31 **Status**: Done **Notes**: typecheck and lint re-confirmed clean on both
+  > touched e2e files after the timeout fix; zero unresolved failures remain.
 
 ### Commit Guidelines — Phase 1
 

--- a/plans/in-progress/ayokoding-www-ai-benchmark-responsive-overhaul/evidence/phase-0-baseline.txt
+++ b/plans/in-progress/ayokoding-www-ai-benchmark-responsive-overhaul/evidence/phase-0-baseline.txt
@@ -1,0 +1,77 @@
+Phase 0 Baseline — ayokoding-www-ai-benchmark-responsive-overhaul
+Recorded: 2026-07-31 02:35 UTC
+
+Scenario count baseline (Phase 9 audit reference):
+grep -cE '^\s+Scenario( Outline)?:' specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature
+49
+
+Quality-gate baseline:
+  npx nx run ayokoding-www:test:quick        -> exit 0 (145 test files, 3196 passed, 6 skipped)
+  npx nx run ayokoding-www:specs:behavior:coverage -> exit 0 (42 specs, 343 scenarios, 1235 steps — all covered)
+  No failures to document for this pair.
+
+Build baseline:
+  npx nx run ayokoding-www:build              -> exit 0
+  apps/ayokoding-www/.next/standalone/ present -> confirmed
+
+e2e baseline: npx nx run ayokoding-www-fe-e2e:test:e2e
+  Initial (cold) run: 3 failed / 656 passed / 301 skipped, exit 1.
+  Root cause (confirmed via single-worker isolation reruns of every failing scenario — all
+  passed in isolation): this project's `webServer` boots exactly one local production Node.js
+  server instance (playwright.config.ts), and `fullyParallel: true` with `workers: undefined`
+  locally opens hundreds of concurrent browser-driven connections against that one instance.
+  Under contention (this dev machine's own load average was observed at 14-37 on 12 cores
+  during these runs — other concurrent processes on a shared machine, not this plan's doing)
+  the server occasionally answers slowly (>10s) or drops a connection mid-handshake
+  (ECONNRESET). Every failing scenario passed deterministically when re-run in isolation
+  (--workers=1), proving these were load-induced test-robustness gaps, not application defects.
+  Preexisting failures observed across repeated full-suite runs while isolating root cause
+  (each run surfaced a different subset/superset of the same failure class — course-rehome
+  network checks, RSS-feed/content-link network checks, and one household-composition UI
+  assertion — all tracing to the single-server-under-full-parallel-load pattern above):
+    - navigation/course-rehome-redirects.feature: "...resolves every re-homed course" (chromium,
+      firefox) — bare `page.request.get(href, { timeout: 10000 })` too tight under load.
+    - navigation/ia-navigation-revamp.feature: "RSS feed item links use bare content URLs"
+      (webkit) — bare `page.request.get("/feed.xml")` hit ECONNRESET under load.
+    - navigation/ia-navigation-revamp.feature: "Internal content links emit bare URLs directly
+      without relying on redirects" (both scenarios in this feature use the same pattern,
+      timeout: 10000) — same ECONNRESET class.
+    - tools/cost-of-living-calculator.feature: "Household composition changes the minimum
+      qualifying role" (firefox) — a bare single-shot `.isVisible()` check sampled the DOM
+      before the URL-driven re-render had caught up under load; no auto-retry.
+    - tools/cost-of-living-calculator.feature: "Minimum role from a reference city and role"
+      (webkit) — `page.locator("[data-testid='minimum-marker']")` used a bare `.toBeVisible()`
+      that throws a strict-mode violation when several cities legitimately tie for the lowest
+      qualifying rank (min-role.tsx's `isMinEntry` intentionally marks every tied entry); a
+      URL-round-trip render race under load could also leave a stale multi-tie view visible
+      momentarily.
+
+  Fixes applied (all in apps/ayokoding-www-fe-e2e, test-code only — no apps/ayokoding-www
+  application-source changes were needed since every failure reproduced was a test-robustness
+  gap, confirmed passing in single-worker isolation before any fix):
+    - Added `apps/ayokoding-www-fe-e2e/src/support/resilient-request.ts` (`getResilient`): a
+      `page.request.get()` wrapper that retries once on a thrown network error (e.g.
+      ECONNRESET), used by every raw `page.request.get()` call site in the step files
+      (course-rehome-redirects, content-namespace, learn-three-bucket, ia-navigation-revamp).
+    - Raised the course-rehome and ia-navigation-revamp per-request `timeout` from 10000ms to
+      30000ms alongside the retry, so a genuine 404/drained route still fails fast while slow
+      (but successful) responses under load are tolerated.
+    - Replaced the household-composition step's bare `.isVisible()` single-shot check with
+      `expect.poll(..., { timeout: 30000 })`, giving it Playwright's normal auto-retry semantics
+      instead of one instantaneous sample.
+    - Changed both "minimum role" step assertions to `page.locator(...).first()` (ties are valid
+      application behavior, not a bug — avoids the strict-mode violation) with an explicit
+      `toBeVisible({ timeout: 15000 })` to tolerate the same URL-round-trip render race.
+    - Raised the project's global Playwright test timeout from the 30000ms default to 90000ms
+      (playwright.config.ts) so the above retries/timeouts have room to complete inside a single
+      test's own deadline instead of being cut off by it (this surfaced as a new, distinct
+      failure — "Test timeout of 30000ms exceeded" — partway through fixing the above, and was
+      resolved by this config change).
+
+  Verification: after all fixes above, `npx nx run ayokoding-www-fe-e2e:test:e2e --skip-nx-cache`
+  was re-run to completion 3 additional consecutive times, each fully green:
+    659 passed, 301 skipped, 0 failed, exit 0 (all three runs).
+  `npx tsc --noEmit -p apps/ayokoding-www-fe-e2e/tsconfig.json` and
+  `npx nx run ayokoding-www-fe-e2e:lint` both exit 0 on the changed files.
+
+No unresolved preexisting failure remains as of this baseline.

--- a/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature
+++ b/specs/apps/ayokoding/behavior/ayokoding-www/gherkin/tools/ai-benchmark.feature
@@ -436,3 +436,20 @@ Feature: AI model benchmark tool
       | theme |
       | light |
       | dark  |
+
+  # AC-52
+  @e2e
+  Scenario Outline: The document never scrolls horizontally
+    Given the AI benchmark page is loaded at a "<width>" px viewport in the "<locale>" locale
+    When the document's scroll width is compared with its client width
+    Then the document scroll width does not exceed the document client width
+
+    Examples:
+      | width | locale |
+      | 320   | en     |
+      | 390   | en     |
+      | 768   | en     |
+      | 1280  | en     |
+      | 1440  | en     |
+      | 320   | id     |
+      | 1440  | id     |


### PR DESCRIPTION
## Summary
- Fixes R5: the AI benchmark table's desktop wrapper override made the whole document scroll horizontally at `lg`+ widths — removes the override so the wrapper contains the table at every breakpoint.
- Adds AC-52 e2e regression coverage (7 viewport/locale combinations) plus a unit-level guard against re-adding the override.
- Bundles a separate, unrelated preexisting-fix commit hardening the e2e suite against shared-machine contention (network retries, `expect.poll`, raised timeouts) discovered while establishing this plan's Phase 0 baseline and again while verifying this PR's own changes.

Trade made here, restored in a later phase of the same plan: the sticky `<thead>` stops sticking at `lg` (a scroll container in both axes can't have a sticky descendant) until the column-reduction work shrinks the table below the `lg` viewport. See `tech-docs.md` §DD-27 in `plans/in-progress/ayokoding-www-ai-benchmark-responsive-overhaul/`.

## Test plan
- [x] `npx nx affected -t typecheck` exits 0
- [x] `npx nx affected -t lint` exits 0
- [x] `npx nx affected -t test:quick` exits 0
- [x] `npx nx affected -t specs:behavior:coverage` exits 0
- [x] `npx nx run ayokoding-www-fe-e2e:test:e2e` — 680 passed, exit 0 (confirmed across multiple consecutive runs)
- [x] `grep -cF 'lg:overflow-visible' apps/ayokoding-www/src/features/ai-benchmark/shell/model-table.tsx` prints `0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)