### PR TITLE
fix(wahidyankf-www): prerender portfolio routes

### DIFF
--- a/apps/wahidyankf-www-fe-e2e/README.md
+++ b/apps/wahidyankf-www-fe-e2e/README.md
@@ -10,10 +10,7 @@ Playwright and `playwright-bdd`. Consumes the Gherkin feature files at
 # Install Chromium for Playwright
 nx run wahidyankf-www-fe-e2e:install
 
-# Start the app first in another shell
-nx dev wahidyankf-www
-
-# Run all E2E scenarios headlessly
+# Build a fresh production Docker image, wait for its health check, and run all E2E scenarios
 nx run wahidyankf-www-fe-e2e:test:e2e
 
 # Run with Playwright UI
@@ -35,8 +32,16 @@ nx run wahidyankf-www-fe-e2e:test:quick
 - `personal-projects.feature`
 - `responsive.feature`
 - `accessibility.feature` — E2E-only, axe-core-driven
+- `static-filterable-routes.feature` — production-container route and crawler checks
 
 ## Default base URL
 
-`http://localhost:3201` — override with `BASE_URL` env var for staging /
-production smoke runs.
+The regular E2E command builds a fresh production Docker image, starts an isolated container on an
+ephemeral loopback port, waits for its health check, then supplies that URL to Playwright. It never
+reuses a checkout server.
+
+Set `BASE_URL` only to run the same suite against an already-running staging or production deployment:
+
+```bash
+BASE_URL=https://example.com nx run wahidyankf-www-fe-e2e:test:e2e
+```

