### PR TITLE
docs(plans): add optimize-cis plan for CI/gate overhead reduction

### DIFF
--- a/plans/in-progress/README.md
+++ b/plans/in-progress/README.md
@@ -15,6 +15,10 @@ execution checklist.
   living reader-facing READMEs, onboarding journeys, related docs, and GitHub About metadata across
   `ose-public`, `ose-primer`, and `ose-private`, with product-first paths, fresh-checkout proof, and
   strict secret-safety.
+- [optimize-cis](./optimize-cis/README.md) — Cuts fixed overhead from the pre-commit, pre-push, and
+  PR-quality-gate lifecycle across the OSE repos — invocation tax, CI job topology, cargo build
+  profile, and disk footprint — with gate coverage held provably invariant. Supersedes and deletes
+  `../backlog/rhino-cli-optimization/`.
 
 Ready-to-execute plans wait in [`../backlog/`](../backlog/README.md); promote one here when
 work begins.

--- a/plans/in-progress/optimize-cis/README.md
+++ b/plans/in-progress/optimize-cis/README.md
@@ -1,0 +1,217 @@
+# Optimize CIs — Gate, CI, Build, and Disk Cost
+
+Make the whole quality-gate lifecycle — pre-commit, pre-push, and the PR quality gate — fast and
+cheap, by removing **fixed per-invocation and per-job overhead** rather than by removing checks or
+changing language.
+
+## Context
+
+Three surfaces enforce quality in this repository: three Husky hooks
+([`.husky/`](../../../.husky/)), the generated `lint-staged` block in
+[`package.json`](../../../package.json), and
+[`.github/workflows/pr-quality-gate.yml`](../../../.github/workflows/pr-quality-gate.yml). All three
+dispatch through [`apps/rhino-cli`](../../../apps/rhino-cli/README.md), and all three feel slow.
+
+The motivating hypothesis was that `rhino-cli` itself is slow to start, and that a rewrite in Go
+would fix it. **That hypothesis was measured and is false.** Every number below was produced by
+experiment on 2026-08-08 — on this machine for local costs, and from GitHub Actions run history
+across all four OSE repos for CI costs. None is estimated.
+
+| Hypothesis                     | Measured result                                                                               |
+| ------------------------------ | --------------------------------------------------------------------------------------------- |
+| `rhino-cli` is slow to start   | `rhino-cli --version` on the built binary: **3.2 ms** (N=100)                                 |
+| …so the gates are slow         | `cargo run --release --quiet -- --version`: **388 ms** — a **121× wrapper tax**               |
+| …and a Go rewrite would fix it | A rewrite carries the identical wrapper and CI topology. It changes none of the numbers below |
+
+The real costs sit in three places, none of which is the Rust:
+
+1. **Process-launch wrappers.** Every generated gate command shells out through `cargo run --release`
+   (~399 ms) or `npx` (~250–263 ms of overhead) to invoke work that takes 30–35 ms.
+2. **CI job topology.** `ose-public` fans the gate registry out to a **41-way matrix, 45 jobs**. Each
+   job is a fresh VM that re-pays a full-history checkout, a complete `npm ci`, and a Rust toolchain
+   install — **268 s of job time to execute a 77 s command, 77.2 % overhead**.
+3. **Build-profile and fingerprint multiplication.** The release profile is tuned for a shipped
+   artifact (`lto = "thin"`, `codegen-units = 1`) but is what every gate rebuilds; and
+   `rhino-cli:test:quick` compiles the same 82-dependency tree under three distinct profiles.
+
+**The fix is not speculative — it is already running in your own repos.** `beaver-nest` groups
+related checks onto shared jobs and costs **4.9× less** for the same coverage. `ose-private` ran both
+topologies in the same sample window, on the same runners: `actionlint` fell from **234 s to 16 s**
+(14.6×) purely by moving from its own job into a grouped one.
+
+## First principles
+
+Each surface's cost decomposes into work and overhead. Every axis below attacks an overhead term;
+no axis removes a check.
+
+| Axis                | Cost identity                                                                     |
+| ------------------- | --------------------------------------------------------------------------------- |
+| **A — invocation**  | `(gate invocations) × (process-launch tax per invocation) + (real work)`          |
+| **B — CI topology** | `(jobs) × (fixed per-job setup) + (real work)`                                    |
+| **C — build**       | `(code recompiled per gate) × (optimization work per unit) × (distinct profiles)` |
+| **D — disk**        | `(target dirs × profiles × size) + (toolchains) + (unbounded scratch)`            |
+
+## Headline measurements
+
+Full evidence, method, and raw data: [`tech-docs.md`](./tech-docs.md) §Measurement Baseline.
+
+### Local — invocation tax
+
+| Invocation                                             |      ms/run |   N |
+| ------------------------------------------------------ | ----------: | --: |
+| `rhino-cli --version` (direct binary)                  |     **3.2** | 100 |
+| `cargo run --release --quiet -- --version`             |     **388** |  20 |
+| `md <validator> validate` (direct binary, 10 md files) |   **30–35** |   3 |
+| the same via `cargo run --release`                     | **375–414** |   3 |
+| `./node_modules/.bin/prettier --check` (10 md files)   |     **359** |   5 |
+| `npx --no -- prettier --check` (same 10 files)         |     **622** |   5 |
+| `./node_modules/.bin/markdownlint-cli2`                |     **189** |   5 |
+| `npx --no -- markdownlint-cli2`                        |     **441** |   5 |
+| `npx nx show projects`                                 |   **3,560** |   3 |
+
+A markdown-only commit runs the full pre-commit path in **~3,047 ms** today (hook shim 388 ms +
+`lint-staged` 2,659 ms); under direct dispatch the same checks cost **~683 ms** — **4.5× faster, with
+nothing removed**.
+
+The two taxes are not equal. `cargo run` costs **~399 ms per invocation to wrap ~33 ms of work** and
+is the dominant local cost; `npx` costs a real but smaller **~250–263 ms** per tool.
+
+### CI — job topology (22-run `pr-quality-gate` sample per repo)
+
+| Repo                      | jobs/run |    runner-seconds/run |   overhead |
+| ------------------------- | -------: | --------------------: | ---------: |
+| ose-public                |       45 | **10,945 s (182:25)** | **77.2 %** |
+| ose-primer                |       48 |     11,683 s (194:43) |     77.0 % |
+| ose-private               |       35 |      9,239 s (153:59) |     91.9 % |
+| **beaver-nest (grouped)** |   **19** |   **2,226 s (37:06)** |     80.3 % |
+
+`setup-node` — which runs a full `npm ci` — executes **792× per 22 runs** in `ose-public` at a p50 of
+**144 s**, accounting for **46.5 % of the entire gate**. Across the four repos in this sample it
+consumed **414,000 runner-seconds (115 hours)**.
+
+### Build and disk
+
+| Measurement                                          | Value                                                                            |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Cold `rhino-cli` release build (current profile)     | **53.0 s** wall / 98.7 s CPU                                                     |
+| Same build, `lto=off, codegen-units=16, opt-level=1` | **19.6 s** — **2.7× faster, identical runtime**                                  |
+| `rhino-cli:test:quick` wall time                     | **194 s** (typecheck 21 s, lint 10 s, test:unit 119 s, coverage 40 s, specs 4 s) |
+| `target/` growth across one `test:quick`             | **222 MB → 2.7 GB** (debug 1.8 GB + llvm-cov 712 MB + release 222 MB)            |
+| `ose-public` GitHub Actions cache                    | **98.0 % of the 10 GiB ceiling**; retention collapsed to ~1 day                  |
+| `ose-public/local-temp/`                             | **12.31 GB** — 88.2 % of the repo, sweeper-exempt and unbounded                  |
+
+## Scope
+
+### In scope
+
+| Area                                          | What changes                                                                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `apps/rhino-cli/src/commands/gate/emit.rs`    | Generated gate commands resolve a prebuilt binary instead of prefixing `cargo run --release`                                   |
+| `.husky/` shims, `package.json` `lint-staged` | Regenerated to the resolved-binary form; `npx` replaced by direct `node_modules/.bin` dispatch                                 |
+| `repo-config.yml` `gates:`                    | New **required** `ci_group` field per gate entry; groups are declared, never derived                                           |
+| `.github/workflows/pr-quality-gate.yml`       | Matrix runs over declared groups, not individual gates; `rhino-cli` built once and passed to jobs as an artifact               |
+| `.github/actions/setup-node/action.yml`       | Nx cache key stops minting a fresh 237.9 MB entry per commit                                                                   |
+| `apps/rhino-cli/Cargo.toml`                   | A dedicated fast gate profile alongside the shipped release profile                                                            |
+| `apps/rhino-cli/project.json`                 | `test:quick` stops compiling the same tree under three profiles                                                                |
+| Disk hygiene                                  | `local-temp/` retention; unpinned toolchain pruning; worktree `target/` sharing                                                |
+| `rust-toolchain.toml` + `Cargo.toml` MSRV     | One Rust version (`1.95.0`) across all three repos, replacing 3 disagreeing declared values; `doctor` validates the channel    |
+| Cross-repo parity                             | `ose-primer` and `ose-private` receive the full change set under the byte-identity gate; `beaver-nest` is excluded (see below) |
+
+### Out of scope
+
+- **Removing, weakening, or skipping any check.** Every gate that runs today still runs after this
+  plan. This is an overhead-removal plan; coverage is invariant and is asserted as such.
+- **Rewriting `rhino-cli` in another language.** The measurements above close that question: the
+  binary's own work is 3–1081 ms, and every cost this plan targets would survive a rewrite
+  unchanged. See [`tech-docs.md`](./tech-docs.md) §Why Not A Rewrite.
+- **`rhino-cli` type-safety work** (`indexing_slicing`, `arithmetic_side_effects` crate-wide). Real,
+  but unrelated to performance; it belongs in its own plan.
+- New `rhino-cli` features, validators, or subcommands.
+- The `TypeScript quality gate`'s 744 s of genuine `nx affected` work. It is the critical path and it
+  is real work, not overhead. Reducing it is a testing-strategy question, not a CI-plumbing one.
+
+### Affected repositories — three of four
+
+| Repo          | In scope |                                                              Measured cost today | Rationale                                                                                                              |
+| ------------- | :------: | -------------------------------------------------------------------------------: | ---------------------------------------------------------------------------------------------------------------------- |
+| `ose-public`  | **yes**  |                                             10,945 runner-s/run, 77.2 % overhead | Primary; all four axes                                                                                                 |
+| `ose-primer`  | **yes**  |                                             11,683 runner-s/run, 77.0 % overhead | Highest absolute CI cost of the four; byte-identity boundary makes propagation mandatory anyway                        |
+| `ose-private` | **yes**  | 9,239 runner-s/run, **91.9 % overhead**, 23 `cargo run` entries in `lint-staged` | Largest proportional win; its self-hosted pool also queues at p50 18:42, so removing jobs relieves contention directly |
+| `beaver-nest` |  **no**  |                                              2,226 runner-s/run, 80.3 % overhead | Excluded — see below                                                                                                   |
+
+**Why `beaver-nest` is excluded.** Three independent reasons, any one of which would be sufficient:
+
+1. Its `rhino-cli` is a **fork with no `src/commands/gate/` subsystem at all** — no `emit.rs`, no
+   `run.rs` `[Repo-grounded]`. Axis A and DD-3/DD-4 have no code to change there; they would have to be
+   hand-written against a divergent copy.
+2. It is **already the fastest repo by 4.9×**, having adopted grouped CI jobs. It is the reference
+   implementation this plan copies, not a laggard.
+3. It is **slated for deprecation immediately after this plan** (maintainer decision, 2026-08-08), so
+   any port would be discarded within days.
+
+**Tripwire.** If that deprecation slips past this plan's completion, the cheap repo-agnostic wins
+(DD-6 gate profile, DD-8 cache key, DD-5 conditional `npm ci` — all present in its config
+`[Repo-grounded]`) should be filed as a small follow-up. `delivery.md` Phase 10 records this
+explicitly rather than leaving it to memory.
+
+### Superseded plan
+
+This plan **replaces and deletes** `plans/backlog/rhino-cli-optimization/`, per an explicit decision
+recorded during pre-write grilling on 2026-08-08. That plan reached the same core conclusion — the
+profile and the invocation sites are the cost, not the language — but scoped only the crate-internal
+axes and never examined the CI topology, which the measurements here show is the single largest cost
+centre. Deleting it is a deliberate choice, made with its contents reviewed;
+[`delivery.md`](./delivery.md) Phase 1 performs the removal and de-indexes it.
+
+## Approach summary
+
+1. **Phase 0** re-establishes the baseline in this worktree and records every "before" number the
+   plan's targets are measured against. It opens no PR.
+2. **Axis A** removes the process-launch tax: the generated commands resolve a prebuilt binary, and
+   `npx` gives way to direct `node_modules/.bin` dispatch. This is the pre-commit win.
+3. **Axis B** adopts the grouped CI topology already proven in `beaver-nest`, keeping
+   `repo-config.yml` authoritative by making the group an explicit required field rather than a
+   derived one. `rhino-cli` is built once per run and passed to jobs as an artifact.
+4. **Axis C** separates the shipped release profile from the fast gate profile, and stops
+   `test:quick` from compiling the same tree three times.
+5. **Axis D** reclaims disk and encodes the hygiene so the footprint does not regrow.
+6. **A propagation phase** carries the change set across the repos each parity boundary requires,
+   and a Knowledge Capture phase closes the plan.
+
+Every axis is **behaviour-preserving by construction and by assertion**: each phase gate re-runs the
+full gate set and diffs its output against the Phase 0 capture. A phase that changes what a gate
+reports fails its own gate.
+
+## Success targets
+
+Committed numeric targets, one per surface, all measured against the Phase 0 baseline. Full
+definitions and measurement commands: [`brd.md`](./brd.md) §Success Metrics.
+
+| Surface                             |                 Baseline (measured) |                Target |
+| ----------------------------------- | ----------------------------------: | --------------------: |
+| pre-commit, markdown-only commit    |                            3,047 ms |          **≤ 900 ms** |
+| pre-push, `rhino-cli` affected      |                               194 s |            **≤ 90 s** |
+| PR quality gate, runner-seconds/run |                            10,945 s |         **≤ 3,500 s** |
+| PR quality gate, wall-clock p50     |                        see `brd.md` |     **no regression** |
+| `target/` after one `test:quick`    |                              2.7 GB |          **≤ 1.2 GB** |
+| Actions cache utilization           |                    98.0 % of 10 GiB |            **≤ 60 %** |
+| Reclaimed local disk                | 28.00 GB, 15.92 GB non-load-bearing | **≥ 10 GB reclaimed** |
+| Rust version cardinality            |                 3 distinct declared |      **1, all repos** |
+
+## Documents
+
+| File                             | Contents                                                                                                |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| [`brd.md`](./brd.md)             | Business rationale, affected roles, success metrics with measurement commands, business risks           |
+| [`prd.md`](./prd.md)             | Personas, user stories, Gherkin acceptance criteria, product scope                                      |
+| [`tech-docs.md`](./tech-docs.md) | Full measurement baseline and method, cost model per axis, design decisions, file-impact tree, rollback |
+| [`delivery.md`](./delivery.md)   | Phased, gated delivery checklist                                                                        |
+| [`learnings.md`](./learnings.md) | Running log drained by the Knowledge Capture phase                                                      |
+
+Raw evidence produced during authoring lives in `local-temp/` (gitignored):
+`local-benchmark-evidence.md`, `ci-history-evidence.md`, `disk-occupancy-evidence.md`.
+
+## Delivery Mode
+
+`worktree-to-pr` — mandatory in `ose-public` (`main` is branch-protected including for admins). See
+[`delivery.md`](./delivery.md) for the worktree declaration and delivery boundaries.

