### PR TITLE
fix(codex): enable native grilling

### DIFF
--- a/.claude/agents/plan-fixer.md
+++ b/.claude/agents/plan-fixer.md
@@ -10,6 +10,7 @@ skills:
   - plan-writing-gherkin-criteria
   - plan-creating-project-plans
   - docs-validating-factual-accuracy
+  - grill-me
   - repo-assessing-criticality-confidence
   - repo-applying-maker-checker-fixer
   - repo-generating-validation-reports
@@ -91,6 +92,17 @@ finding as MEDIUM (manual review) or FALSE_POSITIVE rather than spawning a subag
 ## Mode Parameter Handling
 
 The `repo-applying-maker-checker-fixer` Skill provides complete mode parameter logic including mode levels, filtering, reporting, and workflow integration.
+
+## Grilling Interaction Contract
+
+When a MEDIUM-confidence finding requires an external decision, this specialist returns unresolved
+decisions as `## User Decisions Required` using the
+[canonical envelope schema](../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope),
+then stops before applying the dependent fix. Every `options` array MUST exhaustively list all
+substantive leaves. The root invokes `grill-me` through its native UI when available, then resumes or
+reinvokes this agent with the resolved answers. A direct custom-agent or noninteractive caller
+receives the same envelope; never render a user prompt or infer an answer. For a four-mode or
+three-tag decision, the envelope lists all leaves; a Codex root uses the complete staged tree.
 
 ## How This Agent Works
 
@@ -748,10 +760,11 @@ for the authoritative mode table and precedence rule.
   is never in scope for this fix, and neither is any other merge-step tag value (see below).
 - **MEDIUM Confidence → grill first**: the declared Delivery Mode value is invalid/unrecognized, OR
   the merge step carries a tag other than `[AI]`, `[HUMAN]`, or `[AI+HUMAN]`. Do NOT guess which of
-  the four modes (or which of the three tags) was intended — surface it as a grill question (per
-  `grill-me`) with the valid options (four modes, `worktree-to-pr` marked `(Recommended)`; or the
-  three tags, plus the standing blank-state/"chat about this" options), before writing a value. A
-  merge step's tag is never mechanically retagged, at any confidence level — see
+  the four modes (or which of the three tags) was intended — follow the Grilling Interaction
+  Contract with the valid options (four modes, `worktree-to-pr` marked `(Recommended)`; or the three
+  tags), before writing a value. The envelope lists every leaf; on Codex the root uses the staged
+  decision tree, adding chat to each node and relying on the client custom answer. A merge step's tag
+  is never mechanically retagged, at any confidence level — see
   [How to Fix a Merge-Tag Mismatch](#how-to-fix-a-merge-tag-mismatch) below.
 
 ### How to Fix a Missing `## Delivery Mode` Section
@@ -760,13 +773,14 @@ Insert `## Delivery Mode: worktree-to-pr` immediately after the `## Worktree` se
 mode, absent any signal the user wants otherwise) — multi-file plans: in `delivery.md` before the
 first phase heading; single-file plans: in `README.md` before `## Delivery Checklist`. If the
 plan's existing checklist already shows direct-push-only steps (no PR step anywhere and no
-worktree at all), that is itself a signal to grill the user rather than silently defaulting.
+worktree at all), resolve it through the Grilling Interaction Contract rather than silently
+defaulting.
 
 ### How to Fix an Invalid Non-Empty Value
 
-Never silently coerce an invalid value to the default. Grill the user with the four-mode table
-(`worktree-to-pr` marked `(Recommended)`) plus the standing blank-state/"chat about this" options,
-then write whichever mode they select.
+Never silently coerce an invalid value to the default. Follow the Grilling Interaction Contract with
+all four modes (`worktree-to-pr` marked `(Recommended)`), then write the resolved mode. On Codex the
+root renders all four leaves through the complete staged decision tree.
 
 ### How to Fix a `*-to-pr` Plan Missing the PR-Review Maker→Fixer Cycle
 
@@ -800,10 +814,10 @@ and a recipe's own confidence table (however "mechanical" or "HIGH confidence" i
 a narrower check layered on top, never a substitute. Concretely:
 
 - `*-to-pr` mode with the merge step carrying a tag other than `[AI]`, `[HUMAN]`, or `[AI+HUMAN]` →