--- a/apps/wahidyankf-www-fe-e2e/playwright.config.ts
+++ b/apps/wahidyankf-www-fe-e2e/playwright.config.ts
@@ -19,13 +19,6 @@ export default defineConfig({
     trace: "on-first-retry",
     screenshot: "only-on-failure",
   },
-  webServer: {
-    command: "npx nx run wahidyankf-www:start",
-    url: "http://localhost:3201",
-    reuseExistingServer: true,
-    timeout: 120000,
-    cwd: "../..",
-  },
   projects: [
     {
       name: "chromium",

--- a/apps/wahidyankf-www-fe-e2e/project.json
+++ b/apps/wahidyankf-www-fe-e2e/project.json
@@ -57,6 +57,12 @@
     },
     "test:e2e": {
       "executor": "nx:run-commands",
+      "dependsOn": [
+        {
+          "projects": ["wahidyankf-www"],
+          "target": "build"
+        }
+      ],
       "options": {
         "command": "if grep -rn -E --include='*.ts' --exclude-dir=node_modules --exclude-dir=.features-gen --exclude-dir=test-results --exclude-dir=playwright-report '\\$?test\\.skip\\([^,)]*\\)' .; then echo 'ERROR: unconditional test.skip() found in test files above - use test.skip(condition, reason) for legitimate environment guards, or remove'; exit 1; fi && npx bddgen && npx playwright test",
         "cwd": "{projectRoot}"

--- a/apps/wahidyankf-www-fe-e2e/project.json
+++ b/apps/wahidyankf-www-fe-e2e/project.json
@@ -57,21 +57,15 @@
     },
     "test:e2e": {
       "executor": "nx:run-commands",
-      "dependsOn": [
-        {
-          "projects": ["wahidyankf-www"],
-          "target": "build"
-        }
-      ],
       "options": {
-        "command": "if grep -rn -E --include='*.ts' --exclude-dir=node_modules --exclude-dir=.features-gen --exclude-dir=test-results --exclude-dir=playwright-report '\\$?test\\.skip\\([^,)]*\\)' .; then echo 'ERROR: unconditional test.skip() found in test files above - use test.skip(condition, reason) for legitimate environment guards, or remove'; exit 1; fi && npx bddgen && npx playwright test",
+        "command": "if grep -rn -E --include='*.ts' --exclude-dir=node_modules --exclude-dir=.features-gen --exclude-dir=test-results --exclude-dir=playwright-report '\\$?test\\.skip\\([^,)]*\\)' .; then echo 'ERROR: unconditional test.skip() found in test files above - use test.skip(condition, reason) for legitimate environment guards, or remove'; exit 1; fi && node scripts/run-docker-e2e.mjs",
         "cwd": "{projectRoot}"
       }
     },
     "test:e2e:ui": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "npx bddgen && npx playwright test --ui",
+        "command": "node scripts/run-docker-e2e.mjs --ui",
         "cwd": "{projectRoot}"
       }
     },

--- a/apps/wahidyankf-www-fe-e2e/scripts/run-docker-e2e.mjs
+++ b/apps/wahidyankf-www-fe-e2e/scripts/run-docker-e2e.mjs
@@ -1,0 +1,79 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const e2eRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const workspaceRoot = resolve(e2eRoot, "../..");
+const externalBaseUrl = process.env.BASE_URL;
+const imageTag = `ose-public-wahidyankf-e2e:${process.pid}`;
+const containerName = `ose-public-wahidyankf-e2e-${randomUUID().slice(0, 12)}`;
+
+const run = (command, args, options = {}) => {
+  const output = execFileSync(command, args, {
+    cwd: e2eRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+    ...options,
+  });
+  return typeof output === "string" ? output.trim() : "";
+};
+
+const runPlaywright = (baseUrl) => {
+  run("npx", ["bddgen"]);
+  const result = spawnSync("npx", ["playwright", "test", ...process.argv.slice(2)], {
+    cwd: e2eRoot,
+    env: { ...process.env, BASE_URL: baseUrl },
+    stdio: "inherit",
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) process.exitCode = result.status ?? 1;
+};
+
+const waitForHealthyContainer = () => {
+  for (let attempt = 1; attempt <= 90; attempt += 1) {
+    const health = run("docker", ["inspect", "--format", "{{.State.Health.Status}}", containerName]);
+    if (health === "healthy") return;
+    if (health === "unhealthy") {
+      run("docker", ["logs", containerName], { stdio: ["ignore", "inherit", "inherit"] });
+      throw new Error(`Docker container ${containerName} became unhealthy.`);
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1000);
+  }
+
+  run("docker", ["logs", containerName], { stdio: ["ignore", "inherit", "inherit"] });
+  throw new Error(`Docker container ${containerName} did not become healthy within 90 seconds.`);
+};
+
+const resolveContainerUrl = () => {
+  const publishedPort = run("docker", ["port", containerName, "3201/tcp"]);
+  const match = publishedPort.match(/:(\d+)\s*$/m);
+  if (!match) throw new Error(`Could not resolve the published port for ${containerName}: ${publishedPort}`);
+  return `http://127.0.0.1:${match[1]}`;
+};
+
+if (externalBaseUrl) {
+  runPlaywright(externalBaseUrl);
+} else {
+  try {
+    run("docker", ["build", "--tag", imageTag, "--file", "apps/wahidyankf-www/Dockerfile", "."], {
+      cwd: workspaceRoot,
+      stdio: "inherit",
+    });
+    run("docker", ["run", "--detach", "--rm", "--name", containerName, "--publish", "127.0.0.1::3201", imageTag]);
+    waitForHealthyContainer();
+    runPlaywright(resolveContainerUrl());
+  } finally {
+    try {
+      run("docker", ["rm", "--force", containerName]);
+    } catch {
+      // The container uses --rm, so it may already have been removed after a failed start.
+    }
+    try {
+      run("docker", ["image", "rm", "--force", imageTag]);
+    } catch {
+      // Preserve the test failure when Docker cleanup is unavailable.
+    }
+  }
+}

--- a/apps/wahidyankf-www-fe-e2e/steps/static-filterable-routes.steps.ts
+++ b/apps/wahidyankf-www-fe-e2e/steps/static-filterable-routes.steps.ts
@@ -1,13 +1,11 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { expect } from "@playwright/test";
 import { createBdd } from "playwright-bdd";
 
 const { When, Then } = createBdd();
-const publicPortfolioRoutes = ["/", "/cv", "/personal-projects", "/robots.txt", "/sitemap.xml"];
+const publicPortfolioPages = ["/", "/cv", "/personal-projects"];
+const publicPortfolioRoutes = [...publicPortfolioPages, "/robots.txt", "/sitemap.xml"];
 
-let emittedStaticRoutes: string[] = [];
-let emittedDynamicRoutes: string[] = [];
+let publicPortfolioPageResponses: Array<{ contentType: string | null; pathname: string; status: number }> = [];
 let robotsText = "";
 let sitemapText = "";
 
@@ -29,26 +27,23 @@ Then('the "Database Design Fundamentals for Software Engineers" entry is hidden'
   await expect(page.getByText("Database Design Fundamentals for Software Engineers")).not.toBeVisible();
 });
 
-When("the portfolio build output is inspected", async () => {
-  const appRoot = resolve(process.cwd(), "../wahidyankf-www");
-  const prerenderManifest = JSON.parse(
-    readFileSync(resolve(appRoot, ".next/prerender-manifest.json"), "utf8"),
-  ) as { routes: Record<string, unknown> };
-  const routesManifest = JSON.parse(readFileSync(resolve(appRoot, ".next/routes-manifest.json"), "utf8")) as {
-    dynamicRoutes: Array<{ page: string }>;
-  };
+When("a visitor requests every public portfolio page", async ({ page }) => {
+  publicPortfolioPageResponses = await Promise.all(
+    publicPortfolioPages.map(async (pathname) => {
+      const response = await page.request.get(pathname);
 
-  emittedStaticRoutes = Object.keys(prerenderManifest.routes);
-  emittedDynamicRoutes = routesManifest.dynamicRoutes.map(({ page }) => page);
+      return { contentType: response.headers()["content-type"] ?? null, pathname, status: response.status() };
+    }),
+  );
 });
 
-Then("the portfolio route table contains no dynamic route", async () => {
-  expect(emittedDynamicRoutes).toEqual([]);
-});
-
-// @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature:Public portfolio routes are emitted as static build routes
-Then("the static route table contains every public portfolio route", async () => {
-  expect(emittedStaticRoutes).toEqual(expect.arrayContaining(publicPortfolioRoutes));
+// @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature:Public portfolio routes are available from the production server
+Then("each public portfolio page responds with a successful HTML document", async () => {
+  expect(publicPortfolioPageResponses).toEqual(
+    publicPortfolioPages.map((pathname) =>
+      expect.objectContaining({ contentType: expect.stringContaining("text/html"), pathname, status: 200 }),
+    ),
+  );
 });
 
 When("a crawler requests the robots and sitemap routes", async ({ page }) => {

--- a/apps/wahidyankf-www-fe-e2e/steps/static-filterable-routes.steps.ts
+++ b/apps/wahidyankf-www-fe-e2e/steps/static-filterable-routes.steps.ts
@@ -1,7 +1,15 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { expect } from "@playwright/test";
 import { createBdd } from "playwright-bdd";
 
 const { When, Then } = createBdd();
+const publicPortfolioRoutes = ["/", "/cv", "/personal-projects", "/robots.txt", "/sitemap.xml"];
+
+let emittedStaticRoutes: string[] = [];
+let emittedDynamicRoutes: string[] = [];
+let robotsText = "";
+let sitemapText = "";
 
 When('a visitor opens the shared CV search URL for "TypeScript"', async ({ page }) => {
   await page.goto("/cv?search=TypeScript");
@@ -19,4 +27,50 @@ Then('the "Head of Engineering - Hijra Bank" entry is visible', async ({ page })
 // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature:Search-filtered portfolio routes are static yet still filterable
 Then('the "Database Design Fundamentals for Software Engineers" entry is hidden', async ({ page }) => {
   await expect(page.getByText("Database Design Fundamentals for Software Engineers")).not.toBeVisible();
+});
+
+When("the portfolio build output is inspected", async () => {
+  const appRoot = resolve(process.cwd(), "../wahidyankf-www");
+  const prerenderManifest = JSON.parse(
+    readFileSync(resolve(appRoot, ".next/prerender-manifest.json"), "utf8"),
+  ) as { routes: Record<string, unknown> };
+  const routesManifest = JSON.parse(readFileSync(resolve(appRoot, ".next/routes-manifest.json"), "utf8")) as {
+    dynamicRoutes: Array<{ page: string }>;
+  };
+
+  emittedStaticRoutes = Object.keys(prerenderManifest.routes);
+  emittedDynamicRoutes = routesManifest.dynamicRoutes.map(({ page }) => page);
+});
+
+Then("the portfolio route table contains no dynamic route", async () => {
+  expect(emittedDynamicRoutes).toEqual([]);
+});
+
+// @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature:Public portfolio routes are emitted as static build routes
+Then("the static route table contains every public portfolio route", async () => {
+  expect(emittedStaticRoutes).toEqual(expect.arrayContaining(publicPortfolioRoutes));
+});
+
+When("a crawler requests the robots and sitemap routes", async ({ page }) => {
+  const [robotsResponse, sitemapResponse] = await Promise.all([
+    page.request.get("/robots.txt"),
+    page.request.get("/sitemap.xml"),
+  ]);
+
+  expect(robotsResponse.status()).toBe(200);
+  expect(sitemapResponse.status()).toBe(200);
+  [robotsText, sitemapText] = await Promise.all([robotsResponse.text(), sitemapResponse.text()]);
+});
+
+Then("robots permits crawling and names the canonical sitemap", async () => {
+  expect(robotsText).toContain("User-Agent: *");
+  expect(robotsText).toContain("Allow: /");
+  expect(robotsText).toContain("Sitemap: https://www.wahidyankf.com/sitemap.xml");
+});
+
+// @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature:Crawlers receive discovery directives for every public route
+Then("the sitemap lists every public portfolio route", async () => {
+  for (const route of publicPortfolioRoutes.slice(0, 3)) {
+    expect(sitemapText).toContain(`https://www.wahidyankf.com${route === "/" ? "" : route}`);
+  }
 });

--- a/apps/wahidyankf-www-fe-e2e/steps/static-filterable-routes.steps.ts
+++ b/apps/wahidyankf-www-fe-e2e/steps/static-filterable-routes.steps.ts
@@ -1,0 +1,22 @@
+import { expect } from "@playwright/test";
+import { createBdd } from "playwright-bdd";
+
+const { When, Then } = createBdd();
+
+When('a visitor opens the shared CV search URL for "TypeScript"', async ({ page }) => {
+  await page.goto("/cv?search=TypeScript");
+  await page.waitForLoadState("load");
+});
+
+Then('the CV search input is prefilled with "TypeScript"', async ({ page }) => {
+  await expect(page.getByPlaceholder("Search CV entries...")).toHaveValue("TypeScript");
+});
+
+Then('the "Head of Engineering - Hijra Bank" entry is visible', async ({ page }) => {
+  await expect(page.getByText("Head of Engineering - Hijra Bank")).toBeVisible();
+});
+
+// @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature:Search-filtered portfolio routes are static yet still filterable
+Then('the "Database Design Fundamentals for Software Engineers" entry is hidden', async ({ page }) => {
+  await expect(page.getByText("Database Design Fundamentals for Software Engineers")).not.toBeVisible();
+});

--- a/apps/wahidyankf-www/README.md
+++ b/apps/wahidyankf-www/README.md
@@ -67,7 +67,7 @@ Platform-agnostic specifications for this app live at
   `components/`, `behavior/`
 - **Gherkin features**:
   [`specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/`](../../specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/README.md) —
-  7 feature files organized per feature module
+  feature files organized per feature module
 
 ## Architecture
 

--- a/apps/wahidyankf-www/README.md
+++ b/apps/wahidyankf-www/README.md
@@ -42,7 +42,7 @@ nx run wahidyankf-www:test:quick
 nx run wahidyankf-www:test:integration
 
 # Gherkin spec coverage check
-nx run wahidyankf-www:specs:coverage
+nx run wahidyankf-www:test:specs
 ```
 
 ## Testing stack

--- a/apps/wahidyankf-www/project.json
+++ b/apps/wahidyankf-www/project.json
@@ -63,6 +63,7 @@
     "test:quick": {
       "executor": "nx:run-commands",
       "cache": true,
+      "dependsOn": ["static-routes:validation"],
       "options": {
         "commands": [
           "npx nx run wahidyankf-www:typecheck",
@@ -74,6 +75,15 @@
         "parallel": false
       },
       "inputs": ["default", "specs"]
+    },
+    "static-routes:validation": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "options": {
+        "command": "npx nx run wahidyankf-www:build --skip-nx-cache && node apps/wahidyankf-www/scripts/validate-static-routes.mjs",
+        "cwd": "{workspaceRoot}"
+      },
+      "inputs": ["default", "{workspaceRoot}/specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/**/*.feature"]
     },
     "test:integration": {
       "executor": "nx:run-commands",

--- a/apps/wahidyankf-www/scripts/validate-static-routes.mjs
+++ b/apps/wahidyankf-www/scripts/validate-static-routes.mjs
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const appRoot = resolve(import.meta.dirname, "..");
+const prerenderManifest = JSON.parse(readFileSync(resolve(appRoot, ".next/prerender-manifest.json"), "utf8"));
+const routesManifest = JSON.parse(readFileSync(resolve(appRoot, ".next/routes-manifest.json"), "utf8"));
+const publicRoutes = ["/", "/cv", "/personal-projects", "/robots.txt", "/sitemap.xml"];
+const prerenderedRoutes = Object.keys(prerenderManifest.routes);
+const staticRoutes = routesManifest.staticRoutes.map(({ page }) => page);
+const dynamicRoutes = routesManifest.dynamicRoutes.map(({ page }) => page);
+
+function requireRoutes(routes, manifestName) {
+  const missingRoutes = publicRoutes.filter((route) => !routes.includes(route));
+
+  if (missingRoutes.length > 0) {
+    throw new Error(`${manifestName} is missing static route(s): ${missingRoutes.join(", ")}`);
+  }
+}
+
+requireRoutes(prerenderedRoutes, "prerender-manifest.json");
+requireRoutes(staticRoutes, "routes-manifest.json");
+
+if (dynamicRoutes.length > 0) {
+  throw new Error(`routes-manifest.json contains dynamic route(s): ${dynamicRoutes.join(", ")}`);
+}
+
+console.log(`Verified static build output for ${publicRoutes.join(", ")}.`);

--- a/apps/wahidyankf-www/src/app/cv/page.tsx
+++ b/apps/wahidyankf-www/src/app/cv/page.tsx
@@ -1,6 +1,5 @@
 import { CvContent } from "@/features/cv/shell/CvContent";
 import type { Metadata } from "next";
-import { Suspense } from "react";
 
 export const metadata: Metadata = {
   title: "CV | Wahidyan Kresna Fridayoka",
@@ -9,9 +8,5 @@ export const metadata: Metadata = {
 };
 
 export default function CV() {
-  return (
-    <Suspense>
-      <CvContent />
-    </Suspense>
-  );
+  return <CvContent />;
 }

--- a/apps/wahidyankf-www/src/app/cv/page.tsx
+++ b/apps/wahidyankf-www/src/app/cv/page.tsx
@@ -1,5 +1,6 @@
 import { CvContent } from "@/features/cv/shell/CvContent";
 import type { Metadata } from "next";
+import { Suspense } from "react";
 
 export const metadata: Metadata = {
   title: "CV | Wahidyan Kresna Fridayoka",
@@ -7,7 +8,10 @@ export const metadata: Metadata = {
     "Full curriculum vitae of Wahidyan Kresna Fridayoka — work experience, skills, education, and certifications.",
 };
 
-export default async function CV({ searchParams }: { searchParams: Promise<{ search?: string; scrollTop?: string }> }) {
-  const { search, scrollTop } = await searchParams;
-  return <CvContent initialSearchTerm={search ?? ""} scrollTop={scrollTop === "true"} />;
+export default function CV() {
+  return (
+    <Suspense>
+      <CvContent />
+    </Suspense>
+  );
 }

--- a/apps/wahidyankf-www/src/app/cv/page.unit.test.tsx
+++ b/apps/wahidyankf-www/src/app/cv/page.unit.test.tsx
@@ -87,6 +87,7 @@ describe("CV component", () => {
     vi.clearAllMocks();
     vi.mocked(window.scrollTo).mockReset();
     mockSearchParams = new URLSearchParams();
+    window.history.replaceState({}, "", "/cv");
   });
 
   it("renders the main sections", () => {
@@ -106,7 +107,7 @@ describe("CV component", () => {
   });
 
   it("prefills and filters from a shared search URL", () => {
-    mockSearchParams = new URLSearchParams("search=Software");
+    window.history.replaceState({}, "", "/cv?search=Software");
     render(<CvContent />);
 
     expect(screen.getByTestId("search-component")).toHaveValue("Software");
@@ -174,7 +175,7 @@ describe("CV component", () => {
   });
 
   it("scrolls to top when scrollTop prop is true", () => {
-    mockSearchParams = new URLSearchParams("scrollTop=true");
+    window.history.replaceState({}, "", "/cv?scrollTop=true");
     render(<CvContent />);
     expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
   });

--- a/apps/wahidyankf-www/src/app/cv/page.unit.test.tsx
+++ b/apps/wahidyankf-www/src/app/cv/page.unit.test.tsx
@@ -6,6 +6,7 @@ import { CvContent } from "@/features/cv/shell/CvContent";
 // Mock declarations
 const mockPush = vi.fn();
 const mockReplace = vi.fn();
+let mockSearchParams = new URLSearchParams();
 
 // Add this mock for window.scrollTo
 vi.stubGlobal("scrollTo", vi.fn());
@@ -15,6 +16,7 @@ vi.mock("next/navigation", () => ({
     push: mockPush,
     replace: mockReplace,
   }),
+  useSearchParams: () => mockSearchParams,
 }));
 
 vi.mock("@/features/app-shell/shell/Navigation", () => ({
@@ -39,10 +41,6 @@ vi.mock("@open-sharia-enterprise/web-ui", () => ({
     />
   ),
   HighlightText: ({ text }: { text: string }) => <span>{text}</span>,
-}));
-
-vi.mock("@/features/search/core/search", () => ({
-  filterItems: vi.fn((items) => items),
 }));
 
 vi.mock("@/features/cv/core/data", () => ({
@@ -88,32 +86,42 @@ describe("CV component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(window.scrollTo).mockReset();
+    mockSearchParams = new URLSearchParams();
   });
 
   it("renders the main sections", () => {
-    render(<CvContent initialSearchTerm="" scrollTop={false} />);
+    render(<CvContent />);
     expect(screen.getByText("Curriculum Vitae")).toBeInTheDocument();
     expect(screen.getByText("Highlights")).toBeInTheDocument();
   });
 
   it("renders the Navigation component", () => {
-    render(<CvContent initialSearchTerm="" scrollTop={false} />);
+    render(<CvContent />);
     expect(screen.getByTestId("navigation")).toBeInTheDocument();
   });
 
   it("renders the SearchComponent", () => {
-    render(<CvContent initialSearchTerm="" scrollTop={false} />);
+    render(<CvContent />);
     expect(screen.getByTestId("search-component")).toBeInTheDocument();
   });
 
+  it("prefills and filters from a shared search URL", () => {
+    mockSearchParams = new URLSearchParams("search=Software");
+    render(<CvContent />);
+
+    expect(screen.getByTestId("search-component")).toHaveValue("Software");
+    expect(screen.getByText("Software Engineer")).toBeInTheDocument();
+    expect(screen.queryByText("Bachelor of Science in Computer Science")).not.toBeInTheDocument();
+  });
+
   it("renders the about section", () => {
-    render(<CvContent initialSearchTerm="" scrollTop={false} />);
+    render(<CvContent />);
     expect(screen.getByText("About Me")).toBeInTheDocument();
     expect(screen.getByText(/Test about me/)).toBeInTheDocument();
   });
 
   it("renders work experience", () => {
-    render(<CvContent initialSearchTerm="" scrollTop={false} />);
+    render(<CvContent />);
     expect(screen.getByText("Work Experience")).toBeInTheDocument();
     const softwareElements = screen.getAllByText(/Software/);
     expect(softwareElements.length).toBeGreaterThan(0);
@@ -124,21 +132,21 @@ describe("CV component", () => {
   });
 
   it("renders skills, languages, and frameworks", () => {
-    render(<CvContent initialSearchTerm="" scrollTop={false} />);
+    render(<CvContent />);
     expect(screen.getByText("Top Skills Used in The Last 5 Years")).toBeInTheDocument();
     const reactElements = screen.getAllByText(/React/);
     expect(reactElements.length).toBeGreaterThan(0);
   });
 
   it("updates search term when typing in the search component", () => {
-    render(<CvContent initialSearchTerm="" scrollTop={false} />);
+    render(<CvContent />);
     const searchInput = screen.getByTestId("search-component") as HTMLInputElement;
     fireEvent.change(searchInput, { target: { value: "React" } });
     expect(searchInput.value).toBe("React");
   });
 
   it("filters content based on search term", async () => {
-    render(<CvContent initialSearchTerm="" scrollTop={false} />);
+    render(<CvContent />);
     const searchInput = screen.getByTestId("search-component");
     fireEvent.change(searchInput, { target: { value: "Software" } });
     await waitFor(() => {
@@ -147,7 +155,7 @@ describe("CV component", () => {
   });
 
   it("handles item click and updates search", () => {
-    render(<CvContent initialSearchTerm="" scrollTop={false} />);
+    render(<CvContent />);
     const skillButtons = screen.getAllByText("React");
     fireEvent.click(skillButtons[0]);
     expect(mockPush).toHaveBeenCalled();
@@ -156,7 +164,7 @@ describe("CV component", () => {
   });
 
   it("renders education entries with organization", () => {
-    render(<CvContent initialSearchTerm="" scrollTop={false} />);
+    render(<CvContent />);
 
     expect(screen.getByText("Education")).toBeInTheDocument();
     expect(screen.getByText("Bachelor of Science in Computer Science")).toBeInTheDocument();
@@ -166,7 +174,8 @@ describe("CV component", () => {
   });
 
   it("scrolls to top when scrollTop prop is true", () => {
-    render(<CvContent initialSearchTerm="" scrollTop={true} />);
+    mockSearchParams = new URLSearchParams("scrollTop=true");
+    render(<CvContent />);
     expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
   });
 });

--- a/apps/wahidyankf-www/src/app/layout.tsx
+++ b/apps/wahidyankf-www/src/app/layout.tsx
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
   openGraph: {
     type: "website",
     locale: "en_US",
-    url: "https://wahidyankf.com",
+    url: "https://www.wahidyankf.com",
     siteName: "Wahidyan Kresna Fridayoka",
     title: "Wahidyan Kresna Fridayoka | Software Engineer",
     description:

--- a/apps/wahidyankf-www/src/app/layout.tsx
+++ b/apps/wahidyankf-www/src/app/layout.tsx
@@ -34,21 +34,12 @@ export const metadata: Metadata = {
     title: "Wahidyan Kresna Fridayoka | Software Engineer",
     description:
       "Portfolio and CV of Wahidyan Kresna Fridayoka, a seasoned Software Engineer specializing in Frontend Engineering and Engineering Management.",
-    images: [
-      {
-        url: "https://wahidyankf.com/og-image.jpg", // You'll need to create and host this image
-        width: 1200,
-        height: 630,
-        alt: "Wahidyan Kresna Fridayoka",
-      },
-    ],
   },
   twitter: {
     card: "summary_large_image",
     title: "Wahidyan Kresna Fridayoka | Software Engineer",
     description:
       "Portfolio and CV of Wahidyan Kresna Fridayoka, a seasoned Software Engineer specializing in Frontend Engineering and Engineering Management.",
-    images: ["https://wahidyankf.com/og-image.jpg"], // Same as OpenGraph image
     creator: "@wahidyankf", // Replace with your Twitter handle if you have one
   },
   robots: {

--- a/apps/wahidyankf-www/src/app/layout.unit.test.tsx
+++ b/apps/wahidyankf-www/src/app/layout.unit.test.tsx
@@ -43,4 +43,8 @@ describe("RootLayout", () => {
     expect(metadata.openGraph?.images).toBeUndefined();
     expect(metadata.twitter?.images).toBeUndefined();
   });
+
+  it("uses the canonical public URL for OpenGraph metadata", () => {
+    expect(metadata.openGraph?.url).toBe("https://www.wahidyankf.com");
+  });
 });

--- a/apps/wahidyankf-www/src/app/layout.unit.test.tsx
+++ b/apps/wahidyankf-www/src/app/layout.unit.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import RootLayout from "./layout";
+import RootLayout, { metadata } from "./layout";
 
 vi.mock("@open-sharia-enterprise/web-ui", () => ({
   ScrollToTop: () => <div data-testid="scroll-to-top">ScrollToTop</div>,
@@ -37,5 +37,10 @@ describe("RootLayout", () => {
     );
 
     expect(screen.getByTestId("scroll-to-top")).toBeInTheDocument();
+  });
+
+  it("does not reference the absent og-image.jpg asset", () => {
+    expect(metadata.openGraph?.images).toBeUndefined();
+    expect(metadata.twitter?.images).toBeUndefined();
   });
 });

--- a/apps/wahidyankf-www/src/app/page.tsx
+++ b/apps/wahidyankf-www/src/app/page.tsx
@@ -1,6 +1,10 @@
+import { Suspense } from "react";
 import { HomeContent } from "@/features/home/shell/HomeContent";
 
-export default async function Home({ searchParams }: { searchParams: Promise<{ search?: string }> }) {
-  const { search } = await searchParams;
-  return <HomeContent initialSearchTerm={search ?? ""} />;
+export default function Home() {
+  return (
+    <Suspense>
+      <HomeContent />
+    </Suspense>
+  );
 }

--- a/apps/wahidyankf-www/src/app/page.tsx
+++ b/apps/wahidyankf-www/src/app/page.tsx
@@ -1,10 +1,5 @@
-import { Suspense } from "react";
 import { HomeContent } from "@/features/home/shell/HomeContent";
 
 export default function Home() {
-  return (
-    <Suspense>
-      <HomeContent />
-    </Suspense>
-  );
+  return <HomeContent />;
 }

--- a/apps/wahidyankf-www/src/app/page.unit.test.tsx
+++ b/apps/wahidyankf-www/src/app/page.unit.test.tsx
@@ -82,6 +82,7 @@ describe("Home component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSearchParams = new URLSearchParams();
+    window.history.replaceState({}, "", "/");
   });
 
   it("renders the main sections", () => {
@@ -104,7 +105,7 @@ describe("Home component", () => {
   });
 
   it("initializes search from the URL", () => {
-    mockSearchParams = new URLSearchParams("search=React");
+    window.history.replaceState({}, "", "/?search=React");
     render(<HomeContent />);
     expect(screen.getByTestId("search-component")).toHaveValue("React");
   });

--- a/apps/wahidyankf-www/src/app/page.unit.test.tsx
+++ b/apps/wahidyankf-www/src/app/page.unit.test.tsx
@@ -6,10 +6,12 @@ import { filterItems } from "@/features/search/core/search";
 
 // Mock the next/navigation module
 const mockPush = vi.fn();
+let mockSearchParams = new URLSearchParams();
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mockPush,
   }),
+  useSearchParams: () => mockSearchParams,
 }));
 
 // Mock the components imported from other files
@@ -79,10 +81,11 @@ vi.mock("@/features/cv/core/data", () => ({
 describe("Home component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
   });
 
   it("renders the main sections", () => {
-    render(<HomeContent initialSearchTerm="" />);
+    render(<HomeContent />);
     expect(screen.getByText("Welcome to My Portfolio")).toBeInTheDocument();
     expect(screen.getByText("About Me")).toBeInTheDocument();
     expect(screen.getByText("Skills & Expertise")).toBeInTheDocument();
@@ -91,49 +94,55 @@ describe("Home component", () => {
   });
 
   it("renders the Navigation component", () => {
-    render(<HomeContent initialSearchTerm="" />);
+    render(<HomeContent />);
     expect(screen.getByTestId("navigation")).toBeInTheDocument();
   });
 
   it("renders the SearchComponent", () => {
-    render(<HomeContent initialSearchTerm="" />);
+    render(<HomeContent />);
     expect(screen.getByTestId("search-component")).toBeInTheDocument();
   });
 
+  it("initializes search from the URL", () => {
+    mockSearchParams = new URLSearchParams("search=React");
+    render(<HomeContent />);
+    expect(screen.getByTestId("search-component")).toHaveValue("React");
+  });
+
   it("renders the about me section", () => {
-    render(<HomeContent initialSearchTerm="" />);
+    render(<HomeContent />);
     expect(screen.getByText("Test about me")).toBeInTheDocument();
   });
 
   it("renders skills, languages, and frameworks", () => {
-    render(<HomeContent initialSearchTerm="" />);
+    render(<HomeContent />);
     expect(screen.getByText("Software Engineering")).toBeInTheDocument();
     expect(screen.getByText("JavaScript")).toBeInTheDocument();
     expect(screen.getAllByText("React")).toHaveLength(2);
   });
 
   it("renders quick links", () => {
-    render(<HomeContent initialSearchTerm="" />);
+    render(<HomeContent />);
     expect(screen.getByText("View My CV")).toBeInTheDocument();
     expect(screen.getByText("Browse My Personal Projects")).toBeInTheDocument();
   });
 
   it("renders connect with me links", () => {
-    render(<HomeContent initialSearchTerm="" />);
+    render(<HomeContent />);
     expect(screen.getByText("Github")).toBeInTheDocument();
     expect(screen.getByText("Linkedin")).toBeInTheDocument();
     expect(screen.getByText("Email")).toBeInTheDocument();
   });
 
   it("updates search term when typing in the search component", () => {
-    render(<HomeContent initialSearchTerm="" />);
+    render(<HomeContent />);
     const searchInput = screen.getByTestId("search-component") as HTMLInputElement;
     fireEvent.change(searchInput, { target: { value: "React" } });
     expect(searchInput.value).toBe("React");
   });
 
   it("filters content based on search term", () => {
-    render(<HomeContent initialSearchTerm="" />);
+    render(<HomeContent />);
     const searchInput = screen.getByTestId("search-component");
     fireEvent.change(searchInput, { target: { value: "React" } });
 
@@ -141,35 +150,35 @@ describe("Home component", () => {
   });
 
   it("handles item click and navigates to CV page", () => {
-    render(<HomeContent initialSearchTerm="" />);
+    render(<HomeContent />);
     const skillButtons = screen.getAllByText("React");
     fireEvent.click(skillButtons[0]);
     expect(mockPush).toHaveBeenCalledWith("/cv?search=React&scrollTop=true");
   });
 
   it("handles language button click and navigates to CV page", () => {
-    render(<HomeContent initialSearchTerm="" />);
+    render(<HomeContent />);
     const languageButton = screen.getByText("JavaScript");
     fireEvent.click(languageButton);
     expect(mockPush).toHaveBeenCalledWith("/cv?search=JavaScript&scrollTop=true");
   });
 
   it("handles framework button click and navigates to CV page", () => {
-    render(<HomeContent initialSearchTerm="" />);
+    render(<HomeContent />);
     const frameworkButton = screen.getByText("Next.js");
     fireEvent.click(frameworkButton);
     expect(mockPush).toHaveBeenCalledWith("/cv?search=Next.js&scrollTop=true");
   });
 
   it("updates URL when typing in search", () => {
-    render(<HomeContent initialSearchTerm="" />);
+    render(<HomeContent />);
     const searchInput = screen.getByTestId("search-component") as HTMLInputElement;
     fireEvent.change(searchInput, { target: { value: "TypeScript" } });
     expect(mockPush).toHaveBeenCalledWith("/?search=TypeScript", { scroll: false });
   });
 
   it("handles TypeScript skill pill click navigates with scrollTop", () => {
-    render(<HomeContent initialSearchTerm="" />);
+    render(<HomeContent />);
     const languageButton = screen.getByText("TypeScript");
     fireEvent.click(languageButton);
     expect(mockPush).toHaveBeenCalledWith("/cv?search=TypeScript&scrollTop=true");

--- a/apps/wahidyankf-www/src/app/personal-projects/page.tsx
+++ b/apps/wahidyankf-www/src/app/personal-projects/page.tsx
@@ -1,6 +1,5 @@
 import { PersonalProjectsContent } from "@/features/personal-projects/shell/PersonalProjectsContent";
 import type { Metadata } from "next";
-import { Suspense } from "react";
 
 export const metadata: Metadata = {
   title: "Personal Projects | Wahidyan Kresna Fridayoka",
@@ -9,9 +8,5 @@ export const metadata: Metadata = {
 };
 
 export default function Projects() {
-  return (
-    <Suspense>
-      <PersonalProjectsContent />
-    </Suspense>
-  );
+  return <PersonalProjectsContent />;
 }

--- a/apps/wahidyankf-www/src/app/personal-projects/page.tsx
+++ b/apps/wahidyankf-www/src/app/personal-projects/page.tsx
@@ -1,5 +1,6 @@
 import { PersonalProjectsContent } from "@/features/personal-projects/shell/PersonalProjectsContent";
 import type { Metadata } from "next";
+import { Suspense } from "react";
 
 export const metadata: Metadata = {
   title: "Personal Projects | Wahidyan Kresna Fridayoka",
@@ -7,7 +8,10 @@ export const metadata: Metadata = {
     "Open-source and personal projects by Wahidyan Kresna Fridayoka, including OSE, AyoKoding, OrganicLever, and more.",
 };
 
-export default async function Projects({ searchParams }: { searchParams: Promise<{ search?: string }> }) {
-  const { search } = await searchParams;
-  return <PersonalProjectsContent initialSearchTerm={search ?? ""} />;
+export default function Projects() {
+  return (
+    <Suspense>
+      <PersonalProjectsContent />
+    </Suspense>
+  );
 }

--- a/apps/wahidyankf-www/src/app/personal-projects/page.unit.test.tsx
+++ b/apps/wahidyankf-www/src/app/personal-projects/page.unit.test.tsx
@@ -61,6 +61,7 @@ describe("Personal Projects component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSearchParams = new URLSearchParams();
+    window.history.replaceState({}, "", "/personal-projects");
   });
 
   it("renders the main sections", () => {
@@ -79,7 +80,7 @@ describe("Personal Projects component", () => {
   });
 
   it("initializes search from the URL", () => {
-    mockSearchParams = new URLSearchParams("search=AyoKoding");
+    window.history.replaceState({}, "", "/personal-projects?search=AyoKoding");
     render(<PersonalProjectsContent />);
     expect(screen.getByTestId("search-component")).toHaveValue("AyoKoding");
     expect(screen.getByText("AyoKoding")).toBeInTheDocument();

--- a/apps/wahidyankf-www/src/app/personal-projects/page.unit.test.tsx
+++ b/apps/wahidyankf-www/src/app/personal-projects/page.unit.test.tsx
@@ -5,11 +5,13 @@ import { PersonalProjectsContent } from "@/features/personal-projects/shell/Pers
 
 // Mock declarations
 const mockPush = vi.fn();
+let mockSearchParams = new URLSearchParams();
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mockPush,
   }),
+  useSearchParams: () => mockSearchParams,
 }));
 
 vi.mock("@/features/app-shell/shell/Navigation", () => ({
@@ -58,25 +60,34 @@ vi.mock("@/features/search/core/search", () => ({
 describe("Personal Projects component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
   });
 
   it("renders the main sections", () => {
-    render(<PersonalProjectsContent initialSearchTerm="" />);
+    render(<PersonalProjectsContent />);
     expect(screen.getByText("Personal Projects")).toBeInTheDocument();
     expect(screen.getByTestId("search-component")).toBeInTheDocument();
     expect(screen.getByTestId("navigation")).toBeInTheDocument();
   });
 
   it("renders all projects initially", () => {
-    render(<PersonalProjectsContent initialSearchTerm="" />);
+    render(<PersonalProjectsContent />);
     expect(screen.getByText("Open Sharia Enterprise (OSE)")).toBeInTheDocument();
     expect(screen.getByText("AyoKoding")).toBeInTheDocument();
     expect(screen.getByText("Organic Lever")).toBeInTheDocument();
     expect(screen.getByText("The Organic")).toBeInTheDocument();
   });
 
+  it("initializes search from the URL", () => {
+    mockSearchParams = new URLSearchParams("search=AyoKoding");
+    render(<PersonalProjectsContent />);
+    expect(screen.getByTestId("search-component")).toHaveValue("AyoKoding");
+    expect(screen.getByText("AyoKoding")).toBeInTheDocument();
+    expect(screen.queryByText("Organic Lever")).not.toBeInTheDocument();
+  });
+
   it("filters projects based on search term", async () => {
-    render(<PersonalProjectsContent initialSearchTerm="" />);
+    render(<PersonalProjectsContent />);
     const searchInput = screen.getByTestId("search-component");
     fireEvent.change(searchInput, { target: { value: "AyoKoding" } });
 
@@ -88,7 +99,7 @@ describe("Personal Projects component", () => {
   });
 
   it("displays 'No projects found' message when no matches", async () => {
-    render(<PersonalProjectsContent initialSearchTerm="" />);
+    render(<PersonalProjectsContent />);
     const searchInput = screen.getByTestId("search-component");
     fireEvent.change(searchInput, { target: { value: "NonexistentProject" } });
 
@@ -98,7 +109,7 @@ describe("Personal Projects component", () => {
   });
 
   it("updates URL when searching", async () => {
-    render(<PersonalProjectsContent initialSearchTerm="" />);
+    render(<PersonalProjectsContent />);
     const searchInput = screen.getByTestId("search-component");
     fireEvent.change(searchInput, { target: { value: "AyoKoding" } });
 
@@ -108,7 +119,7 @@ describe("Personal Projects component", () => {
   });
 
   it("renders project links correctly", () => {
-    render(<PersonalProjectsContent initialSearchTerm="" />);
+    render(<PersonalProjectsContent />);
 
     const repositoryLinks = screen.getAllByRole("link", {
       name: /Repository/i,

--- a/apps/wahidyankf-www/src/app/robots.ts
+++ b/apps/wahidyankf-www/src/app/robots.ts
@@ -1,0 +1,8 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [{ userAgent: "*", allow: "/" }],
+    sitemap: "https://www.wahidyankf.com/sitemap.xml",
+  };
+}

--- a/apps/wahidyankf-www/src/app/seo-routes.unit.test.ts
+++ b/apps/wahidyankf-www/src/app/seo-routes.unit.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import robots from "./robots";
+import sitemap from "./sitemap";
+
+describe("SEO metadata routes", () => {
+  it("advertises the canonical sitemap to crawlers", () => {
+    expect(robots()).toEqual({
+      rules: [{ userAgent: "*", allow: "/" }],
+      sitemap: "https://www.wahidyankf.com/sitemap.xml",
+    });
+  });
+
+  it("lists every public portfolio route at the canonical domain", () => {
+    expect(sitemap()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ url: "https://www.wahidyankf.com" }),
+        expect.objectContaining({ url: "https://www.wahidyankf.com/cv" }),
+        expect.objectContaining({ url: "https://www.wahidyankf.com/personal-projects" }),
+      ]),
+    );
+  });
+});

--- a/apps/wahidyankf-www/src/app/sitemap.ts
+++ b/apps/wahidyankf-www/src/app/sitemap.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = "https://www.wahidyankf.com";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    { url: siteUrl, changeFrequency: "monthly", priority: 1 },
+    { url: `${siteUrl}/cv`, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${siteUrl}/personal-projects`, changeFrequency: "monthly", priority: 0.8 },
+  ];
+}

--- a/apps/wahidyankf-www/src/app/static-route-content.unit.test.tsx
+++ b/apps/wahidyankf-www/src/app/static-route-content.unit.test.tsx
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import Home from "./page";
+import CV from "./cv/page";
+import Projects from "./personal-projects/page";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock("@/features/app-shell/shell/Navigation", () => ({
+  Navigation: () => <nav aria-label="Primary navigation" />,
+}));
+
+vi.mock("@open-sharia-enterprise/web-ui", () => ({
+  SearchComponent: ({ placeholder }: { placeholder: string }) => <input placeholder={placeholder} readOnly />,
+  HighlightText: ({ text }: { text: string }) => <>{text}</>,
+}));
+
+const routes = [
+  {
+    pathname: "/",
+    source: "page.tsx",
+    contentSource: "../features/home/shell/HomeContent.tsx",
+    Component: Home,
+    visibleContent: "Welcome to My Portfolio",
+  },
+  {
+    pathname: "/cv",
+    source: "cv/page.tsx",
+    contentSource: "../features/cv/shell/CvContent.tsx",
+    Component: CV,
+    visibleContent: "Curriculum Vitae",
+  },
+  {
+    pathname: "/personal-projects",
+    source: "personal-projects/page.tsx",
+    contentSource: "../features/personal-projects/shell/PersonalProjectsContent.tsx",
+    Component: Projects,
+    visibleContent: "Personal Projects",
+  },
+] as const;
+
+describe("static portfolio route content", () => {
+  for (const route of routes) {
+    it(`${route.pathname} renders visible content before browser query seeding`, () => {
+      const source = readFileSync(resolve(__dirname, route.source), "utf8");
+      const contentSource = readFileSync(resolve(__dirname, route.contentSource), "utf8");
+
+      expect(source).not.toContain("Suspense");
+      expect(contentSource).not.toContain("useSearchParams");
+      expect(renderToStaticMarkup(<route.Component />)).toContain(route.visibleContent);
+    });
+  }
+});

--- a/apps/wahidyankf-www/src/app/static-routes.unit.test.ts
+++ b/apps/wahidyankf-www/src/app/static-routes.unit.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const routes = [
+  { pathname: "/", source: "page.tsx" },
+  { pathname: "/cv", source: "cv/page.tsx" },
+  { pathname: "/personal-projects", source: "personal-projects/page.tsx" },
+] as const;
+
+const declaresSearchParams = /function\s+\w+\s*\(\s*{\s*searchParams\b/;
+const awaitsSearchParams = /\bawait\s+searchParams\b/;
+
+describe("static portfolio routes", () => {
+  for (const route of routes) {
+    it(`${route.pathname} neither declares nor awaits searchParams`, () => {
+      const source = readFileSync(resolve(__dirname, route.source), "utf8");
+
+      expect({
+        declaresSearchParams: declaresSearchParams.test(source),
+        awaitsSearchParams: awaitsSearchParams.test(source),
+      }).toEqual({ declaresSearchParams: false, awaitsSearchParams: false });
+    });
+  }
+});

--- a/apps/wahidyankf-www/src/features/cv/shell/CvContent.tsx
+++ b/apps/wahidyankf-www/src/features/cv/shell/CvContent.tsx
@@ -20,7 +20,7 @@ import {
   Package,
 } from "lucide-react";
 import { useState, useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import {
   CVEntry,
   cvData,
@@ -476,24 +476,27 @@ const WorkExperienceSection = ({
 // In the main CV component, update the type of topSkills
 export function CvContent() {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const search = searchParams.get("search") ?? "";
-  const scrollTop = searchParams.get("scrollTop") === "true";
-  const [searchTerm, setSearchTerm] = useState(search);
+  const [searchTerm, setSearchTerm] = useState("");
   const [showRecentOnly, setShowRecentOnly] = useState(false);
 
   useEffect(() => {
-    setSearchTerm(search);
-  }, [search]);
+    const syncSearchTerm = () => {
+      setSearchTerm(new URLSearchParams(window.location.search).get("search") ?? "");
+    };
+
+    syncSearchTerm();
+    window.addEventListener("popstate", syncSearchTerm);
+    return () => window.removeEventListener("popstate", syncSearchTerm);
+  }, []);
 
   useEffect(() => {
-    if (scrollTop) {
+    if (new URLSearchParams(window.location.search).get("scrollTop") === "true") {
       window.scrollTo(0, 0);
       const newURL = new URL(window.location.href);
       newURL.searchParams.delete("scrollTop");
       router.replace(newURL.toString(), { scroll: false });
     }
-  }, [router, scrollTop]);
+  }, [router]);
 
   const updateURL = (term: string) => {
     const newURL = term ? `/cv?search=${encodeURIComponent(term)}` : "/cv";

--- a/apps/wahidyankf-www/src/features/cv/shell/CvContent.tsx
+++ b/apps/wahidyankf-www/src/features/cv/shell/CvContent.tsx
@@ -20,7 +20,7 @@ import {
   Package,
 } from "lucide-react";
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   CVEntry,
   cvData,
@@ -474,14 +474,17 @@ const WorkExperienceSection = ({
 };
 
 // In the main CV component, update the type of topSkills
-export function CvContent({ initialSearchTerm, scrollTop }: { initialSearchTerm: string; scrollTop: boolean }) {
+export function CvContent() {
   const router = useRouter();
-  const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
+  const searchParams = useSearchParams();
+  const search = searchParams.get("search") ?? "";
+  const scrollTop = searchParams.get("scrollTop") === "true";
+  const [searchTerm, setSearchTerm] = useState(search);
   const [showRecentOnly, setShowRecentOnly] = useState(false);
 
   useEffect(() => {
-    setSearchTerm(initialSearchTerm);
-  }, [initialSearchTerm]);
+    setSearchTerm(search);
+  }, [search]);
 
   useEffect(() => {
     if (scrollTop) {
@@ -490,7 +493,7 @@ export function CvContent({ initialSearchTerm, scrollTop }: { initialSearchTerm:
       newURL.searchParams.delete("scrollTop");
       router.replace(newURL.toString(), { scroll: false });
     }
-  }, []);
+  }, [router, scrollTop]);
 
   const updateURL = (term: string) => {
     const newURL = term ? `/cv?search=${encodeURIComponent(term)}` : "/cv";

--- a/apps/wahidyankf-www/src/features/home/shell/HomeContent.tsx
+++ b/apps/wahidyankf-www/src/features/home/shell/HomeContent.tsx
@@ -2,7 +2,7 @@
 
 import { Briefcase, FolderOpen, Github, Linkedin, Mail, Star, Code, Package } from "lucide-react";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import {
   cvData,
   getTopSkillsLastFiveYears,
@@ -28,9 +28,7 @@ export type FeaturedSkill = {
 
 export function HomeContent() {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const search = searchParams.get("search") ?? "";
-  const [searchTerm, setSearchTerm] = useState(search);
+  const [searchTerm, setSearchTerm] = useState("");
 
   const aboutMe = cvData.find((entry) => entry.type === "about");
   const topSkills = getTopSkillsLastFiveYears(cvData);
@@ -60,8 +58,14 @@ export function HomeContent() {
   );
 
   useEffect(() => {
-    setSearchTerm(search);
-  }, [search]);
+    const syncSearchTerm = () => {
+      setSearchTerm(new URLSearchParams(window.location.search).get("search") ?? "");
+    };
+
+    syncSearchTerm();
+    window.addEventListener("popstate", syncSearchTerm);
+    return () => window.removeEventListener("popstate", syncSearchTerm);
+  }, []);
 
   const updateURL = (term: string) => {
     const newURL = term ? `/?search=${encodeURIComponent(term)}` : "/";

--- a/apps/wahidyankf-www/src/features/home/shell/HomeContent.tsx
+++ b/apps/wahidyankf-www/src/features/home/shell/HomeContent.tsx
@@ -2,7 +2,7 @@
 
 import { Briefcase, FolderOpen, Github, Linkedin, Mail, Star, Code, Package } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   cvData,
   getTopSkillsLastFiveYears,
@@ -26,9 +26,11 @@ export type FeaturedSkill = {
   duration: number;
 };
 
-export function HomeContent({ initialSearchTerm }: { initialSearchTerm: string }) {
+export function HomeContent() {
   const router = useRouter();
-  const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
+  const searchParams = useSearchParams();
+  const search = searchParams.get("search") ?? "";
+  const [searchTerm, setSearchTerm] = useState(search);
 
   const aboutMe = cvData.find((entry) => entry.type === "about");
   const topSkills = getTopSkillsLastFiveYears(cvData);
@@ -58,8 +60,8 @@ export function HomeContent({ initialSearchTerm }: { initialSearchTerm: string }
   );
 
   useEffect(() => {
-    setSearchTerm(initialSearchTerm);
-  }, [initialSearchTerm]);
+    setSearchTerm(search);
+  }, [search]);
 
   const updateURL = (term: string) => {
     const newURL = term ? `/?search=${encodeURIComponent(term)}` : "/";

--- a/apps/wahidyankf-www/src/features/personal-projects/shell/PersonalProjectsContent.tsx
+++ b/apps/wahidyankf-www/src/features/personal-projects/shell/PersonalProjectsContent.tsx
@@ -4,7 +4,7 @@ import { Navigation } from "@/features/app-shell/shell/Navigation";
 import { projects, filterProjects } from "@/features/personal-projects/core/projects";
 import { Github, Globe, Youtube } from "lucide-react";
 import { useState, useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { SearchComponent, HighlightText } from "@open-sharia-enterprise/web-ui";
 
 const LinkIcon = ({ type }: { type: string }) => {
@@ -20,13 +20,17 @@ const LinkIcon = ({ type }: { type: string }) => {
 
 function ProjectsContent() {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const search = searchParams.get("search") ?? "";
-  const [searchTerm, setSearchTerm] = useState(search);
+  const [searchTerm, setSearchTerm] = useState("");
 
   useEffect(() => {
-    setSearchTerm(search);
-  }, [search]);
+    const syncSearchTerm = () => {
+      setSearchTerm(new URLSearchParams(window.location.search).get("search") ?? "");
+    };
+
+    syncSearchTerm();
+    window.addEventListener("popstate", syncSearchTerm);
+    return () => window.removeEventListener("popstate", syncSearchTerm);
+  }, []);
 
   const updateURL = (term: string) => {
     const newURL = term ? `/personal-projects?search=${encodeURIComponent(term)}` : "/personal-projects";

--- a/apps/wahidyankf-www/src/features/personal-projects/shell/PersonalProjectsContent.tsx
+++ b/apps/wahidyankf-www/src/features/personal-projects/shell/PersonalProjectsContent.tsx
@@ -4,7 +4,7 @@ import { Navigation } from "@/features/app-shell/shell/Navigation";
 import { projects, filterProjects } from "@/features/personal-projects/core/projects";
 import { Github, Globe, Youtube } from "lucide-react";
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { SearchComponent, HighlightText } from "@open-sharia-enterprise/web-ui";
 
 const LinkIcon = ({ type }: { type: string }) => {
@@ -18,13 +18,15 @@ const LinkIcon = ({ type }: { type: string }) => {
   }
 };
 
-function ProjectsContent({ initialSearchTerm }: { initialSearchTerm: string }) {
+function ProjectsContent() {
   const router = useRouter();
-  const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
+  const searchParams = useSearchParams();
+  const search = searchParams.get("search") ?? "";
+  const [searchTerm, setSearchTerm] = useState(search);
 
   useEffect(() => {
-    setSearchTerm(initialSearchTerm);
-  }, [initialSearchTerm]);
+    setSearchTerm(search);
+  }, [search]);
 
   const updateURL = (term: string) => {
     const newURL = term ? `/personal-projects?search=${encodeURIComponent(term)}` : "/personal-projects";
@@ -83,12 +85,12 @@ function ProjectsContent({ initialSearchTerm }: { initialSearchTerm: string }) {
   );
 }
 
-export function PersonalProjectsContent({ initialSearchTerm }: { initialSearchTerm: string }) {
+export function PersonalProjectsContent() {
   return (
     <main className="flex min-h-screen flex-col bg-gray-900 p-4 pb-20 text-green-400 sm:p-8 md:p-12 lg:ml-80 lg:p-16 lg:pb-0">
       <Navigation />
       <div className="mx-auto w-full max-w-4xl flex-grow">
-        <ProjectsContent initialSearchTerm={initialSearchTerm} />
+        <ProjectsContent />
       </div>
     </main>
   );

--- a/apps/wahidyankf-www/test/unit/steps/accessibility.steps.ts
+++ b/apps/wahidyankf-www/test/unit/steps/accessibility.steps.ts
@@ -14,6 +14,7 @@ import { PersonalProjectsContent } from "@/features/personal-projects/shell/Pers
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
   usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 // @amiceli/vitest-cucumber registers every Given/When/Then/And as its own vitest
@@ -44,7 +45,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
     // an axe scan checks for.
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/app-shell/accessibility.feature:Home page has zero axe-core WCAG 2.1 AA violations
     Then("an axe-core scan against WCAG 2.1 AA reports zero violations", () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      render(React.createElement(HomeContent));
 
       const main = screen.getByRole("main");
       expect(main).toBeInTheDocument();
@@ -67,7 +68,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/app-shell/accessibility.feature:CV page has zero axe-core WCAG 2.1 AA violations
     Then("an axe-core scan against WCAG 2.1 AA reports zero violations", () => {
-      render(React.createElement(CvContent, { initialSearchTerm: "", scrollTop: false }));
+      render(React.createElement(CvContent));
 
       const main = screen.getByRole("main");
       expect(main).toBeInTheDocument();
@@ -85,19 +86,15 @@ describeFeature(feature, ({ Scenario, Background }) => {
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/app-shell/accessibility.feature:Every page has exactly one H1
     Then("each of those pages has exactly one H1 element", () => {
-      const { unmount: unmountHome } = render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      const { unmount: unmountHome } = render(React.createElement(HomeContent));
       expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
       unmountHome();
 
-      const { unmount: unmountCv } = render(
-        React.createElement(CvContent, { initialSearchTerm: "", scrollTop: false }),
-      );
+      const { unmount: unmountCv } = render(React.createElement(CvContent));
       expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
       unmountCv();
 
-      const { unmount: unmountProjects } = render(
-        React.createElement(PersonalProjectsContent, { initialSearchTerm: "" }),
-      );
+      const { unmount: unmountProjects } = render(React.createElement(PersonalProjectsContent));
       expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
       unmountProjects();
     });
@@ -114,7 +111,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/app-shell/accessibility.feature:Interactive controls expose accessible names
     And("every navigation link exposes link text or an aria-label", () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      render(React.createElement(HomeContent));
       const desktopNav = screen.getByTestId("desktop-nav");
       for (const name of ["Home", "CV", "Personal Projects"]) {
         expect(within(desktopNav).getByRole("link", { name })).toBeInTheDocument();

--- a/apps/wahidyankf-www/test/unit/steps/cv.steps.ts
+++ b/apps/wahidyankf-www/test/unit/steps/cv.steps.ts
@@ -34,6 +34,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
     Given("the app is running", () => {
       vi.mocked(window.scrollTo).mockClear();
       mockSearchParams = new URLSearchParams();
+      window.history.replaceState({}, "", "/cv");
     });
   });
 
@@ -68,11 +69,12 @@ describeFeature(feature, ({ Scenario, Background }) => {
   });
 
   Scenario("CV cross-linked via scrollTop query scrolls into the entries", ({ When, Then }) => {
-    When('a visitor opens the CV page with search term "TypeScript" and scrollTop true', () => {});
+    When('a visitor opens the CV page with search term "TypeScript" and scrollTop true', () => {
+      window.history.replaceState({}, "", "/cv?search=TypeScript&scrollTop=true");
+    });
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/cv/cv.feature:CV cross-linked via scrollTop query scrolls into the entries
     Then("the page scrolls past Highlights into the matching entries", () => {
-      mockSearchParams = new URLSearchParams("search=TypeScript&scrollTop=true");
       render(React.createElement(CvContent));
       expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
       expect(screen.getByRole("heading", { level: 1, name: "Curriculum Vitae" })).toBeInTheDocument();

--- a/apps/wahidyankf-www/test/unit/steps/cv.steps.ts
+++ b/apps/wahidyankf-www/test/unit/steps/cv.steps.ts
@@ -7,9 +7,11 @@ import { CvContent } from "@/features/cv/shell/CvContent";
 
 const mockPush = vi.fn();
 const mockReplace = vi.fn();
+let mockSearchParams = new URLSearchParams();
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush, replace: mockReplace }),
+  useSearchParams: () => mockSearchParams,
 }));
 
 vi.mock("@/features/app-shell/shell/Navigation", () => ({
@@ -31,6 +33,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
   Background(({ Given }) => {
     Given("the app is running", () => {
       vi.mocked(window.scrollTo).mockClear();
+      mockSearchParams = new URLSearchParams();
     });
   });
 
@@ -39,7 +42,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/cv/cv.feature:CV renders the Curriculum Vitae heading
     Then('the H1 shows "Curriculum Vitae"', () => {
-      render(React.createElement(CvContent, { initialSearchTerm: "", scrollTop: false }));
+      render(React.createElement(CvContent));
       expect(screen.getByRole("heading", { level: 1, name: "Curriculum Vitae" })).toBeInTheDocument();
     });
   });
@@ -49,7 +52,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/cv/cv.feature:CV renders a search input
     Then('a search input with placeholder "Search CV entries..." is visible', () => {
-      render(React.createElement(CvContent, { initialSearchTerm: "", scrollTop: false }));
+      render(React.createElement(CvContent));
       expect(screen.getByPlaceholderText("Search CV entries...")).toBeInTheDocument();
     });
   });
@@ -59,7 +62,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/cv/cv.feature:CV renders the Highlights section header
     Then('a "Highlights" section header is visible', () => {
-      render(React.createElement(CvContent, { initialSearchTerm: "", scrollTop: false }));
+      render(React.createElement(CvContent));
       expect(screen.getByRole("heading", { name: "Highlights" })).toBeInTheDocument();
     });
   });
@@ -69,7 +72,8 @@ describeFeature(feature, ({ Scenario, Background }) => {
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/cv/cv.feature:CV cross-linked via scrollTop query scrolls into the entries
     Then("the page scrolls past Highlights into the matching entries", () => {
-      render(React.createElement(CvContent, { initialSearchTerm: "TypeScript", scrollTop: true }));
+      mockSearchParams = new URLSearchParams("search=TypeScript&scrollTop=true");
+      render(React.createElement(CvContent));
       expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
       expect(screen.getByRole("heading", { level: 1, name: "Curriculum Vitae" })).toBeInTheDocument();
       expect(screen.getByPlaceholderText("Search CV entries...")).toBeInTheDocument();

--- a/apps/wahidyankf-www/test/unit/steps/home.steps.ts
+++ b/apps/wahidyankf-www/test/unit/steps/home.steps.ts
@@ -7,6 +7,7 @@ import { HomeContent } from "@/features/home/shell/HomeContent";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 vi.mock("@/features/app-shell/shell/Navigation", () => ({
@@ -32,7 +33,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/home/home.feature:Home renders the welcome heading
     Then('the H1 shows "Welcome to My Portfolio"', () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      render(React.createElement(HomeContent));
       expect(screen.getByRole("heading", { level: 1, name: "Welcome to My Portfolio" })).toBeInTheDocument();
     });
   });
@@ -42,7 +43,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/home/home.feature:Home renders the About Me card
     Then("an About Me card is visible", () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      render(React.createElement(HomeContent));
       expect(screen.getByRole("heading", { name: "About Me" })).toBeInTheDocument();
     });
   });
@@ -51,23 +52,23 @@ describeFeature(feature, ({ Scenario, Background }) => {
     When("a visitor opens the home page", () => {});
 
     Then("a Skills & Expertise card is visible", () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      render(React.createElement(HomeContent));
       expect(screen.getByRole("heading", { name: "Skills & Expertise" })).toBeInTheDocument();
     });
 
     And('the card has a "Top Skills Used in The Last 5 Years" subsection', () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      render(React.createElement(HomeContent));
       expect(screen.getByText("Top Skills Used in The Last 5 Years")).toBeInTheDocument();
     });
 
     And('the card has a "Top Programming Languages Used in The Last 5 Years" subsection', () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      render(React.createElement(HomeContent));
       expect(screen.getByText("Top Programming Languages Used in The Last 5 Years")).toBeInTheDocument();
     });
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/home/home.feature:Home renders the Skills & Expertise card with three subsections
     And('the card has a "Top Frameworks & Libraries Used in The Last 5 Years" subsection', () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      render(React.createElement(HomeContent));
       expect(screen.getByText("Top Frameworks & Libraries Used in The Last 5 Years")).toBeInTheDocument();
     });
   });
@@ -76,18 +77,18 @@ describeFeature(feature, ({ Scenario, Background }) => {
     When("a visitor opens the home page", () => {});
 
     Then("a Quick Links card is visible", () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      render(React.createElement(HomeContent));
       expect(screen.getByRole("heading", { name: "Quick Links" })).toBeInTheDocument();
     });
 
     And('the card contains a "View My CV" link to /cv', () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      render(React.createElement(HomeContent));
       expect(screen.getByRole("link", { name: "View My CV" })).toHaveAttribute("href", "/cv");
     });
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/home/home.feature:Home renders the Quick Links card with two internal links
     And('the card contains a "Browse My Personal Projects" link to /personal-projects', () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      render(React.createElement(HomeContent));
       expect(screen.getByRole("link", { name: "Browse My Personal Projects" })).toHaveAttribute(
         "href",
         "/personal-projects",
@@ -99,13 +100,13 @@ describeFeature(feature, ({ Scenario, Background }) => {
     When("a visitor opens the home page", () => {});
 
     Then("a Connect With Me card is visible", () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      render(React.createElement(HomeContent));
       expect(screen.getByRole("heading", { name: "Connect With Me" })).toBeInTheDocument();
     });
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/home/home.feature:Home renders the Connect With Me card with five external links
     And("the card has Github, GithubOrg, Linkedin, Website, and Email links", () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      render(React.createElement(HomeContent));
       const heading = screen.getByRole("heading", { name: "Connect With Me" });
       const section = heading.closest("section");
       expect(section).not.toBeNull();

--- a/apps/wahidyankf-www/test/unit/steps/personal-projects.steps.ts
+++ b/apps/wahidyankf-www/test/unit/steps/personal-projects.steps.ts
@@ -7,6 +7,7 @@ import { PersonalProjectsContent } from "@/features/personal-projects/shell/Pers
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 vi.mock("@/features/app-shell/shell/Navigation", () => ({
@@ -35,7 +36,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/personal-projects/personal-projects.feature:Personal projects page renders the heading
     Then('the H1 shows "Personal Projects"', () => {
-      render(React.createElement(PersonalProjectsContent, { initialSearchTerm: "" }));
+      render(React.createElement(PersonalProjectsContent));
       expect(screen.getByRole("heading", { level: 1, name: "Personal Projects" })).toBeInTheDocument();
     });
   });
@@ -45,7 +46,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/personal-projects/personal-projects.feature:Personal projects page renders a search input
     Then('a search input with placeholder "Search projects..." is visible', () => {
-      render(React.createElement(PersonalProjectsContent, { initialSearchTerm: "" }));
+      render(React.createElement(PersonalProjectsContent));
       expect(screen.getByPlaceholderText("Search projects...")).toBeInTheDocument();
     });
   });
@@ -55,7 +56,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/personal-projects/personal-projects.feature:Personal projects page lists at least one project card
     Then("at least one project card is visible", () => {
-      render(React.createElement(PersonalProjectsContent, { initialSearchTerm: "" }));
+      render(React.createElement(PersonalProjectsContent));
       const headings = screen.getAllByRole("heading", { level: 2 });
       expect(headings.length).toBeGreaterThan(0);
     });
@@ -68,7 +69,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
     Then(
       "every project card exposes a Repository, Website, or YouTube link where the project has that resource",
       () => {
-        render(React.createElement(PersonalProjectsContent, { initialSearchTerm: "" }));
+        render(React.createElement(PersonalProjectsContent));
         const links = screen.getAllByRole("link", { name: /Repository|Website|YouTube/i });
         expect(links.length).toBeGreaterThan(0);
       },

--- a/apps/wahidyankf-www/test/unit/steps/search.steps.ts
+++ b/apps/wahidyankf-www/test/unit/steps/search.steps.ts
@@ -6,9 +6,11 @@ import { expect, vi } from "vitest";
 import { HomeContent } from "@/features/home/shell/HomeContent";
 
 const mockPush = vi.fn();
+let mockSearchParams = new URLSearchParams();
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => mockSearchParams,
 }));
 
 vi.mock("@/features/app-shell/shell/Navigation", () => ({
@@ -30,6 +32,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
   Background(({ Given }) => {
     Given("the app is running", () => {
       mockPush.mockClear();
+      mockSearchParams = new URLSearchParams();
     });
   });
 
@@ -37,7 +40,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
     When("a visitor opens the home page", () => {});
 
     And('the visitor types "TypeScript" in the search input', () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      render(React.createElement(HomeContent));
       const input = screen.getByPlaceholderText("Search skills, languages, or frameworks...");
       fireEvent.change(input, { target: { value: "TypeScript" } });
     });
@@ -53,7 +56,8 @@ describeFeature(feature, ({ Scenario, Background }) => {
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/search.feature:Matching content is highlighted with a yellow mark
     Then('the matching pill wraps "TypeScript" in a mark element', () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "TypeScript" }));
+      mockSearchParams = new URLSearchParams("search=TypeScript");
+      render(React.createElement(HomeContent));
       const marks = Array.from(document.querySelectorAll("mark"));
       expect(marks.some((mark) => /TypeScript/i.test(mark.textContent ?? ""))).toBe(true);
     });
@@ -64,7 +68,8 @@ describeFeature(feature, ({ Scenario, Background }) => {
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/search.feature:Non-matching About Me shows a placeholder
     Then('the About Me card shows "No matching content in the About Me section."', () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "NoSuchTerm" }));
+      mockSearchParams = new URLSearchParams("search=NoSuchTerm");
+      render(React.createElement(HomeContent));
       expect(screen.getByText("No matching content in the About Me section.")).toBeInTheDocument();
     });
   });
@@ -73,7 +78,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
     When("a visitor opens the home page", () => {});
 
     And('the visitor clicks the "TypeScript" skill pill', () => {
-      render(React.createElement(HomeContent, { initialSearchTerm: "" }));
+      render(React.createElement(HomeContent));
       fireEvent.click(screen.getByRole("button", { name: "TypeScript" }));
     });
 

--- a/apps/wahidyankf-www/test/unit/steps/search.steps.ts
+++ b/apps/wahidyankf-www/test/unit/steps/search.steps.ts
@@ -33,6 +33,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
     Given("the app is running", () => {
       mockPush.mockClear();
       mockSearchParams = new URLSearchParams();
+      window.history.replaceState({}, "", "/");
     });
   });
 
@@ -52,11 +53,12 @@ describeFeature(feature, ({ Scenario, Background }) => {
   });
 
   Scenario("Matching content is highlighted with a yellow mark", ({ When, Then }) => {
-    When('a visitor opens the home page with search term "TypeScript"', () => {});
+    When('a visitor opens the home page with search term "TypeScript"', () => {
+      window.history.replaceState({}, "", "/?search=TypeScript");
+    });
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/search.feature:Matching content is highlighted with a yellow mark
     Then('the matching pill wraps "TypeScript" in a mark element', () => {
-      mockSearchParams = new URLSearchParams("search=TypeScript");
       render(React.createElement(HomeContent));
       const marks = Array.from(document.querySelectorAll("mark"));
       expect(marks.some((mark) => /TypeScript/i.test(mark.textContent ?? ""))).toBe(true);
@@ -64,11 +66,12 @@ describeFeature(feature, ({ Scenario, Background }) => {
   });
 
   Scenario("Non-matching About Me shows a placeholder", ({ When, Then }) => {
-    When('a visitor opens the home page with search term "NoSuchTerm"', () => {});
+    When('a visitor opens the home page with search term "NoSuchTerm"', () => {
+      window.history.replaceState({}, "", "/?search=NoSuchTerm");
+    });
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/search.feature:Non-matching About Me shows a placeholder
     Then('the About Me card shows "No matching content in the About Me section."', () => {
-      mockSearchParams = new URLSearchParams("search=NoSuchTerm");
       render(React.createElement(HomeContent));
       expect(screen.getByText("No matching content in the About Me section.")).toBeInTheDocument();
     });

--- a/apps/wahidyankf-www/test/unit/steps/static-filterable-routes.steps.ts
+++ b/apps/wahidyankf-www/test/unit/steps/static-filterable-routes.steps.ts
@@ -84,12 +84,13 @@ describeFeature(feature, ({ Scenario, Background }) => {
     Given("the app is running", () => {
       mockSearchParams = new URLSearchParams();
       renderedCv = undefined;
+      window.history.replaceState({}, "", "/cv");
     });
   });
 
   Scenario("Search-filtered portfolio routes are static yet still filterable", ({ When, Then, And }) => {
     When('a visitor opens the shared CV search URL for "TypeScript"', () => {
-      mockSearchParams = new URLSearchParams("search=TypeScript");
+      window.history.replaceState({}, "", "/cv?search=TypeScript");
       const { container } = render(React.createElement(CvContent));
       // vitest-cucumber registers each step as a separate test and the shared setup cleans the DOM
       // after each one. Preserve a clone of this exact render so the assertion steps observe the URL
@@ -99,7 +100,7 @@ describeFeature(feature, ({ Scenario, Background }) => {
     });
 
     Then('the CV search input is prefilled with "TypeScript"', () => {
-      expect(mockSearchParams.get("search")).toBe("TypeScript");
+      expect(new URLSearchParams(window.location.search).get("search")).toBe("TypeScript");
       expect(within(getRenderedCv()).getByPlaceholderText("Search CV entries...")).toHaveValue("TypeScript");
     });
 

--- a/apps/wahidyankf-www/test/unit/steps/static-filterable-routes.steps.ts
+++ b/apps/wahidyankf-www/test/unit/steps/static-filterable-routes.steps.ts
@@ -1,18 +1,26 @@
-import { readFileSync } from "node:fs";
 import path from "node:path";
 import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { render, within } from "@testing-library/react";
 import { afterAll, expect, vi } from "vitest";
 import robots from "@/app/robots";
 import sitemap from "@/app/sitemap";
+import Home from "@/app/page";
+import CV from "@/app/cv/page";
+import PersonalProjects from "@/app/personal-projects/page";
 import { CvContent } from "@/features/cv/shell/CvContent";
 
 const mockPush = vi.fn();
 const mockReplace = vi.fn();
 let mockSearchParams = new URLSearchParams();
 let renderedCv: HTMLElement | undefined;
-let staticRouteSources: string[] = [];
+const publicPortfolioPages = [
+  { Component: Home, content: "Welcome to My Portfolio" },
+  { Component: CV, content: "Curriculum Vitae" },
+  { Component: PersonalProjects, content: "Personal Projects" },
+] as const;
+let renderedStaticPortfolioPages: string[] = [];
 let crawlerRobots: ReturnType<typeof robots> | undefined;
 let crawlerSitemap: ReturnType<typeof sitemap> | undefined;
 
@@ -122,30 +130,19 @@ describeFeature(feature, ({ Scenario, Background }) => {
     });
   });
 
-  Scenario("Public portfolio routes are emitted as static build routes", ({ When, Then, And }) => {
-    When("the portfolio build output is inspected", () => {
-      staticRouteSources = ["page.tsx", "cv/page.tsx", "personal-projects/page.tsx"].map((route) =>
-        readFileSync(path.resolve(process.cwd(), "src/app", route), "utf8"),
+  Scenario("Public portfolio routes are available from the production server", ({ When, Then }) => {
+    When("a visitor requests every public portfolio page", () => {
+      renderedStaticPortfolioPages = publicPortfolioPages.map(({ Component }) =>
+        renderToStaticMarkup(React.createElement(Component)),
       );
     });
 
-    Then("the portfolio route table contains no dynamic route", () => {
-      for (const source of staticRouteSources) {
-        expect(source).not.toMatch(/\bsearchParams\b/);
+    // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature:Public portfolio routes are available from the production server
+    Then("each public portfolio page responds with a successful HTML document", () => {
+      expect(renderedStaticPortfolioPages).toHaveLength(publicPortfolioPages.length);
+      for (const [index, page] of renderedStaticPortfolioPages.entries()) {
+        expect(page).toContain(publicPortfolioPages[index]?.content);
       }
-    });
-
-    // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature:Public portfolio routes are emitted as static build routes
-    And("the static route table contains every public portfolio route", () => {
-      expect(staticRouteSources).toHaveLength(3);
-      expect(robots().rules).toEqual([{ userAgent: "*", allow: "/" }]);
-      expect(sitemap()).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ url: "https://www.wahidyankf.com" }),
-          expect.objectContaining({ url: "https://www.wahidyankf.com/cv" }),
-          expect.objectContaining({ url: "https://www.wahidyankf.com/personal-projects" }),
-        ]),
-      );
     });
   });
 

--- a/apps/wahidyankf-www/test/unit/steps/static-filterable-routes.steps.ts
+++ b/apps/wahidyankf-www/test/unit/steps/static-filterable-routes.steps.ts
@@ -1,0 +1,97 @@
+import path from "node:path";
+import React from "react";
+import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
+import { render, screen } from "@testing-library/react";
+import { expect, vi } from "vitest";
+import { CvContent } from "@/features/cv/shell/CvContent";
+
+const mockPush = vi.fn();
+const mockReplace = vi.fn();
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock("@/features/app-shell/shell/Navigation", () => ({
+  Navigation: () => React.createElement("div", { "data-testid": "navigation" }, "Navigation"),
+}));
+
+vi.mock("@open-sharia-enterprise/web-ui", () => ({
+  SearchComponent: ({ searchTerm, placeholder }: { searchTerm: string; placeholder: string }) =>
+    React.createElement("input", {
+      "data-testid": "search-component",
+      value: searchTerm,
+      placeholder,
+      readOnly: true,
+    }),
+  HighlightText: ({ text }: { text: string }) => React.createElement("span", null, text),
+}));
+
+vi.mock("@/features/cv/core/data", () => ({
+  cvData: [
+    {
+      type: "work",
+      title: "Head of Engineering - Hijra Bank",
+      organization: "Hijra",
+      period: "March 2025 - Present",
+      details: ["Leads the engineering organization."],
+      skills: ["Software Engineering"],
+      programmingLanguages: ["TypeScript"],
+      frameworks: ["Next.js"],
+    },
+    {
+      type: "certification",
+      title: "Database Design Fundamentals for Software Engineers",
+      organization: "Educative, Inc.",
+      period: "June 2021",
+      details: ["Credential ID: database-design"],
+    },
+  ],
+  getTopSkillsLastFiveYears: () => [],
+  getTopLanguagesLastFiveYears: () => [],
+  getTopFrameworksLastFiveYears: () => [],
+  formatDuration: (duration: number) => `${duration} months`,
+  parseDate: vi.fn((date: string) => new Date(date)),
+  calculateDuration: vi.fn(() => 12),
+  calculateTotalDuration: vi.fn(() => 12),
+}));
+
+const feature = await loadFeature(
+  path.resolve(
+    process.cwd(),
+    "../../specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature",
+  ),
+);
+
+describeFeature(feature, ({ Scenario, Background }) => {
+  Background(({ Given }) => {
+    Given("the app is running", () => {
+      mockSearchParams = new URLSearchParams();
+    });
+  });
+
+  Scenario("Search-filtered portfolio routes are static yet still filterable", ({ When, Then, And }) => {
+    When('a visitor opens the shared CV search URL for "TypeScript"', () => {});
+
+    Then('the CV search input is prefilled with "TypeScript"', () => {
+      mockSearchParams = new URLSearchParams("search=TypeScript");
+      render(React.createElement(CvContent));
+      expect(screen.getByPlaceholderText("Search CV entries...")).toHaveValue("TypeScript");
+    });
+
+    And('the "Head of Engineering - Hijra Bank" entry is visible', () => {
+      mockSearchParams = new URLSearchParams("search=TypeScript");
+      render(React.createElement(CvContent));
+      expect(screen.getByText("Head of Engineering - Hijra Bank")).toBeInTheDocument();
+    });
+
+    // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature:Search-filtered portfolio routes are static yet still filterable
+    And('the "Database Design Fundamentals for Software Engineers" entry is hidden', () => {
+      mockSearchParams = new URLSearchParams("search=TypeScript");
+      render(React.createElement(CvContent));
+      expect(screen.queryByText("Database Design Fundamentals for Software Engineers")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/wahidyankf-www/test/unit/steps/static-filterable-routes.steps.ts
+++ b/apps/wahidyankf-www/test/unit/steps/static-filterable-routes.steps.ts
@@ -1,14 +1,20 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import React from "react";
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
 import { render, within } from "@testing-library/react";
 import { afterAll, expect, vi } from "vitest";
+import robots from "@/app/robots";
+import sitemap from "@/app/sitemap";
 import { CvContent } from "@/features/cv/shell/CvContent";
 
 const mockPush = vi.fn();
 const mockReplace = vi.fn();
 let mockSearchParams = new URLSearchParams();
 let renderedCv: HTMLElement | undefined;
+let staticRouteSources: string[] = [];
+let crawlerRobots: ReturnType<typeof robots> | undefined;
+let crawlerSitemap: ReturnType<typeof sitemap> | undefined;
 
 function getRenderedCv(): HTMLElement {
   if (!renderedCv) {
@@ -113,6 +119,58 @@ describeFeature(feature, ({ Scenario, Background }) => {
       expect(
         within(getRenderedCv()).queryByText("Database Design Fundamentals for Software Engineers"),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  Scenario("Public portfolio routes are emitted as static build routes", ({ When, Then, And }) => {
+    When("the portfolio build output is inspected", () => {
+      staticRouteSources = ["page.tsx", "cv/page.tsx", "personal-projects/page.tsx"].map((route) =>
+        readFileSync(path.resolve(process.cwd(), "src/app", route), "utf8"),
+      );
+    });
+
+    Then("the portfolio route table contains no dynamic route", () => {
+      for (const source of staticRouteSources) {
+        expect(source).not.toMatch(/\bsearchParams\b/);
+      }
+    });
+
+    // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature:Public portfolio routes are emitted as static build routes
+    And("the static route table contains every public portfolio route", () => {
+      expect(staticRouteSources).toHaveLength(3);
+      expect(robots().rules).toEqual([{ userAgent: "*", allow: "/" }]);
+      expect(sitemap()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ url: "https://www.wahidyankf.com" }),
+          expect.objectContaining({ url: "https://www.wahidyankf.com/cv" }),
+          expect.objectContaining({ url: "https://www.wahidyankf.com/personal-projects" }),
+        ]),
+      );
+    });
+  });
+
+  Scenario("Crawlers receive discovery directives for every public route", ({ When, Then, And }) => {
+    When("a crawler requests the robots and sitemap routes", () => {
+      crawlerRobots = robots();
+      crawlerSitemap = sitemap();
+    });
+
+    Then("robots permits crawling and names the canonical sitemap", () => {
+      expect(crawlerRobots).toEqual({
+        rules: [{ userAgent: "*", allow: "/" }],
+        sitemap: "https://www.wahidyankf.com/sitemap.xml",
+      });
+    });
+
+    // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature:Crawlers receive discovery directives for every public route
+    And("the sitemap lists every public portfolio route", () => {
+      expect(crawlerSitemap).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ url: "https://www.wahidyankf.com" }),
+          expect.objectContaining({ url: "https://www.wahidyankf.com/cv" }),
+          expect.objectContaining({ url: "https://www.wahidyankf.com/personal-projects" }),
+        ]),
+      );
     });
   });
 });

--- a/apps/wahidyankf-www/test/unit/steps/static-filterable-routes.steps.ts
+++ b/apps/wahidyankf-www/test/unit/steps/static-filterable-routes.steps.ts
@@ -1,13 +1,27 @@
 import path from "node:path";
 import React from "react";
 import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
-import { render, screen } from "@testing-library/react";
-import { expect, vi } from "vitest";
+import { render, within } from "@testing-library/react";
+import { afterAll, expect, vi } from "vitest";
 import { CvContent } from "@/features/cv/shell/CvContent";
 
 const mockPush = vi.fn();
 const mockReplace = vi.fn();
 let mockSearchParams = new URLSearchParams();
+let renderedCv: HTMLElement | undefined;
+
+function getRenderedCv(): HTMLElement {
+  if (!renderedCv) {
+    throw new Error("The shared CV URL must be opened before asserting its filtered state.");
+  }
+
+  return renderedCv;
+}
+
+afterAll(() => {
+  renderedCv?.remove();
+  renderedCv = undefined;
+});
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush, replace: mockReplace }),
@@ -69,29 +83,35 @@ describeFeature(feature, ({ Scenario, Background }) => {
   Background(({ Given }) => {
     Given("the app is running", () => {
       mockSearchParams = new URLSearchParams();
+      renderedCv = undefined;
     });
   });
 
   Scenario("Search-filtered portfolio routes are static yet still filterable", ({ When, Then, And }) => {
-    When('a visitor opens the shared CV search URL for "TypeScript"', () => {});
+    When('a visitor opens the shared CV search URL for "TypeScript"', () => {
+      mockSearchParams = new URLSearchParams("search=TypeScript");
+      const { container } = render(React.createElement(CvContent));
+      // vitest-cucumber registers each step as a separate test and the shared setup cleans the DOM
+      // after each one. Preserve a clone of this exact render so the assertion steps observe the URL
+      // state rendered here instead of independently remounting CvContent.
+      renderedCv = container.cloneNode(true) as HTMLElement;
+      document.body.append(renderedCv);
+    });
 
     Then('the CV search input is prefilled with "TypeScript"', () => {
-      mockSearchParams = new URLSearchParams("search=TypeScript");
-      render(React.createElement(CvContent));
-      expect(screen.getByPlaceholderText("Search CV entries...")).toHaveValue("TypeScript");
+      expect(mockSearchParams.get("search")).toBe("TypeScript");
+      expect(within(getRenderedCv()).getByPlaceholderText("Search CV entries...")).toHaveValue("TypeScript");
     });
 
     And('the "Head of Engineering - Hijra Bank" entry is visible', () => {
-      mockSearchParams = new URLSearchParams("search=TypeScript");
-      render(React.createElement(CvContent));
-      expect(screen.getByText("Head of Engineering - Hijra Bank")).toBeInTheDocument();
+      expect(within(getRenderedCv()).getByText("Head of Engineering - Hijra Bank")).toBeVisible();
     });
 
     // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature:Search-filtered portfolio routes are static yet still filterable
     And('the "Database Design Fundamentals for Software Engineers" entry is hidden', () => {
-      mockSearchParams = new URLSearchParams("search=TypeScript");
-      render(React.createElement(CvContent));
-      expect(screen.queryByText("Database Design Fundamentals for Software Engineers")).not.toBeInTheDocument();
+      expect(
+        within(getRenderedCv()).queryByText("Database Design Fundamentals for Software Engineers"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/plans/in-progress/vercel-function-cost-reduction/delivery.md
+++ b/plans/in-progress/vercel-function-cost-reduction/delivery.md
@@ -976,22 +976,29 @@ Independent of Unit 1; runs in parallel in its own worktree.
   - **Files Changed**: `apps/wahidyankf-www/src/app/static-routes.unit.test.ts`.
   - **Result**: `npm exec nx run wahidyankf-www:test:unit` collected the test under `unit-fe` and
     reported exactly three failures, one each for `/`, `/cv`, and `/personal-projects`.
-- [ ] `[AI]` **Build-output proof** — `nx build wahidyankf-www`; the route table must show `ƒ` for
+- [x] `[AI]` **Build-output proof** — `nx build wahidyankf-www`; the route table must show `ƒ` for
       `/`, `/cv`, and `/personal-projects` before the fix. Same tiering rationale as Phase 1: the
       route table is build output and cannot be asserted from a cached `test:unit` run.
+  - **Date**: 2026-08-01. **Status**: done — reconciled from the Phase 0 baseline build record.
+  - **Files Changed**: none (throwaway baseline build).
+  - **Command**: `nx build wahidyankf-www`.
+  - **Result**: Phase 0 recorded the exact pre-fix route table: `ƒ /`, `○ /_not-found`, `ƒ /cv`, and
+    `ƒ /personal-projects`. Thus all three Phase 5 targets were dynamic before this unit changed
+    them; `robots.txt` and `sitemap.xml` were absent as well. See the Phase 0 build record above.
 - [x] `[AI]` **GREEN** — remove the `searchParams` props and read the query client-side.
-  - **Date**: 2026-08-01. **Status**: done.
-  - **Result**: all three route modules are synchronous and query-prop-free; their client content
-    reads `search` through `useSearchParams()` behind Suspense. Typecheck and 179 Unit tests pass.
+  - **Date**: 2026-08-02. **Status**: done — corrected after the delivery review found that a
+    whole-page Suspense boundary would remove portfolio content from static HTML.
+  - **Result**: all three route modules are synchronous and query-prop-free. Their client content
+    renders the unfiltered portfolio during SSR, then a post-hydration effect reads
+    `window.location.search` and re-seeds on `popstate`; CV handles `scrollTop` in a separate
+    post-hydration effect. No content module calls `useSearchParams()`, and no page wraps all content
+    in `<Suspense>`.
   - Files: `src/app/page.tsx:3-4`, `src/app/cv/page.tsx:10-11`,
     `src/app/personal-projects/page.tsx:10-11` — drop the prop.
-  - Read `useSearchParams()` inside the already-`"use client"` consumers
-    (`HomeContent.tsx:29-31`, `CvContent.tsx:477-484`, `PersonalProjectsContent.tsx:21-27`), each
-    wrapped in `<Suspense>`. These components already only use the value to seed `useState`, so this
-    is a prop swap, not a rewrite.
-  - Command: `nx build wahidyankf-www`
-  - Acceptance: all three routes show `○` in the route table (were `ƒ`). The production build fails
-    outright if a `<Suspense>` boundary is missing, so a passing build is real evidence.
+  - **Final verification**: `npm exec -- nx build wahidyankf-www --skip-nx-cache` emits `○ /`,
+    `○ /cv`, and `○ /personal-projects`; generated `index.html`, `cv.html`, and
+    `personal-projects.html` each contain their visible route heading. The static-content regression
+    suite and `test:quick` pass (20 files / 191 tests).
 - [x] `[AI]` **REFACTOR** — add `src/app/robots.ts` and `src/app/sitemap.ts` (neither exists today),
       modelled on `apps/ose-www/src/app/robots.ts` and its `sitemap-builder.ts`.
   - **Date**: 2026-08-02. **Status**: done.

--- a/plans/in-progress/vercel-function-cost-reduction/delivery.md
+++ b/plans/in-progress/vercel-function-cost-reduction/delivery.md
@@ -1035,11 +1035,12 @@ Independent of Unit 1; runs in parallel in its own worktree.
     `static-filterable-routes.feature`, its Vitest and Playwright step bindings, and the feature
     indexes.
   - **Result**: the direct CV query URL pre-fills `TypeScript`, shows a matching entry, and hides an
-    unrelated one. Cycle-1 review added executable static-route and crawler-directive scenarios:
-    the former inspects both emitted manifests, while the latter fetches `robots.txt` and
-    `sitemap.xml` from the production server. Local fixer verification records 20 unit files / 199
-    tests, 8 specs / 40 scenarios / 95 steps, zero new unbound E2E scenarios, and 32 passing
-    Chromium tests.
+    unrelated one. The uncached app `static-routes:validation` gate independently inspects the
+    emitted manifests for static-route proof. The complementary E2E scenarios are black-box HTTP
+    assertions: the required target builds a fresh production Docker image, waits for its health
+    check, then verifies every public HTML route plus `robots.txt` and `sitemap.xml` without reading
+    checkout artifacts. Local fixer verification records 20 unit files / 198 tests, 8 specs / 40
+    scenarios / 95 steps, zero new unbound E2E scenarios, and 32 passing Chromium tests.
 
 ### Phase 5 Gate
 
@@ -1061,9 +1062,9 @@ Independent of Unit 1; runs in parallel in its own worktree.
       Phase 4).
   - **Date**: 2026-08-02. **Status**: done.
   - **Files Changed**: none (verification only).
-  - **Result**: before the Cycle-1 review correction, `npm exec -- nx run
-    wahidyankf-www:test:quick --skip-nx-cache` exited 0 after typecheck, lint, 20 test files / 191
-    unit tests, 97.38% line coverage, specs structure with 0 findings, and behavior coverage of 8
+  - **Result**: before the Cycle-1 review correction, an uncached `wahidyankf-www:test:quick` run
+    exited 0 after typecheck, lint, 20 test files / 191 unit tests, 97.38% line coverage, specs
+    structure with 0 findings, and behavior coverage of 8
     specs / 38 scenarios / 89 steps. The correction adds the uncached manifest proof and six BDD
     steps; its replacement local gate is recorded with the corrective commit. Network access was
     needed only for the configured `npx oxlint@latest` lint invocation.

--- a/plans/in-progress/vercel-function-cost-reduction/delivery.md
+++ b/plans/in-progress/vercel-function-cost-reduction/delivery.md
@@ -960,7 +960,7 @@ Independent of Unit 1; runs in parallel in its own worktree.
 > attribute budget headroom to it**, and if capacity is ever contested, this is the unit to defer —
 > not Unit 1. Phase 7's savings table is corrected accordingly.
 
-- [ ] `[AI]` **RED** — add a failing source-level guard that the three routes take no `searchParams`.
+- [x] `[AI]` **RED** — add a failing source-level guard that the three routes take no `searchParams`.
   - File: `apps/wahidyankf-www/src/app/static-routes.unit.test.ts` (new)
   - This app's vitest globs differ from `ayokoding-www`'s: the `unit-fe` project collects
     `src/**/*.unit.test.{ts,tsx}` under **jsdom**, and there is no `test/unit/**` unit glob at all
@@ -971,10 +971,18 @@ Independent of Unit 1; runs in parallel in its own worktree.
   - Command: `nx run wahidyankf-www:test:unit`
   - Acceptance: the test **fails** today on all three — `page.tsx:3-4`, `cv/page.tsx:10-11`,
     `personal-projects/page.tsx:10-11`. Falsifiable both ways.
+  - **Date**: 2026-08-01. **Status**: done — the source-level guard was added and intentionally
+    fails for all three current dynamic routes.
+  - **Files Changed**: `apps/wahidyankf-www/src/app/static-routes.unit.test.ts`.
+  - **Result**: `npm exec nx run wahidyankf-www:test:unit` collected the test under `unit-fe` and
+    reported exactly three failures, one each for `/`, `/cv`, and `/personal-projects`.
 - [ ] `[AI]` **Build-output proof** — `nx build wahidyankf-www`; the route table must show `ƒ` for
       `/`, `/cv`, and `/personal-projects` before the fix. Same tiering rationale as Phase 1: the
       route table is build output and cannot be asserted from a cached `test:unit` run.
-- [ ] `[AI]` **GREEN** — remove the `searchParams` props and read the query client-side.
+- [x] `[AI]` **GREEN** — remove the `searchParams` props and read the query client-side.
+  - **Date**: 2026-08-01. **Status**: done.
+  - **Result**: all three route modules are synchronous and query-prop-free; their client content
+    reads `search` through `useSearchParams()` behind Suspense. Typecheck and 179 Unit tests pass.
   - Files: `src/app/page.tsx:3-4`, `src/app/cv/page.tsx:10-11`,
     `src/app/personal-projects/page.tsx:10-11` — drop the prop.
   - Read `useSearchParams()` inside the already-`"use client"` consumers
@@ -984,28 +992,66 @@ Independent of Unit 1; runs in parallel in its own worktree.
   - Command: `nx build wahidyankf-www`
   - Acceptance: all three routes show `○` in the route table (were `ƒ`). The production build fails
     outright if a `<Suspense>` boundary is missing, so a passing build is real evidence.
-- [ ] `[AI]` **REFACTOR** — add `src/app/robots.ts` and `src/app/sitemap.ts` (neither exists today),
+- [x] `[AI]` **REFACTOR** — add `src/app/robots.ts` and `src/app/sitemap.ts` (neither exists today),
       modelled on `apps/ose-www/src/app/robots.ts` and its `sitemap-builder.ts`.
+  - **Date**: 2026-08-02. **Status**: done.
+  - **Files Changed**: `src/app/robots.ts`, `src/app/sitemap.ts`, and
+    `src/app/seo-routes.unit.test.ts`.
+  - **Result**: the SEO route unit suite passes 18 files / 181 tests, typecheck passes, and the
+    verified production build emits `/robots.txt` and `/sitemap.xml` as static routes alongside the
+    three converted portfolio routes.
   - Acceptance: both routes prerender (`○` in the route table) and `robots.txt` names the sitemap.
     Falsifiable both ways: before this step, `test -f` on either file exits non-zero.
-- [ ] `[AI]` Fix the 404 `og-image.jpg` referenced at `src/app/layout.tsx:39,51` — either ship the
+- [x] `[AI]` Fix the 404 `og-image.jpg` referenced at `src/app/layout.tsx:39,51` — either ship the
       asset or remove the reference.
+  - **Date**: 2026-08-02. **Status**: done.
+  - **Files Changed**: `apps/wahidyankf-www/src/app/layout.tsx` and
+    `apps/wahidyankf-www/src/app/layout.unit.test.tsx`.
+  - **Result**: no suitable local social image existed, so the stale OpenGraph and Twitter image
+    fields were removed. The focused RED/GREEN metadata test, typecheck, full unit suite (18 files /
+    182 tests), and production build all pass; the build still emits every route as static.
   - Acceptance: no metadata field points at a URL that 404s.
-- [ ] `[AI]` Verify a shared filtered URL still works: opening `/cv?search=<term>` pre-fills the
+- [x] `[AI]` Verify a shared filtered URL still works: opening `/cv?search=<term>` pre-fills the
       search box and filters results.
+  - **Date**: 2026-08-02. **Status**: done.
+  - **Files Changed**: `apps/wahidyankf-www/src/app/cv/page.unit.test.tsx`.
+  - **Result**: `/cv?search=Software` seeds the search box with `Software`, renders the matching
+    `Software Engineer` entry, and excludes the unrelated education entry while using the real search
+    core. Typecheck and the full unit suite (18 files / 182 tests) pass.
 
 **Gherkin (binds) →** "Search-filtered portfolio routes are static yet still filterable".
 
-- [ ] `[AI]` Locate the existing `specs/` path for `wahidyankf-www` (do not invent one) and write the
+- [x] `[AI]` Locate the existing `specs/` path for `wahidyankf-www` (do not invent one) and write the
       companion feature file there.
+  - **Date**: 2026-08-02. **Status**: done.
+  - **Files Changed**: `specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/`
+    `static-filterable-routes.feature`, its Vitest and Playwright step bindings, and the feature
+    indexes.
+  - **Result**: the direct CV query URL pre-fills `TypeScript`, shows a matching entry, and hides an
+    unrelated one. Unit tests (19 files / 187 tests), behavior coverage (8 specs / 38 scenarios / 89
+    steps), E2E coverage (0 new unbound scenarios), and Chromium E2E (30 tests) pass.
 
 ### Phase 5 Gate
 
-- [ ] `[AI]` Zero `ƒ` routes in the `wahidyankf-www` route table (was 3).
-- [ ] `[AI]` `robots.ts` and `sitemap.ts` exist and prerender.
-- [ ] `[AI]` `nx run wahidyankf-www:test:quick` exits 0 — it chains `typecheck`, `lint`, `test:unit`,
+- [x] `[AI]` Zero `ƒ` routes in the `wahidyankf-www` route table (was 3).
+  - **Date**: 2026-08-02. **Status**: done.
+  - **Files Changed**: none (verification only).
+  - **Result**: Phase 0 recorded `ƒ /`, `ƒ /cv`, and `ƒ /personal-projects`. A fresh no-cache
+    production build now prints `○` for all three and no `ƒ` marker.
+- [x] `[AI]` `robots.ts` and `sitemap.ts` exist and prerender.
+  - **Date**: 2026-08-02. **Status**: done.
+  - **Files Changed**: none (verification only).
+  - **Result**: the fresh no-cache build lists `○ /robots.txt` and `○ /sitemap.xml`; the Unit 2
+    change set contains `src/app/robots.ts` and `src/app/sitemap.ts`.
+- [x] `[AI]` `nx run wahidyankf-www:test:quick` exits 0 — it chains `typecheck`, `lint`, `test:unit`,
       `test:coverage`, and `test:specs`. Do **not** call `specs:coverage`; no such target exists on
       this project either (same `targetDefaults`-does-not-create-targets reason as Phase 4).
+  - **Date**: 2026-08-02. **Status**: done.
+  - **Files Changed**: none (verification only).
+  - **Result**: `npm exec -- nx run wahidyankf-www:test:quick --skip-nx-cache` exited 0 after
+    typecheck, lint, 19 test files / 187 unit tests, 97.23% line coverage, specs structure with 0
+    findings, and behavior coverage of 8 specs / 38 scenarios / 89 steps. Network access was needed
+    only for the configured `npx oxlint@latest` lint invocation.
 - [ ] `[AI]` **Unit 2 delivery boundary** — review cycle, then `[AI]` merge; deploy to
       `prod-wahidyankf-www` and confirm `x-vercel-cache: HIT` on a repeat request.
 

--- a/plans/in-progress/vercel-function-cost-reduction/delivery.md
+++ b/plans/in-progress/vercel-function-cost-reduction/delivery.md
@@ -1035,8 +1035,9 @@ Independent of Unit 1; runs in parallel in its own worktree.
     `static-filterable-routes.feature`, its Vitest and Playwright step bindings, and the feature
     indexes.
   - **Result**: the direct CV query URL pre-fills `TypeScript`, shows a matching entry, and hides an
-    unrelated one. Unit tests (19 files / 187 tests), behavior coverage (8 specs / 38 scenarios / 89
-    steps), E2E coverage (0 new unbound scenarios), and Chromium E2E (30 tests) pass.
+    unrelated one. Current green CI records 20 unit files / 191 tests and 97.38% line coverage;
+    behavior coverage is 8 specs / 38 scenarios / 89 steps, E2E coverage has 0 new unbound
+    scenarios, and Chromium E2E has 30 passing tests.
 
 ### Phase 5 Gate
 
@@ -1056,7 +1057,7 @@ Independent of Unit 1; runs in parallel in its own worktree.
   - **Date**: 2026-08-02. **Status**: done.
   - **Files Changed**: none (verification only).
   - **Result**: `npm exec -- nx run wahidyankf-www:test:quick --skip-nx-cache` exited 0 after
-    typecheck, lint, 19 test files / 187 unit tests, 97.23% line coverage, specs structure with 0
+    typecheck, lint, 20 test files / 191 unit tests, 97.38% line coverage, specs structure with 0
     findings, and behavior coverage of 8 specs / 38 scenarios / 89 steps. Network access was needed
     only for the configured `npx oxlint@latest` lint invocation.
 - [ ] `[AI]` **Unit 2 delivery boundary** — review cycle, then `[AI]` merge; deploy to

--- a/plans/in-progress/vercel-function-cost-reduction/delivery.md
+++ b/plans/in-progress/vercel-function-cost-reduction/delivery.md
@@ -1035,9 +1035,11 @@ Independent of Unit 1; runs in parallel in its own worktree.
     `static-filterable-routes.feature`, its Vitest and Playwright step bindings, and the feature
     indexes.
   - **Result**: the direct CV query URL pre-fills `TypeScript`, shows a matching entry, and hides an
-    unrelated one. Current green CI records 20 unit files / 191 tests and 97.38% line coverage;
-    behavior coverage is 8 specs / 38 scenarios / 89 steps, E2E coverage has 0 new unbound
-    scenarios, and Chromium E2E has 30 passing tests.
+    unrelated one. Cycle-1 review added executable static-route and crawler-directive scenarios:
+    the former inspects both emitted manifests, while the latter fetches `robots.txt` and
+    `sitemap.xml` from the production server. Local fixer verification records 20 unit files / 199
+    tests, 8 specs / 40 scenarios / 95 steps, zero new unbound E2E scenarios, and 32 passing
+    Chromium tests.
 
 ### Phase 5 Gate
 
@@ -1052,14 +1054,19 @@ Independent of Unit 1; runs in parallel in its own worktree.
   - **Result**: the fresh no-cache build lists `○ /robots.txt` and `○ /sitemap.xml`; the Unit 2
     change set contains `src/app/robots.ts` and `src/app/sitemap.ts`.
 - [x] `[AI]` `nx run wahidyankf-www:test:quick` exits 0 — it chains `typecheck`, `lint`, `test:unit`,
-      `test:coverage`, and `test:specs`. Do **not** call `specs:coverage`; no such target exists on
-      this project either (same `targetDefaults`-does-not-create-targets reason as Phase 4).
+      `test:coverage`, and `test:specs`, with a non-cached `static-routes:validation` prerequisite.
+      That prerequisite runs `nx build wahidyankf-www --skip-nx-cache` and validates both emitted
+      manifests before the five-stage quick gate starts. Do **not** call `specs:coverage`; no such
+      target exists on this project either (same `targetDefaults`-does-not-create-targets reason as
+      Phase 4).
   - **Date**: 2026-08-02. **Status**: done.
   - **Files Changed**: none (verification only).
-  - **Result**: `npm exec -- nx run wahidyankf-www:test:quick --skip-nx-cache` exited 0 after
-    typecheck, lint, 20 test files / 191 unit tests, 97.38% line coverage, specs structure with 0
-    findings, and behavior coverage of 8 specs / 38 scenarios / 89 steps. Network access was needed
-    only for the configured `npx oxlint@latest` lint invocation.
+  - **Result**: before the Cycle-1 review correction, `npm exec -- nx run
+    wahidyankf-www:test:quick --skip-nx-cache` exited 0 after typecheck, lint, 20 test files / 191
+    unit tests, 97.38% line coverage, specs structure with 0 findings, and behavior coverage of 8
+    specs / 38 scenarios / 89 steps. The correction adds the uncached manifest proof and six BDD
+    steps; its replacement local gate is recorded with the corrective commit. Network access was
+    needed only for the configured `npx oxlint@latest` lint invocation.
 - [ ] `[AI]` **Unit 2 delivery boundary** — review cycle, then `[AI]` merge; deploy to
       `prod-wahidyankf-www` and confirm `x-vercel-cache: HIT` on a repeat request.
 

--- a/specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/README.md
+++ b/specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/README.md
@@ -21,19 +21,19 @@ specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/
 ├── personal-projects/
 │   └── personal-projects.feature
 └── search/
-    └── search.feature
+    ├── search.feature
+    └── static-filterable-routes.feature
 ```
 
 ## Coverage
 
-| Bounded Context     | Features                               | Count |
-| ------------------- | -------------------------------------- | ----- |
-| `app-shell`         | `accessibility`, `responsive`, `theme` | 3     |
-| `cv`                | `cv`                                   | 1     |
-| `home`              | `home`                                 | 1     |
-| `personal-projects` | `personal-projects`                    | 1     |
-| `search`            | `search`                               | 1     |
-| **Total**           |                                        | **7** |
+| Bounded Context     | Features                               |
+| ------------------- | -------------------------------------- |
+| `app-shell`         | `accessibility`, `responsive`, `theme` |
+| `cv`                | `cv`                                   |
+| `home`              | `home`                                 |
+| `personal-projects` | `personal-projects`                    |
+| `search`            | `search`, `static-filterable-routes`   |
 
 ## Consumed by
 

--- a/specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature
+++ b/specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature
@@ -13,3 +13,15 @@ Feature: Static filtered portfolio routes
     Then the CV search input is prefilled with "TypeScript"
     And the "Head of Engineering - Hijra Bank" entry is visible
     And the "Database Design Fundamentals for Software Engineers" entry is hidden
+
+  @e2e
+  Scenario: Public portfolio routes are emitted as static build routes
+    When the portfolio build output is inspected
+    Then the portfolio route table contains no dynamic route
+    And the static route table contains every public portfolio route
+
+  @e2e
+  Scenario: Crawlers receive discovery directives for every public route
+    When a crawler requests the robots and sitemap routes
+    Then robots permits crawling and names the canonical sitemap
+    And the sitemap lists every public portfolio route

--- a/specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature
+++ b/specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature
@@ -1,0 +1,15 @@
+Feature: Static filtered portfolio routes
+
+  As a visitor sharing a portfolio search
+  I want the filtered CV URL to retain its result state
+  So that recipients can open relevant portfolio entries directly
+
+  Background:
+    Given the app is running
+
+  @unit @e2e
+  Scenario: Search-filtered portfolio routes are static yet still filterable
+    When a visitor opens the shared CV search URL for "TypeScript"
+    Then the CV search input is prefilled with "TypeScript"
+    And the "Head of Engineering - Hijra Bank" entry is visible
+    And the "Database Design Fundamentals for Software Engineers" entry is hidden

--- a/specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature
+++ b/specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/search/static-filterable-routes.feature
@@ -14,11 +14,10 @@ Feature: Static filtered portfolio routes
     And the "Head of Engineering - Hijra Bank" entry is visible
     And the "Database Design Fundamentals for Software Engineers" entry is hidden
 
-  @e2e
-  Scenario: Public portfolio routes are emitted as static build routes
-    When the portfolio build output is inspected
-    Then the portfolio route table contains no dynamic route
-    And the static route table contains every public portfolio route
+  @unit @e2e
+  Scenario: Public portfolio routes are available from the production server
+    When a visitor requests every public portfolio page
+    Then each public portfolio page responds with a successful HTML document
 
   @e2e
   Scenario: Crawlers receive discovery directives for every public route


### PR DESCRIPTION
## Summary

- Converts the root, CV, and personal-projects routes to static rendering while preserving client-side search query filtering.
- Adds static robots and sitemap route handlers and removes stale OpenGraph and Twitter image references.
- Adds source guards, unit coverage, bound Gherkin behavior, E2E bindings, and Phase 5 delivery evidence.

## Verification

- npm exec -- nx build wahidyankf-www --skip-nx-cache: all routes, including robots.txt and sitemap.xml, prerendered as static.
- npm exec -- nx run wahidyankf-www:test:quick --skip-nx-cache: passed typecheck, lint, 19 test files / 187 tests, 97.23% line coverage, and specs validation (8 specs / 38 scenarios / 89 steps).
- npm exec -- nx run wahidyankf-www-fe-e2e:test:e2e: 30 Chromium tests passed.

## Delivery

Phase 5 / Unit 2 only. This is a draft PR for the mandated review cycle; it must not be merged until that cycle is complete.