--- a/plans/in-progress/optimize-cis/brd.md
+++ b/plans/in-progress/optimize-cis/brd.md
@@ -1,0 +1,166 @@
+# Business Requirements — Optimize CIs
+
+## Business Goal
+
+Reduce the fixed overhead of the repository's quality-gate lifecycle — pre-commit, pre-push, and the
+PR quality gate — without removing, weakening, or skipping a single check.
+
+The gates exist to keep a pre-alpha, multi-language, four-repo platform coherent while most of the
+work is done by AI agents. They earn their keep. What they should not cost is **77.2 % overhead**:
+of the 10,945 runner-seconds a PR quality gate consumes in `ose-public`, only 2,492 s is work that
+checks anything.
+
+## Why This Matters
+
+**The gates are on the critical path of every change.** Every commit pays pre-commit, every push pays
+pre-push, and every PR pays the quality gate three times over — the
+[PR-Review Maker→Fixer Cycle](../../../repo-governance/workflows/pr/pr-review-quality-gate.md) runs
+three CI-gated cycles before merge. Overhead is therefore multiplied by roughly 3× per delivery unit,
+on top of a plan structure that opens PRs at delivery boundaries across four repos.
+
+**Slow gates corrupt behaviour, not just throughput.** A 194 s pre-push and a 3.5 s wait to commit a
+markdown fix create standing pressure to batch commits, to reach for `--no-verify`, and to defer
+pushes. The
+[CI Blocker Resolution](../../../repo-governance/development/quality/ci-blocker-resolution.md)
+convention forbids bypassing gates; making them fast removes the temptation rather than policing it.
+
+**The measured alternative was a rewrite.** The maintainer was, in their own words, "on the verge of"
+rewriting `rhino-cli` in Go. That would be weeks of work, a full re-validation of every validator's
+behaviour, and a fresh parity-manifest boundary across three repos — to address costs that
+measurement shows the language does not cause. This plan exists partly to make that decision on
+evidence instead of on feel.
+
+## Affected Roles
+
+| Role                          | Current pain                                                                                                          | After                                                          |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| **Maintainer (solo)**         | 3.5 s to commit a doc fix; 194 s to push a `rhino-cli` change; PR gate wall-clock dominated by setup                  | Sub-second commits; ~90 s pushes; PR gate cost cut ~3×         |
+| **AI agents executing plans** | Every agent commit pays the same tax, multiplied by parallel fan-out (N=3 default) and by 3 review cycles             | Proportional reduction across every agent-driven commit        |
+| **CI runner budget**          | `ose-public` burns 10,945 runner-s/run on `ubuntu-latest`; `ose-private` queues p50 18:42 on a small self-hosted pool | Fewer jobs contending for the shared four-repo pool            |
+| **Local disk**                | 28 GB attributable; `local-temp` alone 12.31 GB and unbounded                                                         | ~16 GB reclaimable, with hygiene encoded so it does not regrow |
+
+## Success Metrics
+
+Every metric is measured against the Phase 0 baseline captured in this worktree. Each has an exact
+measurement command so the result is falsifiable in both directions — a target that cannot fail is
+not a target.
+
+### M1 — pre-commit wall time, markdown-only commit
+
+- **Baseline**: 3,047 ms — hook shim 388 ms + `lint-staged` 2,659 ms `[Repo-grounded]`
+- **Target**: **≤ 900 ms**
+- **Measure**: stage 10 markdown files, then time the `lint-staged` run:
+  `bash -c 'time npx lint-staged --no-stash'` — recorded as the mean of 3 runs.
+- **Falsifiable both ways**: a run at 401 ms fails; a run at 399 ms passes.
+
+### M2 — pre-push wall time, `rhino-cli` affected
+
+- **Baseline**: 194 s for `nx run rhino-cli:test:quick` `[Repo-grounded]`
+- **Target**: **≤ 90 s**
+- **Measure**: `bash -c 'time npx nx run rhino-cli:test:quick --skip-nx-cache'`, cold Nx cache,
+  mean of 2 runs.
+- **Guard**: the same command must still report every test that ran at baseline. Phase gate diffs the
+  test-name list, so a speedup achieved by running fewer tests fails.
+
+### M3 — PR quality gate, runner-seconds per run
+
+- **Baseline**: 10,945 s across 45 jobs `[Repo-grounded]`
+- **Target**: **≤ 3,500 s**
+- **Measure**: for 5 completed post-change runs,
+  `gh api repos/wahidyankf/ose-public/actions/runs/<id>/jobs` summed over
+  `completed_at - started_at`; report the median.
+- **Reference point**: `beaver-nest` already achieves 2,226 s for equivalent coverage.
+
+### M4 — PR quality gate, wall-clock p50
+
+- **Baseline**: recorded in Phase 0 from run history
+- **Target**: **no regression** — grouping trades parallelism for setup, so wall-clock must be
+  watched, not assumed. A group that serializes 10 checks behind one runner could get slower even as
+  runner-seconds fall.
+- **Measure**: p50 of `updatedAt - startedAt` over 10 completed runs, before and after.
+
+### M5 — gate coverage invariance
+
+- **Baseline**: the full list of gate ids executed per surface, captured in Phase 0
+- **Target**: **byte-identical set of gate ids executed**, on every surface, before and after
+- **Measure**: `rhino-cli gate list --surface=<s> --format=json` output diffed against the Phase 0
+  capture; and for CI, the union of gate ids across all declared groups (`--by-group`) compared to
+  the Phase 0 matrix list.
+- **This is the plan's most important metric.** A speedup that loses a check is a failure, not a win.
+
+### M6 — `target/` footprint after one `test:quick`
+
+- **Baseline**: 2.7 GB `[Repo-grounded]`
+- **Target**: **≤ 1.2 GB**
+- **Measure**: `rm -rf` an isolated `CARGO_TARGET_DIR`, run `test:quick`, then `du -sk`.
+
+### M7 — GitHub Actions cache utilization
+
+- **Baseline**: 10,525,641,701 bytes = 98.0 % of the 10 GiB ceiling `[Repo-grounded]`
+- **Target**: **≤ 60 %** of ceiling, sustained across 10 consecutive commits
+- **Measure**: `gh api repos/wahidyankf/ose-public/actions/caches` summed over `size_in_bytes`.
+
+### M8 — reclaimed local disk
+
+- **Baseline**: 28.00 GB attributable, of which 15.92 GB measured as non-load-bearing `[Repo-grounded]`
+- **Target**: **≥ 10 GB reclaimed**, and a retention rule in place so `local-temp/` cannot silently
+  return to 12 GB
+- **Measure**: `du -sk` over the same bucket list used in Phase 0.
+
+### M9 — Rust version cardinality
+
+- **Baseline**: **3 distinct declared values** across the three in-scope repos — `channel` is `1.95.0`
+  at 9 sites and `stable` at 2; `rust-version` is `1.88` at 10 sites and `1.94.0` at 1; `doctor`
+  validates against the floor rather than the channel `[Repo-grounded]`
+- **Target**: **exactly 1 distinct value** (`1.95.0`) across every `rust-toolchain.toml` `channel`,
+  every `Cargo.toml` `rust-version`, and `doctor`'s expected-rustc, in all three repos — and on the
+  machine, **no installed toolchain that no repo pins** (baseline: 3 of 6 orphaned, 3.25 GB)
+- **Measure**: per repo, `grep -h '^channel' $(find . -name rust-toolchain.toml) | sort -u` and the
+  equivalent over `^rust-version` each return exactly one line, and the two lines agree; on the
+  machine, every entry of `rustup toolchain list` appears in that set, except `stable` where the
+  non-OSE-project predicate in [`tech-docs.md`](./tech-docs.md) §DD-9 retains it.
+
+## Business Scope Non-Goals
+
+- **Reducing what the gates check.** Coverage is invariant; M5 enforces it.
+- **Reducing the `TypeScript quality gate`'s 744 s of real `nx affected` work.** That is genuine
+  test/typecheck/lint execution and the critical path of the gate. Shrinking it is a testing-strategy
+  question — which tests belong on which surface — not a CI-plumbing one, and it deserves its own
+  plan rather than being smuggled into this one.
+- **Changing the [PR-Review Maker→Fixer Cycle](../../../repo-governance/workflows/pr/pr-review-quality-gate.md)
+  governance workflow itself.** This plan makes each cycle cheaper and, for its own three PRs only,
+  authors an explicit maintainer-authorized deviation from the workflow's standing fixed-3-cycle,
+  escalate-on-exhaustion default — iterate until clean, capped at 10 cycles, merge unconditionally
+  at the cap (see [`delivery.md`](./delivery.md) §Delivery Boundaries). It does not change the
+  governance document, and no other plan or PR inherits the deviation.
+- **A language rewrite.** Explicitly closed by measurement — see
+  [`tech-docs.md`](./tech-docs.md) §Why Not A Rewrite.
+- **Bumping Rust to a newer version.** M9 unifies on `1.95.0`, the value the repos already run.
+  Latest stable is `1.97.1` (2026-07-14), which at authoring fails the 60-day soak on Path B of the
+  [dependency bump policy](../../../repo-governance/development/workflow/dependency-bump-policy.md).
+  Unification and bumping are separate changes with separate risks; bundling them would make a CI
+  regression ambiguous between the two. The bump is follow-up work under that policy.
+- **Retiring the `compat:min-version` gate.** Aligning MSRV to the channel makes it tautological, but
+  removing a check collides with M5 and changes a published quality posture. Recorded as follow-up.
+
+## Business Risks
+
+| Risk                                                                                                                                           | Likelihood                    | Impact       | Mitigation                                                                                                                                                                                                                       |
+| ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A check is silently dropped while regrouping.** The worst outcome: gates look green and stop protecting.                                     | Medium                        | **Critical** | M5 makes coverage invariance a measured, phase-gated assertion. `gate validate` is extended to fail when any registry gate belongs to no CI group, so a gate cannot fall out of the matrix by omission.                          |
+| **Grouping makes wall-clock worse** even as runner-seconds fall, because 10 serial checks in one job beat 10 parallel jobs on latency.         | Medium                        | Medium       | M4 watches wall-clock explicitly as a no-regression target. Group composition is tuned by measurement, and the slowest single gate (`md links validate`, 1,081 ms) is small enough that no group should serialize meaningfully.  |
+| **Failure diagnosis gets harder** — one red group instead of one red check.                                                                    | High                          | Low          | Accepted and mitigated, not denied: `gate run --group` prints a per-gate PASS/FAIL summary so the failing gate id stays greppable. This is a real ergonomic cost, consciously traded for a 3× cost reduction.                    |
+| **The resolver shim mis-resolves after the ambient sweeper deletes `target/`**, making hooks fail confusingly.                                 | High (the sweeper runs often) | Medium       | The shim's build-and-retry fallback is a first-class requirement of DD-1, not an afterthought, and gets its own Gherkin scenario and test.                                                                                       |
+| **Cross-repo parity breaks.** `apps/rhino-cli` is byte-identical across three repos with zero carve-outs; any `src/` edit opens an obligation. | High                          | High         | The propagation phase is a required phase, not a follow-up. The parity-manifest gate is part of the phase gate, so the plan cannot be declared done with parity red.                                                             |
+| **Coverage enforcement weakens** when `test:coverage` moves off `test:quick`.                                                                  | Low                           | High         | Relocation, not removal. The delivery checklist asserts the CI job still enforces `--fail-under-lines 90`, and M5 covers the surface-level gate list.                                                                            |
+| Measurements were taken on one machine and one 22-run CI sample, and may not generalize.                                                       | Low                           | Low          | CI figures come from four independent repos showing the same pattern, and the key intervention is already validated in production in two of them. Local figures are the weaker evidence and are used only for the local targets. |
+
+## Constraints
+
+- **Coverage invariance is absolute.** No check may be removed to hit a number.
+- **`repo-config.yml` stays authoritative.** Groups are declared, never derived — consistent with this
+  repository's standing preference for explicit central registries over convention-based magic.
+- **Generated artifacts are never hand-edited** and land in the same commit as their source.
+- **Byte-identity parity** across `ose-public`, `ose-primer`, and `ose-private` must hold once
+  cross-repo propagation lands (Phase 10) and stay held through plan close.
+- **`worktree-to-pr` is mandatory** in this repo; `main` is branch-protected including for admins.