-  do NOT retag it. Surface it as a MEDIUM-confidence grill question (per the Confidence Assessment
-  above) offering the three valid tags plus the standing blank-state/"chat about this" options, and
-  apply only whichever tag the user selects. An unrecognized tag may carry human-actor semantics
-  this agent must not silently strip — never assume it is safe to overwrite.
+  do NOT retag it. Follow the Grilling Interaction Contract with all three valid tags and apply only
+  the resolved tag. On Codex the root renders all three leaves through the complete staged decision
+  tree. An unrecognized tag may carry human-actor semantics this agent must not silently strip —
+  never assume it is safe to overwrite.
 - **Never retag, delete, or otherwise remove a `[HUMAN]`- or `[AI+HUMAN]`-tagged merge step, in any
   Delivery Mode.** Per [Delivery Mode](../../repo-governance/conventions/structure/plans.md#delivery-mode),
   the tag on the merge step IS the plan's opt-in — there is no separate "explicit opt-in"

--- a/.claude/agents/plan-fixer.md
+++ b/.claude/agents/plan-fixer.md
@@ -762,9 +762,10 @@ for the authoritative mode table and precedence rule.
   the merge step carries a tag other than `[AI]`, `[HUMAN]`, or `[AI+HUMAN]`. Do NOT guess which of
   the four modes (or which of the three tags) was intended — follow the Grilling Interaction
   Contract with the valid options (four modes, `worktree-to-pr` marked `(Recommended)`; or the three
-  tags), before writing a value. The envelope lists every leaf; on Codex the root uses the staged
-  decision tree, adding chat to each node and relying on the client custom answer. A merge step's tag
-  is never mechanically retagged, at any confidence level — see
+  tags), before writing a value. The envelope lists every leaf; when a native tool's option limit
+  requires staging, the root uses the convention's [staged decision procedure](../../repo-governance/development/workflow/grilling-with-options.md#staged-native-rendering),
+  preserving chat and the client-provided custom answer at every node. A merge step's tag is never
+  mechanically retagged, at any confidence level — see
   [How to Fix a Merge-Tag Mismatch](#how-to-fix-a-merge-tag-mismatch) below.
 
 ### How to Fix a Missing `## Delivery Mode` Section
@@ -779,8 +780,10 @@ defaulting.
 ### How to Fix an Invalid Non-Empty Value
 
 Never silently coerce an invalid value to the default. Follow the Grilling Interaction Contract with
-all four modes (`worktree-to-pr` marked `(Recommended)`), then write the resolved mode. On Codex the
-root renders all four leaves through the complete staged decision tree.
+all four modes (`worktree-to-pr` marked `(Recommended)`), then write the resolved mode. When the
+native tool's option limit requires staging, the root follows the convention's [staged decision
+procedure](../../repo-governance/development/workflow/grilling-with-options.md#staged-native-rendering)
+so every leaf remains reachable.
 
 ### How to Fix a `*-to-pr` Plan Missing the PR-Review Maker→Fixer Cycle
 
@@ -815,8 +818,9 @@ a narrower check layered on top, never a substitute. Concretely:
 
 - `*-to-pr` mode with the merge step carrying a tag other than `[AI]`, `[HUMAN]`, or `[AI+HUMAN]` →
   do NOT retag it. Follow the Grilling Interaction Contract with all three valid tags and apply only
-  the resolved tag. On Codex the root renders all three leaves through the complete staged decision
-  tree. An unrecognized tag may carry human-actor semantics this agent must not silently strip —
+  the resolved tag. When the native tool's option limit requires staging, the root follows the
+  convention's [staged decision procedure](../../repo-governance/development/workflow/grilling-with-options.md#staged-native-rendering).
+  An unrecognized tag may carry human-actor semantics this agent must not silently strip —
   never assume it is safe to overwrite.
 - **Never retag, delete, or otherwise remove a `[HUMAN]`- or `[AI+HUMAN]`-tagged merge step, in any
   Delivery Mode.** Per [Delivery Mode](../../repo-governance/conventions/structure/plans.md#delivery-mode),

--- a/.claude/agents/plan-fixer.md
+++ b/.claude/agents/plan-fixer.md
@@ -100,9 +100,11 @@ decisions as `## User Decisions Required` using the
 [canonical envelope schema](../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope),
 then stops before applying the dependent fix. Every `options` array MUST exhaustively list all
 substantive leaves. The root invokes `grill-me` through its native UI when available, then resumes or
-reinvokes this agent with the resolved answers. A direct custom-agent or noninteractive caller
-receives the same envelope; never render a user prompt or infer an answer. For a four-mode or
-three-tag decision, the envelope lists all leaves; a Codex root uses the complete staged tree.
+reinvokes this agent with the canonical [Resolved User Decisions Envelope](../../repo-governance/development/workflow/grilling-with-options.md#resolved-user-decisions-envelope).
+The root builds it from the original IDs after rendering and passes it verbatim; validate it before
+dependent work. A direct custom-agent or noninteractive caller receives the same envelope; never
+render a user prompt or infer an answer. For a four-mode or three-tag decision, the envelope lists
+all leaves; a Codex root uses the complete staged tree.
 
 ## How This Agent Works
 

--- a/.claude/agents/plan-maker.md
+++ b/.claude/agents/plan-maker.md
@@ -71,9 +71,11 @@ write may occur until the root returns resolved answers.
 [canonical envelope schema](../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope),
 then stop before Step 2. Every `options` array MUST exhaustively list all substantive leaves. The
 root invokes `grill-me` through its native UI when available, then resumes or reinvokes this agent
-with the resolved answers. A direct custom-agent or noninteractive caller receives the same
-envelope; never render a user prompt or infer an answer. The discovery pass is the only permitted
-work before that handoff.
+with the canonical [Resolved User Decisions Envelope](../../repo-governance/development/workflow/grilling-with-options.md#resolved-user-decisions-envelope).
+The root builds it from the original IDs after rendering and passes it verbatim; validate it before
+dependent work. A direct custom-agent or noninteractive caller receives the same envelope; never
+render a user prompt or infer an answer. The discovery pass is the only permitted work before that
+handoff.
 
 **Multiple-options requirement (HARD RULE)**: Every grill question MUST present 2-4 concrete
 options with trade-off descriptions — open-ended questions without options are FORBIDDEN. Every
@@ -310,7 +312,8 @@ for the underlying git-workflow details.
 After all plan files are written, invoke the `grill-me` skill again and resolve the validation grill
 before signaling done. Apply the Step 1 interaction-ownership rule: a delegated or noninteractive
 agent returns the exact `## User Decisions Required` envelope and stops; after the root resolves it
-through `grill-me`, resume or reinvoke this agent with the answers.
+through `grill-me`, resume or reinvoke this agent with the verbatim Resolved User Decisions Envelope
+and validate it before dependent work.
 
 **Multiple-options requirement (HARD RULE)**: Same as Step 1 — every validation question MUST
 present 2-4 concrete options plus the two standing options (free-form blank-state type and "chat

--- a/.claude/agents/plan-maker.md
+++ b/.claude/agents/plan-maker.md
@@ -1,6 +1,6 @@
 ---
 name: plan-maker
-description: Creates comprehensive project plans with requirements, technical documentation, and delivery checklists. Grills the user before and after plan creation using multiple-choice options (2-4 options per question via AskUserQuestion tool or markdown format). Structures plans for systematic execution via the plan-execution workflow (orchestrated by the calling context).
+description: Creates comprehensive project plans with requirements, technical documentation, and delivery checklists. Returns unresolved pre-write and post-write decisions to the calling root orchestrator for grilling, then resumes with resolved answers. Structures plans for systematic execution via the plan-execution workflow (orchestrated by the calling context).
 tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, WebFetch
 model:
 color: blue
@@ -58,18 +58,26 @@ See [Plans Organization Convention](../../repo-governance/conventions/structure/
 
 ## Planning Workflow
 
-### Step 1: Grill the User (Mandatory — Pre-Write)
+### Step 1: Resolve the Grill (Mandatory — Pre-Write)
 
 Before reading the codebase or creating any files, invoke the `grill-me` skill
-(`.claude/skills/grill-me/SKILL.md`) to resolve all open design decisions with the user.
+(`.claude/skills/grill-me/SKILL.md`) to resolve all open design decisions.
+
+**Interaction ownership (HARD RULE)**: This specialist agent never owns user interaction. Return
+`## User Decisions Required` using the
+[canonical envelope schema](../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope),
+then stop before Step 2. Every `options` array MUST exhaustively list all substantive leaves. The
+root invokes `grill-me` through its native UI when available, then resumes or reinvokes this agent
+with the resolved answers. A direct custom-agent or noninteractive caller receives the same
+envelope; never render a user prompt or infer an answer.
 
 **Multiple-options requirement (HARD RULE)**: Every grill question MUST present 2-4 concrete
 options with trade-off descriptions — open-ended questions without options are FORBIDDEN. Every
 question MUST ALSO carry two standing options: a free-form **type-your-own (blank state)** path
 (explicit, never merely implicit — the most common omission) and a **"chat about this"** option
-for discussing the branch before deciding. Use the
-`AskUserQuestion` tool (preferred in Claude Code context) or the markdown question format from
-the `grill-me` skill. Read the codebase before asking so options are grounded in repo reality.
+for discussing the branch before deciding. Format every unresolved choice with the linked canonical
+envelope per the `grill-me` skill. Read the codebase before composing it so options are grounded in
+repo reality.
 See [Grilling-With-Options Convention](../../repo-governance/development/workflow/grilling-with-options.md).
 
 Ask about (each as a structured multiple-choice question):
@@ -293,16 +301,18 @@ for the authoritative mode table, precedence rule, and declaration syntax, and
 [Trunk Based Development Convention](../../repo-governance/development/workflow/trunk-based-development.md)
 for the underlying git-workflow details.
 
-### Step 8: Grill the User (Mandatory — Post-Write)
+### Step 8: Resolve the Grill (Mandatory — Post-Write)
 
-After all plan files are written, invoke the `grill-me` skill again to validate the plan with
-the user before signaling done.
+After all plan files are written, invoke the `grill-me` skill again and resolve the validation grill
+before signaling done. Apply the Step 1 interaction-ownership rule: a delegated or noninteractive
+agent returns the exact `## User Decisions Required` envelope and stops; after the root resolves it
+through `grill-me`, resume or reinvoke this agent with the answers.
 
 **Multiple-options requirement (HARD RULE)**: Same as Step 1 — every validation question MUST
 present 2-4 concrete options plus the two standing options (free-form blank-state type and "chat
-about this"). Use `AskUserQuestion` tool (preferred) or markdown question format.
-Never present a binary yes/no without offering design alternatives. See
-[Grilling-With-Options Convention](../../repo-governance/development/workflow/grilling-with-options.md).
+about this"). Return only `## User Decisions Required` using the
+[canonical envelope schema](../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope).
+Never present a binary yes/no without offering design alternatives.
 
 Cover (each as a structured multiple-choice question):
 
@@ -626,7 +636,7 @@ Decide boundaries at authoring time using the four-part boundary test (coherent 
 - [plan-execution workflow](../../repo-governance/workflows/plan/plan-execution.md) - Execute plans (calling context orchestrates; no dedicated subagent); invokes the `grill-me` skill to stress-test unresolved design decisions before execution begins
 - `plan-execution-checker` - Validates completed work
 - `plan-fixer` - Fixes plan issues
-- `grill-me` skill - Stress-test open design decisions before committing to implementation; every question presents 2-4 concrete options plus two standing options — a free-form blank-state type and a "chat about this" path (use `AskUserQuestion` tool in Claude Code or markdown format); invoke via the `grill-me` Skill when requirements have unresolved branches
+- `grill-me` skill - Stress-test open design decisions before committing to implementation; every question presents 2-4 concrete options plus two standing options — a free-form blank-state type and a "chat about this" path; this specialist returns unresolved decisions to the calling root and stops
 
 **Remember**: Good plans are executable blueprints, not vague intentions. Make them specific, structured, and actionable.
 

--- a/.claude/agents/plan-maker.md
+++ b/.claude/agents/plan-maker.md
@@ -60,8 +60,11 @@ See [Plans Organization Convention](../../repo-governance/conventions/structure/
 
 ### Step 1: Resolve the Grill (Mandatory — Pre-Write)
 
-Before reading the codebase or creating any files, invoke the `grill-me` skill
-(`.claude/skills/grill-me/SKILL.md`) to resolve all open design decisions.
+Before composing the decision envelope, perform a read-only discovery pass sufficient to ground its
+options in repo reality. The pass MAY read files and run non-mutating searches, but MUST NOT create,
+edit, delete, stage, or otherwise write any workspace artifact. Then invoke the `grill-me` skill
+(`.claude/skills/grill-me/SKILL.md`) to resolve all open design decisions. No plan artifact or other
+write may occur until the root returns resolved answers.
 
 **Interaction ownership (HARD RULE)**: This specialist agent never owns user interaction. Return
 `## User Decisions Required` using the
@@ -69,15 +72,16 @@ Before reading the codebase or creating any files, invoke the `grill-me` skill
 then stop before Step 2. Every `options` array MUST exhaustively list all substantive leaves. The
 root invokes `grill-me` through its native UI when available, then resumes or reinvokes this agent
 with the resolved answers. A direct custom-agent or noninteractive caller receives the same
-envelope; never render a user prompt or infer an answer.
+envelope; never render a user prompt or infer an answer. The discovery pass is the only permitted
+work before that handoff.
 
 **Multiple-options requirement (HARD RULE)**: Every grill question MUST present 2-4 concrete
 options with trade-off descriptions — open-ended questions without options are FORBIDDEN. Every
 question MUST ALSO carry two standing options: a free-form **type-your-own (blank state)** path
 (explicit, never merely implicit — the most common omission) and a **"chat about this"** option
 for discussing the branch before deciding. Format every unresolved choice with the linked canonical
-envelope per the `grill-me` skill. Read the codebase before composing it so options are grounded in
-repo reality.
+envelope per the `grill-me` skill. Use the read-only discovery pass before composing it so options
+are grounded in repo reality.
 See [Grilling-With-Options Convention](../../repo-governance/development/workflow/grilling-with-options.md).
 
 Ask about (each as a structured multiple-choice question):

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -62,23 +62,31 @@ yourself writing a question without listing concrete options, rewrite it with op
 sending. **Dropping the blank-state type option (Rule 6) is the second most common failure** —
 every question MUST let the user type their own answer.
 
-## Mechanism — use the AskUserQuestion tool
+## Mechanism — use the native interactive tool
 
-Grilling MUST use the **`AskUserQuestion` tool** (the harness's native interactive
-multiple-choice mechanism), not free-text prose questions. It renders options as selectable
-choices and returns a structured answer — eliminating parse ambiguity — and always offers a
-free-form "Other" path.
+Grilling in an interactive root thread MUST use the harness's native interactive
+multiple-choice tool when available, not free-text prose questions. It renders options as
+selectable choices and returns a structured answer, eliminating parse ambiguity. The root
+orchestrator owns every grill and passes resolved answers to a delegated `plan-maker` or
+`plan-fixer`; it MUST NOT delegate the user interaction itself.
 
-- One `AskUserQuestion` call carries 1–4 questions; use multiple questions only for
-  tightly-coupled decision clusters (Rule 4).
-- Each question carries 2–4 options (Rule 2); put the Recommended one first and append
-  `(Recommended)` to its label with the rationale in its description (Rule 3).
-- Every question keeps a standing **"Let's chat about this"** option and relies on the
-  auto-provided free-text **"Other"** entry for the blank-state type (Rule 6); use ≤3
-  substantive options so the chat option fits within the 4-option cap.
+Use the harness-specific invocation contract in
+[Platform Binding Examples](#platform-binding-examples). In all bindings, put the Recommended
+option first and append `(Recommended)` to its label, place the rationale in its description,
+keep **"Let's chat about this"** as the final explicit option, and rely on the client-provided
+free-text **"Other"** entry for the blank-state type.
 
-**Fallback only when `AskUserQuestion` is unavailable** (non-interactive harness): use inline
-markdown options instead, still satisfying Rules 2–5:
+**Delegated-agent handoff**: a subagent MUST NOT render markdown as if it were asking the user.
+It returns `## User Decisions Required` using the
+[canonical envelope schema](../../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope)
+and stops before work that depends on those answers. Every `options` array exhaustively lists all
+substantive leaves; the root adds the standing chat option and relies on the client's implicit
+custom answer. The root invokes this skill through its native UI when available, then resumes or
+reinvokes the specialist with the resolved answers. Direct custom-agent callers receive the same
+envelope.
+
+**Fallback only for a genuinely non-interactive root or harness without a native tool**: emit
+inline markdown options to the caller, still satisfying Rules 2–5:
 
 > **[Question]**
 >
@@ -89,7 +97,8 @@ markdown options instead, still satisfying Rules 2–5:
 > - **Chat about this**: talk the decision through before deciding. Always present.
 
 No bare "What do you think about X?" questions. No yes/no questions without an options list.
-Present the choices; let the user pick or override.
+Present the choices; let the user pick or override. Never silently select the Recommended option
+or infer an answer because interactive input is unavailable.
 
 ## After the grilling
 
@@ -98,3 +107,53 @@ When all decision tree branches are resolved:
 1. Summarize every decision made and its rationale
 2. Confirm shared understanding explicitly
 3. Signal readiness to proceed to plan writing or implementation
+
+## Platform Binding Examples
+
+The content under this heading is intentionally vendor-specific. Per the
+[Governance Vendor-Independence Convention](../../../repo-governance/conventions/structure/governance-vendor-independence.md),
+the vendor-audit scanner skips every line under this heading until the next same-level heading or
+end of file.
+
+### Claude Code
+
+Use `AskUserQuestion` with 1–4 tightly coupled questions per call. Each question object has a
+`header` of at most 12 characters, a self-contained `question`, 2–3 substantive
+`{ label, description }` option objects plus **"Let's chat about this"** (3–4 total), and
+`multiSelect: false`. The client-provided free-text **"Other"** entry remains implicit and satisfies
+the blank-state type requirement.
+
+### OpenCode
+
+Use OpenCode's `question` tool with 2–4 substantive options plus the standing **"Let's chat about
+this"** option per question, preserving its rich multiple-choice UI path. The client-provided custom
+answer remains implicit. If the current version does not expose `question` to the interactive root
+thread, use the markdown fallback.
+
+### Codex
+
+Use `request_user_input` in the root thread. One call carries 1–3 tightly coupled question objects;
+each object MUST have:
+
+- `header`: a short label of at most 12 characters
+- `id`: a stable `snake_case` identifier
+- `question`: one self-contained decision prompt
+- `options`: 2–3 option objects total; Rule 2's two-substantive-option minimum plus the standing
+  **"Let's chat about this"** option means a grill uses exactly 3
+
+Put the Recommended option first and suffix its label with `(Recommended)`. Give every option a
+1–5 word `label`, including that suffix, and a one-sentence trade-off in `description`. Do not add an
+`Other` option: the client supplies the free-form entry. Each question accepts one answer only; do
+not request or simulate multi-select.
+
+When any decision has 3–4 substantive leaves, render a complete staged decision tree.
+Every `request_user_input` question still has exactly 2 substantive branch options plus chat. A
+branch may group remaining leaves only when its label and description enumerate them; selecting it
+opens a subsequent question until every leaf is reachable exactly once. Never truncate the envelope
+to fit one prompt.
+
+Codex currently classifies `default_mode_request_user_input` as under development and keeps it off
+by default. This repository opts in through `.codex/config.toml` so interactive root threads expose
+the native tool outside plan mode. A non-root subagent returns `## User Decisions Required` to the
+root and stops. A non-interactive root, including `codex exec`, emits the markdown fallback to its
+caller. No context chooses silently.

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -85,6 +85,15 @@ custom answer. The root invokes this skill through its native UI when available,
 reinvokes the specialist with the resolved answers. Direct custom-agent callers receive the same
 envelope.
 
+### Staged native rendering
+
+When a native tool permits only 2–3 substantive options but the envelope has 3–4 leaves, preserve
+the whole envelope and use the [canonical staged procedure](../../../repo-governance/development/workflow/grilling-with-options.md#staged-native-rendering).
+The root first presents two named branch groups that enumerate their contained leaves, plus chat and
+the client-provided type-your-own entry; it then presents the selected group's original leaves. Do
+not omit, collapse, auto-select, or reinterpret a leaf. Chat and the blank-state type path remain
+available at every stage, and only the final original leaf is recorded as the answer.
+
 **Fallback only for a genuinely non-interactive root or harness without a native tool**: emit
 inline markdown options to the caller, still satisfying Rules 2–5:
 
@@ -121,7 +130,8 @@ Use `AskUserQuestion` with 1–4 tightly coupled questions per call. Each questi
 `header` of at most 12 characters, a self-contained `question`, 2–3 substantive
 `{ label, description }` option objects plus **"Let's chat about this"** (3–4 total), and
 `multiSelect: false`. The client-provided free-text **"Other"** entry remains implicit and satisfies
-the blank-state type requirement.
+the blank-state type requirement. For a 3–4-leaf envelope, follow [Staged native
+rendering](#staged-native-rendering).
 
 ### OpenCode
 
@@ -146,11 +156,7 @@ Put the Recommended option first and suffix its label with `(Recommended)`. Give
 `Other` option: the client supplies the free-form entry. Each question accepts one answer only; do
 not request or simulate multi-select.
 
-When any decision has 3–4 substantive leaves, render a complete staged decision tree.
-Every `request_user_input` question still has exactly 2 substantive branch options plus chat. A
-branch may group remaining leaves only when its label and description enumerate them; selecting it
-opens a subsequent question until every leaf is reachable exactly once. Never truncate the envelope
-to fit one prompt.
+For a 3–4-leaf envelope, follow [Staged native rendering](#staged-native-rendering).
 
 Codex currently classifies `default_mode_request_user_input` as under development and keeps it off
 by default. This repository opts in through `.codex/config.toml` so interactive root threads expose

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -82,7 +82,9 @@ It returns `## User Decisions Required` using the
 and stops before work that depends on those answers. Every `options` array exhaustively lists all
 substantive leaves; the root adds the standing chat option and relies on the client's implicit
 custom answer. The root invokes this skill through its native UI when available, then resumes or
-reinvokes the specialist with the resolved answers. Direct custom-agent callers receive the same
+reinvokes the specialist with the canonical [Resolved User Decisions Envelope](../../../repo-governance/development/workflow/grilling-with-options.md#resolved-user-decisions-envelope).
+It builds that payload from the original IDs only after rendering and passes it verbatim; the
+specialist validates it before dependent work. Direct custom-agent callers receive the same
 envelope.
 
 ### Staged native rendering
@@ -90,9 +92,11 @@ envelope.
 When a native tool permits only 2–3 substantive options but the envelope has 3–4 leaves, preserve
 the whole envelope and use the [canonical staged procedure](../../../repo-governance/development/workflow/grilling-with-options.md#staged-native-rendering).
 The root first presents two named branch groups that enumerate their contained leaves, plus chat and
-the client-provided type-your-own entry; it then presents the selected group's original leaves. Do
-not omit, collapse, auto-select, or reinterpret a leaf. Chat and the blank-state type path remain
-available at every stage, and only the final original leaf is recorded as the answer.
+the client-provided type-your-own entry. A selected singleton group is terminal: record its original
+leaf ID immediately in the Resolved User Decisions Envelope. Render a follow-up only for a selected
+multi-leaf group. Do not omit, collapse, auto-select, or reinterpret a leaf. Chat and the blank-state
+type path remain available at every rendered stage, and only the final original leaf is recorded as
+the answer.
 
 **Fallback only for a genuinely non-interactive root or harness without a native tool**: emit
 inline markdown options to the caller, still satisfying Rules 2–5:

--- a/.claude/skills/plan-creating-project-plans/SKILL.md
+++ b/.claude/skills/plan-creating-project-plans/SKILL.md
@@ -20,9 +20,9 @@ This Skill provides comprehensive guidance for creating **structured project pla
 
 ## Mandatory Pre-Write and Post-Write Grilling
 
-Before writing any plan content, resolve all open design decisions with the user via structured
-multiple-choice grilling (pre-write grill). After writing the plan, validate and stress-test it
-with the user the same way (post-write grill). Neither gate is optional.
+Before writing any plan content, the calling root resolves all open design decisions through a
+structured multiple-choice pre-write grill. After writing the plan, the root runs the same
+post-write validation grill. Neither gate is optional.
 
 **HARD RULE — 2-4 options required**: Every grilling question MUST present **2-4 concrete,
 mutually exclusive options**. Each option MUST state its trade-off in one sentence. Exactly one
@@ -30,12 +30,17 @@ option MUST be marked `(Recommended)` with a one-sentence rationale. Open-ended 
 options are FORBIDDEN. Resolve one decision per question; tightly coupled decisions may be batched
 in a single multi-question prompt.
 
-**Mechanism**: use the `AskUserQuestion` tool (or the harness's native interactive multiple-choice
-tool) first when available; fall back to inline markdown options when it is not.
+**Interaction ownership**: the root owns native UI interaction and, when it is noninteractive or
+lacks a native tool, emits markdown choices to its caller. A plan specialist never questions the
+user directly. It returns `## User Decisions Required` using the
+[canonical envelope schema](../../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope),
+with stable decision ID, question, recommended option and rationale, and exhaustive option objects
+with trade-offs, then stops. The root resolves the envelope and resumes or reinvokes the specialist.
+A direct custom-agent or noninteractive specialist caller receives the same envelope.
 
-**Explore before asking**: read the relevant repo artifacts before composing any question. Never
-ask the user something a file read can answer — the repo is the ground truth; the user is the
-tiebreaker for genuinely ambiguous decisions.
+**Explore before composing**: read the relevant repo artifacts before creating an envelope or root
+question. Never surface a decision a file read can answer — the repo is the ground truth; the user
+is the tiebreaker for genuinely ambiguous decisions.
 
 **Pre-write grill covers** (each as a structured multiple-choice question):
 
@@ -58,7 +63,8 @@ tiebreaker for genuinely ambiguous decisions.
 - Does `delivery.md` open with the `[AI]`/`[HUMAN]` executor legend, and is every step that only a human can do tagged `[HUMAN]`?
 - Does every phase end with a `### Phase N Gate` (must-pass verification) followed by a Pause Safety note?
 
-**Do NOT proceed to writing until all pre-write branches are resolved.** Unresolved design
+**Do NOT proceed to writing until all pre-write branches are resolved.** A specialist with any open
+branch returns `## User Decisions Required` and stops; it never infers an answer. Unresolved design
 decisions force expensive rewrites.
 
 See [Grilling-With-Options Convention](../../../repo-governance/development/workflow/grilling-with-options.md)
@@ -165,9 +171,9 @@ without its design funnel.
 
 ### Design-funnel grilling questions (UI-bearing plans)
 
-When grilling the user on a UI-bearing plan, the pre-write grill MUST cover the UI-design-funnel
-decisions as structured multiple-choice questions (each with 2-4 concrete options plus the two
-standing options — a free-form blank-state type and "chat about this"):
+For a UI-bearing plan, the specialist's envelope and the root-owned pre-write grill MUST cover the
+UI-design-funnel decisions as structured multiple-choice questions (each with 2-4 concrete options
+plus the two standing options — a free-form blank-state type and "chat about this"):
 
 - **Which alternatives?** Present 2-4 candidate low-fi layouts for the screen (e.g. Ranked Table /
   Card Grid / Split Layout), each option stating its trade-off in one sentence, one marked
@@ -175,8 +181,8 @@ standing options — a free-form blank-state type and "chat about this"):
 - **What prior art?** Present 2-4 ways to ground the alternatives (e.g. delegate a
   `web-researcher` survey of comparable tools / reuse a named sibling screen pattern / blend the
   web-ui kit only), so the diverge stage is informed rather than invented.
-- **Which selection, and why?** Present the finalists as options (e.g. Option A / Option B) and ask
-  which design wins and the one-sentence rationale, so the Select + Justify stages are explicit.
+- **Which selection, and why?** Present the finalists as options (e.g. Option A / Option B) and
+  capture the winning design plus one-sentence rationale, so Select + Justify are explicit.
 - **What responsive strategy?** Present 2-4 ways the selected layout reflows from **mobile** to
   **desktop** (e.g. table collapses to stacked cards / side rail moves into a top sheet / two-pane
   split becomes a single column), so the **responsive** behaviour across mobile/tablet/desktop is
@@ -584,8 +590,9 @@ sections, and new Skills for agent coverage, with its open questions and promoti
 
 ### 2. Planning (backlog/)
 
-**Gate**: Resolve all open design decisions with the user via pre-write grilling before writing
-any plan content. See [Mandatory Pre-Write and Post-Write Grilling](#mandatory-pre-write-and-post-write-grilling).
+**Gate**: The root resolves all open design decisions via pre-write grilling before the specialist
+writes plan content. A specialist returns `## User Decisions Required` and stops when any branch is
+open. See [Mandatory Pre-Write and Post-Write Grilling](#mandatory-pre-write-and-post-write-grilling).
 
 **Actions**:
 
@@ -609,8 +616,9 @@ any plan content. See [Mandatory Pre-Write and Post-Write Grilling](#mandatory-p
 
 ### 4. Completion (done/)
 
-**Gate**: Validate the finished plan with the user via post-write grilling before archiving. See
-[Mandatory Pre-Write and Post-Write Grilling](#mandatory-pre-write-and-post-write-grilling).
+**Gate**: The root validates the finished plan via post-write grilling before archiving. A
+specialist returns `## User Decisions Required` and stops until the root resumes it with answers.
+See [Mandatory Pre-Write and Post-Write Grilling](#mandatory-pre-write-and-post-write-grilling).
 
 **Actions**:
 
@@ -1023,7 +1031,8 @@ Every delivery plan MUST end with a plan archival section:
 
 **Related Skills**:
 
-- `grill-me` - Mandatory pre-write and post-write grilling; every question presents 2-4 concrete options
+- `grill-me` - Mandatory pre-write and post-write grilling; specialists return the exact
+  `## User Decisions Required` envelope and the root renders its exhaustive choices
 - `plan-writing-gherkin-criteria` - Detailed Gherkin guidance
 - `repo-practicing-trunk-based-development` - Git workflow
 - `docs-applying-content-quality` - Universal content standards

--- a/.claude/skills/plan-creating-project-plans/SKILL.md
+++ b/.claude/skills/plan-creating-project-plans/SKILL.md
@@ -35,8 +35,11 @@ lacks a native tool, emits markdown choices to its caller. A plan specialist nev
 user directly. It returns `## User Decisions Required` using the
 [canonical envelope schema](../../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope),
 with stable decision ID, question, recommended option and rationale, and exhaustive option objects
-with trade-offs, then stops. The root resolves the envelope and resumes or reinvokes the specialist.
-A direct custom-agent or noninteractive specialist caller receives the same envelope.
+with trade-offs, then stops. The root resolves the envelope and resumes or reinvokes the specialist
+with the canonical [Resolved User Decisions Envelope](../../../repo-governance/development/workflow/grilling-with-options.md#resolved-user-decisions-envelope),
+constructed from the original IDs after rendering and passed verbatim. The specialist validates it
+before dependent work. A direct custom-agent or noninteractive specialist caller receives the same
+envelope.
 
 **Explore before composing**: read the relevant repo artifacts before creating an envelope or root
 question. Never surface a decision a file read can answer — the repo is the ground truth; the user

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -3,6 +3,7 @@ command = "npx"
 args = [ "nx-mcp@latest", "--minimal" ]
 
 [features]
+default_mode_request_user_input = true
 multi_agent = true
 
 [agents.ci-monitor-subagent]

--- a/.cursor/agents/plan-fixer.md
+++ b/.cursor/agents/plan-fixer.md
@@ -750,9 +750,10 @@ for the authoritative mode table and precedence rule.
   the merge step carries a tag other than `[AI]`, `[HUMAN]`, or `[AI+HUMAN]`. Do NOT guess which of
   the four modes (or which of the three tags) was intended — follow the Grilling Interaction
   Contract with the valid options (four modes, `worktree-to-pr` marked `(Recommended)`; or the three
-  tags), before writing a value. The envelope lists every leaf; on Codex the root uses the staged
-  decision tree, adding chat to each node and relying on the client custom answer. A merge step's tag
-  is never mechanically retagged, at any confidence level — see
+  tags), before writing a value. The envelope lists every leaf; when a native tool's option limit
+  requires staging, the root uses the convention's [staged decision procedure](../../repo-governance/development/workflow/grilling-with-options.md#staged-native-rendering),
+  preserving chat and the client-provided custom answer at every node. A merge step's tag is never
+  mechanically retagged, at any confidence level — see
   [How to Fix a Merge-Tag Mismatch](#how-to-fix-a-merge-tag-mismatch) below.
 
 ### How to Fix a Missing `## Delivery Mode` Section
@@ -767,8 +768,10 @@ defaulting.
 ### How to Fix an Invalid Non-Empty Value
 
 Never silently coerce an invalid value to the default. Follow the Grilling Interaction Contract with
-all four modes (`worktree-to-pr` marked `(Recommended)`), then write the resolved mode. On Codex the
-root renders all four leaves through the complete staged decision tree.
+all four modes (`worktree-to-pr` marked `(Recommended)`), then write the resolved mode. When the
+native tool's option limit requires staging, the root follows the convention's [staged decision
+procedure](../../repo-governance/development/workflow/grilling-with-options.md#staged-native-rendering)
+so every leaf remains reachable.
 
 ### How to Fix a `*-to-pr` Plan Missing the PR-Review Maker→Fixer Cycle
 
@@ -803,8 +806,9 @@ a narrower check layered on top, never a substitute. Concretely:
 
 - `*-to-pr` mode with the merge step carrying a tag other than `[AI]`, `[HUMAN]`, or `[AI+HUMAN]` →
   do NOT retag it. Follow the Grilling Interaction Contract with all three valid tags and apply only
-  the resolved tag. On Codex the root renders all three leaves through the complete staged decision
-  tree. An unrecognized tag may carry human-actor semantics this agent must not silently strip —
+  the resolved tag. When the native tool's option limit requires staging, the root follows the
+  convention's [staged decision procedure](../../repo-governance/development/workflow/grilling-with-options.md#staged-native-rendering).
+  An unrecognized tag may carry human-actor semantics this agent must not silently strip —
   never assume it is safe to overwrite.
 - **Never retag, delete, or otherwise remove a `[HUMAN]`- or `[AI+HUMAN]`-tagged merge step, in any
   Delivery Mode.** Per [Delivery Mode](../../repo-governance/conventions/structure/plans.md#delivery-mode),

--- a/.cursor/agents/plan-fixer.md
+++ b/.cursor/agents/plan-fixer.md
@@ -88,9 +88,11 @@ decisions as `## User Decisions Required` using the
 [canonical envelope schema](../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope),
 then stops before applying the dependent fix. Every `options` array MUST exhaustively list all
 substantive leaves. The root invokes `grill-me` through its native UI when available, then resumes or
-reinvokes this agent with the resolved answers. A direct custom-agent or noninteractive caller
-receives the same envelope; never render a user prompt or infer an answer. For a four-mode or
-three-tag decision, the envelope lists all leaves; a Codex root uses the complete staged tree.
+reinvokes this agent with the canonical [Resolved User Decisions Envelope](../../repo-governance/development/workflow/grilling-with-options.md#resolved-user-decisions-envelope).
+The root builds it from the original IDs after rendering and passes it verbatim; validate it before
+dependent work. A direct custom-agent or noninteractive caller receives the same envelope; never
+render a user prompt or infer an answer. For a four-mode or three-tag decision, the envelope lists
+all leaves; a Codex root uses the complete staged tree.
 
 ## How This Agent Works
 

--- a/.cursor/agents/plan-fixer.md
+++ b/.cursor/agents/plan-fixer.md
@@ -81,6 +81,17 @@ finding as MEDIUM (manual review) or FALSE_POSITIVE rather than spawning a subag
 
 The `repo-applying-maker-checker-fixer` Skill provides complete mode parameter logic including mode levels, filtering, reporting, and workflow integration.
 
+## Grilling Interaction Contract
+
+When a MEDIUM-confidence finding requires an external decision, this specialist returns unresolved
+decisions as `## User Decisions Required` using the
+[canonical envelope schema](../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope),
+then stops before applying the dependent fix. Every `options` array MUST exhaustively list all
+substantive leaves. The root invokes `grill-me` through its native UI when available, then resumes or
+reinvokes this agent with the resolved answers. A direct custom-agent or noninteractive caller
+receives the same envelope; never render a user prompt or infer an answer. For a four-mode or
+three-tag decision, the envelope lists all leaves; a Codex root uses the complete staged tree.
+
 ## How This Agent Works
 
 ### 1. Report Discovery
@@ -737,10 +748,11 @@ for the authoritative mode table and precedence rule.
   is never in scope for this fix, and neither is any other merge-step tag value (see below).
 - **MEDIUM Confidence → grill first**: the declared Delivery Mode value is invalid/unrecognized, OR
   the merge step carries a tag other than `[AI]`, `[HUMAN]`, or `[AI+HUMAN]`. Do NOT guess which of
-  the four modes (or which of the three tags) was intended — surface it as a grill question (per
-  `grill-me`) with the valid options (four modes, `worktree-to-pr` marked `(Recommended)`; or the
-  three tags, plus the standing blank-state/"chat about this" options), before writing a value. A
-  merge step's tag is never mechanically retagged, at any confidence level — see
+  the four modes (or which of the three tags) was intended — follow the Grilling Interaction
+  Contract with the valid options (four modes, `worktree-to-pr` marked `(Recommended)`; or the three
+  tags), before writing a value. The envelope lists every leaf; on Codex the root uses the staged
+  decision tree, adding chat to each node and relying on the client custom answer. A merge step's tag
+  is never mechanically retagged, at any confidence level — see
   [How to Fix a Merge-Tag Mismatch](#how-to-fix-a-merge-tag-mismatch) below.
 
 ### How to Fix a Missing `## Delivery Mode` Section
@@ -749,13 +761,14 @@ Insert `## Delivery Mode: worktree-to-pr` immediately after the `## Worktree` se
 mode, absent any signal the user wants otherwise) — multi-file plans: in `delivery.md` before the
 first phase heading; single-file plans: in `README.md` before `## Delivery Checklist`. If the
 plan's existing checklist already shows direct-push-only steps (no PR step anywhere and no
-worktree at all), that is itself a signal to grill the user rather than silently defaulting.
+worktree at all), resolve it through the Grilling Interaction Contract rather than silently
+defaulting.
 
 ### How to Fix an Invalid Non-Empty Value
 
-Never silently coerce an invalid value to the default. Grill the user with the four-mode table
-(`worktree-to-pr` marked `(Recommended)`) plus the standing blank-state/"chat about this" options,
-then write whichever mode they select.
+Never silently coerce an invalid value to the default. Follow the Grilling Interaction Contract with
+all four modes (`worktree-to-pr` marked `(Recommended)`), then write the resolved mode. On Codex the
+root renders all four leaves through the complete staged decision tree.
 
 ### How to Fix a `*-to-pr` Plan Missing the PR-Review Maker→Fixer Cycle
 
@@ -789,10 +802,10 @@ and a recipe's own confidence table (however "mechanical" or "HIGH confidence" i
 a narrower check layered on top, never a substitute. Concretely:
 
 - `*-to-pr` mode with the merge step carrying a tag other than `[AI]`, `[HUMAN]`, or `[AI+HUMAN]` →
-  do NOT retag it. Surface it as a MEDIUM-confidence grill question (per the Confidence Assessment
-  above) offering the three valid tags plus the standing blank-state/"chat about this" options, and
-  apply only whichever tag the user selects. An unrecognized tag may carry human-actor semantics
-  this agent must not silently strip — never assume it is safe to overwrite.
+  do NOT retag it. Follow the Grilling Interaction Contract with all three valid tags and apply only
+  the resolved tag. On Codex the root renders all three leaves through the complete staged decision
+  tree. An unrecognized tag may carry human-actor semantics this agent must not silently strip —
+  never assume it is safe to overwrite.
 - **Never retag, delete, or otherwise remove a `[HUMAN]`- or `[AI+HUMAN]`-tagged merge step, in any
   Delivery Mode.** Per [Delivery Mode](../../repo-governance/conventions/structure/plans.md#delivery-mode),
   the tag on the merge step IS the plan's opt-in — there is no separate "explicit opt-in"

--- a/.cursor/agents/plan-maker.md
+++ b/.cursor/agents/plan-maker.md
@@ -52,8 +52,11 @@ See [Plans Organization Convention](../../repo-governance/conventions/structure/
 
 ### Step 1: Resolve the Grill (Mandatory — Pre-Write)
 
-Before reading the codebase or creating any files, invoke the `grill-me` skill
-(`.claude/skills/grill-me/SKILL.md`) to resolve all open design decisions.
+Before composing the decision envelope, perform a read-only discovery pass sufficient to ground its
+options in repo reality. The pass MAY read files and run non-mutating searches, but MUST NOT create,
+edit, delete, stage, or otherwise write any workspace artifact. Then invoke the `grill-me` skill
+(`.claude/skills/grill-me/SKILL.md`) to resolve all open design decisions. No plan artifact or other
+write may occur until the root returns resolved answers.
 
 **Interaction ownership (HARD RULE)**: This specialist agent never owns user interaction. Return
 `## User Decisions Required` using the
@@ -61,15 +64,16 @@ Before reading the codebase or creating any files, invoke the `grill-me` skill
 then stop before Step 2. Every `options` array MUST exhaustively list all substantive leaves. The
 root invokes `grill-me` through its native UI when available, then resumes or reinvokes this agent
 with the resolved answers. A direct custom-agent or noninteractive caller receives the same
-envelope; never render a user prompt or infer an answer.
+envelope; never render a user prompt or infer an answer. The discovery pass is the only permitted
+work before that handoff.
 
 **Multiple-options requirement (HARD RULE)**: Every grill question MUST present 2-4 concrete
 options with trade-off descriptions — open-ended questions without options are FORBIDDEN. Every
 question MUST ALSO carry two standing options: a free-form **type-your-own (blank state)** path
 (explicit, never merely implicit — the most common omission) and a **"chat about this"** option
 for discussing the branch before deciding. Format every unresolved choice with the linked canonical
-envelope per the `grill-me` skill. Read the codebase before composing it so options are grounded in
-repo reality.
+envelope per the `grill-me` skill. Use the read-only discovery pass before composing it so options
+are grounded in repo reality.
 See [Grilling-With-Options Convention](../../repo-governance/development/workflow/grilling-with-options.md).
 
 Ask about (each as a structured multiple-choice question):

--- a/.cursor/agents/plan-maker.md
+++ b/.cursor/agents/plan-maker.md
@@ -1,6 +1,6 @@
 ---
 name: plan-maker
-description: Creates comprehensive project plans with requirements, technical documentation, and delivery checklists. Grills the user before and after plan creation using multiple-choice options (2-4 options per question via AskUserQuestion tool or markdown format). Structures plans for systematic execution via the plan-execution workflow (orchestrated by the calling context).
+description: Creates comprehensive project plans with requirements, technical documentation, and delivery checklists. Returns unresolved pre-write and post-write decisions to the calling root orchestrator for grilling, then resumes with resolved answers. Structures plans for systematic execution via the plan-execution workflow (orchestrated by the calling context).
 model: composer-2.5
 ---
 
@@ -50,18 +50,26 @@ See [Plans Organization Convention](../../repo-governance/conventions/structure/
 
 ## Planning Workflow
 
-### Step 1: Grill the User (Mandatory — Pre-Write)
+### Step 1: Resolve the Grill (Mandatory — Pre-Write)
 
 Before reading the codebase or creating any files, invoke the `grill-me` skill
-(`.claude/skills/grill-me/SKILL.md`) to resolve all open design decisions with the user.
+(`.claude/skills/grill-me/SKILL.md`) to resolve all open design decisions.
+
+**Interaction ownership (HARD RULE)**: This specialist agent never owns user interaction. Return
+`## User Decisions Required` using the
+[canonical envelope schema](../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope),
+then stop before Step 2. Every `options` array MUST exhaustively list all substantive leaves. The
+root invokes `grill-me` through its native UI when available, then resumes or reinvokes this agent
+with the resolved answers. A direct custom-agent or noninteractive caller receives the same
+envelope; never render a user prompt or infer an answer.
 
 **Multiple-options requirement (HARD RULE)**: Every grill question MUST present 2-4 concrete
 options with trade-off descriptions — open-ended questions without options are FORBIDDEN. Every
 question MUST ALSO carry two standing options: a free-form **type-your-own (blank state)** path
 (explicit, never merely implicit — the most common omission) and a **"chat about this"** option
-for discussing the branch before deciding. Use the
-`AskUserQuestion` tool (preferred in Claude Code context) or the markdown question format from
-the `grill-me` skill. Read the codebase before asking so options are grounded in repo reality.
+for discussing the branch before deciding. Format every unresolved choice with the linked canonical
+envelope per the `grill-me` skill. Read the codebase before composing it so options are grounded in
+repo reality.
 See [Grilling-With-Options Convention](../../repo-governance/development/workflow/grilling-with-options.md).
 
 Ask about (each as a structured multiple-choice question):
@@ -285,16 +293,18 @@ for the authoritative mode table, precedence rule, and declaration syntax, and
 [Trunk Based Development Convention](../../repo-governance/development/workflow/trunk-based-development.md)
 for the underlying git-workflow details.
 
-### Step 8: Grill the User (Mandatory — Post-Write)
+### Step 8: Resolve the Grill (Mandatory — Post-Write)
 
-After all plan files are written, invoke the `grill-me` skill again to validate the plan with
-the user before signaling done.
+After all plan files are written, invoke the `grill-me` skill again and resolve the validation grill
+before signaling done. Apply the Step 1 interaction-ownership rule: a delegated or noninteractive
+agent returns the exact `## User Decisions Required` envelope and stops; after the root resolves it
+through `grill-me`, resume or reinvoke this agent with the answers.
 
 **Multiple-options requirement (HARD RULE)**: Same as Step 1 — every validation question MUST
 present 2-4 concrete options plus the two standing options (free-form blank-state type and "chat
-about this"). Use `AskUserQuestion` tool (preferred) or markdown question format.
-Never present a binary yes/no without offering design alternatives. See
-[Grilling-With-Options Convention](../../repo-governance/development/workflow/grilling-with-options.md).
+about this"). Return only `## User Decisions Required` using the
+[canonical envelope schema](../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope).
+Never present a binary yes/no without offering design alternatives.
 
 Cover (each as a structured multiple-choice question):
 
@@ -618,7 +628,7 @@ Decide boundaries at authoring time using the four-part boundary test (coherent 
 - [plan-execution workflow](../../repo-governance/workflows/plan/plan-execution.md) - Execute plans (calling context orchestrates; no dedicated subagent); invokes the `grill-me` skill to stress-test unresolved design decisions before execution begins
 - `plan-execution-checker` - Validates completed work
 - `plan-fixer` - Fixes plan issues
-- `grill-me` skill - Stress-test open design decisions before committing to implementation; every question presents 2-4 concrete options plus two standing options — a free-form blank-state type and a "chat about this" path (use `AskUserQuestion` tool in Claude Code or markdown format); invoke via the `grill-me` Skill when requirements have unresolved branches
+- `grill-me` skill - Stress-test open design decisions before committing to implementation; every question presents 2-4 concrete options plus two standing options — a free-form blank-state type and a "chat about this" path; this specialist returns unresolved decisions to the calling root and stops
 
 **Remember**: Good plans are executable blueprints, not vague intentions. Make them specific, structured, and actionable.
 

--- a/.cursor/agents/plan-maker.md
+++ b/.cursor/agents/plan-maker.md
@@ -63,9 +63,11 @@ write may occur until the root returns resolved answers.
 [canonical envelope schema](../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope),
 then stop before Step 2. Every `options` array MUST exhaustively list all substantive leaves. The
 root invokes `grill-me` through its native UI when available, then resumes or reinvokes this agent
-with the resolved answers. A direct custom-agent or noninteractive caller receives the same
-envelope; never render a user prompt or infer an answer. The discovery pass is the only permitted
-work before that handoff.
+with the canonical [Resolved User Decisions Envelope](../../repo-governance/development/workflow/grilling-with-options.md#resolved-user-decisions-envelope).
+The root builds it from the original IDs after rendering and passes it verbatim; validate it before
+dependent work. A direct custom-agent or noninteractive caller receives the same envelope; never
+render a user prompt or infer an answer. The discovery pass is the only permitted work before that
+handoff.
 
 **Multiple-options requirement (HARD RULE)**: Every grill question MUST present 2-4 concrete
 options with trade-off descriptions — open-ended questions without options are FORBIDDEN. Every
@@ -302,7 +304,8 @@ for the underlying git-workflow details.
 After all plan files are written, invoke the `grill-me` skill again and resolve the validation grill
 before signaling done. Apply the Step 1 interaction-ownership rule: a delegated or noninteractive
 agent returns the exact `## User Decisions Required` envelope and stops; after the root resolves it
-through `grill-me`, resume or reinvoke this agent with the answers.
+through `grill-me`, resume or reinvoke this agent with the verbatim Resolved User Decisions Envelope
+and validate it before dependent work.
 
 **Multiple-options requirement (HARD RULE)**: Same as Step 1 — every validation question MUST
 present 2-4 concrete options plus the two standing options (free-form blank-state type and "chat

--- a/.opencode/agents/plan-fixer.md
+++ b/.opencode/agents/plan-fixer.md
@@ -17,6 +17,7 @@ skills:
   - plan-writing-gherkin-criteria
   - plan-creating-project-plans
   - docs-validating-factual-accuracy
+  - grill-me
   - repo-assessing-criticality-confidence
   - repo-applying-maker-checker-fixer
   - repo-generating-validation-reports
@@ -98,6 +99,17 @@ finding as MEDIUM (manual review) or FALSE_POSITIVE rather than spawning a subag
 ## Mode Parameter Handling
 
 The `repo-applying-maker-checker-fixer` Skill provides complete mode parameter logic including mode levels, filtering, reporting, and workflow integration.
+
+## Grilling Interaction Contract
+
+When a MEDIUM-confidence finding requires an external decision, this specialist returns unresolved
+decisions as `## User Decisions Required` using the
+[canonical envelope schema](../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope),
+then stops before applying the dependent fix. Every `options` array MUST exhaustively list all
+substantive leaves. The root invokes `grill-me` through its native UI when available, then resumes or
+reinvokes this agent with the resolved answers. A direct custom-agent or noninteractive caller
+receives the same envelope; never render a user prompt or infer an answer. For a four-mode or
+three-tag decision, the envelope lists all leaves; a Codex root uses the complete staged tree.
 
 ## How This Agent Works
 
@@ -755,10 +767,11 @@ for the authoritative mode table and precedence rule.
   is never in scope for this fix, and neither is any other merge-step tag value (see below).
 - **MEDIUM Confidence → grill first**: the declared Delivery Mode value is invalid/unrecognized, OR
   the merge step carries a tag other than `[AI]`, `[HUMAN]`, or `[AI+HUMAN]`. Do NOT guess which of
-  the four modes (or which of the three tags) was intended — surface it as a grill question (per
-  `grill-me`) with the valid options (four modes, `worktree-to-pr` marked `(Recommended)`; or the
-  three tags, plus the standing blank-state/"chat about this" options), before writing a value. A
-  merge step's tag is never mechanically retagged, at any confidence level — see
+  the four modes (or which of the three tags) was intended — follow the Grilling Interaction
+  Contract with the valid options (four modes, `worktree-to-pr` marked `(Recommended)`; or the three
+  tags), before writing a value. The envelope lists every leaf; on Codex the root uses the staged
+  decision tree, adding chat to each node and relying on the client custom answer. A merge step's tag
+  is never mechanically retagged, at any confidence level — see
   [How to Fix a Merge-Tag Mismatch](#how-to-fix-a-merge-tag-mismatch) below.
 
 ### How to Fix a Missing `## Delivery Mode` Section
@@ -767,13 +780,14 @@ Insert `## Delivery Mode: worktree-to-pr` immediately after the `## Worktree` se
 mode, absent any signal the user wants otherwise) — multi-file plans: in `delivery.md` before the
 first phase heading; single-file plans: in `README.md` before `## Delivery Checklist`. If the
 plan's existing checklist already shows direct-push-only steps (no PR step anywhere and no
-worktree at all), that is itself a signal to grill the user rather than silently defaulting.
+worktree at all), resolve it through the Grilling Interaction Contract rather than silently
+defaulting.
 
 ### How to Fix an Invalid Non-Empty Value
 
-Never silently coerce an invalid value to the default. Grill the user with the four-mode table
-(`worktree-to-pr` marked `(Recommended)`) plus the standing blank-state/"chat about this" options,
-then write whichever mode they select.
+Never silently coerce an invalid value to the default. Follow the Grilling Interaction Contract with
+all four modes (`worktree-to-pr` marked `(Recommended)`), then write the resolved mode. On Codex the
+root renders all four leaves through the complete staged decision tree.
 
 ### How to Fix a `*-to-pr` Plan Missing the PR-Review Maker→Fixer Cycle
 
@@ -807,10 +821,10 @@ and a recipe's own confidence table (however "mechanical" or "HIGH confidence" i
 a narrower check layered on top, never a substitute. Concretely:
 
 - `*-to-pr` mode with the merge step carrying a tag other than `[AI]`, `[HUMAN]`, or `[AI+HUMAN]` →
-  do NOT retag it. Surface it as a MEDIUM-confidence grill question (per the Confidence Assessment
-  above) offering the three valid tags plus the standing blank-state/"chat about this" options, and
-  apply only whichever tag the user selects. An unrecognized tag may carry human-actor semantics
-  this agent must not silently strip — never assume it is safe to overwrite.
+  do NOT retag it. Follow the Grilling Interaction Contract with all three valid tags and apply only
+  the resolved tag. On Codex the root renders all three leaves through the complete staged decision
+  tree. An unrecognized tag may carry human-actor semantics this agent must not silently strip —
+  never assume it is safe to overwrite.
 - **Never retag, delete, or otherwise remove a `[HUMAN]`- or `[AI+HUMAN]`-tagged merge step, in any
   Delivery Mode.** Per [Delivery Mode](../../repo-governance/conventions/structure/plans.md#delivery-mode),
   the tag on the merge step IS the plan's opt-in — there is no separate "explicit opt-in"

--- a/.opencode/agents/plan-fixer.md
+++ b/.opencode/agents/plan-fixer.md
@@ -107,9 +107,11 @@ decisions as `## User Decisions Required` using the
 [canonical envelope schema](../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope),
 then stops before applying the dependent fix. Every `options` array MUST exhaustively list all
 substantive leaves. The root invokes `grill-me` through its native UI when available, then resumes or
-reinvokes this agent with the resolved answers. A direct custom-agent or noninteractive caller
-receives the same envelope; never render a user prompt or infer an answer. For a four-mode or
-three-tag decision, the envelope lists all leaves; a Codex root uses the complete staged tree.
+reinvokes this agent with the canonical [Resolved User Decisions Envelope](../../repo-governance/development/workflow/grilling-with-options.md#resolved-user-decisions-envelope).
+The root builds it from the original IDs after rendering and passes it verbatim; validate it before
+dependent work. A direct custom-agent or noninteractive caller receives the same envelope; never
+render a user prompt or infer an answer. For a four-mode or three-tag decision, the envelope lists
+all leaves; a Codex root uses the complete staged tree.
 
 ## How This Agent Works
 

--- a/.opencode/agents/plan-fixer.md
+++ b/.opencode/agents/plan-fixer.md
@@ -769,9 +769,10 @@ for the authoritative mode table and precedence rule.
   the merge step carries a tag other than `[AI]`, `[HUMAN]`, or `[AI+HUMAN]`. Do NOT guess which of
   the four modes (or which of the three tags) was intended — follow the Grilling Interaction
   Contract with the valid options (four modes, `worktree-to-pr` marked `(Recommended)`; or the three
-  tags), before writing a value. The envelope lists every leaf; on Codex the root uses the staged
-  decision tree, adding chat to each node and relying on the client custom answer. A merge step's tag
-  is never mechanically retagged, at any confidence level — see
+  tags), before writing a value. The envelope lists every leaf; when a native tool's option limit
+  requires staging, the root uses the convention's [staged decision procedure](../../repo-governance/development/workflow/grilling-with-options.md#staged-native-rendering),
+  preserving chat and the client-provided custom answer at every node. A merge step's tag is never
+  mechanically retagged, at any confidence level — see
   [How to Fix a Merge-Tag Mismatch](#how-to-fix-a-merge-tag-mismatch) below.
 
 ### How to Fix a Missing `## Delivery Mode` Section
@@ -786,8 +787,10 @@ defaulting.
 ### How to Fix an Invalid Non-Empty Value
 
 Never silently coerce an invalid value to the default. Follow the Grilling Interaction Contract with
-all four modes (`worktree-to-pr` marked `(Recommended)`), then write the resolved mode. On Codex the
-root renders all four leaves through the complete staged decision tree.
+all four modes (`worktree-to-pr` marked `(Recommended)`), then write the resolved mode. When the
+native tool's option limit requires staging, the root follows the convention's [staged decision
+procedure](../../repo-governance/development/workflow/grilling-with-options.md#staged-native-rendering)
+so every leaf remains reachable.
 
 ### How to Fix a `*-to-pr` Plan Missing the PR-Review Maker→Fixer Cycle
 
@@ -822,8 +825,9 @@ a narrower check layered on top, never a substitute. Concretely:
 
 - `*-to-pr` mode with the merge step carrying a tag other than `[AI]`, `[HUMAN]`, or `[AI+HUMAN]` →
   do NOT retag it. Follow the Grilling Interaction Contract with all three valid tags and apply only
-  the resolved tag. On Codex the root renders all three leaves through the complete staged decision
-  tree. An unrecognized tag may carry human-actor semantics this agent must not silently strip —
+  the resolved tag. When the native tool's option limit requires staging, the root follows the
+  convention's [staged decision procedure](../../repo-governance/development/workflow/grilling-with-options.md#staged-native-rendering).
+  An unrecognized tag may carry human-actor semantics this agent must not silently strip —
   never assume it is safe to overwrite.
 - **Never retag, delete, or otherwise remove a `[HUMAN]`- or `[AI+HUMAN]`-tagged merge step, in any
   Delivery Mode.** Per [Delivery Mode](../../repo-governance/conventions/structure/plans.md#delivery-mode),

--- a/.opencode/agents/plan-maker.md
+++ b/.opencode/agents/plan-maker.md
@@ -1,5 +1,5 @@
 ---
-description: Creates comprehensive project plans with requirements, technical documentation, and delivery checklists. Grills the user before and after plan creation using multiple-choice options (2-4 options per question via AskUserQuestion tool or markdown format). Structures plans for systematic execution via the plan-execution workflow (orchestrated by the calling context).
+description: Creates comprehensive project plans with requirements, technical documentation, and delivery checklists. Returns unresolved pre-write and post-write decisions to the calling root orchestrator for grilling, then resumes with resolved answers. Structures plans for systematic execution via the plan-execution workflow (orchestrated by the calling context).
 model: zai-coding-plan/glm-5.2
 permission:
   bash: allow
@@ -65,18 +65,26 @@ See [Plans Organization Convention](../../repo-governance/conventions/structure/
 
 ## Planning Workflow
 
-### Step 1: Grill the User (Mandatory — Pre-Write)
+### Step 1: Resolve the Grill (Mandatory — Pre-Write)
 
 Before reading the codebase or creating any files, invoke the `grill-me` skill
-(`.claude/skills/grill-me/SKILL.md`) to resolve all open design decisions with the user.
+(`.claude/skills/grill-me/SKILL.md`) to resolve all open design decisions.
+
+**Interaction ownership (HARD RULE)**: This specialist agent never owns user interaction. Return
+`## User Decisions Required` using the
+[canonical envelope schema](../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope),
+then stop before Step 2. Every `options` array MUST exhaustively list all substantive leaves. The
+root invokes `grill-me` through its native UI when available, then resumes or reinvokes this agent
+with the resolved answers. A direct custom-agent or noninteractive caller receives the same
+envelope; never render a user prompt or infer an answer.
 
 **Multiple-options requirement (HARD RULE)**: Every grill question MUST present 2-4 concrete
 options with trade-off descriptions — open-ended questions without options are FORBIDDEN. Every
 question MUST ALSO carry two standing options: a free-form **type-your-own (blank state)** path
 (explicit, never merely implicit — the most common omission) and a **"chat about this"** option
-for discussing the branch before deciding. Use the
-`AskUserQuestion` tool (preferred in Claude Code context) or the markdown question format from
-the `grill-me` skill. Read the codebase before asking so options are grounded in repo reality.
+for discussing the branch before deciding. Format every unresolved choice with the linked canonical
+envelope per the `grill-me` skill. Read the codebase before composing it so options are grounded in
+repo reality.
 See [Grilling-With-Options Convention](../../repo-governance/development/workflow/grilling-with-options.md).
 
 Ask about (each as a structured multiple-choice question):
@@ -300,16 +308,18 @@ for the authoritative mode table, precedence rule, and declaration syntax, and
 [Trunk Based Development Convention](../../repo-governance/development/workflow/trunk-based-development.md)
 for the underlying git-workflow details.
 
-### Step 8: Grill the User (Mandatory — Post-Write)
+### Step 8: Resolve the Grill (Mandatory — Post-Write)
 
-After all plan files are written, invoke the `grill-me` skill again to validate the plan with
-the user before signaling done.
+After all plan files are written, invoke the `grill-me` skill again and resolve the validation grill
+before signaling done. Apply the Step 1 interaction-ownership rule: a delegated or noninteractive
+agent returns the exact `## User Decisions Required` envelope and stops; after the root resolves it
+through `grill-me`, resume or reinvoke this agent with the answers.
 
 **Multiple-options requirement (HARD RULE)**: Same as Step 1 — every validation question MUST
 present 2-4 concrete options plus the two standing options (free-form blank-state type and "chat
-about this"). Use `AskUserQuestion` tool (preferred) or markdown question format.
-Never present a binary yes/no without offering design alternatives. See
-[Grilling-With-Options Convention](../../repo-governance/development/workflow/grilling-with-options.md).
+about this"). Return only `## User Decisions Required` using the
+[canonical envelope schema](../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope).
+Never present a binary yes/no without offering design alternatives.
 
 Cover (each as a structured multiple-choice question):
 
@@ -633,7 +643,7 @@ Decide boundaries at authoring time using the four-part boundary test (coherent 
 - [plan-execution workflow](../../repo-governance/workflows/plan/plan-execution.md) - Execute plans (calling context orchestrates; no dedicated subagent); invokes the `grill-me` skill to stress-test unresolved design decisions before execution begins
 - `plan-execution-checker` - Validates completed work
 - `plan-fixer` - Fixes plan issues
-- `grill-me` skill - Stress-test open design decisions before committing to implementation; every question presents 2-4 concrete options plus two standing options — a free-form blank-state type and a "chat about this" path (use `AskUserQuestion` tool in Claude Code or markdown format); invoke via the `grill-me` Skill when requirements have unresolved branches
+- `grill-me` skill - Stress-test open design decisions before committing to implementation; every question presents 2-4 concrete options plus two standing options — a free-form blank-state type and a "chat about this" path; this specialist returns unresolved decisions to the calling root and stops
 
 **Remember**: Good plans are executable blueprints, not vague intentions. Make them specific, structured, and actionable.
 

--- a/.opencode/agents/plan-maker.md
+++ b/.opencode/agents/plan-maker.md
@@ -78,9 +78,11 @@ write may occur until the root returns resolved answers.
 [canonical envelope schema](../../repo-governance/development/workflow/grilling-with-options.md#user-decisions-required-envelope),
 then stop before Step 2. Every `options` array MUST exhaustively list all substantive leaves. The
 root invokes `grill-me` through its native UI when available, then resumes or reinvokes this agent
-with the resolved answers. A direct custom-agent or noninteractive caller receives the same
-envelope; never render a user prompt or infer an answer. The discovery pass is the only permitted
-work before that handoff.
+with the canonical [Resolved User Decisions Envelope](../../repo-governance/development/workflow/grilling-with-options.md#resolved-user-decisions-envelope).
+The root builds it from the original IDs after rendering and passes it verbatim; validate it before
+dependent work. A direct custom-agent or noninteractive caller receives the same envelope; never
+render a user prompt or infer an answer. The discovery pass is the only permitted work before that
+handoff.
 
 **Multiple-options requirement (HARD RULE)**: Every grill question MUST present 2-4 concrete
 options with trade-off descriptions — open-ended questions without options are FORBIDDEN. Every
@@ -317,7 +319,8 @@ for the underlying git-workflow details.
 After all plan files are written, invoke the `grill-me` skill again and resolve the validation grill
 before signaling done. Apply the Step 1 interaction-ownership rule: a delegated or noninteractive
 agent returns the exact `## User Decisions Required` envelope and stops; after the root resolves it
-through `grill-me`, resume or reinvoke this agent with the answers.
+through `grill-me`, resume or reinvoke this agent with the verbatim Resolved User Decisions Envelope
+and validate it before dependent work.
 
 **Multiple-options requirement (HARD RULE)**: Same as Step 1 — every validation question MUST
 present 2-4 concrete options plus the two standing options (free-form blank-state type and "chat

--- a/.opencode/agents/plan-maker.md
+++ b/.opencode/agents/plan-maker.md
@@ -67,8 +67,11 @@ See [Plans Organization Convention](../../repo-governance/conventions/structure/
 
 ### Step 1: Resolve the Grill (Mandatory — Pre-Write)
 
-Before reading the codebase or creating any files, invoke the `grill-me` skill
-(`.claude/skills/grill-me/SKILL.md`) to resolve all open design decisions.
+Before composing the decision envelope, perform a read-only discovery pass sufficient to ground its
+options in repo reality. The pass MAY read files and run non-mutating searches, but MUST NOT create,
+edit, delete, stage, or otherwise write any workspace artifact. Then invoke the `grill-me` skill
+(`.claude/skills/grill-me/SKILL.md`) to resolve all open design decisions. No plan artifact or other
+write may occur until the root returns resolved answers.
 
 **Interaction ownership (HARD RULE)**: This specialist agent never owns user interaction. Return
 `## User Decisions Required` using the
@@ -76,15 +79,16 @@ Before reading the codebase or creating any files, invoke the `grill-me` skill
 then stop before Step 2. Every `options` array MUST exhaustively list all substantive leaves. The
 root invokes `grill-me` through its native UI when available, then resumes or reinvokes this agent
 with the resolved answers. A direct custom-agent or noninteractive caller receives the same
-envelope; never render a user prompt or infer an answer.
+envelope; never render a user prompt or infer an answer. The discovery pass is the only permitted
+work before that handoff.
 
 **Multiple-options requirement (HARD RULE)**: Every grill question MUST present 2-4 concrete
 options with trade-off descriptions — open-ended questions without options are FORBIDDEN. Every
 question MUST ALSO carry two standing options: a free-form **type-your-own (blank state)** path
 (explicit, never merely implicit — the most common omission) and a **"chat about this"** option
 for discussing the branch before deciding. Format every unresolved choice with the linked canonical
-envelope per the `grill-me` skill. Read the codebase before composing it so options are grounded in
-repo reality.
+envelope per the `grill-me` skill. Use the read-only discovery pass before composing it so options
+are grounded in repo reality.
 See [Grilling-With-Options Convention](../../repo-governance/development/workflow/grilling-with-options.md).
 
 Ask about (each as a structured multiple-choice question):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,25 +489,22 @@ same-level heading or end of file.
 
 ### Platform Bindings Catalog
 
-Concrete tool integrations live **outside** `repo-governance/` in platform-binding directories:
+Codex interactive roots MUST use `request_user_input` at
+[Grilling-With-Options](./repo-governance/development/workflow/grilling-with-options.md) checkpoints;
+specialists return a `## User Decisions Required` envelope.
 
-Tier-1 harnesses — OpenAI Codex CLI, GitHub Copilot, Cursor, Windsurf, Junie, Antigravity CLI, Pi,
-and Kiro CLI — read `AGENTS.md` natively and get **no** per-tool instruction file (no-shadowing).
-The exceptions:
+Tier-1 harnesses in the [platform catalog](./docs/reference/platform-bindings.md) read `AGENTS.md`
+natively with no per-tool instruction file. Exceptions:
 
-- **Claude Code** → `.claude/`, with `CLAUDE.md` as the discoverable shim importing this file
-- **OpenCode** → `.opencode/agents/`; reads `AGENTS.md` and `.claude/skills/<name>/SKILL.md` natively
+- **Claude Code** → `.claude/`; `CLAUDE.md` imports this file
+- **OpenCode** → `.opencode/agents/`; natively reads `AGENTS.md` and `.claude/skills/`
 - **Cursor** → additionally emits `.cursor/agents/`
-- **Amazon Q Developer** (sunsetting — IDE plugins EOS 2027-04-30, succeeded by Kiro CLI) → does not
-  read `AGENTS.md`; gets a generated `.amazonq/` bridge (`rules/00-agents-md.md` + agent config)
-- **Aider** → reads `CONVENTIONS.md` per [its own docs](https://aider.chat/docs/usage/conventions.html)
+- **Amazon Q Developer** → generated `.amazonq/` bridge; does not read `AGENTS.md`
+- **Aider** → `CONVENTIONS.md`
 
-Every generated directory above is emitted by `rhino-cli harness bindings generate` — never hand-edited.
-
-See [platform-bindings.md](./docs/reference/platform-bindings.md) for the full catalog
-of binding directories, root instruction files, and mechanical translation artifacts. The two-tier
-binding model and no-shadowing rule are defined in
-[multi-harness-binding.md](./repo-governance/conventions/structure/multi-harness-binding.md).
+Generate mirrors with `rhino-cli harness bindings generate`; never hand-edit. Complete paths and
+rules: [platform catalog](./docs/reference/platform-bindings.md),
+[binding convention](./repo-governance/conventions/structure/multi-harness-binding.md).
 
 ### Concrete Vendor Model IDs
 

--- a/repo-governance/development/workflow/grilling-with-options.md
+++ b/repo-governance/development/workflow/grilling-with-options.md
@@ -159,12 +159,43 @@ independent. Present them separately.
 
 ### Rule 6 — Mechanism: Native Interactive Tool First, Markdown Fallback
 
-When the AI coding agent harness provides a native interactive multiple-choice question tool,
-grilling MUST use it. The native tool renders options as selectable UI elements and returns
-the user's choice as structured data, eliminating parse ambiguity.
+When the interactive root thread provides a native multiple-choice question tool, grilling MUST
+use it. The native tool renders options as selectable UI elements and returns the user's choice as
+structured data, eliminating parse ambiguity.
 
-When no such native tool is available, fall back to inline markdown options in the following
-format:
+#### User Decisions Required Envelope
+
+A subagent MUST NOT render markdown as if it were asking the user. It returns this exact envelope to
+the root orchestrator and stops before work that depends on the answer:
+
+````markdown
+## User Decisions Required
+
+```yaml
+decisions:
+  - id: stable_snake_case_id
+    question: One self-contained decision prompt
+    recommended:
+      option_id: recommended_option_id
+      rationale: One context-grounded recommendation rationale
+    options:
+      - id: recommended_option_id
+        label: Recommended option label
+        tradeoff: One decision-specific trade-off
+      - id: alternative_option_id
+        label: Alternative option label
+        tradeoff: One decision-specific trade-off
+```
+````
+
+The stable `id` identifies the decision across reinvocation. `options` exhaustively lists every
+substantive leaf with its trade-off; the root adds the standing chat option and relies on the
+client's implicit custom answer. After the envelope, the specialist stops. The root presents the
+decision through its native UI, then resumes or reinvokes the specialist with the resolved answer.
+Direct custom-agent callers receive the same envelope.
+
+Only a genuinely non-interactive root or harness without a native tool falls back to inline
+markdown options emitted to its caller in the following format:
 
 ```markdown
 **Question**: [Decision to resolve]
@@ -338,12 +369,14 @@ A grill question is invalid when ANY of the following hold:
 
 When `plan-maker` is invoked by `plan-planning`, the macro design decisions
 are already resolved by Steps 1 and 3 of that workflow. The `plan-maker` grilling sessions
-in that context become **validation passes** for micro-decisions (exact Gherkin phrasing,
-section ordering, step granularity). The structured format (Rules 2–5) still applies, but
-questions are narrower.
+in that context become root-orchestrated **validation passes** for micro-decisions (exact Gherkin
+phrasing, section ordering, step granularity). The specialist returns `## User Decisions Required`
+and stops; the root resolves it and resumes or reinvokes the specialist. The structured format
+(Rules 2–5) still applies, but questions are narrower.
 
-When `plan-maker` is invoked standalone (not via `plan-establishment`), both the pre-write
-and post-write grills are full grill sessions resolving all open decisions.
+Standalone plan-maker triggers still require full pre-write and post-write grill sessions, but the
+calling root orchestrates them. A directly invoked specialist returns the envelope; it never renders
+the native UI itself.
 
 ### Grilling Is a Process Artifact, Not a Document Artifact
 
@@ -388,18 +421,23 @@ heading or end of file.
 ### Primary Coding Harness — Claude Code
 
 Claude Code exposes `AskUserQuestion` as its native interactive multiple-choice tool. When
-grilling inside a Claude Code session, the `grill-me` skill MUST invoke `AskUserQuestion`
+grilling inside an interactive Claude Code root session, the `grill-me` skill MUST invoke
+`AskUserQuestion`
 with:
 
 - `questions`: 1–4 questions (one per tightly-coupled decision cluster)
-- `options` per question: 2–3 substantive selectable options plus a standing
-  `"Let's chat about this"` option (≤4 array entries total, reserving room for chat)
+- `header` per question: a short label of at most 12 characters
+- `question` per question: one self-contained decision prompt
+- `options` per question: 2–3 substantive `{ label, description }` option objects plus the standing
+  `"Let's chat about this"` option (3–4 total)
+- `multiSelect` per question: `false`
 - The harness's auto-provided free-text `"Other"` entry is the blank-state type option — the
   answer is whatever the user writes; it is always present and satisfies the Rule 8 blank-state
   requirement
 
 `AskUserQuestion` returns a structured response the agent uses directly without parsing
-free-text. Markdown option lists are only a fallback when `AskUserQuestion` is unavailable.
+free-text. A delegated agent returns unresolved decisions to the root and stops; only a genuinely
+non-interactive root without `AskUserQuestion` emits the markdown fallback to its caller.
 
 Example invocation shape:
 
@@ -407,12 +445,23 @@ Example invocation shape:
 AskUserQuestion({
   questions: [
     {
+      header: "Plan scope",
       question: "Where should the new convention live?",
       options: [
-        "development/workflow/grilling-with-options.md  [RECOMMENDED — layer-coherent, matches adjacent workflow docs]",
-        "conventions/writing/grilling-with-options.md  [fails layer-coherence; conventions/ is documentation-scoped]",
-        "Let's chat about this  [discuss the decision before committing]"
-      ]
+        {
+          label: "Development workflow (Recommended)",
+          description: "Layer-coherent and matches adjacent workflow documentation."
+        },
+        {
+          label: "Writing convention",
+          description: "Co-locates writing rules but conflicts with the documentation-only layer."
+        },
+        {
+          label: "Let's chat about this",
+          description: "Discuss the placement before selecting an option."
+        }
+      ],
+      multiSelect: false
       // The harness auto-appends a free-text "Other" entry — that is the blank-state type
       // option (answer = whatever the user writes), always present per Rule 8.
     }
@@ -422,16 +471,52 @@ AskUserQuestion({
 
 ### Secondary Harness — OpenCode
 
-OpenCode provides an interactive prompt equivalent. When running in an OpenCode session, use
-its interactive prompt API with 2-4 selectable options per question. If the interactive
-prompt API is unavailable in the current OpenCode version, fall back to the markdown option
-format defined in Rule 6.
+OpenCode provides the `question` tool. When running in an interactive OpenCode root session, use
+`question` with 2-4 substantive options plus the standing `"Let's chat about this"` option per
+question. The client-provided custom answer remains implicit. If `question` is unavailable in the
+current OpenCode version, fall back to the markdown option format defined in Rule 6.
+
+### OpenAI Codex
+
+Codex exposes `request_user_input` to the interactive root thread when the repository enables
+`[features].default_mode_request_user_input = true` in `.codex/config.toml`. Codex currently marks
+this feature as under development and keeps it off by default, so the repository-level opt-in is
+required.
+
+The root orchestrator MUST own every grill and invoke `request_user_input` directly. After the user
+resolves the questions, it passes the structured answers to any delegated `plan-maker` or
+`plan-fixer`; it MUST NOT delegate the user interaction itself.
+
+One `request_user_input` call carries 1–3 tightly coupled question objects. Each object MUST use:
+
+- `header`: a short label of at most 12 characters
+- `id`: a stable `snake_case` identifier
+- `question`: one self-contained decision prompt
+- `options`: 2–3 option objects total; Rule 2's two-substantive-option minimum plus the standing
+  **"Let's chat about this"** option means a grill uses exactly 3
+
+Put the Recommended option first and suffix its label with `(Recommended)`. Every option object has
+a 1–5 word `label`, including that suffix, and a one-sentence trade-off in `description`. Do not add
+an `Other` option because the client supplies the free-form entry. Each question accepts one answer
+only; never request or simulate multi-select.
+
+When any decision has 3–4 substantive leaves, the root MUST render a complete staged
+decision tree. Every `request_user_input` question still carries exactly 2 substantive branch
+options plus chat. A branch may group remaining leaves only when its label and description enumerate
+them; selecting it opens a subsequent question until every original leaf is reachable exactly once.
+The root MUST NOT omit or silently collapse leaves to satisfy the per-question limit.
+
+A non-root subagent returns `## User Decisions Required` to the root and stops; it MUST NOT render a
+user prompt or select an answer. The root asks through `request_user_input`, then resumes or
+reinvokes the delegated agent with the resolved answers. A non-interactive root, including
+`codex exec`, emits the Rule 6 markdown fallback to its caller.
 
 ### All Other Harnesses
 
-Any harness that does not provide a native interactive multiple-choice tool falls back to the
-inline markdown format defined in Rule 6. The structured format requirements (Rules 2–5) are
-identical regardless of rendering mechanism.
+A genuinely non-interactive root or harness without a native interactive multiple-choice tool emits
+the inline markdown format defined in Rule 6 to its caller. A subagent returns unresolved decisions
+to the root and stops. The structured format requirements (Rules 2–5) are identical regardless of
+rendering mechanism.
 
 ## Related Documentation
 

--- a/repo-governance/development/workflow/grilling-with-options.md
+++ b/repo-governance/development/workflow/grilling-with-options.md
@@ -194,6 +194,32 @@ client's implicit custom answer. After the envelope, the specialist stops. The r
 decision through its native UI, then resumes or reinvokes the specialist with the resolved answer.
 Direct custom-agent callers receive the same envelope.
 
+#### Staged Native Rendering
+
+When a native tool can display only 2–3 substantive options while a decision envelope contains
+3–4 substantive leaves, the root MUST render a complete staged decision tree rather than trimming
+the envelope. This procedure applies to Claude, Codex, and every other native tool with that
+effective limit:
+
+1. Retain every original leaf, its stable ID, trade-off, and the one recommendation in the envelope.
+2. Partition the leaves into two named branch groups: one leaf versus the remaining two for three
+   leaves, or two leaves versus two leaves for four. Each root-stage label and description MUST name
+   every leaf it contains; a grouped branch is navigation, never a collapsed or selected outcome.
+3. Render the two branch groups plus **"Let's chat about this"**. The tool-provided free-form
+   **"Other"** entry remains the type-your-own blank state. The root-stage recommendation identifies
+   the recommended branch and gives its context-grounded rationale.
+4. After the user selects a group, render that group's original leaves as the next single-choice
+   question, again with chat and type available and exactly one context-grounded recommendation.
+   Continue staging if a future tool limit requires it; a write-in that creates a new branch follows
+   Rule 7 before continuing.
+5. Record only the final original leaf as the answer. Every original leaf MUST remain reachable
+   exactly once; the root MUST NOT omit, silently collapse, auto-select, or reinterpret any leaf to
+   fit a native tool's limit.
+
+The staged UI is a rendering of the exhaustive envelope, not a weaker substitute for it. Chat and
+the blank-state type path are required at every stage, and the resulting final leaf remains subject
+to the envelope's one-decision, trade-off, and recommendation requirements.
+
 Only a genuinely non-interactive root or harness without a native tool falls back to inline
 markdown options emitted to its caller in the following format:
 
@@ -438,6 +464,7 @@ with:
 `AskUserQuestion` returns a structured response the agent uses directly without parsing
 free-text. A delegated agent returns unresolved decisions to the root and stops; only a genuinely
 non-interactive root without `AskUserQuestion` emits the markdown fallback to its caller.
+For a 3–4-leaf envelope, the root follows [Staged Native Rendering](#staged-native-rendering).
 
 Example invocation shape:
 
@@ -500,11 +527,7 @@ a 1–5 word `label`, including that suffix, and a one-sentence trade-off in `de
 an `Other` option because the client supplies the free-form entry. Each question accepts one answer
 only; never request or simulate multi-select.
 
-When any decision has 3–4 substantive leaves, the root MUST render a complete staged
-decision tree. Every `request_user_input` question still carries exactly 2 substantive branch
-options plus chat. A branch may group remaining leaves only when its label and description enumerate
-them; selecting it opens a subsequent question until every original leaf is reachable exactly once.
-The root MUST NOT omit or silently collapse leaves to satisfy the per-question limit.
+For a 3–4-leaf envelope, the root follows [Staged Native Rendering](#staged-native-rendering).
 
 A non-root subagent returns `## User Decisions Required` to the root and stops; it MUST NOT render a
 user prompt or select an answer. The root asks through `request_user_input`, then resumes or
@@ -515,8 +538,9 @@ reinvokes the delegated agent with the resolved answers. A non-interactive root,
 
 A genuinely non-interactive root or harness without a native interactive multiple-choice tool emits
 the inline markdown format defined in Rule 6 to its caller. A subagent returns unresolved decisions
-to the root and stops. The structured format requirements (Rules 2–5) are identical regardless of
-rendering mechanism.
+to the root and stops. A native tool with a 2–3-substantive-option limit follows
+[Staged Native Rendering](#staged-native-rendering). The structured format requirements (Rules 2–5)
+are identical regardless of rendering mechanism.
 
 ## Related Documentation
 

--- a/repo-governance/development/workflow/grilling-with-options.md
+++ b/repo-governance/development/workflow/grilling-with-options.md
@@ -194,6 +194,42 @@ client's implicit custom answer. After the envelope, the specialist stops. The r
 decision through its native UI, then resumes or reinvokes the specialist with the resolved answer.
 Direct custom-agent callers receive the same envelope.
 
+#### Resolved User Decisions Envelope
+
+After rendering an outbound envelope, the root MUST return this versioned, harness-neutral payload
+to the specialist **verbatim**. It is the only inbound representation of a resolved decision:
+
+````markdown
+## Resolved User Decisions
+
+```yaml
+schema_version: 1
+decisions:
+  - id: stable_snake_case_id
+    answer:
+      kind: selected_option
+      option_id: original_option_id
+  - id: another_stable_snake_case_id
+    answer:
+      kind: custom_answer
+      value: Exact user-supplied answer
+```
+````
+
+`id` MUST be the original decision ID from `## User Decisions Required`. A `selected_option`
+answer MUST name the original leaf ID in `option_id`, including when staged rendering reaches that
+leaf through a branch group. A `custom_answer` MUST preserve the user's answer in `value`; the root
+MUST NOT recast a write-in as a selected option because its text resembles an option label. These
+two discriminated forms make listed selections and user-authored answers unambiguous across every
+harness.
+
+Before performing work that depends on an answer, the receiving specialist MUST validate that the
+payload has `schema_version: 1`, contains each requested decision ID exactly once and no unknown ID,
+uses a known original leaf ID for every `selected_option`, and carries a non-empty `value` for every
+`custom_answer`. On failure, it MUST stop and request a corrected resolved-decision payload; it
+MUST NOT infer, normalize, or silently repair an answer. The root constructs this payload only after
+rendering is complete and passes it unchanged on every resume or reinvocation.
+
 #### Staged Native Rendering
 
 When a native tool can display only 2–3 substantive options while a decision envelope contains
@@ -208,17 +244,21 @@ effective limit:
 3. Render the two branch groups plus **"Let's chat about this"**. The tool-provided free-form
    **"Other"** entry remains the type-your-own blank state. The root-stage recommendation identifies
    the recommended branch and gives its context-grounded rationale.
-4. After the user selects a group, render that group's original leaves as the next single-choice
-   question, again with chat and type available and exactly one context-grounded recommendation.
-   Continue staging if a future tool limit requires it; a write-in that creates a new branch follows
-   Rule 7 before continuing.
-5. Record only the final original leaf as the answer. Every original leaf MUST remain reachable
-   exactly once; the root MUST NOT omit, silently collapse, auto-select, or reinterpret any leaf to
-   fit a native tool's limit.
+4. After the user selects a group containing multiple original leaves, render those leaves as the
+   next single-choice question, again with chat and type available and exactly one context-grounded
+   recommendation. If the selected group contains one original leaf, it is terminal: record that
+   original leaf ID immediately and do not pose a singleton follow-up. Continue staging only when a
+   selected group has multiple leaves; a write-in that creates a new branch follows Rule 7 before
+   continuing.
+5. Record the final original leaf ID through the `selected_option` form in the Resolved User
+   Decisions Envelope. Every original leaf MUST remain reachable exactly once; the root MUST NOT
+   omit, silently collapse, auto-select, or reinterpret any leaf to fit a native tool's limit.
 
 The staged UI is a rendering of the exhaustive envelope, not a weaker substitute for it. Chat and
-the blank-state type path are required at every stage, and the resulting final leaf remains subject
-to the envelope's one-decision, trade-off, and recommendation requirements.
+the blank-state type path are required at every rendered stage, and the resulting final leaf remains
+subject to the envelope's one-decision, trade-off, and recommendation requirements. Every staged
+root renders two branch groups plus Chat at the first stage, and two leaves plus Chat at a multi-leaf
+follow-up; its platform binding defines any additional native-tool constraints.
 
 Only a genuinely non-interactive root or harness without a native tool falls back to inline
 markdown options emitted to its caller in the following format:
@@ -511,8 +551,9 @@ this feature as under development and keeps it off by default, so the repository
 required.
 
 The root orchestrator MUST own every grill and invoke `request_user_input` directly. After the user
-resolves the questions, it passes the structured answers to any delegated `plan-maker` or
-`plan-fixer`; it MUST NOT delegate the user interaction itself.
+resolves the questions, it constructs and passes the canonical Resolved User Decisions Envelope
+verbatim to any delegated `plan-maker` or `plan-fixer`; it MUST NOT delegate the user interaction
+itself.
 
 One `request_user_input` call carries 1–3 tightly coupled question objects. Each object MUST use:
 
@@ -527,7 +568,10 @@ a 1–5 word `label`, including that suffix, and a one-sentence trade-off in `de
 an `Other` option because the client supplies the free-form entry. Each question accepts one answer
 only; never request or simulate multi-select.
 
-For a 3–4-leaf envelope, the root follows [Staged Native Rendering](#staged-native-rendering).
+For a 3–4-leaf envelope, the root follows [Staged Native Rendering](#staged-native-rendering): the
+first stage has two branch groups plus Chat, and a multi-leaf follow-up has two original leaves plus
+Chat. A selected singleton group is terminal and records its original leaf ID without a follow-up
+prompt.
 
 A non-root subagent returns `## User Decisions Required` to the root and stops; it MUST NOT render a
 user prompt or select an answer. The root asks through `request_user_input`, then resumes or

--- a/repo-governance/workflows/plan/plan-planning.md
+++ b/repo-governance/workflows/plan/plan-planning.md
@@ -479,14 +479,20 @@ Delegate via the Agent tool. Provide a self-contained handoff prompt containing 
 scaffold in the plan folder as part of every generated plan, per the
 [Knowledge Capture Convention](../../development/quality/knowledge-capture.md).
 
-**Note on plan-maker's own grill protocol**: `plan-maker` mandates a pre-write grill (Step 1) and
-a post-write grill (Step 8). When invoked by `plan-establishment`, these become
-**validation passes** — macro-decisions are already resolved. Micro-decisions (exact Gherkin
-phrasing, section ordering, step granularity) are still resolved by plan-maker's grills.
+**Decision-envelope loop (HARD GATE)**: After every `plan-maker` invocation, inspect its response.
+If it returns `## User Decisions Required` in the
+[canonical envelope schema](../../development/workflow/grilling-with-options.md#user-decisions-required-envelope),
+the root invokes `grill-me` through the native UI when available (or emits the convention's markdown
+fallback to its caller), records the answers by stable decision ID, and resumes or reinvokes
+`plan-maker` with them. Repeat until `plan-maker` returns completed artifacts without an envelope.
+An envelope is a required checkpoint, not a failure, and MUST NOT skip plan-maker's post-write
+validation grill. Macro-decisions from Steps 1 and 3 remain resolved; later envelopes cover only
+newly discovered or validation-pass micro-decisions.
 
 **Output**: Plan files created in the resolved `<plan-dir>`.
 
-**On failure**: Terminate with status `fail`. Surface the error.
+**On failure**: Terminate with status `fail` only for a technical error. A
+`## User Decisions Required` envelope enters the loop above instead.
 
 ### 5. Plan Review (Sequential)
 
@@ -516,7 +522,9 @@ Read the created plan files and verify structural completeness before the qualit
 10. Verify `tech-docs.md` has a `## File-Impact Analysis` whose primary view is one root-relative,
     annotated file tree with `[E]`/`[N]`/`[D]`/`[G]` markers. If `### More Detail` exists, verify it
     immediately follows the tree and provides context rather than a second prose scope list.
-11. If structural gaps found: provide a focused prompt to `plan-maker` or fix trivially via `Edit`
+11. If structural gaps found: provide a focused prompt to `plan-maker` or fix trivially via `Edit`.
+    Any reinvoked `plan-maker` response follows the same decision-envelope loop from Step 4; do not
+    treat its envelope as the one-retry failure.
 
 **Output**: Plan structurally complete. Ready for quality gate.
 

--- a/repo-governance/workflows/plan/plan-planning.md
+++ b/repo-governance/workflows/plan/plan-planning.md
@@ -484,7 +484,10 @@ If it returns `## User Decisions Required` in the
 [canonical envelope schema](../../development/workflow/grilling-with-options.md#user-decisions-required-envelope),
 the root invokes `grill-me` through the native UI when available (or emits the convention's markdown
 fallback to its caller), records the answers by stable decision ID, and resumes or reinvokes
-`plan-maker` with them. Repeat until `plan-maker` returns completed artifacts without an envelope.
+`plan-maker` with them. After rendering, the root MUST construct the canonical
+[Resolved User Decisions Envelope](../../development/workflow/grilling-with-options.md#resolved-user-decisions-envelope)
+from the original IDs and pass that payload verbatim; `plan-maker` validates it before dependent
+work. Repeat until `plan-maker` returns completed artifacts without an envelope.
 An envelope is a required checkpoint, not a failure, and MUST NOT skip plan-maker's post-write
 validation grill. Macro-decisions from Steps 1 and 3 remain resolved; later envelopes cover only
 newly discovered or validation-pass micro-decisions.

--- a/repo-governance/workflows/plan/plan-quality-gate.md
+++ b/repo-governance/workflows/plan/plan-quality-gate.md
@@ -51,6 +51,7 @@ outputs:
 
 **Preferred Mode**: Agent Delegation — invoke `plan-checker` and `plan-fixer` via the Agent
 tool with `subagent_type` (see [Workflow Execution Modes Convention](../meta/execution-modes.md)).
+The calling root owns every user interaction; delegated specialists return decision envelopes.
 
 **Fallback Mode**: Manual Orchestration — execute workflow logic directly using
 Read/Write/Edit tools when Agent Delegation is unavailable.
@@ -68,9 +69,11 @@ The AI will:
 
 1. Invoke `plan-checker` via the Agent tool (reads plan files, writes audit report)
 2. Invoke `plan-fixer` via the Agent tool (reads audit, applies fixes, writes fix report)
-3. Iterate until zero findings achieved
-4. Show git status with modified files
-5. Wait for user commit approval
+3. Resolve any `## User Decisions Required` envelope through root-owned `grill-me`, then resume or
+   reinvoke the fixer
+4. Iterate until zero findings achieved
+5. Show git status with modified files
+6. Wait for user commit approval
 
 **Fallback (Manual Mode)**:
 
@@ -195,7 +198,16 @@ Apply all validated fixes from the audit report.
 
 **Success criteria**: Fixer successfully applies all fixes without errors.
 
-**On failure**: Log errors, proceed to step 4 for verification.
+**Decision-envelope loop (HARD GATE)**: If `plan-fixer` returns `## User Decisions Required`, the
+root validates it against the
+[canonical envelope schema](../../development/workflow/grilling-with-options.md#user-decisions-required-envelope),
+invokes `grill-me` through its native UI when available (or emits the convention's markdown fallback
+to its caller), records answers by stable decision ID, and resumes or reinvokes `plan-fixer`. Repeat
+until the fixer returns completed fixes without an envelope. An envelope is not a failure, skipped
+fix, or iteration; do not advance to Step 4 while it remains unresolved.
+
+**On failure**: For a technical error, log it and proceed to Step 4 for verification. Never classify
+a `## User Decisions Required` envelope as failure.
 
 **Notes**:
 
@@ -279,6 +291,8 @@ Report final status and summary.
 **Failure** (`fail`):
 
 - Checker or fixer encountered technical errors
+
+`## User Decisions Required` is a resumable checkpoint, not a failure or partial result.
 
 **Note**: Below-threshold findings are reported in final audit but don't prevent success status. Success requires two consecutive zero-finding validations (consecutive pass requirement).
 
@@ -493,7 +507,8 @@ Track across executions:
 
 ## Notes
 
-- **Fully automated**: No human checkpoints, runs to completion
+- **Root-orchestrated**: Runs automatically except explicit `## User Decisions Required`
+  checkpoints, which the root resolves and feeds back to the specialist
 - **Idempotent**: Safe to run multiple times, won't break working plans
 - **Conservative**: Fixer skips uncertain changes (preserves plan intent)
 - **Observable**: Generates audit reports for every iteration
@@ -505,7 +520,8 @@ This workflow ensures plan quality and implementation readiness through iterativ
 ## Principles Implemented/Respected
 
 - PASS: **Explicit Over Implicit**: All steps, conditions, and termination criteria are explicit
-- PASS: **Automation Over Manual**: Fully automated validation and fixing without human intervention
+- PASS: **Automation Over Manual**: Automates validation and unambiguous fixes while routing genuine
+  decisions through explicit root-owned checkpoints
 - PASS: **Simplicity Over Complexity**: Clear linear flow with loop control
 - PASS: **Accessibility First**: Generates human-readable audit reports
 - PASS: **Progressive Disclosure**: Can run with different scopes and iteration limits

--- a/repo-governance/workflows/plan/plan-quality-gate.md
+++ b/repo-governance/workflows/plan/plan-quality-gate.md
@@ -203,8 +203,11 @@ root validates it against the
 [canonical envelope schema](../../development/workflow/grilling-with-options.md#user-decisions-required-envelope),
 invokes `grill-me` through its native UI when available (or emits the convention's markdown fallback
 to its caller), records answers by stable decision ID, and resumes or reinvokes `plan-fixer`. Repeat
-until the fixer returns completed fixes without an envelope. An envelope is not a failure, skipped
-fix, or iteration; do not advance to Step 4 while it remains unresolved.
+until the fixer returns completed fixes without an envelope. After rendering, the root MUST
+construct the canonical [Resolved User Decisions Envelope](../../development/workflow/grilling-with-options.md#resolved-user-decisions-envelope)
+from the original IDs and pass that payload verbatim; `plan-fixer` validates it before dependent
+work. An envelope is not a failure, skipped fix, or iteration; do not advance to Step 4 while it
+remains unresolved.
 
 **On failure**: For a technical error, log it and proceed to Step 4 for verification. Never classify
 a `## User Decisions Required` envelope as failure.


### PR DESCRIPTION
## Summary

- enable Codex native grilling in root sessions
- route specialist decision handoffs through the root orchestrator
- synchronize Claude Code and OpenCode bindings

## Validation

- two completed review cycles: 4 findings fixed and resolved
- full harness audit, binding and sync validation, markdown and diff checks
- Codex CLI behavior: `codex features list` reports `default_mode_request_user_input` enabled; strict project-config parsing succeeds

## Surface verification

This changes repository configuration and agent instructions, not an application UI or API. The reachable Codex CLI configuration surface was exercised through the feature listing and strict configuration parser; both accepted the project setting. UI and API tester gates are not applicable.