### PR TITLE
fix(rhino-cli): propagate lint-staged shell fixture regression test

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -105,7 +105,7 @@ f6fa57246449b8ae40d51d9958cd96cb2fc6ca816147888d8e468d953e75b24c  apps/rhino-cli
 94712c3653f9e91111f0136cd90ab434f58d2ec6d20ce80b4dec2fc2364fd899  apps/rhino-cli/src/commands/env_restore.rs
 2eb52e7dbd4601beb261cc17c34e72e604eab1ac0444586f05cbda7f3691e58b  apps/rhino-cli/src/commands/env_staged_guard.rs
 abc10d0efefbfab5dba718cc5d0010d86adfc33fa8ec1191d35841c3625d6918  apps/rhino-cli/src/commands/env_validate.rs
-58ba9bae8e1402d058305fe9314289312f0100078d6d0af7e8683f58b03b2402  apps/rhino-cli/src/commands/gate/emit.rs
+c601b0e8e0b65877d7d0f55a1eb22be6f4a553851c6f4dda9f9b682181cc3ba4  apps/rhino-cli/src/commands/gate/emit.rs
 e3b5d928187db598a68b67f097810515cb517327834694b2780d991e45763991  apps/rhino-cli/src/commands/gate/list.rs
 d500838c85c402bd260502f1a28d489db2ea4e74bc5769f4adf42bb4fc2035b9  apps/rhino-cli/src/commands/gate/mod.rs
 d64b1bff0e34d30918e3d5b04363cf2d2cd1ef06764f7b3f7fabe7efd4153fb3  apps/rhino-cli/src/commands/gate/run.rs

--- a/apps/rhino-cli/src/commands/gate/emit.rs
+++ b/apps/rhino-cli/src/commands/gate/emit.rs
@@ -444,3 +444,83 @@ fn lint_staged_shell_overrides_wrap_or_own_the_derived_file_invocation() {
         ]),
     );
 }
+
+/// Regression: a `lint-staged-shell` template that used a bare
+/// `for f; do <command> -f "$f" ...; done` loop with no `set -e` masked an
+/// earlier file's failure whenever a later file in the same batch succeeded —
+/// a POSIX `for` loop's exit status is the *last* command's, not the first
+/// failure's. The fix hands the whole batch to the wrapped command in one
+/// call (`{{command}} "$@"`) so that command's own exit status propagates
+/// untouched. This is a self-contained fixture (not the repository's own
+/// `repo-config.yml`, which is not required to be identical across the
+/// sibling repositories this file's parity manifest covers): it drives the
+/// exact emitted, wrapped command this file produces against a fixture batch
+/// whose checker fails on the first file and succeeds on the second, so a
+/// regression back to the fail-open shape is caught here rather than only in
+/// a specific repository's own registry declaration.
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+#[test]
+fn lint_staged_shell_forwarding_the_whole_batch_fails_fast_on_a_leading_failure() {
+    let repo = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        repo.path().join("repo-config.yml"),
+        concat!(
+            "gates:\n",
+            "  - id: fixture-checker\n",
+            "    type: check\n",
+            "    command: sh check.sh\n",
+            "    kind: external\n",
+            "    surfaces:\n",
+            "      pre-commit:\n",
+            "        scope: affected-file-type\n",
+            "        glob: '*.fixture'\n",
+            "        lint-staged-shell: '{{command}} \"$@\"'\n",
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        repo.path().join("check.sh"),
+        // Mirrors the shape of a real per-file wrapper script: it owns its
+        // own fail-fast loop over every argument it is handed.
+        "#!/bin/sh\nset -eu\nfor f; do\n  if grep -q FAIL \"$f\"; then\n    exit 1\n  fi\ndone\n",
+    )
+    .unwrap();
+
+    let config = repo_config::load(repo.path()).unwrap();
+    let command = lint_staged_from_config(&config)["*.fixture"][0]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let invalid = repo.path().join("invalid.fixture");
+    std::fs::write(&invalid, "FAIL\n").unwrap();
+    let valid = repo.path().join("valid.fixture");
+    std::fs::write(&valid, "ok\n").unwrap();
+
+    // Forward the fixture files as "$@" to the emitted command exactly as
+    // lint-staged appends matched files after the configured command line.
+    let script = repo.path().join("run.sh");
+    std::fs::write(&script, format!("#!/bin/sh\n{command} \"$@\"\n")).unwrap();
+
+    let status = std::process::Command::new("sh")
+        .arg(&script)
+        .arg(&invalid)
+        .arg(&valid)
+        .current_dir(repo.path())
+        .status()
+        .expect("run the generated lint-staged command");
+    assert!(
+        !status.success(),
+        "an earlier failing file must fail the batch even when a later file passes"
+    );
+
+    // Control: an all-passing batch must still succeed.
+    let status = std::process::Command::new("sh")
+        .arg(&script)
+        .arg(&valid)
+        .current_dir(repo.path())
+        .status()
+        .expect("run the generated lint-staged command");
+    assert!(status.success(), "an all-passing batch must still succeed");
+}


### PR DESCRIPTION
## Summary

- Propagates ose-private's PR27 Cycle 3 fix to ose-public's canonical `apps/rhino-cli/src/commands/gate/emit.rs`: a hermetic-fixture-based regression test, `lint_staged_shell_forwarding_the_whole_batch_fails_fast_on_a_leading_failure`.
- Regenerates `apps/rhino-cli/parity-manifest.sha256` for the changed file.
- Keeps `apps/rhino-cli` byte-identical across the three bound repos for this file (ose-public, ose-primer, ose-private already carries this fix via PR27).

## Test plan

- [x] `cargo test --release --manifest-path apps/rhino-cli/Cargo.toml --lib lint_staged_shell_forwarding_the_whole_batch_fails_fast_on_a_leading_failure` passes
- [x] `nx run rhino-cli:test:quick` passes (full gate suite, incl. spec coverage)
- [x] `rhino-cli parity manifest validate` self-consistency check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)