--- a/plans/in-progress/optimize-cis/delivery.md
+++ b/plans/in-progress/optimize-cis/delivery.md
@@ -1,0 +1,824 @@
+# Delivery Checklist — Optimize CIs
+
+> **Legend** — `[AI]`: an agent performs the step (the default; unmarked steps are `[AI]`).
+> `[HUMAN]`: only a human can do it (physical action, out-of-band approval, real-secret or
+> privileged-credential handling). `[AI+HUMAN]`: agent prepares, human approves or finishes.
+
+## Worktree
+
+Worktree path: `worktrees/optimize-cis/`
+
+Optional manual pre-provisioning (run from repo root):
+
+```bash
+claude --worktree optimize-cis
+```
+
+The plan-execution Step 0 gate enters this worktree by default: it auto-provisions from the latest
+`origin/main` when missing, syncs with `origin/main` before implementing, and — capped at one per
+repository per plan and reused across every delivery unit landed there — is removed immediately once
+the plan is done using this repo, not deferred to archival.
+
+See [Worktree Path Convention](../../../repo-governance/conventions/structure/worktree-path.md) and
+[Plans Organization Convention §Worktree Specification](../../../repo-governance/conventions/structure/plans.md#worktree-specification).
+
+## Delivery Mode: worktree-to-pr
+
+Mandatory in `ose-public` — `main` is branch-protected including for admins, so no direct-push mode
+has an executable path here. Exactly one PR per repo (three total) stays open across every phase
+that touches it and runs the
+[PR-Review Maker→Fixer Cycle](../../../repo-governance/workflows/pr/pr-review-quality-gate.md),
+run under this plan's explicit, maintainer-authorized deviation from that workflow's standing
+fixed-3-cycle/escalate default — **iteratively until clean, capped at 10 cycles** — before merge;
+see §Delivery Boundaries for the deviation's exact terms. `[AI]` merges once the five hardened
+preconditions hold.
+
+## Autonomy Contract — this plan runs unattended
+
+**Every one of this plan's steps is `[AI]`. There is no `[HUMAN]` or `[AI+HUMAN]` step.** Maintainer
+authorization for that was given on 2026-08-08, and the conditions that make it safe are structural,
+not conventional:
+
+| Would normally need a human          | Why it does not here                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Merging PRs                          | `ose-public` `main` requires **0 approving reviews** and exactly one status check, `Quality gate` `[Repo-grounded]`. `[AI]` merges once the five hardened preconditions hold and the review cycle has run to clean or to its 10-cycle cap, under this plan's explicit deviation from the governance workflow's standing fixed-3-cycle/escalate default (§Delivery Boundaries) — and authors no `[HUMAN]` merge gate. |
+| Deleting 9.32 GB of scratch          | Restructured as quarantine-then-verify: candidates are `mv`d aside, proven non-load-bearing by `doctor --fix` + `test:quick` + `nx affected -t build`, and only then deleted. Reversible until the final `rm`.                                                                                                                                                                                                       |
+| Pruning rustup toolchains            | Fully re-fetchable; the acceptance criterion re-runs `doctor --fix` and `test:quick` to prove restoration.                                                                                                                                                                                                                                                                                                           |
+| Deleting the superseded backlog plan | Recoverable from git history; maintainer authorized it explicitly on 2026-08-08.                                                                                                                                                                                                                                                                                                                                     |
+| Changing repo settings               | **Never done.** The plan instead treats each repo's required status-check context as a fixed external contract and asserts the emitting job keeps its exact name.                                                                                                                                                                                                                                                    |
+
+**The two hard stops that are not human gates but must halt execution:**
+
+1. A phase gate fails — fix the root cause, never bypass, never proceed.
+2. The protected `Quality gate` context stops reporting on a PR — revert the workflow change and
+   re-verify before merging. Merging a PR whose required context never reported is forbidden.
+
+A PR's review cycle exhausting its 10-cycle cap is explicitly **not** a hard stop — see §Delivery
+Boundaries: merge proceeds regardless of what remains open, recorded rather than silently dropped.
+
+**One thing an agent must never do in this plan**: modify branch protection or any repository setting
+to make a merge possible. If merging is blocked, the change is wrong — not the setting.
+
+## Delivery Boundaries
+
+**PR budget: 3 total — exactly one per repo.** `ose-public` opens a single draft PR right after
+Phase 1's gate passes and keeps it open through Phase 12; `ose-primer` and `ose-private` each open
+their own single PR inside Phase 10. **Phase 0 opens no PR.** No phase opens a second PR in a repo
+that already has one open — if a phase is about to open one, stop: that means this section drifted,
+not that a new PR is warranted.
+
+**This plan authors an explicit, maintainer-authorized deviation from the
+[Plans Organization Convention §PRs Open at Delivery Boundaries](../../../repo-governance/conventions/structure/plans.md#prs-open-at-delivery-boundaries-not-every-phase-hard-rule)
+HARD RULE**, whose standing shape is one branch → one PR → one delivery unit, opened and merged at
+that unit's own boundary, never held open across later units merely to batch them. This plan does
+not change that convention, and no other plan inherits the deviation below.
+
+`ose-public`'s work below is still organized into four delivery units (the table's `Unit` column),
+each an independently shippable increment. What changes is PR _cardinality_, not unit structure:
+instead of four branches/PRs (one opened and merged per unit), all four units land on the same
+single PR, opened once after Phase 1 and merged once at plan close. This was considered and chosen
+over the convention's default because several phase gates need a **live** PR to check CI/status
+against (Phase 6 Gate's `gh pr checks`, Phase 7 Gate's completed-run counts, Phase 8 Gate's
+scratch-commit-turns-red check, Phase 10 Gate's "CI green in all three repos") — a boundary model
+that only opens the PR at the _end_ of the unit containing those phases cannot satisfy its own
+gates, since `pr-quality-gate.yml` only triggers on an open PR or a push to `main` (forbidden here).
+Opening one PR early and pushing to it at the end of every phase gate below gives every gate a live
+target throughout, and reviewing the whole diff once — iteratively until clean, not at a fixed count,
+so nothing is lost by not compartmentalizing the diff — costs less than four narrower PRs plus
+resolving the timing contradiction some other way. Maintainer authorization for this deviation was
+given 2026-08-08.
+
+| Unit                      | Phases | What it contains                                                                                        |
+| ------------------------- | -----: | ------------------------------------------------------------------------------------------------------- |
+| **plan + invocation tax** |    1–4 | Local gate speedup: hooks and `lint-staged` work end-to-end with no CI change                           |
+| **CI topology**           |    5–7 | Grouped CI: the registry field, the build-once artifact, and the setup slimming land together           |
+| **build and disk**        |    8–9 | `test:quick` recomposition and disk hygiene, independent of CI topology                                 |
+| **propagation and close** |  10–12 | Cross-repo parity, measurement rollup, Knowledge Capture, and archival — all pushed to the same open PR |
+
+**This plan authors an explicit, maintainer-authorized deviation from the standing
+[PR-Review Maker→Fixer Cycle](../../../repo-governance/workflows/pr/pr-review-quality-gate.md)
+default for the three PRs it opens.** The governance workflow's standing behavior is a **fixed
+3-cycle** loop with no early exit, that **escalates rather than merges** when cycles exhaust with
+unresolved findings — `output.final-status: escalated`, and the caller "MUST NOT proceed to the
+merge." This plan does not change that workflow, and no other plan or PR in this repo inherits the
+deviation below. For this plan's three PRs only, maintainer authorization given 2026-08-08
+overrides two parameters:
+
+1. **Iterate until clean, not a fixed 3 cycles.** After each cycle, `pr-review-synthesis-maker`'s
+   consolidated review is re-run; if it reports any CRITICAL/HIGH/MEDIUM finding, run another
+   fixer pass and repeat. LOW findings never block.
+2. **Cap at 10 cycles, then merge unconditionally regardless of what remains open, at any
+   severity** — record any still-open finding as accepted-with-reason in the PR description, the
+   same accepted-as-is pattern Phase 11 already uses for a missed metric target, and merge. The
+   cap is chosen so a clean review is expected well before it binds, not so it is expected to bind
+   routinely; reaching it is not a hard stop (Autonomy Contract, above), unlike the governance
+   workflow's own exhaustion behavior.
+
+## Parallelization Model
+
+`1 main thread + N background agents`, **N=3**. Dependency DAG:
+
+```text
+Phase 0 ──> Phase 1 ──> Phase 2 ──> Phase 3 ─┐
+                              └──> Phase 4 ──┼──> Phase 5 ──> Phase 6 ──> Phase 7 ─┐
+                                              │                                     │
+                                              └──> Phase 8 ──> Phase 9 ─────────────┼──> Phase 10 ──> Phase 11 ──> Phase 12
+                                                                                    │
+                                                                                    ┘
+```
+
+Phases 3 and 4 are independent of each other and may fan out. Phases 8–9 are independent of 5–7 and
+may fan out. Phase 10 requires every source change to be final.
+
+## Progress Scoreboard
+
+`plans/in-progress/optimize-cis/scoreboard.md` is an **append-only** ledger, not a single before/after
+snapshot. Every phase gate step that (re-)measures a metric appends one row — no row is ever edited
+or removed — so a regression is visible at the phase that introduced it, not only at the final rollup.
+
+Row shape: `| Phase | Metric | Value | Δ vs Phase 0 baseline | Δ vs previous row for this metric | vs Target | Status |`.
+`Status` is one of `BASELINE` (Phase 0's first row per metric), `IMPROVED`, `REGRESSED`, `UNCHANGED`,
+or `PASS`/`FAIL` (only at Phase 11's final row, against the committed target). A `REGRESSED` row is
+not itself a failure — cumulative progress toward the target is what phase gates enforce — but it
+must never pass unremarked: the step appending it also states the suspected cause inline.
+
+Phase 0 initializes the file with one `BASELINE` row per metric (M1–M9). Every subsequent
+measurement step already present in this checklist (Phase 2/3 → M1, Phase 7 → M3/M4/M7, Phase 8 →
+M2/M6, Phase 9 → M8 partial, Phase 10 → M3/M8 full/M9, Phase 11 → final PASS/FAIL) appends its row to
+this same file instead of only recording into `baseline/measurements.md` or `results.md`. Phase 6
+verifies M5 inline against the Phase 0 capture but appends no scoreboard row — M5 is a
+byte-identical-or-fail gate check, not a trending measurement. `results.md`
+(Phase 11) becomes a rendered summary **derived from** the scoreboard's last row per metric, not an
+independent measurement pass.
+
+---
+
+## Phase 0 — Baseline and capture
+
+**Opens no PR.** Everything here is measurement; nothing is changed.
+
+- [ ] [AI] Sync the worktree: `git -C . fetch origin && git rebase origin/main` — acceptance: `git status` reports the branch up to date with no conflicts.
+- [ ] [AI] Initialize the toolchain from the repo root (not this worktree): `npm install && npm run doctor -- --fix` — acceptance: both commands exit 0.
+- [ ] [AI] Create `plans/in-progress/optimize-cis/learnings.md` if absent, containing the H1 `# Learnings: optimize-cis` — acceptance: `test -f plans/in-progress/optimize-cis/learnings.md` succeeds and `npx markdownlint-cli2 plans/in-progress/optimize-cis/learnings.md` exits 0.
+- [ ] [AI] Capture the executed gate id set for every surface into `plans/in-progress/optimize-cis/baseline/gates-<surface>.txt` for each of `pre-commit`, `pre-push`, `commit-msg`, `ci`, using `cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- gate list --surface=<surface> --format=json` — acceptance: four non-empty files exist; the `ci` file contains at least 36 gate ids.
+  - _This capture is the ground truth for M5/AC-4. Every later phase gate diffs against it._
+- [ ] [AI] Capture the `rhino-cli` test-name list into `baseline/test-names.txt` via `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --lib -- --list` — acceptance: file is non-empty and contains one line per test.
+- [ ] [AI] Measure and record M1 baseline (pre-commit, 10 md files) into `baseline/measurements.md`, using a `bash` loop-and-divide harness — acceptance: a recorded ms figure with the run count stated.
+  - _Harness constraint: measure under `bash`, never `zsh` (unquoted vars do not word-split), and never with `python3` timestamp subprocesses. See `tech-docs.md` §Method note._
+- [ ] [AI] Measure and record M2 baseline: `bash -c 'time npx nx run rhino-cli:test:quick --skip-nx-cache'` — acceptance: wall time recorded in `baseline/measurements.md`.
+- [ ] [AI] Measure and record M6 baseline: `du -sk` of an isolated `CARGO_TARGET_DIR` after one `test:quick` — acceptance: size in MB recorded.
+- [ ] [AI] Record M3 and M4 baselines from run history: `gh run list -R wahidyankf/ose-public -L 50 --json databaseId,workflowName,status,conclusion,createdAt,startedAt,updatedAt` plus per-run job durations — acceptance: median runner-seconds and p50 wall-clock recorded for `pr-quality-gate`.
+- [ ] [AI] Record each repo's branch-protection **required status check contexts** into `baseline/required-checks.md`: `gh api repos/wahidyankf/<repo>/branches/main/protection --jq '.required_status_checks.contexts'` for `ose-public`, `ose-primer`, `ose-private` — acceptance: the file records, per repo, the exact context strings (`ose-public` is known to require exactly `Quality gate` `[Repo-grounded]`) or an explicit "no protection payload readable" note.
+  - _**Load-bearing.** A required context is satisfied only by a job reporting under that exact name. Phase 6 rewrites the workflow that emits it; if the name drifts, every PR in that repo becomes permanently unmergeable and only a repo-settings change — which an agent must not make — can undo it._
+- [ ] [AI] Record M7 baseline: `gh api repos/wahidyankf/ose-public/actions/caches --jq '[.actions_caches[].size_in_bytes] | add'` — acceptance: byte total and percentage of the 10 GiB ceiling recorded.
+- [ ] [AI] Record M8 baseline: `du -sk` over each bucket listed in `tech-docs.md` §D.1 — acceptance: per-bucket table recorded.
+- [ ] [AI] Record M9 baseline into `baseline/rust-versions.md`: every `rust-toolchain.toml` `channel` and every `Cargo.toml` `rust-version` across `.` (`ose-public`), `/Users/wkf/ose-projects/ose-primer`, `/Users/wkf/ose-projects/ose-private`, and `/Users/wkf/ose-projects/beaver-nest`, plus `rustup toolchain list` — acceptance: the file reproduces the DD-9 evidence table and records 3 distinct declared values. `beaver-nest` is already `channel = "1.95.0"` at both its `rust-toolchain.toml` sites `[Repo-grounded]` — the capture should show it matching, not diverging.
+- [ ] [AI] Initialize `plans/in-progress/optimize-cis/scoreboard.md` with the `## Progress Scoreboard` header and one `BASELINE` row per metric M1–M9, sourced from the measurements just recorded above — acceptance: nine rows exist, each with a non-empty `Value` and `Status = BASELINE`.
+
+### Phase 0 Gate
+
+> All checks below must pass before starting Phase 1.
+
+- [ ] [AI] Verify `baseline/` contains four gate-id captures, a test-name list, `measurements.md` with M1–M8 baselines, and `rust-versions.md` with the M9 baseline — acceptance: `ls plans/in-progress/optimize-cis/baseline/` lists all seven artifacts.
+- [ ] [AI] Verify `scoreboard.md` carries nine `BASELINE` rows, one per metric — acceptance: `grep -c '| BASELINE |' plans/in-progress/optimize-cis/scoreboard.md` returns 9.
+- [ ] [AI] Verify the working tree is otherwise clean: `git status --porcelain` shows only the new plan and baseline files — acceptance: no unexplained modified file appears.
+
+> **Pause Safety**: nothing has changed; only measurements were recorded. Safe to stop. To resume: re-read `plans/in-progress/optimize-cis/baseline/measurements.md`.
+
+---
+
+## Phase 1 — Supersede the backlog plan and index this one
+
+- [ ] [AI] Delete the superseded plan: `git rm -r plans/backlog/rhino-cli-optimization/` — acceptance: the directory no longer exists and `git status` shows the deletions staged.
+  - _Decision recorded during pre-write grilling on 2026-08-08: delete outright, do not archive. Its contents were reviewed before this decision._
+- [ ] [AI] Remove the entry at `plans/backlog/README.md:101` referencing `rhino-cli-optimization` — acceptance: `grep -c "rhino-cli-optimization" plans/backlog/README.md` returns 0.
+- [ ] [AI] Confirm this plan is indexed in `plans/in-progress/README.md` under `## Active Plans` (added at plan-authoring time) — acceptance: `grep -c "optimize-cis" plans/in-progress/README.md` returns at least 1.
+- [ ] [AI] Verify no other file references the deleted plan: `grep -rn "rhino-cli-optimization" --exclude-dir=node_modules --exclude-dir=target --exclude-dir=.git --exclude-dir=local-temp .` — acceptance: returns no hits outside `plans/done/` historical records.
+
+### Phase 1 Gate
+
+> All checks below must pass before starting Phase 2.
+
+- [ ] [AI] `npx markdownlint-cli2 plans/**/*.md` — acceptance: exits 0.
+- [ ] [AI] `cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- md links validate` — acceptance: exits 0, proving no dangling link to the deleted plan.
+
+> **Pause Safety**: the plan set is coherent — one active plan, no superseded duplicate, no dangling links. Safe to stop. To resume: `npx markdownlint-cli2 plans/**/*.md`.
+
+---
+
+### Open the `ose-public` PR
+
+> This is the plan's **only** `ose-public` PR-open event. Every phase from here through Phase 12
+> pushes into this same branch; see §Delivery Boundaries for why it opens this early.
+
+- [ ] [AI] Commit Phase 1's changes thematically and push a new branch; open a draft PR against `main` titled `perf(gates): optimize pre-commit, pre-push, and PR quality gate` — acceptance: the PR exists and its number is recorded in `baseline/pr-numbers.md` under `ose-public`.
+
+---
+
+## Phase 2 — Resolver shim replaces `cargo run` (DD-1)
+
+- [ ] [AI] Add the scenario below to `specs/apps/rhino/behavior/rhino-cli/gherkin/gate/gate-emission.feature` (sibling scenarios already cover emitter behaviour) — acceptance: `cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs gherkin-cardinality validate specs/apps/rhino/behavior/rhino-cli/gherkin/gate/gate-emission.feature` exits 0.
+  - _Suggested executor: `specs-maker`_
+- [ ] [AI] **RED**: Write a failing test in the `apps/rhino-cli/src/commands/gate/emit.rs` tests module binding the scenario below
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --lib gate::emit`
+      — acceptance: test fails, reporting the rendered string still contains `cargo run --release`.
+  - **Gherkin (binds) →** "Rhino CLI kind renders a resolver shim invocation"
+
+    ```gherkin
+    Scenario: Rhino CLI kind renders a resolver shim invocation
+      Given the registry declares a gate of kind "rhino-cli" on surface "pre-commit"
+      When "rhino-cli gate emit --surface=pre-commit" runs
+      Then the generated command invokes the resolver shim at "apps/rhino-cli/scripts/rhino-bin.sh"
+      And the generated command contains no "cargo run" substring
+    ```
+
+  - _Suggested executor: `swe-rust-dev`_
+
+- [ ] [AI] **GREEN**: Change `command_with_fixed_arguments` in `apps/rhino-cli/src/commands/gate/emit.rs` (lines 122–125) so `GateKind::RhinoCli` renders `apps/rhino-cli/scripts/rhino-bin.sh <command>`
+      — command: same as above
+      — acceptance: test passes and no other `gate::emit` test breaks.
+  - _Suggested executor: `swe-rust-dev`_
+- [ ] [AI] **REFACTOR**: Extract the shim path to a single named constant in `emit.rs` so the three Husky shims and `validate.rs` share one definition
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --lib`
+      — acceptance: all lib tests pass; `grep -c "cargo run --release" apps/rhino-cli/src/commands/gate/emit.rs` returns 0.
+- [ ] [AI] Create `apps/rhino-cli/scripts/rhino-bin.sh` (sibling: `apps/rhino-cli/scripts/deny-check.sh`) resolving in order: `$RHINO_CLI_BIN` if executable; else `apps/rhino-cli/target/gate/rhino-cli` if newer than `src/`; else `cargo build --profile gate` then execute. Make it executable with `chmod +x`
+      — command: `shellcheck --severity=warning apps/rhino-cli/scripts/rhino-bin.sh && shfmt -d apps/rhino-cli/scripts/rhino-bin.sh`
+      — acceptance: both exit 0.
+  - _Suggested executor: `swe-rust-dev`_
+- [ ] [AI] Create `specs/apps/rhino/behavior/rhino-cli/gherkin/gate/gate-binary-resolution.feature` containing the two scenarios bound below, copied verbatim from `prd.md` AC-7 and AC-8 — acceptance: `cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs gherkin-cardinality validate specs/apps/rhino/behavior/rhino-cli/gherkin/gate/gate-binary-resolution.feature` exits 0.
+  - _Suggested executor: `specs-maker`_
+- [ ] [AI] **RED**: Write a failing integration test in `apps/rhino-cli/tests/gate_specs.rs` binding the scenario below
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --test gate_specs`
+      — acceptance: test fails because the shim does not yet build-and-retry.
+  - **Gherkin (binds) →** "A swept target directory produces a slow run, not a failure"
+
+    ```gherkin
+    Scenario: A swept target directory produces a slow run, not a failure
+      Given the rhino-cli binary is absent because the ambient sweeper removed target/
+      When a generated gate command runs through the resolver shim
+      Then the shim builds the binary and then executes the requested gate
+      And the gate reports the same result it would have reported with the binary present
+      And a subsequent invocation reuses the built binary without rebuilding
+    ```
+
+  - _Suggested executor: `swe-rust-dev`_
+
+- [ ] [AI] **GREEN**: Implement the build-and-retry path in `apps/rhino-cli/scripts/rhino-bin.sh`
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --test gate_specs`
+      — acceptance: the bound scenario passes.
+- [ ] [AI] **RED**: Write a failing integration test in `apps/rhino-cli/tests/gate_specs.rs` binding the scenario below
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --test gate_specs`
+      — acceptance: test fails because the override is not yet honoured.
+  - **Gherkin (binds) →** "RHINO_CLI_BIN takes precedence over discovery"
+
+    ```gherkin
+    Scenario: RHINO_CLI_BIN takes precedence over discovery
+      Given the environment variable RHINO_CLI_BIN points at an executable rhino-cli binary
+      When a generated gate command runs through the resolver shim
+      Then the shim executes the binary at that path
+      And it performs no cargo build
+    ```
+
+  - _Suggested executor: `swe-rust-dev`_
+
+- [ ] [AI] **GREEN**: Implement the `RHINO_CLI_BIN` override path in `apps/rhino-cli/scripts/rhino-bin.sh`
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --test gate_specs`
+      — acceptance: the bound scenario passes.
+- [ ] [AI] **REFACTOR**: Collapse the three resolution branches in `rhino-bin.sh` into one ordered lookup
+      — command: `shellcheck --severity=warning apps/rhino-cli/scripts/rhino-bin.sh && env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --test gate_specs`
+      — acceptance: both exit 0.
+- [ ] [AI] Regenerate the derived artifacts: `cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- gate emit && npm run generate:bindings`
+      — acceptance: `.husky/pre-commit`, `.husky/pre-push`, `.husky/commit-msg`, and the `lint-staged` block in `package.json` contain no `cargo run` substring; `npm run validate:sync` exits 0.
+  - _These generated files land in the SAME commit as `emit.rs`. See [File-Touch Discipline](../../../repo-governance/development/practice/file-touch-discipline.md)._
+
+### Phase 2 Gate
+
+> All checks below must pass before starting Phase 3.
+
+- [ ] [AI] `cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- gate validate` — acceptance: exits 0, confirming shims and registry agree.
+- [ ] [AI] Diff the executed gate id set against Phase 0 for all four surfaces — acceptance: byte-identical to `baseline/gates-<surface>.txt` (M5/AC-4).
+- [ ] [AI] Measure M1 with the same `bash` harness used at baseline, then append a `Phase 2` row to `scoreboard.md` with `Status = IMPROVED`/`REGRESSED`/`UNCHANGED` against the Phase 0 baseline row — acceptance: recorded; expected to fall from 3,047 ms toward ~1,200 ms (the remaining `npx` tax is removed in Phase 3).
+- [ ] [AI] Commit this phase's changes thematically and push to the open PR branch — acceptance: push succeeds; the PR's check run starts.
+
+> **Pause Safety**: hooks dispatch through the shim and all gates still run identically. Safe to stop. To resume: `cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- gate validate`.
+
+---
+
+## Phase 3 — Direct `node_modules/.bin` dispatch (DD-2)
+
+- [ ] [AI] Add the scenario below to `specs/apps/rhino/behavior/rhino-cli/gherkin/gate/gate-emission.feature` — acceptance: `cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs gherkin-cardinality validate specs/apps/rhino/behavior/rhino-cli/gherkin/gate/gate-emission.feature` exits 0.
+  - _Suggested executor: `specs-maker`_
+- [ ] [AI] **RED**: Write a failing test in the `apps/rhino-cli/src/commands/gate/emit.rs` tests module binding the scenario below
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --lib gate::emit`
+      — acceptance: test fails on the rendered command string.
+  - **Gherkin (binds) →** "Node-resolved external tools render a repository-local bin path"
+
+    ```gherkin
+    Scenario: Node-resolved external tools render a repository-local bin path
+      Given the registry declares an external gate whose tool resolves from node_modules
+      When "rhino-cli gate emit --surface=pre-commit" runs
+      Then the generated command invokes that tool through "node_modules/.bin"
+      And the generated command contains no "npx" substring
+    ```
+
+  - _Suggested executor: `swe-rust-dev`_
+
+- [ ] [AI] **GREEN**: Add node-tool resolution to `emit.rs`, gated on the registry distinguishing node-resolved tools from system tools via the existing `doctor_tools` field
+      — command: same as above
+      — acceptance: test passes; system tools such as `shellcheck` and `hadolint` are unchanged.
+- [ ] [AI] **REFACTOR**: Consolidate the resolution logic so node-tool and rhino-cli resolution share one code path
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --lib`
+      — acceptance: all lib tests pass.
+- [ ] [AI] Regenerate: `cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- gate emit && npm run generate:bindings`
+      — acceptance: `npm run validate:sync` exits 0; the `lint-staged` block references `node_modules/.bin/` for prettier and markdownlint-cli2.
+
+### Phase 3 Gate
+
+> All checks below must pass before starting Phase 5.
+
+- [ ] [AI] Diff the executed gate id set against Phase 0 for all four surfaces — acceptance: byte-identical (M5/AC-4).
+- [ ] [AI] Stage 10 markdown files and measure M1, then append a `Phase 3` row to `scoreboard.md` — acceptance: **mean over three runs is at most 900 ms** (AC-1); figure recorded in `baseline/measurements.md` beside the baseline, and the scoreboard row's `vs Target` column reads `PASS`.
+- [ ] [AI] Run a real commit of a markdown-only change and confirm the hook passes — acceptance: `git commit` succeeds and every markdown gate reports its baseline result.
+- [ ] [AI] Commit this phase's remaining changes thematically and push to the open PR branch — acceptance: push succeeds; the PR's check run starts.
+
+> **Pause Safety**: pre-commit is at target and coverage is proven unchanged. Safe to stop. To resume: re-measure M1.
+
+---
+
+## Phase 4 — Rust build configuration: profiles and version pin (DD-6, DD-9)
+
+Independent of Phase 3; may run in parallel.
+
+- [ ] [AI] Add `[profile.gate]` to `apps/rhino-cli/Cargo.toml` inheriting from `release` with `lto = false`, `codegen-units = 16`, `opt-level = 1`, leaving `[profile.release]` untouched
+      — command: `cargo build --profile gate --manifest-path apps/rhino-cli/Cargo.toml`
+      — acceptance: builds successfully and produces `apps/rhino-cli/target/gate/rhino-cli`.
+  - _Suggested executor: `swe-rust-dev`_
+- [ ] [AI] Measure the cold build under both profiles into isolated target dirs and record both figures
+      — command: `rm -rf /tmp/ct && bash -c 'time CARGO_TARGET_DIR=/tmp/ct cargo build --profile gate --manifest-path apps/rhino-cli/Cargo.toml'`
+      — acceptance: the gate profile builds materially faster than release; both figures recorded (baseline measured 53.0 s release vs 19.6 s fast).
+- [ ] [AI] Confirm runtime parity between the two binaries on the slowest gate
+      — command: `bash -c 'time (for i in 1 2 3; do apps/rhino-cli/target/gate/rhino-cli md links validate >/dev/null; done)'`
+      — acceptance: within 15 % of the release binary's time for the same command.
+- [ ] [AI] Point `apps/rhino-cli/scripts/rhino-bin.sh` and the gate-path Nx targets in `apps/rhino-cli/project.json` at `--profile gate`, leaving `build` on `--release`
+      — command: `npx nx run rhino-cli:typecheck`
+      — acceptance: exits 0.
+
+### Version unification, `ose-public` side (DD-9)
+
+- [ ] [AI] Confirm `baseline/rust-versions.md` from Phase 0 is still current (no drift since baseline capture): re-run its capture commands and diff — acceptance: identical output, or the delta is recorded and folded into the scoreboard's M9 baseline row before proceeding.
+- [ ] [AI] Set `rust-version = "1.95.0"` in all four `ose-public` Rust manifests (`apps/rhino-cli`, `apps/ose-cli`, `apps/ayokoding-cli`, `libs/rust-commons`), matching the `channel` those crates already pin
+      — command: `grep -h '^rust-version' apps/*/Cargo.toml libs/*/Cargo.toml | sort -u`
+      — acceptance: exactly one line, reading `rust-version = "1.95.0"`.
+  - _`ose-public` needs no `channel` edit: all four sites already pin `1.95.0`. Only the floor moves._
+- [ ] [AI] Confirm the MSRV move does not break the compatibility gate — command: `npx nx run rhino-cli:compat:min-version` — acceptance: exits 0, and the run installs no toolchain (the floor now equals the already-present pinned channel).
+- [ ] [AI] Add the scenario below to `specs/apps/rhino/behavior/rhino-cli/gherkin/system/doctor.feature` — acceptance: `cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs gherkin-cardinality validate specs/apps/rhino/behavior/rhino-cli/gherkin/system/doctor.feature` exits 0.
+  - _Suggested executor: `specs-maker`_
+- [ ] [AI] **RED**: Write a failing test in the `apps/rhino-cli/src/application/doctor/tools.rs` tests module binding the scenario below
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --lib doctor::tools`
+      — acceptance: test fails because the `rust` tool definition still reads `Cargo.toml → rust-version` and compares with `compare_gte`.
+  - **Gherkin (binds) →** "doctor compares rustc against the toolchain that builds"
+
+    ```gherkin
+    Scenario: doctor compares rustc against the toolchain that builds
+      Given the installed rustc differs from the pinned rust-toolchain.toml channel
+      When "npm run doctor" runs
+      Then it reports the Rust toolchain as mismatched
+      And it names the pinned channel as the expected value
+    ```
+
+  - _Suggested executor: `swe-rust-dev`_
+
+- [ ] [AI] **GREEN**: Repoint the `rust` entry in `tool_defs_rust()` at `apps/rhino-cli/rust-toolchain.toml → channel` — new `read_req` reader, `source` string updated, and `compare` switched from `compare_gte` to exact equality, since a pinned channel is not a floor
+      — command: same as above
+      — acceptance: test passes (AC-20).
+- [ ] [AI] **REFACTOR**: Fold the `1.88` literals in the existing `read_rust_version` doc comments and tests to the new pinned value where they assert current behaviour, leaving fixtures that only exercise parsing untouched
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --lib doctor`
+      — acceptance: exits 0, and `grep -c '1\.88' apps/rhino-cli/src/application/doctor/` returns only parser-fixture hits, each verified individually.
+- [ ] [AI] Update `docs/explanation/software-engineering/programming-languages/rust/README.md:81` so the MSRV bullet states that the floor and the toolchain pin are deliberately the same value — command: `npx markdownlint-cli2 docs/explanation/software-engineering/programming-languages/rust/README.md` — acceptance: exits 0.
+  - _Suggested executor: `docs-maker`_
+
+### Phase 4 Gate
+
+> All checks below must pass before starting Phase 5.
+
+- [ ] [AI] `npx nx run rhino-cli:lint` — acceptance: exits 0.
+- [ ] [AI] Diff the executed gate id set against Phase 0 — acceptance: byte-identical.
+- [ ] [AI] Confirm `[profile.release]` is unchanged: `git diff apps/rhino-cli/Cargo.toml` — acceptance: the release block shows no modification.
+- [ ] [AI] Confirm `ose-public` declares one Rust version: `cat $(find . -name rust-toolchain.toml -not -path './target/*' -not -path './node_modules/*') | grep '^channel' | sort -u` and the `^rust-version` equivalent — acceptance: each returns exactly one line and both name `1.95.0` (AC-19, M9 for this repo).
+- [ ] [AI] `npm run doctor` — acceptance: exits 0 and reports the Rust source as the `rust-toolchain.toml` channel, not `Cargo.toml → rust-version`.
+- [ ] [AI] Run local quality gates (see §Local Quality Gates), then commit this phase's changes thematically and push to the open PR branch — acceptance: local gates exit 0; push succeeds and the PR's check run starts.
+
+> **Pause Safety**: two profiles coexist; the shipped artifact is unchanged; the version change is a one-number revert in five files. Safe to stop. To resume: `cargo build --profile gate --manifest-path apps/rhino-cli/Cargo.toml`.
+
+---
+
+## Phase 5 — `ci_group` becomes a required registry field (DD-3)
+
+- [ ] [AI] Add the scenario below to `specs/apps/rhino/behavior/rhino-cli/gherkin/gate/gate-validation.feature` — acceptance: `cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs gherkin-cardinality validate specs/apps/rhino/behavior/rhino-cli/gherkin/gate/gate-validation.feature` exits 0.
+  - _Suggested executor: `specs-maker`_
+- [ ] [AI] **RED**: Write a failing test in the `apps/rhino-cli/src/commands/gate/validate.rs` tests module binding the scenario below
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --lib gate::validate`
+      — acceptance: test fails because `ci_group` is not yet required.
+  - **Gherkin (binds) →** "A gate declared without a CI group fails validation"
+
+    ```gherkin
+    Scenario: A gate declared without a CI group fails validation
+      Given a gate entry in repo-config.yml carrying a ci surface and no ci_group field
+      When "rhino-cli gate validate" runs
+      Then it exits non-zero
+      And its output names the offending gate id
+      And its output states that ci_group is required
+    ```
+
+  - _Suggested executor: `swe-rust-dev`_
+
+- [ ] [AI] **GREEN**: Add the `ci_group` field to the gate schema in the `repo_config` module and enforce its presence in `validate.rs`
+      — command: same as above
+      — acceptance: test passes (AC-5).
+- [ ] [AI] Add the scenario below to `specs/apps/rhino/behavior/rhino-cli/gherkin/gate/gate-enumeration.feature` — acceptance: `cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs gherkin-cardinality validate specs/apps/rhino/behavior/rhino-cli/gherkin/gate/gate-enumeration.feature` exits 0.
+  - _Suggested executor: `specs-maker`_
+- [ ] [AI] **RED**: Write a failing test in the `apps/rhino-cli/src/commands/gate/list.rs` tests module binding the scenario below
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --lib gate::list`
+      — acceptance: test fails because `--by-group` is unrecognized.
+  - **Gherkin (binds) →** "Enumeration can group CI gates by declared group"
+
+    ```gherkin
+    Scenario: Enumeration can group CI gates by declared group
+      Given every ci-surface gate in the registry declares a ci_group
+      When "rhino-cli gate list --surface=ci --format=json --by-group" runs
+      Then it emits one entry per distinct ci_group value
+      And each entry lists its member gate ids in registry declaration order
+    ```
+
+  - _Suggested executor: `swe-rust-dev`_
+
+- [ ] [AI] **GREEN**: Implement `--by-group` in `apps/rhino-cli/src/commands/gate/list.rs`
+      — command: same as above
+      — acceptance: test passes.
+- [ ] [AI] Add the scenario below to `specs/apps/rhino/behavior/rhino-cli/gherkin/gate/gate-execution.feature` — acceptance: `cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs gherkin-cardinality validate specs/apps/rhino/behavior/rhino-cli/gherkin/gate/gate-execution.feature` exits 0.
+  - _Suggested executor: `specs-maker`_
+- [ ] [AI] **RED**: Write a failing test in the `apps/rhino-cli/src/commands/gate/run.rs` tests module binding the scenario below
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --lib gate::run`
+      — acceptance: test fails because `--group` is unrecognized.
+  - **Gherkin (binds) →** "A failing gate inside a group is named in the output"
+
+    ```gherkin
+    Scenario: A failing gate inside a group is named in the output
+      Given a CI group containing several gates where exactly one fails
+      When "rhino-cli gate run --surface=ci --group=<id>" runs
+      Then it exits non-zero
+      And its output contains a per-gate summary line for every gate in the group
+      And the failing gate id appears on a line marked FAIL
+    ```
+
+  - _Suggested executor: `swe-rust-dev`_
+
+- [ ] [AI] **GREEN**: Implement `--group` in `apps/rhino-cli/src/commands/gate/run.rs`, including the per-gate summary output
+      — command: same as above
+      — acceptance: test passes (AC-6).
+- [ ] [AI] **REFACTOR**: Deduplicate group filtering between `list.rs` and `run.rs`
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --lib`
+      — acceptance: all lib tests pass.
+- [ ] [AI] Add `ci_group` to every gate entry in `repo-config.yml` carrying a `ci` surface. Group by required toolchain, mirroring `beaver-nest`'s proven job names: markdown, shell/docker/actions, governance, specs, naming, formatting-verify
+      — command: `cargo run --profile gate --quiet --manifest-path apps/rhino-cli/Cargo.toml -- gate validate`
+      — acceptance: exits 0; every `ci`-surface gate declares a group.
+- [ ] [AI] Add the CI-topology scenarios AC-9 and AC-10 from `prd.md` to `specs/apps/rhino/behavior/rhino-cli/gherkin/gate/gate-execution.feature` (AC-5, AC-6, and AC-18 already landed with their RED cycles above)
+      — command: `cargo run --profile gate --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs gherkin-cardinality validate specs/apps/rhino/behavior/rhino-cli/gherkin/gate/gate-execution.feature`
+      — acceptance: exits 0.
+  - _Suggested executor: `specs-maker`_
+
+### Phase 5 Gate
+
+> All checks below must pass before starting Phase 6.
+
+- [ ] [AI] Verify the union of gate ids across all declared groups equals the Phase 0 `ci` capture — command: compare `gate list --surface=ci --by-group --format=json` flattened member ids against `baseline/gates-ci.txt` — acceptance: sets are byte-identical (AC-4). **No gate may be orphaned by grouping.**
+- [ ] [AI] `npx nx run rhino-cli:test:quick` — acceptance: exits 0.
+- [ ] [AI] Commit this phase's changes thematically and push to the open PR branch — acceptance: push succeeds; the PR's check run starts.
+
+> **Pause Safety**: the registry declares groups and the CLI can enumerate and run them; the workflow still uses the old matrix, so CI is unaffected. Safe to stop. To resume: `cargo run --profile gate --quiet --manifest-path apps/rhino-cli/Cargo.toml -- gate validate`.
+
+---
+
+## Phase 6 — Build once, matrix over groups (DD-4)
+
+- [ ] [AI] Add a `build-rhino` job to `.github/workflows/pr-quality-gate.yml` that checks out, sets up Rust, builds `--profile gate`, and uploads `apps/rhino-cli/target/gate/rhino-cli` via `actions/upload-artifact`
+      — acceptance: `actionlint .github/workflows/pr-quality-gate.yml` exits 0.
+- [ ] [AI] Change the `enumerate` job to emit groups: `gate list --surface=ci --format=json --by-group`
+      — acceptance: `actionlint` exits 0.
+- [ ] [AI] Change the `gate` job to matrix over groups, download the artifact, export `RHINO_CLI_BIN`, and run `gate run --surface=ci --group="$GROUP_ID"`; remove `./.github/actions/setup-rust` from it
+      — acceptance: `actionlint` exits 0 and the job contains no `setup-rust` reference.
+- [ ] [AI] Update the workflow-conformance assertions in `apps/rhino-cli/src/commands/gate/validate.rs` (`validate_ci_workflow`, whose assertions currently expect the per-gate `--only=` form; the fixture strings at lines 1473–1480 are one of ~12 `--only=` occurrences to update) to assert the new group form
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --lib gate::validate`
+      — acceptance: tests pass against the edited workflow.
+  - _Suggested executor: `swe-rust-dev`_
+- [ ] [AI] Preserve the protected status-check contract: the terminal job in `.github/workflows/pr-quality-gate.yml` MUST keep the job key `quality-gate` and the literal `name: Quality gate`, and must still fail when any dependency job fails — update only its `needs:` list to name the new group matrix — acceptance: `grep -c "name: Quality gate" .github/workflows/pr-quality-gate.yml` returns 1, and the string matches `baseline/required-checks.md` for this repo byte-for-byte.
+  - _Renaming this job silently bricks merging for the whole repo. Treat the name as an external API._
+- [ ] [AI] Reduce `fetch-depth` from `0` to a targeted fetch on every job that does not need full history — acceptance: only jobs running `nx affected` or `git diff` against a base ref retain `fetch-depth: 0`; `actionlint` exits 0.
+
+### Phase 6 Gate
+
+> All checks below must pass before starting Phase 7.
+
+- [ ] [AI] Commit this phase's changes thematically, push to the open PR branch, and confirm the workflow runs green — command: `gh run list -R wahidyankf/ose-public -L 1 --json status,conclusion` polled every 2 minutes — acceptance: conclusion is `success`.
+  - _Poll at the 2-minute cadence; never `gh run watch`. A queued job is often runner contention across the four repos, not a defect._
+- [ ] [AI] Verify every Phase 0 `ci` gate id appears in the run's logs — acceptance: all ids present (AC-4). **This is the phase's most important check.**
+- [ ] [AI] Verify no gate job installed a Rust toolchain or ran `cargo install` — acceptance: grep of job logs returns no hits (AC-9).
+- [ ] [AI] Verify the protected context still reports on the PR: `gh pr checks <pr> --json name,state` — acceptance: a check named exactly `Quality gate` is present and concluded; **if it is absent, revert the workflow change before merging — do not merge a PR whose required context never reported.**
+
+> **Pause Safety**: CI is green under the grouped topology with coverage proven unchanged. Safe to stop. To resume: `gh run list -R wahidyankf/ose-public -L 1`.
+
+---
+
+## Phase 7 — Slim node setup and fix the cache key (DD-5, DD-8)
+
+- [ ] [AI] Add a boolean input to `.github/actions/setup-node/action.yml` controlling whether `npm ci` runs, defaulting to `true` so existing callers are unaffected
+      — acceptance: `actionlint` exits 0 and all existing call sites behave identically.
+- [ ] [AI] Set that input to `false` for every gate group whose gates require no node-resolved tool
+      — acceptance: those jobs' logs contain no `npm ci` (AC-10).
+- [ ] [AI] Remove `-${{ github.sha }}` from the `.nx/cache` key at `.github/actions/setup-node/action.yml:30`, retaining the existing `restore-keys` fallbacks
+      — acceptance: the key no longer interpolates `github.sha`; `actionlint` exits 0.
+
+### Phase 7 Gate
+
+> All checks below must pass before starting Phase 10.
+
+- [ ] [AI] Commit this phase's changes thematically, push to the open PR branch, and confirm CI green — acceptance: push succeeds; conclusion is `success` and every Phase 0 `ci` gate id appears in the logs.
+- [ ] [AI] Measure M3 over 5 completed runs, then append a `Phase 7` row to `scoreboard.md` — acceptance: **median at most 3,500 runner-seconds** (AC-3).
+- [ ] [AI] Measure M4 over 10 completed runs, then append a `Phase 7` row to `scoreboard.md` (`Status = REGRESSED` is a hard stop here, not a note-and-continue — M4 is a no-regression target) — acceptance: **p50 wall-clock no greater than the Phase 0 baseline** (AC-3). If wall-clock regressed, re-balance group composition before proceeding.
+- [ ] [AI] After 10 further commits, measure M7, then append a `Phase 7` row to `scoreboard.md` — acceptance: **cache at most 60 % of the 10 GiB ceiling** (AC-11).
+
+> **Pause Safety**: CI topology is complete and measured against targets. Safe to stop. To resume: re-measure M3 and M4.
+
+---
+
+## Phase 8 — Recompose `test:quick` (DD-7)
+
+Independent of Phases 5–7; may run in parallel.
+
+- [ ] [AI] Remove `npx nx run rhino-cli:test:coverage` from the `test:quick` command chain in `apps/rhino-cli/project.json`, leaving the `test:coverage` target itself intact and unchanged
+      — command: `npx nx run rhino-cli:test:quick --skip-nx-cache`
+      — acceptance: exits 0 and the run no longer produces a `llvm-cov-target` directory.
+- [ ] [AI] Add `test:coverage` to the Rust quality-gate job in `.github/workflows/pr-quality-gate.yml` so coverage still gates merge
+      — command: `actionlint .github/workflows/pr-quality-gate.yml`
+      — acceptance: exits 0 and the job runs `test:coverage` with `--fail-under-lines 90` intact (AC-13).
+- [ ] [AI] Collapse the seven sequential `cargo test` invocations in the `test:unit` target where they share a profile, preserving `--test-threads=1` for the lib run
+      — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --lib -- --list`
+      — acceptance: the emitted test-name list is byte-identical to `baseline/test-names.txt` (AC-2 guard).
+- [ ] [AI] Update `repo-governance/development/infra/nx-targets.md` to document the new `test:quick` composition and state that coverage is enforced on CI
+      — command: `npx markdownlint-cli2 repo-governance/development/infra/nx-targets.md`
+      — acceptance: exits 0.
+  - _Suggested executor: `repo-rules-maker`_
+
+### Phase 8 Gate
+
+> All checks below must pass before starting Phase 9.
+
+- [ ] [AI] Measure M2, then append a `Phase 8` row to `scoreboard.md` — acceptance: **mean over two runs at most 90 s** (AC-2).
+- [ ] [AI] Measure M6 into an isolated target dir, then append a `Phase 8` row to `scoreboard.md` — acceptance: **at most 1.2 GB** (AC-12).
+- [ ] [AI] Diff the executed test-name list against `baseline/test-names.txt` — acceptance: byte-identical. **A speedup by running fewer tests fails here.**
+- [ ] [AI] Commit this phase's changes thematically, push to the open PR branch, and confirm the Rust quality gate still fails on a deliberate coverage drop — acceptance: a scratch commit dropping coverage below 90 % turns the job red (AC-13).
+- [ ] [AI] Revert the scratch commit and confirm the job returns green — acceptance: `git log -1 --oneline` no longer shows the scratch commit and the Rust quality gate concludes `success`. **This step is mandatory; the branch must never be left carrying a knowingly-red commit.**
+
+> **Pause Safety**: pre-push is at target, coverage enforcement relocated and proven still binding. Safe to stop. To resume: re-measure M2.
+
+---
+
+## Phase 9 — Disk hygiene (Axis D)
+
+- [ ] [AI] Enumerate `local-temp/` reclaim candidates into `plans/in-progress/optimize-cis/local-temp-reclaim-manifest.md`, admitting a path **only** when every predicate below holds. Each is machine-checkable; no human judgement is involved.
+  1. It is a build-artifact directory — its name is `.next`, `dist`, `out`, `build`, `target`, or `node_modules`, **and** for `.next` it contains a `BUILD_ID` file.
+  2. A named command regenerates it (record the command per row, e.g. `nx build organiclever-www`).
+  3. Its mtime is older than 7 days.
+  4. It is not under, and does not contain, any of: `generated-reports/`, any `.env*` file, any git-tracked file, any path inside a `worktrees/` entry from `git worktree list`, or any `.git` directory.
+  5. No git-tracked file in any of the four repos references its path (`grep -rl "<path>"` across tracked files returns nothing).
+  - acceptance: every row records size, mtime, the matched artifact type, and its regeneration command; rows sum to at least 9 GB; **nothing is moved or deleted by this step**.
+- [ ] [AI] Move — do not delete — every manifest row into a dated quarantine: `mkdir -p local-temp/.reclaim-quarantine-$(date +%F)` then `mv` each path into it — acceptance: `du -sk local-temp` is unchanged (the bytes moved, not freed); every manifest path now resolves inside the quarantine; a single `mv` back restores the prior state.
+  - _Quarantine-then-verify is what makes this step safely `[AI]`. The destructive act is deferred until after the phase gate has proved nothing load-bearing was taken, and until then the whole operation is one `mv` from undone._
+- [ ] [AI] With the quarantine in place, prove nothing load-bearing was captured: `npm run doctor -- --fix && npx nx run rhino-cli:test:quick && npx nx affected -t build` — acceptance: all exit 0. **If any fails, `mv` the quarantine contents back and re-derive the manifest — do not proceed.**
+- [ ] [AI] Delete the quarantine: `rm -rf local-temp/.reclaim-quarantine-*` — acceptance: `du -sk local-temp` falls by at least 9 GB; `git status --porcelain` shows no tracked-file change from this phase.
+
+- [ ] [AI] Add a retention rule for `local-temp/` to `repo-governance/development/infra/temporary-files.md`, stating the window and that the sweeper still must not touch it automatically — command: `npx markdownlint-cli2 repo-governance/development/infra/temporary-files.md` — acceptance: exits 0 (AC-14).
+  - _Suggested executor: `repo-rules-maker`_
+- [ ] [AI] Extend `doctor --fix`'s target-share step to cover worktrees, so `worktrees/*/apps/rhino-cli/target` symlinks into the shared cache rather than duplicating 221.8 MB per worktree — command: `npx nx run rhino-cli:test:unit` — acceptance: the `cargo_target_share` tests pass and a worktree's `target` resolves to a symlink.
+  - _Suggested executor: `swe-rust-dev`_
+- [ ] [AI] Record the cross-worktree cargo build-lock contention finding (65 s observed block) in `learnings.md` for triage — acceptance: an entry exists with context, observation, and generalization reasoning.
+  - _Not fixed here: the shared cache trades disk for serialization, and reversing that tradeoff is a design question deserving its own plan._
+
+### Phase 9 Gate
+
+> All checks below must pass before starting Phase 10.
+
+- [ ] [AI] Measure M8 **partial**, then append a `Phase 9` row to `scoreboard.md` — acceptance: **at least 9 GB reclaimed** versus the Phase 0 bucket table. The remaining ≥1 GB comes from the toolchain prune in Phase 10; M8's full **≥10 GB** target is asserted at the Phase 10 Gate, not here.
+- [ ] [AI] `npm run doctor -- --fix` then `npx nx run rhino-cli:test:quick` — acceptance: both exit 0, proving nothing load-bearing was removed.
+- [ ] [AI] Run local quality gates (see §Local Quality Gates), then commit this phase's changes thematically and push to the open PR branch — acceptance: local gates exit 0; push succeeds and the PR's check run starts.
+
+> **Pause Safety**: disk reclaimed and hygiene documented; the toolchain rebuilds cleanly. Safe to stop. To resume: `npm run doctor -- --fix`.
+
+---
+
+## Phase 10 — Cross-repo propagation (`ose-primer`, `ose-private`)
+
+**Repo scope is exactly three: `ose-public`, `ose-primer`, `ose-private`.** `beaver-nest` is
+excluded — its `rhino-cli` is a fork with no `src/commands/gate/` subsystem, it is already the
+fastest repo of the four, and it is slated for deprecation immediately after this plan. See
+[`README.md` §Affected repositories](./README.md#affected-repositories--three-of-four).
+
+- [ ] [AI] Resolve the parity-message contradiction this plan trips over. `apps/rhino-cli/src/application/parity.rs:560` and its test at line 867 both state the manifest files are "byte-identical across ose-public, ose-primer, ose-private, and beaver-nest", but `AGENTS.md:445-447` scopes the boundary to three repos and `beaver-nest` has no `apps/rhino-cli/parity-manifest.sha256` — command: `env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR cargo test --manifest-path apps/rhino-cli/Cargo.toml --lib parity` — acceptance: both strings name exactly the three parity repos, the test asserting the message passes, and `grep -c "beaver-nest" apps/rhino-cli/src/application/parity.rs` returns 0.
+  - _Not scope creep: this plan edits `apps/rhino-cli/src/` heavily, so every parity failure during this phase prints an instruction to propagate into a repo that has no manifest to propagate into._
+  - _Suggested executor: `swe-rust-dev`_
+- [ ] [AI] Provision one worktree per sibling repo — `git -C /Users/wkf/ose-projects/ose-primer worktree add worktrees/optimize-cis` and the same for `ose-private` — acceptance: both worktrees exist on a branch off the latest `origin/main`.
+  - _One worktree per repo per plan (HARD RULE). Never run git-mutating agents in a primary checkout._
+- [ ] [AI] Propagate every `apps/rhino-cli/` source change to both sibling worktrees, then regenerate derived artifacts in each: `cargo run --profile gate --quiet --manifest-path apps/rhino-cli/Cargo.toml -- gate emit && npm run generate:bindings` — acceptance: `npm run validate:sync` exits 0 in each, and generated artifacts are staged in the same commit as their source.
+- [ ] [AI] Add the `ci_group` field to every `ci`-surface gate in each sibling's `repo-config.yml`, mirroring the group taxonomy adopted in Phase 5 — command: `cargo run --profile gate --quiet --manifest-path apps/rhino-cli/Cargo.toml -- gate validate` in each — acceptance: exits 0 in both; every `ci`-surface gate declares a group.
+  - _`ose-private` is the largest single win available: 23 of its 33 `lint-staged` entries are `cargo run` invocations (vs 7 here), and its CI overhead is **91.9 %** `[Repo-grounded]`._
+- [ ] [AI] Apply the grouped workflow, `build-rhino` artifact job, conditional `npm ci`, and the `github.sha`-free Nx cache key to `.github/` in each sibling — command: `actionlint .github/workflows/pr-quality-gate.yml` in each — acceptance: exits 0; each sibling's gate jobs contain no `setup-rust` and no `cargo install`.
+  - _All three repos carry the same `github.sha` cache-key defect and the same unconditional `npm ci` `[Repo-grounded]`._
+- [ ] [AI] Apply the same protected-context guard in each sibling: confirm that repo's terminal job name still matches the contexts captured in `baseline/required-checks.md` — acceptance: for each sibling, either the recorded context string is still emitted by a job, or the file recorded that no protection payload was readable.
+- [ ] [AI] Verify per-repo coverage invariance: in each sibling, diff the executed `ci` gate id set against that repo's own pre-change capture — acceptance: byte-identical per repo (AC-4 applied per repo). **A gate must not be orphaned by grouping in any repo.**
+- [ ] [AI] Sweep every doc naming the old invocation form across all three repos: `grep -rn "cargo run --release --quiet --manifest-path apps/rhino-cli" --exclude-dir=node_modules --exclude-dir=target --exclude-dir=.git .` — acceptance: remaining hits are only in `plans/done/` historical records, verified per repo with a per-file verdict.
+  - _Fix the class, not just the cited sites: enumerate every file stating the rule, per repo._
+
+### Version unification, sibling side (DD-9)
+
+- [ ] [AI] Replace `channel = "stable"` with `channel = "1.95.0"` in `ose-primer/apps/crud-be-rust-axum/rust-toolchain.toml` and `ose-private/apps/coralpolyp-be/rust-toolchain.toml` — acceptance: `grep -h '^channel' $(find . -name rust-toolchain.toml -not -path './target/*' -not -path './node_modules/*') | sort -u` returns exactly one line per repo, reading `1.95.0`.
+  - _These two crates are the only sites in any repo that build on a floating alias. Everything else is already pinned._
+- [ ] [AI] Align every sibling `rust-version` to `1.95.0`, including the lone `1.94.0` outlier in `ose-primer/apps/crud-be-rust-axum/Cargo.toml` — acceptance: the `^rust-version` `sort -u` returns exactly one line per repo (AC-19).
+- [ ] [AI] Propagate the Phase 4 `doctor` change (channel-sourced expected-rustc) into both siblings as part of the `apps/rhino-cli/` propagation, then run `npm run doctor` in each — acceptance: exits 0 in both and reports the `rust-toolchain.toml` channel as the source (AC-20).
+- [ ] [AI] Replace `ose-private`'s `dtolnay/rust-toolchain@stable` in `.github/actions/setup-rust/action.yml` with the `actions-rust-lang/setup-rust-toolchain@v1` form the other repos use, so the pinned channel is installed rather than fetched lazily on first `cargo` call — command: `actionlint .github/actions/setup-rust/action.yml` — acceptance: exits 0; the action installs the toolchain `rust-toolchain.toml` names.
+  - _Today `ose-private` installs `stable`, never uses it, then downloads `1.95.0` mid-job — a full toolchain fetch per Rust job `[Repo-grounded]`._
+- [ ] [AI] Correct the two stale version claims: `ose-private/repo-governance/workflows/infra/infra-development-environment-setup.md:59` states `>= 1.80 (MSRV)` where `apps/coralpolyp-be/Cargo.toml` declares otherwise, and `docs/.../rust/README.md:84` in **both** siblings hardcodes `Rust 1.82+ (stable)` — acceptance: neither file states a version number; both point at the declaring file, matching the `ose-public`/`beaver-nest` pattern.
+  - _Fix the class, not the cited sites: `grep -rn 'Rust 1\.\|rustc 1\.\|>= 1\.' docs repo-governance` per repo, with a per-file verdict._
+  - _Suggested executor: `docs-fixer`_
+
+### Toolchain prune (DD-9, machine side)
+
+> Runs only after the pin convergence above. Deriving the required set beforehand would read
+> `stable` from the two unconverged crates and orphan whatever they then need.
+
+- [ ] [AI] Re-derive the required-toolchain set from **all four** repos — `sort -u` over every `channel` in `rust-toolchain.toml` across `.` (`ose-public`), `/Users/wkf/ose-projects/ose-primer`, `/Users/wkf/ose-projects/ose-private`, and `/Users/wkf/ose-projects/beaver-nest` — acceptance: written to `baseline/rust-versions.md`, and the set is exactly `1.95.0`, matching Phase 0's capture of `beaver-nest` unchanged.
+  - _`beaver-nest` is excluded from this plan's **changes**, not from the machine it shares. Pruning a toolchain it pins would break a repo this plan never touched._
+- [ ] [AI] Decide `stable`'s fate by predicate, not judgement: `find ~ -name Cargo.toml -not -path '*/ose-projects/*' -not -path '*/.cargo/*' -not -path '*/.rustup/*' -not -path '*/target/*' -not -path '*/node_modules/*'` — acceptance: the result is recorded verbatim; `stable` is admitted to the prune list **only when this returns nothing**, and otherwise retained with the matching paths recorded as the reason.
+  - _This is the one step whose blast radius leaves the OSE repos. The predicate is what keeps it `[AI]`: no repo-local evidence can rule out an unrelated consumer, so the plan looks instead of guessing._
+- [ ] [AI] Uninstall each toolchain in `rustup toolchain list` absent from the required set (baseline orphans: `1.80` 1.1 GB, `1.94` 1.2 GB, `1.96.0` 952 MB; plus `1.88` 1.2 GB once the MSRV alignment has landed in all three repos) — command: `rustup toolchain uninstall <name>` per orphan — acceptance: `du -sh ~/.rustup` falls by at least 3 GB; `rustup toolchain list` contains only the required set plus any retained `stable`.
+  - _Reversible via `rustup toolchain install <name>`, but the undo needs network, so the proof step below runs immediately rather than waiting for the phase gate._
+- [ ] [AI] Set the default toolchain explicitly so nothing depends on a floating alias: `rustup default 1.95.0` — acceptance: `rustup show` reports `1.95.0` as active and default.
+- [ ] [AI] Prove nothing was over-pruned: `npx nx run rhino-cli:test:quick` in `ose-public`, and `cargo build --manifest-path apps/rhino-cli/Cargo.toml` in each of `ose-primer`, `ose-private`, and `beaver-nest` — acceptance: all exit 0 **and none emits `info: downloading component` or `syncing channel updates`**, proving each needed toolchain was still present rather than silently re-fetched.
+  - _Without the no-download assertion this step passes either way: rustup would transparently re-fetch what was just removed and report success. Same false-pass shape as the benchmark trap recorded in `learnings.md`._
+
+- [ ] [AI] Record the `beaver-nest` exclusion and its tripwire in `learnings.md`: if deprecation slips past this plan, file a follow-up `plans/backlog/` entry for the three repo-agnostic wins it would still benefit from (DD-6 gate profile, DD-8 cache key, DD-5 conditional `npm ci`) — acceptance: an entry exists naming all three.
+- [ ] [AI] Commit this phase's `ose-public`-side changes (the `parity.rs` message fix) thematically and push to the open `ose-public` PR branch — acceptance: push succeeds and the PR's check run starts. **This step must run before the Phase 10 Gate's "CI green" check below — otherwise that check validates a stale run from before this phase's own change.**
+
+### Sibling PRs — `ose-primer` and `ose-private`
+
+> Each sibling is its own repo with its own PR and its own required-status-check surface. The
+> **PR-Review Maker→Fixer Cycle runs independently in each** — running it once in `ose-public` does
+> not cover the propagated changes landing in the siblings. This is the step that makes "CI green in
+> all three repos" and the identical parity hash in the Phase 10 Gate below actually reachable: both
+> assertions need each sibling's changes to have gone through a PR and merged first.
+
+- [ ] [AI] In the `ose-primer` worktree: run that repo's local quality gates, commit thematically, push the branch, and open a draft PR against `main` titled `chore(gates): propagate optimize-cis gate changes and unify Rust version` — acceptance: PR exists and CI (`pr-quality-gate`) has started.
+- [ ] [AI] Run the PR-Review Maker→Fixer Cycle on the `ose-primer` PR, iteratively until clean, capped at 10 cycles (see §Delivery Boundaries) — acceptance: a cycle reports zero CRITICAL/HIGH/MEDIUM findings, or the cap is reached with residue recorded as accepted-with-reason.
+- [ ] [AI] Flip the `ose-primer` PR to ready for review — `gh pr ready -R wahidyankf/ose-primer <n>` — acceptance: `gh pr view -R wahidyankf/ose-primer <n> --json isDraft` reports `false`.
+- [ ] [AI] Merge the `ose-primer` PR once the five hardened preconditions hold — acceptance: `gh pr view -R wahidyankf/ose-primer <n> --json state` reports `MERGED`.
+- [ ] [AI] In the `ose-private` worktree: run that repo's local quality gates, commit thematically, push the branch, and open a draft PR against `main` titled `chore(gates): propagate optimize-cis gate changes and unify Rust version` — acceptance: PR exists and CI (`pr-quality-gate`) has started.
+- [ ] [AI] Run the PR-Review Maker→Fixer Cycle on the `ose-private` PR, iteratively until clean, capped at 10 cycles (see §Delivery Boundaries) — acceptance: a cycle reports zero CRITICAL/HIGH/MEDIUM findings, or the cap is reached with residue recorded as accepted-with-reason.
+- [ ] [AI] Flip the `ose-private` PR to ready for review — `gh pr ready -R wahidyankf/ose-private <n>` — acceptance: `gh pr view -R wahidyankf/ose-private <n> --json isDraft` reports `false`.
+- [ ] [AI] Merge the `ose-private` PR once the five hardened preconditions hold — acceptance: `gh pr view -R wahidyankf/ose-private <n> --json state` reports `MERGED`.
+- [ ] [AI] Remove both sibling worktrees now that their PRs have merged: `git -C <repo> worktree remove worktrees/optimize-cis` — acceptance: `git worktree list` in each repo no longer lists it.
+
+### Phase 10 Gate
+
+> All checks below must pass before starting Phase 11.
+
+- [ ] [AI] `parity manifest validate` in `ose-public`, `ose-primer`, and `ose-private` — acceptance: exits 0 with an identical manifest hash in all three (AC-15).
+- [ ] [AI] CI green in all three repos — acceptance: latest `pr-quality-gate` conclusion is `success` in each.
+- [ ] [AI] Measure M3 per sibling repo, then append `Phase 10` rows to `scoreboard.md` (one per repo) — acceptance: `ose-primer` and `ose-private` each record a post-change median runner-seconds figure against their Phase 0 baselines (11,683 s and 9,239 s respectively); both show a reduction.
+- [ ] [AI] Confirm `beaver-nest` was not modified — acceptance: `git -C /Users/wkf/ose-projects/beaver-nest status --porcelain` is empty.
+- [ ] [AI] Measure M9, then append a `Phase 10` row to `scoreboard.md` — acceptance: across all three repos the `^channel` and `^rust-version` `sort -u` sets each contain **exactly one** value and the two agree (`1.95.0`), down from 3 distinct declared values at baseline (AC-19).
+- [ ] [AI] Measure M9's machine half, folded into the same `Phase 10` scoreboard row as the repo-side M9 measurement above — acceptance: every entry of `rustup toolchain list` appears in the required set, except a `stable` retained with its recorded predicate result (AC-21).
+- [ ] [AI] Measure M8 **in full**, then append a `Phase 10` row to `scoreboard.md` superseding the Phase 9 partial row — acceptance: **at least 10 GB reclaimed** versus the Phase 0 bucket table, combining the Phase 9 quarantine deletion with this phase's toolchain prune.
+
+> **Pause Safety**: all three parity repos are consistent, their gates pass, and both sibling worktrees are removed. Safe to stop. To resume: re-run `parity manifest validate` in each of the three repos.
+
+---
+
+## Phase 11 — Measurement rollup against targets
+
+- [ ] [AI] Confirm M5 one final time across all four surfaces, then append a `Phase 11` row to `scoreboard.md` — acceptance: gate id sets byte-identical to Phase 0 (AC-4).
+- [ ] [AI] Render `plans/in-progress/optimize-cis/results.md` from `scoreboard.md`'s last row per metric (M1–M9) — every row gets a final `Status = PASS`/`FAIL` against its committed target, not just `IMPROVED`/`REGRESSED` — acceptance: nine before/after pairs with a PASS/FAIL verdict, and each links back to the scoreboard phase that produced its final measurement.
+- [ ] [AI] For any metric that missed its target, record the measured shortfall and either a follow-up `plans/backlog/` entry or an explicit accepted-as-is note — acceptance: no metric is left without a verdict.
+  - _A missed target is a finding to record honestly, not a number to quietly restate._
+
+### Phase 11 Gate
+
+> All checks below must pass before starting Phase 12.
+
+- [ ] [AI] Verify `results.md` carries a verdict for all nine metrics — acceptance: nine PASS/FAIL rows present.
+- [ ] [AI] Verify `scoreboard.md` has no gap: every phase that appended a row per this checklist did so — acceptance: the set of `Phase` values in `scoreboard.md` is `{0, 2, 3, 7, 8, 9, 10, 11}` with no phase skipped that was supposed to measure something.
+
+> **Pause Safety**: outcomes are recorded honestly against committed targets. Safe to stop. To resume: read `results.md`.
+
+---
+
+## Phase 12 — Knowledge Capture
+
+- [ ] [AI] Apply the litmus test to every `learnings.md` entry — keep only entries where a durable surface would catch this automatically next time; discard the rest with a one-line reason.
+- [ ] [AI] Apply the **secret/sensitivity gate** to every surviving entry — sanitize to `<placeholder>` tokens or discard if the entry cannot be sanitized without losing its meaning.
+- [ ] [AI] Apply the **repo-relevance gate** to every surviving entry — infra-private content stays in `ose-private` only; public-governance content may route to `ose-public`/`ose-primer`; never cross-route private content into a public repo.
+- [ ] [AI] Route each surviving entry to exactly one durable home (`repo-governance/`, `docs/`, `.claude/agents/`, `.claude/skills/`, or a `plans/backlog/` follow-up), landing small non-code edits inline.
+  - _Two entries are already expected: the `zsh`-word-splitting measurement trap (a benchmarking-method rule) and the cross-worktree cargo lock contention finding._
+- [ ] [AI] For any entry routed to `plans/ideas/`, scan `plans/ideas/README.md` and the existing two-pagers FIRST for a brief already covering the same area — fold into that brief rather than creating a new file.
+- [ ] [AI] **Code-routing rule**: if a learning's home is `apps/`, `libs/`, or tests, file it as a separate `plans/backlog/` plan — NEVER land it inline in this plan's commits/PR.
+- [ ] [AI] Record the terminal state of every entry (routed inline / filed as backlog at `<path>` / discarded with reason) directly in `learnings.md`.
+- [ ] [AI] If execution genuinely surfaced no generalizable learning, record the explicit escape `No generalizable learnings — <one-line reason>` instead of individual entries.
+
+### Phase 12 Gate
+
+> All checks below must pass before starting Plan Archival.
+
+- [ ] [AI] Verify every `learnings.md` entry has reached a terminal state or the explicit "none" escape is present — acceptance: no entry left open.
+- [ ] [AI] Verify no code-homed learning landed inline — acceptance: every code-routed learning has a corresponding `plans/backlog/` folder.
+
+> **Pause Safety**: all learnings are triaged to durable homes or explicitly discarded. Safe to stop. To resume: re-check `learnings.md` for entries without a terminal-state marker.
+
+---
+
+---
+
+### Close the `ose-public` PR
+
+> This is the plan's only `ose-public` merge event. The PR has been open and accumulating pushed
+> commits since the end of Phase 1 — see §Open the `ose-public` PR — through the ose-public side of
+> Phase 10 (the `parity.rs` message fix), Phase 11 (`results.md`), and Phase 12 (Knowledge Capture
+> routing). The plan folder's `git mv` to `plans/done/` happens here, in this section's first step,
+> not inside Phase 12 — it must ride inside this PR before merge, since `main` is branch-protected
+> and the PR budget is exactly 3. The `ose-primer`/`ose-private` PRs are separate repos and already
+> merged inside Phase 10 — see its "Sibling PRs" subsection; they are not part of this PR's diff.
+
+- [ ] [AI] Move the plan folder — `git mv plans/in-progress/optimize-cis plans/done/YYYY-MM-DD__optimize-cis` using the actual completion date — update `plans/in-progress/README.md` (remove the entry), `plans/done/README.md` (add the entry with completion date), and any other README referencing this plan. This must land inside the open PR: `main` is branch-protected with no direct-push path, and the plan's PR budget is exactly 3 (§Delivery Boundaries) — there is no follow-up PR to carry it — acceptance: `git status` shows the move staged; `grep -rl 'plans/in-progress/optimize-cis' plans/ docs/` (excluding the moved folder itself) returns nothing.
+- [ ] [AI] Run local quality gates (see §Local Quality Gates), then commit Phase 11/12's changes and the plan-archival move thematically and push a final time to the open PR branch — acceptance: local gates exit 0; push succeeds and the PR's check run starts.
+- [ ] [AI] Run the PR-Review Maker→Fixer Cycle on the `ose-public` PR, iteratively until clean, capped at 10 cycles (see §Delivery Boundaries) — acceptance: a cycle reports zero CRITICAL/HIGH/MEDIUM findings, or the cap is reached with residue recorded as accepted-with-reason.
+- [ ] [AI] Flip the `ose-public` PR to ready for review — `gh pr ready -R wahidyankf/ose-public <n>` — acceptance: `gh pr view -R wahidyankf/ose-public <n> --json isDraft` reports `false`.
+- [ ] [AI] Merge once the five hardened preconditions hold.
+- [ ] [AI] Final confirmation, closing the plan's full PR budget: `parity manifest validate` exits 0 in `ose-public`, `ose-primer`, and `ose-private` with an identical hash, and all 3 PRs opened across this plan (1 per repo) are merged — acceptance: `gh pr list -R wahidyankf/<repo> --state open` returns empty for all three repos.
+
+---
+
+## Local Quality Gates (Before Push)
+
+- [ ] [AI] Run affected typecheck: `npx nx affected -t typecheck`
+- [ ] [AI] Run affected linting: `npx nx affected -t lint`
+- [ ] [AI] Run affected quick tests: `npx nx affected -t test:quick`
+- [ ] [AI] Run affected spec coverage: `npx nx affected -t specs:behavior:coverage`
+- [ ] [AI] Fix ALL failures found — including preexisting issues not caused by these changes
+- [ ] [AI] Verify all checks pass before pushing
+
+> **Important**: Fix ALL failures found during quality gates, not just those caused by your changes.
+> This follows the root cause orientation principle — proactively fix preexisting errors encountered
+> during work.
+
+## Post-Push Verification
+
+- [ ] [AI] Push changes to the PR branch (Delivery Mode is `worktree-to-pr`)
+- [ ] [AI] Monitor the PR's check run — poll `gh run view --json status,conclusion` every **2 minutes**; never `gh run watch`
+- [ ] [AI] Verify all CI checks pass
+- [ ] [AI] If any CI check fails, investigate the root cause and push a follow-up commit — never bypass
+- [ ] [AI] Do NOT proceed to the next delivery unit until CI is green
+
+> A queued or stalled job is often runner contention across the four OSE repos, not a code defect.
+> Check `gh run list --status=queued --status=in_progress` across repos before debugging code.
+
+## Commit Guidelines
+
+- [ ] [AI] Commit changes thematically — group related changes into logically cohesive commits
+- [ ] [AI] Follow Conventional Commits format: `<type>(<scope>): <description>`
+- [ ] [AI] Split different domains/concerns into separate commits
+- [ ] [AI] Land every generated artifact in the SAME commit as the source that produced it
+- [ ] [AI] Do NOT bundle unrelated fixes into a single commit
+
+## Validation Checklist
+
+- [ ] [AI] All TDD cycles complete (RED→GREEN→REFACTOR for every code change)
+- [ ] [AI] All tests pass (`npx nx affected -t test:quick`)
+- [ ] [AI] All nine success metrics have a recorded verdict in `results.md`
+- [ ] [AI] Gate coverage proven invariant on all four surfaces (M5/AC-4)
+- [ ] [AI] Parity manifest identical across `ose-public`, `ose-primer`, and `ose-private`
+- [ ] [AI] Documentation updated wherever the old invocation form was named
+
+## Plan Archival
+
+- [ ] [AI] Verify ALL delivery checklist items are ticked
+- [ ] [AI] Verify ALL quality gates pass (local + CI)
+- [ ] [AI] Confirm the plan-folder move already landed in the merged PR (§Close the `ose-public` PR) —
+      acceptance: `plans/done/<completion-date>__optimize-cis/` exists on `main`,
+      `plans/in-progress/optimize-cis/` does not, and `plans/in-progress/README.md` /
+      `plans/done/README.md` reflect the move. No new commit or PR is created here — the move was
+      already committed pre-merge, since `main` is branch-protected and the plan's PR budget is
+      exactly 3 (§Delivery Boundaries).
+- [ ] [AI] Remove the worktree immediately once this repo's work is done: `git worktree remove worktrees/optimize-cis`
+
+> **Note on manual behavioral assertions**: this plan touches no web UI and no API surface — it
+> changes build, hook, and CI plumbing only. The Playwright-MCP and curl verification sections, and
+> the rule-15 web-triad and rule-16 API retests, are **not applicable**. Behavioral verification here
+> is the coverage-invariance assertion (M5/AC-4), which is stronger for this change class: it proves
+> the observable gate behaviour is byte-identical before and after.

--- a/plans/in-progress/optimize-cis/learnings.md
+++ b/plans/in-progress/optimize-cis/learnings.md
@@ -1,0 +1,31 @@
+<!-- Knowledge Capture running log — append entries during execution. -->
+<!-- Triage every entry (or record the explicit "none" escape) before archival. -->
+
+# Learnings: optimize-cis
+
+## Learning: zsh does not word-split unquoted variables, silently voiding timing harnesses
+
+- **Context**: benchmarking `rhino-cli` gate commands during plan authoring, using a
+  `for c in "md links validate" ...; do $BIN $c; done` loop under `zsh`.
+- **Observation**: `zsh` passed `"md links validate"` as a single argument, so every invocation
+  exited with `unrecognized subcommand` in ~3 ms. The measurements looked like a spectacular result
+  and were entirely fabricated by the harness. A second harness variant used `python3` subprocesses
+  for timestamps, whose ~700 ms startup swamped the thing being measured. Both were caught only by
+  checking exit codes and output, not by looking at the timings.
+- **Why it might generalize**: this repo's default shell is `zsh`, and agents write ad-hoc timing
+  loops routinely. A benchmarking-method rule — measure under `bash`, loop N times and divide, and
+  always verify non-error execution before trusting a number — would catch this class every time.
+  Same family as the recorded `grep -L`, `ls`-is-eza, and RTK-output-transform traps: a builtin
+  quietly transforms the thing being measured and a false zero reads as a pass.
+
+## Learning: cross-worktree cargo build-lock contention costs more than the disk it saves
+
+- **Context**: first `cargo run` invocation of the session in a fresh worktree.
+- **Observation**: blocked **65.05 s wall at 0.31 s user / 0.50 s sys** — pure lock wait, no
+  compilation. Cause: `doctor --fix` symlinks every worktree's per-crate `target/` into one shared
+  `~/.cache/ose-cargo-target/<repo>/<crate>`, so concurrent cargo processes across worktrees
+  serialize on a single build-directory lock.
+- **Why it might generalize**: the repo mandates `worktree-to-pr` and assumes concurrent agents on
+  one disk, so shared-mutable-build-state is a standing design tension, not a one-off. Whether the
+  disk saving is worth the serialization is a real design question — possibly answered by per-profile
+  sharing or a content-addressed cache instead of a shared target dir.

--- a/plans/in-progress/optimize-cis/prd.md
+++ b/plans/in-progress/optimize-cis/prd.md
@@ -1,0 +1,345 @@
+# Product Requirements — Optimize CIs
+
+## Product Overview
+
+The "product" here is the quality-gate lifecycle itself: the three Husky hooks, the generated
+`lint-staged` block, and the `pr-quality-gate` workflow, all dispatching through
+[`apps/rhino-cli`](../../../apps/rhino-cli/README.md).
+
+This plan changes **how gates are invoked and scheduled**, never **what they check**. Every user
+story below is a latency, cost, or footprint story; none adds or removes a validator.
+
+**Not UI-bearing** — no user-facing screen or component under `apps/` or `libs/` changes, so the
+UI-design-funnel binding does not apply. **Not learning-bearing** — no course or curriculum content is
+authored, so the syllabus-record binding does not apply.
+
+## Personas
+
+### P1 — The solo maintainer
+
+Works across four repos, often with several agent sessions running concurrently on the same disk and
+the same shared cargo target cache. Commits frequently and in small increments per Trunk Based
+Development. Feels the gate cost most acutely on documentation and governance edits, where a 3.5 s
+commit tax dwarfs the edit itself.
+
+**Needs**: a commit that feels instant for doc-shaped changes; a push that does not invite
+context-switching; confidence that speed did not come out of coverage.
+
+### P2 — An AI agent executing a plan
+
+Runs unattended, commits often, and multiplies every fixed cost by the parallel fan-out (N=3 default)
+and by the three PR-review cycles. Cannot judge whether a slow gate is broken or merely slow, and has
+a standing instruction never to bypass gates.
+
+**Needs**: gates fast enough that a normal run never looks hung; a clear failing gate id even when
+checks are grouped; a binary that resolves correctly after the ambient sweeper deletes `target/`.
+
+### P3 — The CI runner pool
+
+Four repos share a limited pool — free `ubuntu-latest` for three, a small self-hosted pool for
+`ose-private` where job queueing already runs at p50 18:42. Every unnecessary job is contention
+imposed on the other three repos.
+
+**Needs**: fewer, denser jobs; no job that installs a toolchain it never uses.
+
+## User Stories
+
+### US-1 — Fast doc commits
+
+**As** the solo maintainer, **I want** a markdown-only commit to complete in well under half a
+second, **so that** documentation work does not carry a tax larger than the edit.
+
+### US-2 — Fast pre-push
+
+**As** the solo maintainer, **I want** `test:quick` on `rhino-cli` to finish in about a minute and a
+half, **so that** pushing is not a decision I have to schedule around.
+
+### US-3 — Cheap PR gate
+
+**As** the CI runner pool, **I want** the PR quality gate to consume roughly a third of today's
+runner-seconds for the same coverage, **so that** four repos can share one pool without queueing each
+other out.
+
+### US-4 — Provably unchanged coverage
+
+**As** the solo maintainer, **I want** machine-checkable proof that the same set of gates runs before
+and after, **so that** I can accept a large speedup without wondering what it cost me.
+
+### US-5 — Diagnosable grouped failures
+
+**As** an AI agent, **I want** a failing grouped CI job to name the individual gate that failed, **so
+that** grouping does not make failures harder to act on.
+
+### US-6 — A binary that always resolves
+
+**As** an AI agent, **I want** gate invocation to work even immediately after the ambient sweeper
+deletes `target/`, **so that** a swept artifact produces a slow run, never a broken hook.
+
+### US-7 — Bounded disk
+
+**As** the solo maintainer, **I want** build artifacts and scratch space to stay bounded, **so that**
+the working set does not creep back to 28 GB.
+
+### US-8 — A registry that still tells the truth
+
+**As** the solo maintainer, **I want** CI job composition declared in `repo-config.yml` rather than
+hand-maintained in a workflow file, **so that** the registry cannot drift from what CI actually runs.
+
+### US-9 — One Rust version
+
+**As** the solo maintainer, **I want** exactly one Rust version declared across every repo and
+installed on my machine, **so that** `doctor` reporting healthy actually means my environment matches
+what builds, and CI stops installing toolchains it never uses.
+
+## Acceptance Criteria
+
+### AC-1 — Pre-commit latency (US-1)
+
+```gherkin
+Scenario: A markdown-only commit completes well under half a second
+  Given ten markdown files are staged in a clean worktree
+  When the lint-staged pre-commit path runs to completion
+  Then the mean wall time over three runs is at most 900 milliseconds
+  And every markdown gate that ran at the Phase 0 baseline has run again
+  And no gate reports a different result than it did at baseline
+```
+
+### AC-2 — Pre-push latency (US-2)
+
+```gherkin
+Scenario: The rhino-cli pre-push gate finishes in about ninety seconds
+  Given a cold Nx cache and an empty cargo target directory
+  When "npx nx run rhino-cli:test:quick --skip-nx-cache" runs to completion
+  Then the mean wall time over two runs is at most 90 seconds
+  And the list of executed test names is identical to the Phase 0 capture
+```
+
+### AC-3 — PR gate cost (US-3)
+
+```gherkin
+Scenario: The PR quality gate costs roughly a third of its former runner-seconds
+  Given five completed pr-quality-gate runs after the topology change
+  When each run's job durations are summed from the GitHub Actions jobs API
+  Then the median total is at most 3500 runner-seconds
+  And the median wall-clock duration is no greater than the Phase 0 baseline
+```
+
+### AC-4 — Coverage invariance (US-4)
+
+```gherkin
+Scenario: Every gate that ran before still runs after
+  Given the Phase 0 capture of executed gate ids for every surface
+  When the gate set is enumerated again after all axes have landed
+  Then the set of gate ids for each of pre-commit, pre-push, commit-msg, and ci is byte-identical to the capture
+  And the union of gate ids across all CI groups equals the former per-gate matrix list
+```
+
+### AC-5 — No gate may escape the matrix (US-4, US-8)
+
+```gherkin
+Scenario: A gate declared without a CI group fails validation
+  Given a gate entry in repo-config.yml carrying a ci surface and no ci_group field
+  When "rhino-cli gate validate" runs
+  Then it exits non-zero
+  And its output names the offending gate id
+  And its output states that ci_group is required
+```
+
+### AC-6 — Grouped failures stay diagnosable (US-5)
+
+```gherkin
+Scenario: A failing gate inside a group is named in the output
+  Given a CI group containing several gates where exactly one fails
+  When "rhino-cli gate run --surface=ci --group=<id>" runs
+  Then it exits non-zero
+  And its output contains a per-gate summary line for every gate in the group
+  And the failing gate id appears on a line marked FAIL
+```
+
+### AC-7 — Binary resolution survives the sweeper (US-6)
+
+```gherkin
+Scenario: A swept target directory produces a slow run, not a failure
+  Given the rhino-cli binary is absent because the ambient sweeper removed target/
+  When a generated gate command runs through the resolver shim
+  Then the shim builds the binary and then executes the requested gate
+  And the gate reports the same result it would have reported with the binary present
+  And a subsequent invocation reuses the built binary without rebuilding
+```
+
+### AC-8 — Explicit override is honoured (US-6)
+
+```gherkin
+Scenario: RHINO_CLI_BIN takes precedence over discovery
+  Given the environment variable RHINO_CLI_BIN points at an executable rhino-cli binary
+  When a generated gate command runs through the resolver shim
+  Then the shim executes the binary at that path
+  And it performs no cargo build
+```
+
+### AC-9 — CI gate jobs need no Rust toolchain (US-3)
+
+```gherkin
+Scenario: Gate group jobs consume a prebuilt binary
+  Given the build-rhino job has published the rhino-cli artifact for the run
+  When a gate group job executes
+  Then it downloads the artifact rather than building from source
+  And it runs no cargo install command
+  And its step list contains no Rust toolchain setup
+```
+
+### AC-10 — Node setup is skipped where unused (US-3)
+
+```gherkin
+Scenario: A gate group with no node tooling skips npm ci
+  Given a CI gate group whose gates require no node-resolved tool
+  When that group's job executes
+  Then its step list contains no npm ci invocation
+  And every gate in the group still reports its baseline result
+```
+
+### AC-11 — Cache stays under the ceiling (US-7)
+
+```gherkin
+Scenario: The Nx cache key stops minting an entry per commit
+  Given ten consecutive commits have been pushed after the cache-key change
+  When the repository's Actions caches are enumerated
+  Then the summed cache size is at most 60 percent of the 10 GiB ceiling
+  And no single key family accounts for more than half of the total
+```
+
+### AC-12 — Build footprint (US-7)
+
+```gherkin
+Scenario: One test:quick run no longer produces 2.7 GB of build output
+  Given an empty isolated cargo target directory
+  When "nx run rhino-cli:test:quick" runs to completion
+  Then the resulting target directory is at most 1.2 gigabytes
+  And the test-name list is identical to the Phase 0 capture
+```
+
+### AC-13 — Coverage enforcement is relocated, not weakened (US-4)
+
+```gherkin
+Scenario: Coverage still gates merge after moving off test:quick
+  Given test:coverage no longer runs as part of the test:quick chain
+  When the PR quality gate runs on a change that drops line coverage below ninety percent
+  Then the coverage job fails
+  And the overall quality-gate job reports failure
+```
+
+### AC-14 — Disk hygiene is encoded (US-7)
+
+```gherkin
+Scenario: Scratch space cannot silently regrow
+  Given local-temp has been reclaimed to its post-cleanup size
+  When the recorded retention rule is applied
+  Then content older than the retention window is removed
+  And no tracked file, .env file, generated-report, worktree, or git ref is touched
+```
+
+### AC-15 — Cross-repo parity holds (US-8)
+
+```gherkin
+Scenario: The byte-identity gate passes after propagation
+  Given the change set has been propagated to ose-primer and ose-private
+  When "rhino-cli parity manifest validate" runs in each of the three repos
+  Then each run exits zero
+  And the reported manifest hash is identical across all three
+```
+
+### AC-16 — Generated rhino-cli commands carry no `cargo run` (US-1)
+
+```gherkin
+Scenario: Rhino CLI kind renders a resolver shim invocation
+  Given the registry declares a gate of kind "rhino-cli" on surface "pre-commit"
+  When "rhino-cli gate emit --surface=pre-commit" runs
+  Then the generated command invokes the resolver shim at "apps/rhino-cli/scripts/rhino-bin.sh"
+  And the generated command contains no "cargo run" substring
+```
+
+### AC-17 — Node-resolved tools render a repository-local bin path (US-1)
+
+```gherkin
+Scenario: Node-resolved external tools render a repository-local bin path
+  Given the registry declares an external gate whose tool resolves from node_modules
+  When "rhino-cli gate emit --surface=pre-commit" runs
+  Then the generated command invokes that tool through "node_modules/.bin"
+  And the generated command contains no "npx" substring
+```
+
+### AC-18 — CI gates can be enumerated by declared group (US-8)
+
+```gherkin
+Scenario: Enumeration can group CI gates by declared group
+  Given every ci-surface gate in the registry declares a ci_group
+  When "rhino-cli gate list --surface=ci --format=json --by-group" runs
+  Then it emits one entry per distinct ci_group value
+  And each entry lists its member gate ids in registry declaration order
+```
+
+### AC-19 — Every repo declares one Rust version (US-9)
+
+> **`.feature` binding note.** AC-20 describes `rhino-cli` application behavior (what `doctor`
+> reports) and is bound to `specs/apps/rhino/behavior/rhino-cli/gherkin/system/doctor.feature` with a
+> RED/GREEN/REFACTOR cycle in `delivery.md` Phase 4. AC-19 and AC-21 describe cross-repo file-content
+> and machine-toolchain state, not `rhino-cli` behavior — there is no `rhino-cli` command whose
+> output these scenarios assert against, so they are verified directly by shell commands in
+> `delivery.md`'s Phase 4/10 gates instead of a `.feature` file. This mirrors how the plan already
+> treats other non-application-behavior criteria (e.g. AC-14's disk-retention rule, prose-only).
+
+```gherkin
+Scenario: Toolchain channel and MSRV agree within a repo
+  Given a repository among ose-public, ose-primer, and ose-private
+  When every rust-toolchain.toml channel and every Cargo.toml rust-version is collected
+  Then both sets contain exactly one distinct value
+  And that value is the same in both sets
+```
+
+### AC-20 — The environment check validates the channel, not the floor (US-9)
+
+```gherkin
+Scenario: doctor compares rustc against the toolchain that builds
+  Given the installed rustc differs from the pinned rust-toolchain.toml channel
+  When "npm run doctor" runs
+  Then it reports the Rust toolchain as mismatched
+  And it names the pinned channel as the expected value
+```
+
+### AC-21 — No unpinned toolchain remains installed (US-9)
+
+```gherkin
+Scenario: Installed toolchains are limited to those the repos pin
+  Given the set of channels pinned by rust-toolchain.toml across the three repos
+  When "rustup toolchain list" is compared against that set
+  Then every installed toolchain appears in the pinned set or is the retained stable default
+  And a rebuild of rhino-cli succeeds without fetching an absent toolchain
+```
+
+## Product Scope
+
+### In scope
+
+- Invocation form of every generated gate command (hooks, `lint-staged`, CI).
+- CI job composition and the registry field that declares it.
+- Cargo profile selection for gate-path builds.
+- Composition of the `test:quick` chain.
+- Build-artifact and scratch-space retention.
+- Propagation of the above across the repos each parity boundary requires.
+
+### Out of scope
+
+- The identity, logic, or strictness of any individual validator.
+- New `rhino-cli` subcommands or flags beyond those DD-3/DD-4 require (`--by-group`, `--group`).
+- The `TypeScript quality gate`'s real `nx affected` work.
+- `rhino-cli` type-safety hardening (`indexing_slicing`, `arithmetic_side_effects`).
+- Any language rewrite.
+
+## Product Risks
+
+| Risk                                              | Mitigation                                                                                        |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Grouping changes failure ergonomics for the worse | AC-6 makes per-gate PASS/FAIL output a hard acceptance criterion, not a nicety                    |
+| A fast path is taken that quietly skips work      | AC-2, AC-4, and AC-12 all assert the executed set is unchanged, so a "speedup" by omission fails  |
+| The shim adds a new failure mode on a hot path    | AC-7 and AC-8 cover both the swept-artifact and override paths with their own scenarios and tests |
+| Wall-clock regresses while runner-seconds improve | AC-3 carries wall-clock as an explicit no-regression clause alongside the cost target             |

--- a/plans/in-progress/optimize-cis/tech-docs.md
+++ b/plans/in-progress/optimize-cis/tech-docs.md
@@ -1,0 +1,593 @@
+# Technical Documentation — Optimize CIs
+
+## Measurement Baseline
+
+All figures were produced by experiment on **2026-08-08**. Local figures come from this machine
+(Darwin 24.5.0, Apple Silicon) in `worktrees/optimize-cis`; CI figures come from GitHub Actions run
+history via `gh api` across all four OSE repos. Nothing here is estimated. Raw data and analysis
+scripts are in `local-temp/` (gitignored): `local-benchmark-evidence.md`, `ci-history-evidence.md`,
+`disk-occupancy-evidence.md`.
+
+### Method note — a measurement trap worth recording
+
+An early local pass timed commands with `$BIN $cmd` inside a `zsh` loop. **`zsh` does not word-split
+unquoted variables**, so `"md links validate"` was passed as a single argument and every command
+exited with `unrecognized subcommand` in ~3 ms. The numbers looked spectacular and were meaningless.
+Every local figure below was re-measured under `bash` with non-error execution verified. A second
+early pass timed with `python3` timestamp subprocesses, whose ~700 ms startup swamped the
+measurement. **Timing harnesses in this repo must loop N times under `bash` and divide.**
+`[Repo-grounded]`
+
+### A.1 — Process-launch tax (loop N times under `bash`, divide)
+
+| Invocation                                 |    ms/run |   N |
+| ------------------------------------------ | --------: | --: |
+| `rhino-cli --version` (direct binary)      |       3.2 | 100 |
+| `rhino-cli --help` (direct binary)         |       4.0 |  20 |
+| `cargo run --release --quiet -- --version` |   **388** |  20 |
+| `npx nx show projects`                     | **3,560** |   3 |
+
+### A.2 — Pre-commit per-file gates, 10 markdown files
+
+Every row below was re-measured with the exit code asserted and the command's output inspected, after
+an earlier pass produced fabricated figures (see the Method note above). `[Repo-grounded]`
+
+| Gate                            | Current form                    | ms/run | Direct form                             | ms/run | Saving |
+| ------------------------------- | ------------------------------- | -----: | --------------------------------------- | -----: | -----: |
+| prettier `--check`              | `npx --no -- prettier`          |    622 | `./node_modules/.bin/prettier`          |    359 | 263 ms |
+| markdownlint-cli2               | `npx --no -- markdownlint-cli2` |    441 | `./node_modules/.bin/markdownlint-cli2` |    189 | 252 ms |
+| `md mermaid validate`           | `cargo run --release …`         |    406 | direct binary                           |     34 | 372 ms |
+| `md heading-hierarchy validate` | `cargo run --release …`         |    375 | direct binary                           |     33 | 342 ms |
+| `md naming validate`            | `cargo run --release …`         |    414 | direct binary                           |     30 | 384 ms |
+| `md frontmatter validate`       | `cargo run --release …`         |    401 | direct binary                           |     35 | 366 ms |
+
+**`lint-staged` path total: 2,659 ms → 680 ms (3.9×). Including the hook shim's own `cargo run`
+(388 ms → ~3 ms): 3,047 ms → 683 ms (4.5×).** `[Repo-grounded]`
+
+**The two taxes are not comparable in size.** `cargo run` wraps ~33 ms of work in ~399 ms of cargo
+fingerprint-checking — a ~12× multiplier, and the dominant local cost. `npx` adds ~250–263 ms per
+tool, which is real and worth removing but roughly a third of the `cargo run` saving. A plan that
+treated them as equivalent would misallocate its effort.
+
+### A.3 — Whole-repo scanner gates (pre-push surface), direct binary, N=3
+
+| Gate                                          |  ms/run |
+| --------------------------------------------- | ------: |
+| `md links validate` (gate exclusions applied) | **436** |
+| `md mermaid validate` (whole repo)            |     592 |
+| `parity manifest validate`                    |     285 |
+| `harness instruction-size validate`           |     194 |
+| `md heading-hierarchy validate`               |     173 |
+| `harness duplication validate`                |     125 |
+| `specs structure validate`                    |      95 |
+| `repo-governance vendor validate`             |      92 |
+| `env validate`                                |      58 |
+| `md readme-index validate`                    |      55 |
+| `harness bindings validate`                   |      51 |
+| `md frontmatter validate`                     |      49 |
+| `md naming validate`                          |      31 |
+
+Sum ≈ **1.5 s** of genuine work across the pre-push scanners. `md links validate` is the largest
+single contributor and the only `rhino-cli` code path whose own runtime is worth optimizing on its
+merits.
+
+**Measure gates as they are actually configured.** A bare `md links validate` takes 882 ms and exits 1,
+reporting 147 broken links — all of them preexisting in `plans/done/`. The registry invokes it with
+`--exclude plans/done --exclude apps/ayokoding-www/content --exclude apps/ose-www/content`
+`[Repo-grounded]`, under which it takes **436 ms and exits 0**. Timing a gate without its registry
+arguments overstates both its cost and its failure rate.
+
+### B.1 — CI cost roll-up, `pr-quality-gate`, 22 completed runs per repo
+
+| repo        | jobs/run |   job-s/run |  setup-node | setup-lang | checkout | provision | real work |   overhead |
+| ----------- | -------: | ----------: | ----------: | ---------: | -------: | --------: | --------: | ---------: |
+| ose-public  |       45 |    10,945 s | **5,894 s** |    1,082 s |    503 s |     534 s |   2,492 s | **77.2 %** |
+| ose-primer  |       48 |    11,683 s | **6,597 s** |    1,241 s |    169 s |     275 s |   2,684 s |     77.0 % |
+| ose-private |       35 |     9,239 s | **5,024 s** |    1,932 s |    117 s |     968 s |     751 s |     91.9 % |
+| beaver-nest |       19 | **2,226 s** |     1,302 s |      251 s |    170 s |       0 s |     438 s |     80.3 % |
+
+### B.2 — The 41-job validator fleet in `ose-public` (n = 792 job instances)
+
+| category                            | total s | avg s per job instance |
+| ----------------------------------- | ------: | ---------------------: |
+| **toolchain-setup**                 | 134,477 |     **169.8 s (2:50)** |
+| lint/validate (the actual gate)     |  48,643 |          61.4 s (1:01) |
+| `Provision registry-declared tools` |  11,747 |                 14.8 s |
+| checkout                            |   9,382 |                 11.8 s |
+| runner-internal                     |   8,320 |                 10.5 s |
+
+**268.4 s per job instance, of which 77 s (29 %) is the gate command and ~191 s (71 %) is setup the
+job did not need to be alone to pay.**
+
+| step                                                  |   n |       p50 | total s across 22 runs |
+| ----------------------------------------------------- | --: | --------: | ---------------------: |
+| `Run ./.github/actions/setup-node`                    | 792 | **144 s** |            **113,151** |
+| `cargo run … gate run --surface=ci --only="$GATE_ID"` | 791 |      77 s |                 48,643 |
+| `Run ./.github/actions/setup-rust`                    | 791 |      27 s |                 21,326 |
+| `Run actions/checkout@v6`                             | 792 |      11 s |                  9,382 |
+
+`setup-node` alone is **46.5 % of the entire `ose-public` PR quality gate**.
+
+**Reconciling 36, 41, and 45.** The registry currently declares **36** `ci`-surface gates
+(`gate list --surface=ci` on the working tree) `[Repo-grounded]`, which become 36 matrix legs. The run
+history's "41-job validator fleet" is those 36 plus the five sibling validator jobs that are not
+matrix legs — `typescript`, `dotnet`, `rust`, `compat-min-version`, `specs-structure`. Adding the four
+orchestration jobs — `detect`, `format`, `enumerate`, `quality-gate` — gives the 45 jobs per run.
+The figures are consistent; only the grouping differs.
+
+### B.3 — The controlled experiment already run in your repos
+
+`ose-private` ran both topologies inside the sample window, same repo, same runners:
+
+| Check            | As its own job |  Grouped | Ratio |
+| ---------------- | -------------: | -------: | ----: |
+| `actionlint`     |          234 s | **16 s** | 14.6× |
+| `shellcheck`     |          248 s | **16 s** | 15.5× |
+| `hadolint`       |          238 s |     16 s | 14.9× |
+| 3 IaC validators |         3 jobs | **34 s** |  ~21× |
+
+And in fully-migrated `beaver-nest`, `convention license validate`,
+`specs gherkin-cardinality validate`, `actionlint`, `hadolint`, and `ShellCheck` each cost **0–1 s**,
+versus **263–270 s** as dedicated jobs in `ose-public`. `[Repo-grounded]`
+
+This is the single most important fact in the plan: **the intervention is already validated in
+production, in this repo family, on these runners.** Axis B is adoption, not experiment.
+
+### B.4 — Cache, contention, and waste channels
+
+| Finding                    | Value                                                                                                               |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `ose-public` Actions cache | **10,525,641,701 bytes = 98.0 % of the 10 GiB ceiling**                                                             |
+| Cause                      | `key: nx-…-${{ github.sha }}` mints a fresh **237.9 MB** entry per commit; 35 entries = 8.13 GB = 83 % of the cache |
+| Effective retention        | **~1 day** (vs 5–6 days in sibling repos)                                                                           |
+| Measured flakiness         | **Zero** — no failure-then-success on an unchanged SHA in any repo                                                  |
+| Cancellations              | ose-public **24/200 (12.0 %)**, burning 38,320 s                                                                    |
+| Explicit re-runs           | 0.5–1.5 %                                                                                                           |
+
+The other three repos share the same key shape harmlessly because their `.nx/cache` payload is
+1 KB–70 KB, not 237.9 MB. This is an `ose-public`-specific defect. `[Repo-grounded]`
+
+### C.1 — Build profile
+
+`apps/rhino-cli/Cargo.toml [profile.release]` is
+`opt-level = 3, lto = "thin", codegen-units = 1, panic = "abort", strip = "symbols"`. `[Repo-grounded]`
+
+| Profile                  | Cold build (isolated target dir, warm registry) | target/ | Real-work runtime |
+| ------------------------ | ----------------------------------------------: | ------: | ----------------: |
+| Current                  |                    **53.0 s** wall / 98.7 s CPU |  221 MB |           0.097 s |
+| `lto=off, cgu=16, opt=1` |                    **19.6 s** wall / 88.7 s CPU |  206 MB |           0.086 s |
+
+**2.7× faster cold build, no runtime penalty.** The crate is 82 dependencies, 59,402 LOC across 195
+source files, producing a 4.08 MB binary.
+
+### C.2 — Fingerprint multiplication in `test:quick`
+
+`rhino-cli:test:quick` chains five subtargets whose flags differ, so cargo treats each as a distinct
+build: `[Repo-grounded]`
+
+| Subtarget       | Command shape                                                      |        Wall | `target/` after |
+| --------------- | ------------------------------------------------------------------ | ----------: | --------------: |
+| (start)         | —                                                                  |           — |          222 MB |
+| `typecheck`     | `cargo check --all-targets`                                        |      21.0 s |          637 MB |
+| `lint`          | `cargo fmt --check` + `cargo clippy --all-targets`                 |      10.3 s |          842 MB |
+| `test:unit`     | **7 separate `cargo test` invocations**, lib at `--test-threads=1` | **119.0 s** |          2.0 GB |
+| `test:coverage` | `cargo llvm-cov` (`-Cinstrument-coverage`) `--fail-under-lines 90` |      40.1 s |      **2.7 GB** |
+| `test:specs`    | `cargo run --release` ×2                                           |       3.7 s |          2.7 GB |
+| **total**       |                                                                    |   **194 s** |      **2.7 GB** |
+
+Final breakdown: `debug` 1.8 GB, `llvm-cov-target` 712 MB, `release` 222 MB — three full builds of
+one crate.
+
+### D.1 — Disk
+
+Post-sweep snapshot (the ambient sweeper had already run; no `node_modules/` existed at measurement
+time, so `node_modules` duplication is unmeasured, not zero).
+
+| #   | Bucket                                 |        GB | Share of 28.00 GB attributable |
+| --- | -------------------------------------- | --------: | -----------------------------: |
+| 1   | `ose-public/local-temp/`               | **12.31** |                        43.96 % |
+| 2   | `~/.rustup/toolchains/` (6 toolchains) |      7.21 |                        25.73 % |
+| 3   | `~/.cache/ose-cargo-target/`           |      1.97 |                         7.04 % |
+| 4   | `~/.dotnet/`                           |      1.51 |                         5.39 % |
+| 5   | `~/Library/Caches/ms-playwright/`      |      1.33 |                         4.74 % |
+
+Top three = **76.7 %**. Measured reclaim candidates total **15.92 GB (56.8 %)**, none load-bearing —
+the six components sum exactly: `[Repo-grounded]`
+
+| Reclaim candidate                                                         |        GB |
+| ------------------------------------------------------------------------- | --------: |
+| Orphaned `.next` builds in `local-temp` (three generations, 57,811 files) |      9.32 |
+| Unpinned rustup toolchains (only `ose-primer` pins a channel)             |      4.45 |
+| `debug/incremental` in the shared cargo cache                             |      0.96 |
+| Duplicated toolchain roots inside `local-temp`                            |      0.79 |
+| This worktree's unshared `apps/rhino-cli/target`                          |      0.22 |
+| Stale `mcp-chrome-*` builds                                               |      0.18 |
+| **total**                                                                 | **15.92** |
+
+Two structural findings:
+
+- **This worktree's `target/` is not shared.** All three sibling repos symlink
+  `apps/rhino-cli/target` into `~/.cache/ose-cargo-target/<repo>/rhino-cli`, but
+  `worktrees/optimize-cis/apps/rhino-cli/target` is a real directory — a 985-file, 221.8 MB
+  duplicate. The sharing convention does not cover worktrees, which matters because
+  `worktree-to-pr` is mandatory.
+- **`local-temp/` is sweeper-exempt and unbounded** per [`AGENTS.md`](../../../AGENTS.md). Nothing
+  prunes it; it is now 88.2 % of `ose-public`.
+
+### D.2 — Cross-worktree cargo build-lock contention
+
+A `cargo run` during this session blocked **65.05 s wall at 0.31 s user / 0.50 s sys** — pure lock
+wait, no compilation. Because `doctor --fix` points every worktree of a repo at one shared per-crate
+`target/`, concurrent cargo processes across worktrees serialize on a single build-directory lock.
+The shared cache trades disk for serialization. `[Repo-grounded]`
+
+## Why Not A Rewrite
+
+The plan that this one supersedes considered a language change, and an earlier plan proposed OCaml.
+The measurements close the question:
+
+- `rhino-cli`'s own work is **3.2 ms** (`--version`) to **1,081 ms** (`md links validate`, the worst
+  gate). A Go binary would land in the same range; Go's startup is comparable to Rust's, and
+  `md links validate` is I/O- and parse-bound, not language-bound.
+- **Every cost this plan targets survives a rewrite unchanged.** `cargo run` becomes `go run` (same
+  tax, arguably worse). 41 CI jobs stay 41 CI jobs. `npm ci` still runs 792 times. The
+  237.9 MB-per-commit cache key is untouched. `setup-node`'s 46.5 % share is untouched.
+- The one cost a rewrite genuinely removes — the 53 s cold Rust build — is **already removed by a
+  profile change measured at 19.6 s**, and removed entirely in CI by building once per run.
+
+A rewrite is a large, risky, coverage-threatening change that addresses none of the top five cost
+centres. This plan addresses all five without touching the language.
+
+## Design Decisions
+
+### DD-1 — Generated gate commands resolve a prebuilt binary, not `cargo run`
+
+**Decision.** `apps/rhino-cli/src/commands/gate/emit.rs` currently renders every `GateKind::RhinoCli`
+entry as `cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- <command>`
+(lines 122–125). `[Repo-grounded]` It will instead render a call to a single resolver shim that locates an
+already-built binary and executes it.
+
+**Why a shim and not a bare path.** The binary can legitimately be absent: the ambient build-artifact
+sweeper deletes `target/` at any time, and a fresh worktree has never built. A bare path would make
+the hook fail with a confusing `no such file`. The shim resolves in order — an explicit
+`RHINO_CLI_BIN` override, then the built binary, then a build-and-retry — so the slow path happens
+once after a sweep instead of on every invocation.
+
+**Rejected alternative — keep `cargo run` but add `--offline`.** Measured: the 388 ms is cargo's
+fingerprint check over the whole dependency graph, not network access. `--offline` does not remove it.
+
+**Note.** `gate/run.rs:432` already dispatches gate-internal leaves via `std::env::current_exe()`
+`[Repo-grounded]` — the cheap path. Only the generated `lint-staged` commands, the three Husky shims,
+and the CI workflow sites pay the tax, which is why this change is narrow.
+
+### DD-2 — `npx` gives way to direct `node_modules/.bin` dispatch
+
+**Decision.** Generated commands for `GateKind::External` node tools resolve
+`node_modules/.bin/<tool>` directly. Measured: 622 ms → 359 ms for prettier, 441 ms → 189 ms for
+markdownlint-cli2 — a real but modest ~250 ms saving per tool, an order of magnitude smaller than the
+`cargo run` saving.
+
+**Constraint.** `lint-staged` runs commands through a shell with the repo root as cwd, so a
+repo-relative `.bin` path is stable. Tools genuinely absent from `node_modules` keep `npx`; the
+registry's existing `doctor_tools` field already distinguishes them.
+
+### DD-3 — CI groups are a required registry field, never derived
+
+**Decision.** `repo-config.yml` gains a **required** `ci_group` field on every gate entry.
+`gate list --surface=ci --format=json --by-group` emits one matrix entry per group;
+`gate run --surface=ci --group=<id>` runs every gate in that group inside one job.
+
+**Why explicit rather than derived.** `beaver-nest` proves the topology but hand-maintains its ~19
+jobs in the workflow file with no registry backing, so its job list and its gate registry can drift
+silently. Deriving groups from a gate's `doctor_tools` or category would reintroduce exactly the
+name-and-folder-derivation magic this repository avoids. A required field keeps `repo-config.yml`
+authoritative — `gate validate` fails when a gate declares no group — and keeps the workflow
+generated rather than hand-written.
+
+**Consequence, stated plainly.** One job's log now covers several checks instead of one, and a single
+red group names the group rather than the individual check. Mitigated by `gate run --group` printing
+a per-gate PASS/FAIL summary line, so the failing gate id is still greppable in the log.
+
+### DD-4 — `rhino-cli` is built once per CI run and passed as an artifact
+
+**Decision.** A `build-rhino` job compiles the binary once under the fast gate profile and uploads it;
+every gate group downloads it and sets `RHINO_CLI_BIN`. Gate groups then need **no Rust toolchain at
+all**, removing `setup-rust` (27 s p50 × 791 instances = 21,326 s per 22 runs) from every gate job.
+
+**This also removes the three `cargo install` calls** (`cargo-llvm-cov`, `cargo-deny`, `cargo-hack`)
+from gate jobs. They are guarded only by `command -v` and serve `test:coverage`, `deps:audit`, and
+`compat:min-version` — never a gate leg. `[Repo-grounded]`
+
+### DD-5 — `setup-node` stops running `npm ci` in jobs that do not need node
+
+**Decision.** `.github/actions/setup-node` gains an input controlling whether `npm ci` runs. Gate
+groups whose tools are all native binaries or the `rhino-cli` artifact skip it entirely.
+
+**Evidence.** `setup-node` is 46.5 % of the whole gate at 144 s p50 × 792 instances.
+`beaver-nest` already demonstrates the pattern: its `setup-node` runs in **158 of 224** job
+instances, not all of them. `[Repo-grounded]`
+
+### DD-6 — Two cargo profiles: shipped and gate
+
+**Decision.** Keep `[profile.release]` as-is for the shipped artifact. Add a
+`[profile.gate]` inheriting from release with `lto = false, codegen-units = 16, opt-level = 1`.
+Gates, hooks, and CI build `--profile gate`; `nx run rhino-cli:build` keeps `--release`.
+
+**Why not just relax `release`.** The parity manifest and any published binary should stay
+maximally optimized. Splitting the profiles gets the 2.7× build win without changing what ships.
+
+### DD-7 — `test:quick` stops compiling the same tree three times
+
+**Decision.** `test:coverage` (which forces its own `-Cinstrument-coverage` fingerprint and 712 MB of
+`llvm-cov-target`) moves out of the `test:quick` chain and onto CI only. `test:unit`'s seven
+sequential `cargo test` invocations collapse where they share a profile.
+
+**Rationale.** `test:quick` is the **pre-push** gate; a 194 s pre-push and a 2.7 GB `target/` are
+what makes local iteration painful. Coverage thresholds are a CI concern — they gate merge, not
+push. Coverage enforcement is not weakened, only relocated; `delivery.md` asserts the CI job still
+enforces `--fail-under-lines 90`.
+
+### DD-8 — Nx cache key stops including the commit SHA
+
+**Decision.** Drop `-${{ github.sha }}` from the `.nx/cache` key in
+`.github/actions/setup-node/action.yml:30` `[Repo-grounded]`, retaining the existing `restore-keys`
+fallbacks.
+
+**Evidence.** The SHA suffix guarantees a cache miss and a fresh 237.9 MB write on every commit,
+consuming 83 % of a 10 GiB budget and collapsing retention to ~1 day. The `restore-keys` already
+provide the intended partial-match behaviour.
+
+### DD-9 — One Rust version, declared once per crate and agreed everywhere
+
+**Decision.** Converge every Rust version declaration in the three in-scope repos on **`1.95.0`**,
+the value 9 of the 11 existing `rust-toolchain.toml` sites already carry, and align the MSRV field
+to the same number so the toolchain channel and the declared floor stop disagreeing. Prune the
+machine's `~/.rustup` to the toolchains the repos actually pin, retaining `stable` only when a
+non-OSE Rust project is found on the machine.
+
+**Evidence — three independent sources of truth disagree today** `[Repo-grounded]`:
+
+| Source                            | Mechanism                                                           | Value today                                                                   |
+| --------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `rust-toolchain.toml` → `channel` | what `cargo` actually builds with                                   | `1.95.0` at 9 sites; **`stable` at 2** (`crud-be-rust-axum`, `coralpolyp-be`) |
+| `Cargo.toml` → `rust-version`     | MSRV floor; drives `compat:min-version` and the CI pre-install loop | `1.88` at 10 sites; **`1.94.0` at 1** (`crud-be-rust-axum`)                   |
+| `doctor`'s expected-rustc         | `tools.rs:698` reads `apps/rhino-cli/Cargo.toml → rust-version`     | `1.88` — so `doctor` validates against the **floor**, never the channel       |
+
+The third row is the sharpest: `doctor` reports the environment healthy when `rustc` matches `1.88`,
+while every build actually runs on `1.95.0`. The check cannot detect the drift it exists to catch.
+
+**Consequences of the drift, all measured:**
+
+- `~/.rustup` holds **6 toolchains / 7.2 GB**, of which `1.80` (1.1 GB), `1.94` (1.2 GB), and
+  `1.96.0` (952 MB) are pinned by nothing in any of the four repos.
+- `ose-private`'s `setup-rust` installs `stable` via `dtolnay/rust-toolchain@stable` (default input,
+  no caller overrides it) — a different mechanism from the `actions-rust-lang/setup-rust-toolchain@v1`
+  the other three use. Since `apps/rhino-cli/rust-toolchain.toml` pins `1.95.0`, rustup then
+  downloads `1.95.0` on the first `cargo` call. **Every `ose-private` Rust job installs a toolchain
+  it never uses, then fetches the one it needs.**
+- The `Pre-install pinned MSRV toolchain(s)` block exists verbatim in all four `setup-rust` actions
+  purely to work around the floor/channel gap — it serialises a rustup install to stop parallel
+  `cargo hack check --rust-version` tasks corrupting the shared download dir. Aligning MSRV to the
+  channel makes the block install the already-present pinned toolchain, dissolving the race.
+- `ose-private/repo-governance/workflows/infra/infra-development-environment-setup.md:59` states the
+  Rust requirement as `>= 1.80 (MSRV) | apps/coralpolyp-be/Cargo.toml`, but that file declares
+  `1.88`. The doc is stale and is the likely origin of the orphaned `1.80` toolchain.
+- `ose-primer` and `ose-private` both carry `docs/.../rust/README.md:84` → `**Version**: Rust 1.82+
+(stable)`, a hardcoded number matching no declaration. `ose-public` and `beaver-nest` instead
+  point at `Cargo.toml` with no number — the correct pattern, and the one to converge on.
+
+**Why `1.95.0` and not the newest.** Latest stable is **1.97.1**, released 2026-07-14 — 25 days old
+at plan authoring, so it fails the 60-day soak the
+[dependency bump policy](../../../repo-governance/development/workflow/dependency-bump-policy.md)
+requires on Path B. `1.95.0` is what the repos already run, so unification carries **zero
+version-change risk** and keeps this plan's CI-performance thesis separable from a version bump. A
+later bump is explicitly out of scope here and must run the policy's own soak and CVE checks.
+
+**Why MSRV is aligned rather than deleted.** Setting `rust-version = "1.95.0"` makes
+`compat:min-version` tautological — it proves a crate builds on the toolchain it already builds on.
+Deleting the gate would be the honest end state, but it removes a check and so collides with M5
+coverage invariance; it also changes a published quality posture. Alignment achieves one version,
+keeps the check set intact, dissolves the pre-install race, and is a one-number revert. Retiring the
+gate is recorded as follow-up work, not done here. The declared floor buys nothing today regardless:
+`rust-commons` is internal-only and the three CLIs are applications, so no downstream crate compiles
+against a floor.
+
+**Why `stable` may survive the prune.** Deleting `stable` is the only step here whose blast radius
+leaves the OSE repos — an unrelated project on this machine may depend on it, and no repo-local
+evidence can rule that out. The delivery step therefore decides by predicate rather than by
+judgement: scan for `Cargo.toml` outside `~/ose-projects`, and delete `stable` only when that scan
+returns nothing. This keeps the step fully `[AI]` without guessing.
+
+## Diagrams
+
+### Current versus proposed CI topology
+
+```mermaid
+flowchart LR
+  subgraph CUR["Current — 45 jobs, 10,945 runner-s/run"]
+    direction TB
+    E1["enumerate<br/>gate list --surface=ci"] --> M1["matrix: 41 gates"]
+    M1 --> J1["job 1<br/>checkout + npm ci + rust<br/>268s to run 77s"]
+    M1 --> J2["job 2<br/>same setup again"]
+    M1 --> J3["…39 more<br/>same setup each"]
+  end
+
+  subgraph NEW["Proposed — grouped, ~8 jobs"]
+    direction TB
+    B1["build-rhino<br/>build once, upload artifact"]
+    E2["enumerate<br/>gate list --by-group"] --> M2["matrix: ~6 groups"]
+    B1 -.->|"RHINO_CLI_BIN"| M2
+    M2 --> G1["markdown group<br/>no rust, no npm ci"]
+    M2 --> G2["shell/docker/actions group"]
+    M2 --> G3["governance group"]
+  end
+
+  CUR ==>|"Axis B"| NEW
+
+  style CUR fill:#D55E00,stroke:#000000,color:#FFFFFF
+  style NEW fill:#009E73,stroke:#000000,color:#FFFFFF
+  style B1 fill:#0072B2,stroke:#000000,color:#FFFFFF
+```
+
+### Gate invocation path, before and after
+
+```mermaid
+flowchart TB
+  H["git commit"] --> LS["lint-staged"]
+
+  LS --> OLD["Current path"]
+  OLD --> C1["cargo run --release<br/>~399 ms fingerprint check"]
+  C1 --> W1["rhino-cli work<br/>30-35 ms"]
+  OLD --> N1["npx prettier<br/>622 ms"]
+  N1 --> W2["of which ~263 ms<br/>is npx overhead"]
+
+  LS --> NEWP["Proposed path"]
+  NEWP --> R1["resolver shim<br/>~1 ms"]
+  R1 --> W3["rhino-cli work<br/>30-35 ms"]
+  NEWP --> B2["node_modules/.bin/prettier<br/>direct"]
+  B2 --> W4["prettier<br/>359 ms"]
+
+  style OLD fill:#D55E00,stroke:#000000,color:#FFFFFF
+  style NEWP fill:#009E73,stroke:#000000,color:#FFFFFF
+  style C1 fill:#E69F00,stroke:#000000,color:#000000
+  style N1 fill:#E69F00,stroke:#000000,color:#000000
+```
+
+### Build-fingerprint multiplication in `test:quick`
+
+```mermaid
+flowchart LR
+  SRC["rhino-cli source<br/>82 deps, 59,402 LOC"]
+
+  SRC --> P1["cargo check<br/>--all-targets"]
+  SRC --> P2["cargo clippy<br/>--all-targets"]
+  SRC --> P3["cargo test<br/>x7 invocations"]
+  SRC --> P4["cargo llvm-cov<br/>-Cinstrument-coverage"]
+  SRC --> P5["cargo run<br/>--release"]
+
+  P1 --> D1["debug/<br/>1.8 GB"]
+  P2 --> D1
+  P3 --> D1
+  P4 --> D2["llvm-cov-target/<br/>712 MB"]
+  P5 --> D3["release/<br/>222 MB"]
+
+  D1 --> T["target/ = 2.7 GB<br/>194 s wall"]
+  D2 --> T
+  D3 --> T
+
+  style T fill:#D55E00,stroke:#000000,color:#FFFFFF
+  style D2 fill:#E69F00,stroke:#000000,color:#000000
+  style SRC fill:#0072B2,stroke:#000000,color:#FFFFFF
+```
+
+### Phase flow and gates
+
+```mermaid
+stateDiagram-v2
+  [*] --> Phase0: baseline captured
+  Phase0 --> Phase1: supersede backlog plan
+  Phase1 --> AxisA: invocation tax
+  AxisA --> AxisB: CI topology
+  AxisB --> AxisC: build profile + test:quick
+  AxisC --> AxisD: disk hygiene
+  AxisD --> Propagate: cross-repo parity
+  Propagate --> Knowledge: learnings triage
+  Knowledge --> [*]: archived
+
+  note right of AxisA
+    Gate: gate output byte-identical
+    to Phase 0 capture
+  end note
+
+  note right of AxisB
+    Gate: CI green, runner-seconds
+    measured and recorded
+  end note
+```
+
+## File-Impact Analysis
+
+```text
+ose-public/
+├── apps/rhino-cli/
+│   ├── Cargo.toml                                    [E] add [profile.gate]; rust-version → 1.95.0 (DD-9)
+│   ├── project.json                                  [E] test:quick chain; gate-profile targets
+│   ├── scripts/rhino-bin.sh                          [N] resolver shim (DD-1)
+│   ├── src/application/doctor/tools.rs               [E] expected rustc reads channel, not MSRV (DD-9)
+│   └── src/commands/gate/
+│       ├── emit.rs                                   [E] render shim, not `cargo run` (DD-1, DD-2)
+│       ├── list.rs                                   [E] `--by-group` output mode (DD-3)
+│       ├── run.rs                                    [E] `--group=<id>` selector (DD-3)
+│       └── validate.rs                               [E] require ci_group; assert workflow conformance
+├── apps/{ose-cli,ayokoding-cli}/Cargo.toml           [E] rust-version → 1.95.0 (DD-9)
+├── libs/rust-commons/Cargo.toml                      [E] rust-version → 1.95.0 (DD-9)
+├── repo-config.yml                                   [E] required `ci_group` on every gate entry
+├── package.json                                      [G] lint-staged block, regenerated
+├── .husky/{pre-commit,pre-push,commit-msg}           [G] shims, regenerated
+├── .github/
+│   ├── actions/setup-node/action.yml                 [E] optional npm ci (DD-5); cache key (DD-8)
+│   ├── actions/setup-rust/action.yml                 [E] optional cargo-install block (DD-4)
+│   └── workflows/pr-quality-gate.yml                 [E] build-rhino job; matrix over groups
+├── specs/apps/rhino/behavior/rhino-cli/gherkin/system/
+│   └── doctor.feature                                [E] rustc checked against channel (DD-9)
+├── specs/apps/rhino/behavior/rhino-cli/gherkin/gate/
+│   ├── gate-binary-resolution.feature                [N] shim resolution (DD-1)
+│   ├── gate-emission.feature                         [E] shim + node-bin rendering (DD-1, DD-2)
+│   ├── gate-enumeration.feature                      [E] --by-group (DD-3)
+│   ├── gate-execution.feature                        [E] --group, CI topology (DD-3, DD-4, DD-5)
+│   └── gate-validation.feature                       [E] ci_group required (DD-3)
+├── repo-governance/development/
+│   ├── infra/nx-targets.md                           [E] test:quick composition change (DD-7)
+│   └── infra/temporary-files.md                      [E] local-temp retention (Axis D)
+├── docs/reference/                                   [E] any doc naming the old invocation form
+├── docs/explanation/.../rust/README.md               [E] MSRV bullet states floor == pin (DD-9)
+├── plans/backlog/rhino-cli-optimization/             [D] superseded — deleted in Phase 1
+├── plans/backlog/README.md                           [E] de-index the deleted plan
+└── plans/in-progress/
+    ├── README.md                                     [E] index this plan
+    └── optimize-cis/                                 [N] this plan
+```
+
+Markers: `[E]` edited · `[N]` new · `[D]` deleted · `[G]` generated (never hand-edited).
+
+### More Detail
+
+- **Generated artifacts are not optional touches.** `package.json`'s `lint-staged` block and the three
+  `.husky/` shims are emitted by `gate emit`; `.opencode/`, `.cursor/`, and `.amazonq/` are emitted by
+  `npm run generate:bindings`. Per [File-Touch Discipline](../../../repo-governance/development/practice/file-touch-discipline.md)
+  they belong on the ledger and land in the **same commit** as the source that produced them.
+- **Ordering is load-bearing.** DD-3 (`ci_group` required) must land before DD-4 (build-once artifact),
+  because the workflow's matrix source changes shape first. DD-1 must land before the CI sites are
+  rewritten, since CI consumes the same emitted form.
+- **`repo-config.yml` is byte-relevant across repos.** `apps/rhino-cli` is under a byte-identity parity
+  gate spanning `ose-public`, `ose-primer`, and `ose-private` with zero carve-outs
+  ([Related Repositories](../../../docs/reference/related-repositories.md)). Any `src/` edit here opens a
+  cross-repo obligation that the propagation phase must discharge before the parity gate can pass.
+- **`beaver-nest` carries a fork** of `rhino-cli` and is in neither parity boundary, so it receives the
+  workflow-level changes only if its own measurements justify them — it is already the fast repo.
+- **Four files exist only in the siblings** and so cannot appear in the `ose-public` tree above:
+  `ose-primer/apps/crud-be-rust-axum/rust-toolchain.toml` and
+  `ose-private/apps/coralpolyp-be/rust-toolchain.toml` (`channel = "stable"` → `1.95.0`),
+  `ose-private/.github/actions/setup-rust/action.yml` (`dtolnay/rust-toolchain@stable` → the
+  `actions-rust-lang` form the other repos use), and
+  `ose-private/repo-governance/workflows/infra/infra-development-environment-setup.md` (stale
+  `>= 1.80` claim). Phase 10 owns all four.
+- **`beaver-nest` still constrains the machine-side prune.** It is excluded from this plan's changes,
+  not from the machine whose `~/.rustup` the prune edits, so its pinned channel is part of the
+  required set the prune is derived from.
+
+## Rollback
+
+Each axis is independently revertible, and none changes what a gate reports.
+
+| Axis | Rollback                                                                                                                                                                                                                                                                                                                                                   |
+| ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A    | Revert `emit.rs`, re-run `gate emit` + `generate:bindings`; the `cargo run` form returns                                                                                                                                                                                                                                                                   |
+| B    | Revert `pr-quality-gate.yml` and the `ci_group` field; matrix returns to per-gate fan-out                                                                                                                                                                                                                                                                  |
+| C    | Remove `[profile.gate]`; targets fall back to `--release`                                                                                                                                                                                                                                                                                                  |
+| D    | Reclamation is quarantine-then-verify: candidates are `mv`d into `local-temp/.reclaim-quarantine-<date>/` and only deleted after `doctor --fix`, `test:quick`, and `nx affected -t build` all pass. Until that final `rm`, a single `mv` back restores everything; after it, all removed content is regenerable via `nx build` / `npm run doctor -- --fix` |
+
+| E | Version unification reverts as five one-number edits (`rust-version` per manifest) plus a `channel` revert in the two sibling crates; the `doctor` source change reverts with `tools.rs`. The rustup prune reverts via `rustup toolchain install <name>` — reversible, but the only step here whose undo needs network, which is why its no-download proof runs inline rather than at the phase gate |
+
+The behaviour-preservation assertion is the real safety net: every phase gate diffs the full gate
+output against the Phase 0 capture, so a regression in what is checked fails the phase, not review.


### PR DESCRIPTION
## Summary
- Adds a five-document plan (README, brd, prd, tech-docs, delivery) to cut fixed overhead from the pre-commit, pre-push, and PR-quality-gate lifecycle across the OSE repos.
- Gate coverage is held provably invariant (M5); includes a Rust-toolchain-unification workstream (DD-9) unifying every repo + this machine on a single Rust version.
- Supersedes `plans/backlog/rhino-cli-optimization/`, which is deleted during plan execution (Phase 1), not in this PR.
- Docs-only change — no code, no CI, no secrets. Went through 5 iterations of the plan-quality-gate loop (plan-checker/plan-fixer) before landing.

## Test plan
- [x] `npx prettier --check` clean
- [x] `npx markdownlint-cli2` clean
- [x] `rhino-cli md heading-hierarchy validate` clean
- [x] `rhino-cli md links validate` clean
- [x] `rhino-cli specs gherkin-cardinality validate` clean on `prd.md`
- [x] Secrets/`.env` scan of the diff — no matches
- [ ] CI (`Quality gate`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)