### PR TITLE
fix(ose-www): allow local HMR origin

### DIFF
--- a/apps/ose-www/next.config.ts
+++ b/apps/ose-www/next.config.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  allowedDevOrigins: ["127.0.0.1"],
   transpilePackages: ["@t3-oss/env-nextjs", "@t3-oss/env-core"],
   outputFileTracingRoot: path.join(__dirname, "../../"),
   outputFileTracingIncludes: {

--- a/apps/ose-www/src/features/landing/shell/social-icons.tsx
+++ b/apps/ose-www/src/features/landing/shell/social-icons.tsx
@@ -1,36 +1,25 @@
 import Link from "next/link";
 import { Github, Rss } from "lucide-react";
 import { Button } from "@open-sharia-enterprise/web-ui";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@open-sharia-enterprise/web-ui";
 
 export function SocialIcons() {
   return (
     <div className="flex items-center justify-center gap-2 py-8">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button variant="ghost" size="icon" asChild>
-            <a
-              href="https://github.com/wahidyankf/ose-public"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="GitHub repository"
-            >
-              <Github className="h-5 w-5" />
-            </a>
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>GitHub</TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button variant="ghost" size="icon" asChild>
-            <Link href="/feed.xml" aria-label="RSS feed">
-              <Rss className="h-5 w-5" />
-            </Link>
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>RSS Feed</TooltipContent>
-      </Tooltip>
+      <Button variant="ghost" size="icon" asChild>
+        <a
+          href="https://github.com/wahidyankf/ose-public"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="GitHub repository"
+        >
+          <Github className="h-5 w-5" />
+        </a>
+      </Button>
+      <Button variant="ghost" size="icon" asChild>
+        <Link href="/feed.xml" aria-label="RSS feed">
+          <Rss className="h-5 w-5" />
+        </Link>
+      </Button>
     </div>
   );
 }

--- a/apps/ose-www/test/unit/next-config.unit.test.ts
+++ b/apps/ose-www/test/unit/next-config.unit.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import nextConfig from "../../next.config";
+
+describe("ose-www development origin policy", () => {
+  it("allows the documented loopback origin for development HMR", () => {
+    expect(nextConfig.allowedDevOrigins).toEqual(["127.0.0.1"]);
+  });
+});


### PR DESCRIPTION
Fixes the public fresh-checkout loopback development journey. Limits the Next development allowlist to `127.0.0.1`, removes SocialIcons tooltip portal hydration errors, and adds a regression test.