### PR TITLE
docs(plans): add PR review rule convergence

### DIFF
--- a/plans/in-progress/README.md
+++ b/plans/in-progress/README.md
@@ -11,6 +11,9 @@ execution checklist.
 
 ## Active Plans
 
+- [pr-review-rule-convergence](./pr-review-rule-convergence/README.md) — Routes executable PRs through
+  a bounded, convergence-aware review cycle, keeps prose delivery on its named CI workflow, and
+  aligns secret remediation plus public/private governance parity.
 - [repository-onboarding-readme-refresh](./repository-onboarding-readme-refresh/README.md) — Refreshes
   living reader-facing READMEs, onboarding journeys, related docs, and GitHub About metadata across
   `ose-public`, `ose-primer`, and `ose-private`, with product-first paths, fresh-checkout proof, and

--- a/plans/in-progress/pr-review-rule-convergence/README.md
+++ b/plans/in-progress/pr-review-rule-convergence/README.md
@@ -1,0 +1,98 @@
+# PR Review Rule Convergence
+
+## Status
+
+In Progress — plan-quality validation and the initial plan-delivery PR are the active prerequisites
+to implementation.
+
+## Context
+
+The current PR Review Maker→Fixer Cycle is a fixed three-pass gate for every `*-to-pr` delivery,
+including prose-only and plan-only pull requests. Its exit and merge rules are duplicated across the
+workflow, merge protocol, plan convention, root instructions, and agent guidance. That broad default
+adds review work where the repository's deterministic PR quality gate is sufficient, while it does not
+create a structured learning loop when a code review takes many passes to converge.
+
+This plan replaces that shape with a diff-classified policy. A PR touching executable behavior gets a
+strict, sequential review loop of up to seven cycles and may exit as soon as no Medium, High, or
+Critical code finding remains. Other PRs merge after `.github/workflows/pr-quality-gate.yml` succeeds.
+The same decision rule applies whether work came from a plan or an ad-hoc task.
+
+## Scope
+
+### In scope
+
+- Define a behavior-based executable-artifact classifier for PR review eligibility.
+- Update every canonical OSE-public rule that currently mandates a fixed PR-review cycle or broader
+  merge condition.
+- Retrofit every related, forward-looking plan in `plans/backlog/` and `plans/in-progress/` so its
+  delivery instructions use this policy rather than embedding the retired fixed-cycle rule.
+- Require cycle-six-and-later non-convergence learning capture and maintain non-blocking Low findings
+  as deduplicated entries in `plans/ideas/`.
+- Define secret-leak containment, full affected-ref rewrite, compromised-PR replacement, and provider
+  purge-request handling without recording secret values.
+- Propagate patient runner-contention handling: keep the active goal, investigate contention, and poll
+  at the documented cadence rather than cancelling work because CI is queued or stalled.
+- Propagate direct post-completion cleanup across all in-scope repositories: remove each exact plan
+  worktree immediately after its final delivery is complete, while preserving the root checkout.
+- Propagate governance and agent guidance to `ose-private` immediately after the public source change
+  merges, then deliver the same applicable policy changes to `ose-primer` through its own companion PR.
+- Regenerate bindings from the canonical `.claude/` source and validate the generated surfaces.
+
+### Out of scope
+
+- Changing the implementation of `.github/workflows/pr-quality-gate.yml` beyond verifying it.
+- Treating documentation, plan, governance, agent, or skill prose as specialized-review-eligible by
+  itself.
+- Rewriting historical execution records or completed plans merely to make their already-executed
+  delivery claims look current.
+- Altering application behavior, adding a new issue tracker, or exposing a secret in a plan, log,
+  commit, review, or PR description.
+- Claiming that a history rewrite removes data from third-party clones, forks, caches, or notifications.
+
+## Resolved Design Decisions
+
+1. Review eligibility is behavior-based: a tracked artifact is eligible when it can build, test,
+   deploy, provision, validate, or change runtime/CI behavior. This includes `apps/`, `libs/`,
+   `scripts/`, `infra/`, workflows, and equivalent executable configuration.
+2. Eligible PRs run sequential cycles with a maximum of seven and stop after the first completed
+   cycle with no unresolved code-related Medium, High, or Critical finding.
+3. Low code findings are consolidated, dispositioned, and captured in a deduplicated `plans/ideas/`
+   two-pager; they neither extend the cycle nor block merge.
+4. A seventh-cycle PR still cannot merge with a code-related Medium, High, or Critical finding.
+5. A non-eligible PR does not run the specialist cycle; it needs a passing `pr-quality-gate.yml`
+   workflow before merge, subject to universal secret handling.
+6. A confirmed secret leak triggers standing authorization to contain and rotate it, rewrite every
+   reachable affected ref, delete the contaminated branch, replace any contaminated PR, and request
+   provider cache/purge support. The result cannot erase independent external copies.
+7. `ose-public` remains canonical. Its governance PR merges first; a prepared, passing `ose-private`
+   companion is merged immediately afterward, with any temporary skew recorded. This plan then
+   delivers the applicable same-policy OSE Primer companion; it is no longer deferred from this work.
+8. The policy reclassifies every still-open PR at its next review or merge action; no legacy opt-in
+   route remains.
+9. Plan-backed cycle-six-and-later work records sanitized evidence in both its `learnings.md` and a
+   deduplicated idea; ad-hoc work records the reusable learning directly in `plans/ideas/`.
+10. Public/private parity uses an explicit manifest of portable canonical governance, agent, skill, and
+    related-rule files that must be byte-identical. Documented private-only operational files remain
+    outside the manifest.
+11. Runner contention is an expected operational condition: the active goal remains active while the
+    agent investigates and waits at the documented cadence; it is never cancelled solely for a queued
+    or stalled runner.
+12. **One-plan OSE-private exception:** this plan's private changes use a worktree but commit and push
+    directly to `origin/main`, with no private PR or PR-quality wait. This user-authorized exception
+    applies to no other repository, workflow, or future plan.
+13. The concurrent OSE-private PR-quality remediation is outside this plan's ledger. It is never edited
+    or awaited; this plan uses its own worktree based on `origin/main`.
+14. After all plan delivery units in a repository have completed, the executor immediately removes the
+    exact worktree used by this plan. The root checkout is never a cleanup target and remains available
+    for final `origin/main` synchronization.
+15. Every delivery, validation, merge, reconciliation, archival, and cleanup task in this plan is
+    executed by `[AI]`; it declares no human approval, review, or manual-check gate.
+
+## Plan Documents
+
+- [Business requirements](./brd.md)
+- [Product requirements](./prd.md)
+- [Technical design](./tech-docs.md)
+- [Delivery checklist](./delivery.md)
+- [Learnings](./learnings.md)

--- a/plans/in-progress/pr-review-rule-convergence/brd.md
+++ b/plans/in-progress/pr-review-rule-convergence/brd.md
@@ -1,0 +1,65 @@
+# Business Requirements: PR Review Rule Convergence
+
+## Goal
+
+Make review effort proportionate to behavior-changing risk while retaining a clear, bounded path to
+merge and a rigorous response to credential exposure.
+
+## Rationale
+
+The current universal three-cycle review requirement consumes specialist capacity for text-only work
+that is already checked by `.github/workflows/pr-quality-gate.yml`. Conversely, a complex executable
+diff may need more than three review/fix passes; without an explicit cycle-six learning trigger, the
+maintainer gets no reusable explanation of slow convergence.
+
+## Business Impact
+
+- Maintainers spend specialist-review effort on changed executable behavior instead of prose-only
+  delivery, while the named CI workflow remains the merge gate for the latter.
+- A difficult executable change produces reusable evidence and an idea for improving convergence rather
+  than silently consuming more review cycles.
+- A confirmed secret leak has a containment and reachable-history response that does not reproduce the
+  exposed material in new records.
+
+## Affected Roles
+
+- **Repository maintainer**: chooses the correct PR route and observes the final merge conditions.
+- **PR-review orchestrator and specialists**: classify diffs, run only eligible cycles, and capture
+  convergence evidence.
+- **Repo-rules maker**: propagates canonical instructions, generated bindings, and the portable
+  cross-repository manifest.
+- **Security responder**: executes the documented containment and remediation flow without retaining
+  secret values in evidence.
+
+## Success Metrics
+
+- An agent can classify a PR from its diff and determine one merge path without knowing whether the
+  change originated from `plans/`.
+- An eligible PR cannot merge while Medium, High, or Critical code findings remain; the loop ends no
+  later than cycle seven.
+- A non-eligible PR can merge without specialist review after its named quality workflow is green.
+- A secret incident has a credential-safe, executable containment and history-remediation route.
+- Public, private, and Primer governance consumers receive the applicable equivalent rules through
+  documented public-first companion deliveries.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Ambiguous executable-config classification produces inconsistent reviews | Define the classifier by behavior, require the scout to record its evidence, and treat uncertainty as eligible. |
+| Seven cycles normalize unresolved defects | Make seven a ceiling, never a permission to merge with code M/H/C findings; capture why convergence was slow starting at cycle six. |
+| A rewrite amplifies secret exposure through logs or review text | Never copy candidate values; use sanitized incident identifiers and silent scanners only. |
+| Separate public/private merges briefly drift | Prepare and validate the private companion first, merge the public canonical source, then immediately merge the private counterpart and record the reconciliation. |
+| Primer drift persists because it is a delayed-sync consumer | Include its companion delivery and live-plan retrofit in this plan after public/private reconciliation. |
+| Queued CI is mistaken for a failed goal and abandoned | Codify contention investigation and patient cadence-based polling across all in-scope repositories. |
+| The private companion is delayed by an unavailable quality check | Apply the user's one-plan, OSE-private-only direct-push exception while retaining expected-head, secret-safety, and manifest checks. |
+| Concurrent private PR-quality work blocks unrelated delivery | Use a separate plan worktree from `origin/main`; do not modify or wait for foreign work. |
+| Completed plan worktrees accumulate and confuse later work | Propagate immediate, exact-path worktree cleanup after each repository's final plan delivery. |
+
+## Non-Goals
+
+- Guaranteeing removal from private clones, forks, notification emails, or uncooperative third-party
+  caches.
+- Replacing required branch protection or bypassing a failed workflow.
+- Rewriting unrelated OSE Primer product or private-only operational documentation.
+- Extending the OSE-private direct-push exception to another repository, workflow, or plan.

--- a/plans/in-progress/pr-review-rule-convergence/delivery.md
+++ b/plans/in-progress/pr-review-rule-convergence/delivery.md
@@ -1,0 +1,346 @@
+# Delivery Checklist: PR Review Rule Convergence
+
+## Delivery Mode
+
+`worktree-to-pr` in `worktrees/ose-new-rules/` for the OSE-public policy delivery. OSE Primer uses one
+worktree and a separate companion PR. The OSE-private companion uses one worktree but, under the
+user's one-plan exception, commits and pushes directly to `origin/main` with no PR. The public PR
+merges first, the private direct push follows immediately, and the OSE Primer companion follows.
+
+## Worktree
+
+| Repository | Exact plan worktree | Delivery mode | Cleanup owner |
+| --- | --- | --- | --- |
+| OSE Public | `worktrees/ose-new-rules/` | `worktree-to-pr` | `[AI]` after P5 archival merges |
+| OSE Private | `worktrees/pr-review-rule-convergence/` | this-plan direct push to `origin/main` | `[AI]` after P4 verification |
+| OSE Primer | `worktrees/pr-review-rule-convergence/` | `worktree-to-pr` | `[AI]` after P4P merge |
+
+Before work in any repository, run `git fetch origin`, compare `git rev-parse HEAD` with
+`git rev-parse origin/main`, and read the full incoming diff after any integration. Provision only a
+missing exact path with `git worktree add <exact-path> -b <branch> origin/main`; never use a foreign
+or concurrent worktree.
+
+## Delivery Boundaries
+
+| Unit | Repository | Phases | Branch | Boundary | Delivery action |
+| --- | --- | --- | --- | --- | --- |
+| Canonical policy | OSE Public | P1, P1R, P2, P3 | `governance/pr-review-rule-convergence-public` | P3 | Draft PR, applicable review route, merge |
+| Private propagation | OSE Private | P3, P4 | `governance/pr-review-rule-convergence-private` | P4 | Commit and direct push to `origin/main` under this-plan exception |
+| Primer propagation | OSE Primer | P4P | `governance/pr-review-rule-convergence-primer` | P4P | Draft PR, applicable review route, merge |
+| Public closeout | OSE Public | P5 | `docs/pr-review-rule-convergence-closeout` | P5 | Draft archival PR and merge |
+
+## Command Catalog
+
+| ID | Command | Use |
+| --- | --- | --- |
+| C1 | `git status --short && git diff --check` | Safe ledger and diff baseline |
+| C2 | `rg -n -i '<policy-pattern>' <target-paths>` | Canonical and live-plan reference inventory |
+| C3 | `apps/rhino-cli/scripts/rhino-bin.sh gate run --surface=pre-push` | Full local gate registry |
+| C4 | `npm run generate:bindings && npm run validate:sync` | Canonical-agent binding regeneration and validation |
+| C5 | `npm run format:md:check && npm run lint:md` | Markdown validation |
+| C6 | `gh pr checks <pr-number>` | PR final-head status at the required cadence |
+| C7 | `git worktree list && git status --short` | Exact worktree cleanup precondition |
+| C8 | `git worktree remove <exact-plan-worktree>` | Direct cleanup of a verified plan worktree |
+
+## Legend
+
+- `[AI]` — agent executes the task and records sanitized evidence.
+
+Every checkbox in this plan is `[AI]`; no manual review, approval, check, or gate is required.
+
+## Parallelization Model
+
+Chosen N = 3 background slots. Public canonical wording serializes before generated bindings, the
+immediate private companion, and the in-scope Primer companion; read-only reference discovery may run
+independently. Cleanup is terminal.
+
+| Node | Work | blockedBy | blocks |
+| --- | --- | --- | --- |
+| P0 | Baseline and canonical-reference inventory | — | P1 |
+| P1 | Define the public workflow and merge algorithm | P0 | P1R |
+| P1R | Retrofit all related live plans | P1 | P2 |
+| P2 | Propagate public instructions, maker guidance, and generated bindings | P1R | P3 |
+| P3 | Validate and merge the public canonical PR | P2 | P4 |
+| P4 | Merge and reconcile the OSE-private companion | P3 | P4P |
+| P4P | Deliver the OSE Primer companion and retrofit | P4 | P5 |
+| P5 | Capture knowledge, archive, and remove exact plan worktrees | P4P | — |
+
+## Phase 0: Baseline and Inventory
+
+Run C1 before this phase and C2 for every inventory task below. Store only paths, hashes, and
+sanitized statuses in `plans/in-progress/pr-review-rule-convergence/learnings.md`.
+
+- [ ] [AI] [P0-001] Record the starting public branch, worktree status, and path-only file-touch
+  ledger in the plan's `learnings.md` — acceptance: no pre-existing change is claimed.
+- [ ] [AI] [P0-002] Search for every canonical mention of fixed PR-review cycle counts, merge
+  preconditions, executable/configuration routing, secret remediation, and public/private parity —
+  acceptance: the impact tree is reconciled or amended with each discovered canonical path.
+- [ ] [AI] [P0-003] Inspect `.github/workflows/pr-quality-gate.yml` and record its workflow/check names
+  without copying sensitive output — acceptance: later verification targets the exact workflow.
+- [ ] [AI] [P0-004] Inspect `plans/ideas/README.md` and existing two-pagers for an already-owned Low
+  finding/non-convergence topic — acceptance: no duplicate idea is planned.
+- [ ] [AI] [P0-005] Inventory portable governance, agent, skill, and related-rule files shared with
+  OSE-private; record their public path and byte hash in a sanitized manifest — acceptance: every
+  private-only operational exception is explicit.
+
+### Phase 0 Gate
+
+- [ ] [AI] [P0-006] Run C1 in `worktrees/ose-new-rules/` and reconcile its output with the
+  `plans/in-progress/pr-review-rule-convergence/learnings.md` ledger — acceptance: no foreign change
+  is modified.
+
+> **Pause Safety:** Discovery is complete and no policy file has changed. Resume with P1-001.
+
+## Phase 1: Canonical Public Rules
+
+For P1-001 through P1-007B, first run C2 against the named canonical file, edit only that file, then
+run C5 before continuing. Each task changes documentation, not application code, so no TDD cycle is
+applicable.
+
+- [ ] [AI] [P1-001] Update `repo-governance/workflows/pr/pr-review-quality-gate.md` frontmatter and
+  input contract for behavior-based eligibility, default ceiling seven, and early clean M/H/C exit —
+  acceptance: the workflow owns the algorithm rather than a copied variant.
+- [ ] [AI] [P1-002] Add the scout classification record, fail-safe ambiguity behavior, code-finding
+  filter, and sequential cycle transition rules in
+  `repo-governance/workflows/pr/pr-review-quality-gate.md` — acceptance: every PR selects exactly one route.
+- [ ] [AI] [P1-003] Add cycle-six-and-seven sanitized learning capture plus Low-finding disposition to
+  `repo-governance/workflows/pr/pr-review-quality-gate.md` — acceptance: Lows are routed to
+  deduplicated ideas and do not prolong the loop.
+- [ ] [AI] [P1-004] Add the seven-cycle non-convergence merge block for code Medium, High, and Critical
+  findings in `repo-governance/workflows/pr/pr-review-quality-gate.md` — acceptance: a green CI run
+  alone cannot merge that PR.
+- [ ] [AI] [P1-004A] Add immediate reclassification of every still-open PR at its next review or merge
+  action in `repo-governance/workflows/pr/pr-review-quality-gate.md` — acceptance: no legacy or
+  per-PR opt-in route remains.
+- [ ] [AI] [P1-005] Update `repo-governance/development/workflow/pr-merge-protocol.md` preconditions
+  and terminal steps for eligible versus non-eligible PRs — acceptance: non-eligible PRs require the
+  named workflow only, while universal secret handling remains explicit.
+- [ ] [AI] [P1-006] Update `repo-governance/development/quality/pr-review-disciplines.md` to limit
+  specialist findings to eligible code behavior and retain Low-finding evidence requirements —
+  acceptance: severity labels match the new workflow.
+- [ ] [AI] [P1-007] Update `repo-governance/development/workflow/git-push-safety.md` and the canonical
+  secrets rule with the standing full-rewrite and replacement-PR algorithm — acceptance: each names
+  all affected reachable refs and never records a secret value.
+- [ ] [AI] [P1-007A] Update `repo-governance/development/workflow/ci-monitoring.md` so runner contention
+  preserves the active goal and requires patient cadence-based investigation — acceptance: it forbids
+  cancellation solely for a queued or stalled runner and retains the required-check gate.
+- [ ] [AI] [P1-007B] Update `repo-governance/development/workflow/worktree-and-artifact-cleanup.md`,
+  `repo-governance/conventions/structure/plans.md`, and
+  `repo-governance/workflows/plan/plan-execution.md` for immediate exact-path cleanup — acceptance:
+  each preserves root checkouts and excludes foreign worktrees.
+
+## Phase 1R: Retrofit Related Live Plans
+
+For each P1R task, run C2 against the named plan folder, edit only `edit`-classified forward-facing
+documents, then run C5 for that folder. Do not change a completed-plan document or an append-only
+execution record merely to retrofit a historical instruction.
+
+- [ ] [AI] [P1R-001] Create an exact, path-level retrofit manifest from a deterministic search of
+  `plans/backlog/` and `plans/in-progress/` for retired PR-cycle, merge, secret-remediation,
+  public/private-parity, and runner-contention language — acceptance: every candidate is classified
+  `edit`, `current`, or `historical-record-exempt` with a reason.
+- [ ] [AI] [P1R-002] Retrofit every `edit`-classified document in
+  `ayokoding-learning-path-06-course-authoring-architecture-and-ai-harness` — acceptance: its README
+  and delivery instructions route future PRs through the new classifier and cycle ceiling.
+- [ ] [AI] [P1R-003] Retrofit every `edit`-classified document in
+  `ayokoding-learning-path-07-course-authoring-low-level-systems` — acceptance: remaining workflow,
+  merge, and learning instructions no longer mandate a retired fixed cycle.
+- [ ] [AI] [P1R-004] Retrofit every `edit`-classified document in
+  `ayokoding-learning-path-08-course-authoring-security-and-ops` — acceptance: its secret response
+  and PR delivery rules agree with the canonical incident and routing policy.
+- [ ] [AI] [P1R-005] Retrofit every `edit`-classified document in
+  `ayokoding-learning-path-09-course-authoring-interview-technique` — acceptance: requirements,
+  delivery, and learnings references remain mutually consistent.
+- [ ] [AI] [P1R-006] Retrofit every `edit`-classified document in
+  `ayokoding-learning-path-10-course-authoring-jvm-and-build-your-own` — acceptance: its future PR
+  instructions refer to the canonical routing workflow instead of a copied count.
+- [ ] [AI] [P1R-007] Retrofit every `edit`-classified document in
+  `ayokoding-learning-path-11-course-authoring-capstones` — acceptance: its BRD, PRD, README, and
+  delivery references agree with the bounded review policy.
+- [ ] [AI] [P1R-008] Retrofit every `edit`-classified document in
+  `ayokoding-learning-path-12-careers-se-manifests` — acceptance: its future delivery path is
+  plan-origin independent.
+- [ ] [AI] [P1R-009] Retrofit every `edit`-classified document in
+  `ayokoding-learning-path-13-careers-ai-manifest` — acceptance: the specialist loop is conditional
+  on behavior-changing content, not on plan existence.
+- [ ] [AI] [P1R-010] Retrofit every `edit`-classified document in
+  `ayokoding-learning-path-14-skills-accounting-foundations` — acceptance: its planned PR boundary
+  references the same exit, Low-finding, and non-convergence rules.
+- [ ] [AI] [P1R-011] Retrofit every `edit`-classified document in
+  `ayokoding-learning-path-15-skills-accounting-enterprise-reporting` — acceptance: no old merge
+  precondition remains in its active delivery language.
+- [ ] [AI] [P1R-012] Retrofit every `edit`-classified document in
+  `ayokoding-learning-path-16-skills-accounting-sharia-extension` — acceptance: its delivery text
+  delegates to the canonical policy where appropriate.
+- [ ] [AI] [P1R-013] Retrofit every `edit`-classified document in
+  `ayokoding-learning-path-17-skills-erp-foundations` — acceptance: all matching future-facing plan
+  documents are updated while its curriculum content remains untouched.
+- [ ] [AI] [P1R-014] Retrofit every `edit`-classified document in
+  `ayokoding-learning-path-18-skills-erp-enterprise-depth` — acceptance: all matching future-facing
+  plan documents are updated while its curriculum content remains untouched.
+- [ ] [AI] [P1R-015] Retrofit remaining unchecked delivery instructions in
+  `repository-onboarding-readme-refresh` — acceptance: future work uses the new policy and its
+  append-only execution records preserve historical evidence unchanged.
+- [ ] [AI] [P1R-016] Re-run the deterministic live-plan search and manually review every remaining
+  match — acceptance: no forward-facing backlog or active-plan instruction retains the retired rule;
+  every retained historical-record match has an explicit exemption reason.
+
+### Phase 1 Gate
+
+- [ ] [AI] [P1-008] Run C3 and C5 from `worktrees/ose-new-rules/` plus
+  `apps/rhino-cli/scripts/rhino-bin.sh md mermaid validate`,
+  `apps/rhino-cli/scripts/rhino-bin.sh md heading-hierarchy validate`, and
+  `apps/rhino-cli/scripts/rhino-bin.sh md links validate --exclude plans/done` — acceptance: every
+  changed public canonical and retrofitted plan document passes.
+
+> **Pause Safety:** The canonical public algorithm and every related live plan are coherent but not yet propagated to entry points. Resume with P2-001.
+
+## Phase 2: Manual and Generated Propagation
+
+For P2-001 through P2-004, run C2 against the named canonical path before editing it. Run C4 after
+the `.claude/agents/repo-rules-maker.md` edit; do not hand-edit generated mirrors.
+
+- [ ] [AI] [P2-001] Update `AGENTS.md` with the plan-independent eligible/non-eligible routing,
+  cycle ceiling, convergence, secret, parity, and runner-contention rules — acceptance: all interactive
+  roots receive the same decision rule.
+- [ ] [AI] [P2-002] Update Plans Organization so plan execution does not create a different review
+  path from ad-hoc work — acceptance: planned and unplanned PRs point to one canonical workflow.
+- [ ] [AI] [P2-003] Update Related Repositories with public-first, immediate private governance
+  reconciliation, this plan's OSE Primer companion, runner contention, and direct cleanup — acceptance:
+  it states the bounded skew and all three delivery paths honestly.
+- [ ] [AI] [P2-004] Update `.claude/agents/repo-rules-maker.md` to require manual canonical propagation,
+  generated-binding regeneration, patient runner-contention guidance, and portable public/private
+  byte-identity verification — acceptance: the maker cannot update one rule surface in isolation or
+  silently omit a parity-manifest exception.
+- [ ] [AI] [P2-005] Run `npm run generate:bindings` — acceptance: generated harness mirrors are changed
+  only by the generator and remain in the same delivery diff as their `.claude/` source.
+- [ ] [AI] [P2-006] Run `npm run validate:sync` — acceptance: canonical and generated bindings agree.
+
+### Phase 2 Gate
+
+- [ ] [AI] [P2-007] Run C3, C4, and C5 from `worktrees/ose-new-rules/` — acceptance: public entry
+  points, canonical rules, and generated files are all clean.
+
+> **Pause Safety:** Public policy and all local bindings are ready for a draft PR. Resume with P3-001.
+
+## Phase 3: Public Delivery
+
+Use `git add -- <ledger-paths>`, `git commit -m 'docs(governance): converge PR review rules'`, and
+`git push -u origin governance/pr-review-rule-convergence-public` for P3-003. Use
+`gh pr create --draft --base main --head governance/pr-review-rule-convergence-public` for P3-004,
+C6 for its status, and `gh pr merge <public-pr> --merge --delete-branch` only after P3-005 passes.
+
+- [ ] [AI] [P3-001] Create a sanitized OSE-private companion diff and governed-path equivalence manifest
+  in its own repository/worktree — acceptance: no private facts are copied into OSE-public.
+- [ ] [AI] [P3-002] Prepare the OSE-private worktree diff and verify its intended post-public base,
+  secret-safety status, and public/private byte-identity manifest — acceptance: it is ready for the
+  one-plan direct push without a PR or PR-quality wait.
+- [ ] [AI] [P3-002A] Record the narrow user-authorized OSE-private direct-push exception in sanitized
+  delivery evidence — acceptance: it names this plan only, never a reusable bypass.
+- [ ] [AI] [P3-003] Commit and push the public policy branch using a Conventional Commit — acceptance:
+  the explicit file-touch ledger matches the staged paths.
+- [ ] [AI] [P3-004] Open a draft public PR and verify the `pr-quality-gate` workflow's final-head run —
+  acceptance: every required job in that workflow is green.
+- [ ] [AI] [P3-004A] If the public workflow is queued or stalled, investigate shared runner contention
+  and continue polling at the documented cadence — acceptance: the active goal remains active and no
+  run is cancelled merely to escape a queue.
+- [ ] [AI] [P3-005] Classify this policy PR under the new behavior-based rule and perform only the
+  applicable review route — acceptance: the route and evidence are recorded without circular guessing.
+- [ ] [AI] [P3-006] Merge the public PR after its selected route and named workflow pass — acceptance:
+  public canonical content is on `main`.
+
+### Phase 3 Gate
+
+- [ ] [AI] [P3-007] Run `git fetch origin && git rev-parse origin/main` in OSE Public and
+  `git rev-parse HEAD` in the private worktree; record the revisions and manifest digest in the
+  sanitized reconciliation record — acceptance: P4 can execute without rediscovery.
+
+> **Pause Safety:** Public is canonical and private is prepared. Resume immediately with P4-001.
+
+## Phase 4: OSE-Private Reconciliation
+
+Use `git add -- <private-ledger-paths>`, `git commit -m 'docs(governance): converge PR review rules'`,
+and `git push origin HEAD:main` only for this plan's exact private worktree after P4-001 succeeds.
+
+- [ ] [AI] [P4-001] Reconfirm the private companion still matches the final public governed-path
+  manifest byte-for-byte — acceptance: any public merge-time edit is propagated before private merge.
+- [ ] [AI] [P4-002] Commit the OSE-private worktree and push its verified change directly to
+  `origin/main` immediately after public merge — acceptance: post-public base, secret-safety, and
+  manifest checks passed; no PR or quality-check result is required.
+- [ ] [AI] [P4-003] Record public/private revisions, manifest outcome, and temporary-skew closure using
+  safe identifiers only — acceptance: governed paths are on-par after the companion merge.
+- [ ] [AI] [P4-005] Run C7 in `worktrees/pr-review-rule-convergence/` for OSE-private, then run C8
+  against that exact path — acceptance: only this plan's clean private worktree is removed immediately.
+
+### Phase 4 Gate
+
+- [ ] [AI] [P4-004] Run `shasum -a 256 <manifest-paths>` in the public and private repository roots and
+  compare the sanitized manifest — acceptance: zero unintended divergence; the ready OSE Primer
+  companion is explicitly in scope.
+
+> **Pause Safety:** Public/private parity is restored. Resume with P4P-001.
+
+## Phase 4P: OSE Primer Companion and Retrofit
+
+Use C1 and C2 in the OSE Primer worktree before edits, C4 after canonical agent edits, C3 and C5
+before push, `git push -u origin governance/pr-review-rule-convergence-primer`,
+`gh pr create --draft --base main --head governance/pr-review-rule-convergence-primer`, C6, and
+`gh pr merge <primer-pr> --merge --delete-branch` after the selected review route passes.
+
+- [ ] [AI] [P4P-001] Provision or enter the plan's single OSE Primer worktree and record its separate
+  file-touch ledger — acceptance: no OSE-public or OSE-private working tree is modified from Primer.
+- [ ] [AI] [P4P-002] Build an applicable-policy manifest from final public canonical files, naming each
+  documented Primer-specific path or wording exception — acceptance: every routing, convergence, and
+  secret-response rule has a Primer disposition.
+- [ ] [AI] [P4P-003] Propagate the applicable PR-review workflow, merge protocol, plan convention,
+  CI-monitoring, root instructions, and repo-rules-maker guidance in OSE Primer — acceptance: its
+  canonical sources implement the same policy semantics.
+- [ ] [AI] [P4P-004] Regenerate OSE Primer bindings from `.claude/` and run its binding-sync validation
+  — acceptance: no generated mirror is hand-edited or omitted from the companion diff.
+- [ ] [AI] [P4P-005] Search OSE Primer's `plans/backlog/` and `plans/in-progress/`, classify every
+  retired-rule match, and retrofit each forward-facing plan document — acceptance: its live plans no
+  longer encode the retired fixed-cycle rule; historical execution records stay historical.
+- [ ] [AI] [P4P-006] Run applicable OSE Primer Markdown, policy-manifest, and quality-gate checks —
+  acceptance: changed canonical, generated, and plan files pass without a bypass.
+- [ ] [AI] [P4P-007] Commit, push, open a draft OSE Primer companion PR, apply its classifier-selected
+  review route, and verify its final-head `pr-quality-gate` run — acceptance: the PR is ready to merge
+  under the new plan-independent policy.
+- [ ] [AI] [P4P-007A] If the OSE Primer workflow is queued or stalled, investigate contention and
+  continue patient monitoring — acceptance: runner availability never cancels the active goal.
+- [ ] [AI] [P4P-008] Merge the passing OSE Primer companion and record public/private/Primer revision
+  reconciliation using safe identifiers only — acceptance: this plan's three-repository policy change
+  is complete.
+- [ ] [AI] [P4P-010] Run C7 in the OSE Primer `worktrees/pr-review-rule-convergence/`, then run C8
+  against that exact path — acceptance: only this plan's clean OSE Primer worktree is removed immediately.
+
+### Phase 4P Gate
+
+- [ ] [AI] [P4P-009] Run `git fetch origin && git rev-parse origin/main` and C2 against OSE Primer
+  `plans/backlog/ plans/in-progress/` — acceptance: all in-scope Primer changes landed and every
+  exception is documented.
+
+> **Pause Safety:** The three-repository policy rollout is complete. Resume with P5-001.
+
+## Phase 5: Knowledge, Archive, and Cleanup
+
+Use `git mv plans/in-progress/pr-review-rule-convergence
+plans/done/2026-08-11__pr-review-rule-convergence`, update the two plan indexes, run C3 and C5, then
+create and merge the `docs/pr-review-rule-convergence-closeout` archival PR before P5-004.
+
+- [ ] [AI] [P5-001] Triage every `learnings.md` item: move reusable items into an existing/new
+  `plans/ideas/` two-pager, or record the explicit none outcome — acceptance: no untriaged learning
+  remains.
+- [ ] [AI] [P5-002] Move the completed plan to `plans/done/YYYY-MM-DD__pr-review-rule-convergence/`
+  and update plan indexes — acceptance: archival is included in the public delivery boundary.
+- [ ] [AI] [P5-003] Reconcile `git status --short` with the full file-touch ledger — acceptance:
+  no foreign file is staged or committed.
+- [ ] [AI] [P5-004] Run C7 in `worktrees/ose-new-rules/`, verify its public delivery units and archival
+  PR are complete, then run C8 against `worktrees/ose-new-rules/` — acceptance: only this plan's clean
+  public worktree is removed immediately; no root checkout, broad path, glob, or foreign worktree is targeted.
+
+### Phase 5 Gate
+
+- [ ] [AI] [P5-005] Confirm all delivery nodes P0–P5 have evidence, planned indexes are current, and
+  only repository root checkouts remain — acceptance: the plan has a safe terminal state.
+
+> **Pause Safety:** The implementation is archived, all exact plan worktrees are removed, and root checkouts remain for final synchronization.

--- a/plans/in-progress/pr-review-rule-convergence/learnings.md
+++ b/plans/in-progress/pr-review-rule-convergence/learnings.md
@@ -1,0 +1,6 @@
+# Learnings: PR Review Rule Convergence
+
+<!-- Append sanitized, generalizable convergence observations during execution. -->
+<!-- Never record secret values, matching fragments, private paths, or hosting-provider case details. -->
+<!-- Before archival, triage every entry to an existing/new plans/ideas two-pager or record none. -->
+

--- a/plans/in-progress/pr-review-rule-convergence/prd.md
+++ b/plans/in-progress/pr-review-rule-convergence/prd.md
@@ -1,0 +1,146 @@
+# Product Requirements: PR Review Rule Convergence
+
+## Product Overview
+
+This policy is the repository's deterministic decision surface for reviewing and merging pull
+requests. It gives every agent one route for executable changes and a lightweight route for
+non-executable changes, independent of whether a plan initiated the delivery.
+
+## Personas
+
+- **Maintainer**: needs a predictable merge decision without running expensive review work for prose.
+- **PR-review orchestrator**: must route a PR deterministically and retain evidence for the chosen path.
+- **Repo-rules maker**: must apply the same rule coherently to governance documentation and generated
+  harness bindings.
+
+## User Stories
+
+- As a maintainer, I want a code-affecting PR to receive a bounded, substantive review loop so it is
+  safe to merge without routine human approval.
+- As a maintainer, I want a prose-only PR to merge after the named CI workflow so routine documentation
+  work is not delayed by irrelevant specialist review.
+- As a security responder, I want a confirmed leak to use a documented full-history response so the
+  exposed value is not retained in reachable repository or PR history.
+
+## Acceptance Criteria
+
+### Eligible PR exits early
+
+```gherkin
+Scenario: An executable PR reaches a clean review state before the ceiling
+  Given an open PR with an executable artifact in its diff
+  And its latest completed cycle has no unresolved code-related Medium, High, or Critical finding
+  When the orchestrator evaluates the cycle result
+  Then it stops the specialist cycle without starting another pass
+  And it may merge only after the configured quality workflow is green
+```
+
+### Eligible PR fails to converge
+
+```gherkin
+Scenario: An executable PR still has a qualifying code finding at cycle seven
+  Given an open eligible PR has completed seven sequential cycles
+  And a code-related Medium, High, or Critical finding remains
+  When the merge preconditions are evaluated
+  Then the PR is not merged
+  And cycle-six-or-later learning evidence and any reusable improvement idea are recorded
+```
+
+### Non-eligible PR follows the lightweight route
+
+```gherkin
+Scenario: A prose-only PR is ready to merge
+  Given an open PR changes no executable artifact
+  And .github/workflows/pr-quality-gate.yml has succeeded for its head commit
+  When the merge route is evaluated
+  Then the specialist PR-review cycle is skipped
+  And the PR is merged unless universal secret handling blocks it
+```
+
+### Open PRs transition immediately
+
+```gherkin
+Scenario: A PR was open when the policy landed
+  Given a PR predates the policy merge
+  When it next enters a review or merge action
+  Then the orchestrator classifies its current diff under the new routing rule
+  And it does not retain a legacy review path
+```
+
+### Runner contention preserves the active goal
+
+```gherkin
+Scenario: A PR workflow is queued because runners are contended
+  Given the PR's current-head quality workflow is queued or stalled
+  When the agent monitors the workflow
+  Then it retains the active goal
+  And it investigates cross-repository runner contention at the documented cadence
+  And it does not cancel the goal solely because runner capacity is unavailable
+```
+
+### The OSE-private companion uses its one-plan direct-push exception
+
+```gherkin
+Scenario: This plan's OSE-private companion is ready to deliver
+  Given the companion's expected head and public/private byte-identity manifest are verified
+  And no secret incident blocks the delivery
+  When the public canonical revision has merged
+  Then the agent commits and pushes the private worktree directly to origin main
+  And it does not extend that exception to another repository, workflow, or plan
+```
+
+### Completion removes the exact plan worktree
+
+```gherkin
+Scenario: A repository has completed this plan's final delivery
+  Given every delivery unit for that repository is merged or pushed
+  And the repository has no uncommitted or unpushed plan change
+  When the executor completes its post-delivery verification
+  Then it removes the exact worktree used by this plan immediately
+  And it retains the repository root checkout for final origin main synchronization
+```
+
+### AI completes the entire delivery
+
+```gherkin
+Scenario: The plan reaches a delivery or verification boundary
+  Given all required evidence for the boundary is available to the agent
+  When the next task is selected
+  Then the agent performs the task and its verification without a human approval gate
+  And it records the result in the persistent delivery checklist
+```
+
+### Confirmed secret leak replaces a PR
+
+```gherkin
+Scenario: A real secret is confirmed in an open PR history
+  Given the secret is contained and rotated without exposing its value in evidence
+  When affected reachable refs are identified
+  Then each affected ref is rewritten under the standing incident authorization
+  And the contaminated branch and PR are replaced with a clean branch and PR
+  And provider purge support is requested without claiming external copies were erased
+```
+
+## Product Scope
+
+The rule covers all planned and ad-hoc PR delivery work. A text change only becomes review-eligible
+when its content itself controls behavior, such as a workflow, script, runtime configuration, or
+validation registry; its filename extension or plan origin does not decide eligibility.
+
+### In Scope
+
+- Review classification, bounded review cycles, merge routing, convergence learning, secret response,
+  runner-contention handling, plan-worktree cleanup, and cross-repository propagation.
+
+### Out of Scope
+
+- Application features, UI/API behavior, external clone deletion, and a reusable direct-push exception
+  for non-private deliveries.
+
+## Product Risks
+
+- A classifier may be ambiguous for a novel configuration surface; the safe route is eligible review.
+- A single-plan delivery exception could be copied into standing governance; it is therefore recorded
+  only in this plan and must not be propagated as a canonical rule.
+- A delayed or failed cross-repository companion can produce temporary drift; manifests and the defined
+  delivery ordering make that drift observable.

--- a/plans/in-progress/pr-review-rule-convergence/tech-docs.md
+++ b/plans/in-progress/pr-review-rule-convergence/tech-docs.md
@@ -1,0 +1,190 @@
+# Technical Design: PR Review Rule Convergence
+
+## Architecture
+
+```mermaid
+%% Color palette: Blue #0173B2, Teal #029E73, Orange #DE8F05, Purple #CC78BC
+flowchart LR
+  D["PR diff classifier"]:::blue --> E{"Executable behavior?"}:::blue
+  E -->|Yes| R["Sequential review: max 7\nexit when code M/H/C = 0"]:::orange
+  E -->|No| Q["pr-quality-gate workflow"]:::teal
+  R --> P["Public canonical merge"]:::teal
+  Q --> P
+  P --> V["Private worktree direct push\nthis-plan exception"]:::purple
+  V --> M["Primer companion PR"]:::teal
+  M --> C["Exact worktree cleanup\nthen root main sync"]:::blue
+
+  classDef blue fill:#0173B2,stroke:#000000,color:#FFFFFF
+  classDef teal fill:#029E73,stroke:#000000,color:#FFFFFF
+  classDef orange fill:#DE8F05,stroke:#000000,color:#FFFFFF
+  classDef purple fill:#CC78BC,stroke:#000000,color:#000000
+```
+
+## Implementation Approach
+
+The PR-review scout becomes the sole classifier. It records the head SHA, changed paths, the
+behavioral reason for every eligible path, and the chosen route before any specialist is invoked.
+Uncertainty fails safe into the eligible route. The plan updates every duplicate policy statement to
+refer to this workflow as the single algorithm owner.
+
+For eligible PRs, cycles are strictly sequential and cap at seven. Each completed cycle evaluates
+unresolved findings whose subject is executable behavior or code affected by the diff. Low findings
+receive a reasoned disposition and a deduplicated idea entry. Starting at cycle six, the orchestrator
+adds sanitized convergence evidence to the owning plan's `learnings.md` and a deduplicated idea when
+the PR belongs to a plan; ad-hoc work creates or updates the appropriate idea directly. A clean code
+M/H/C evaluation exits early. Every still-open PR is reclassified under this policy at its next review
+or merge action; no legacy route is retained.
+
+## Design Decisions
+
+- The behavior-based classifier, rather than a path allowlist, keeps newly introduced executable
+  configuration in scope without waiting for rule maintenance.
+- Seven cycles are a hard ceiling for review activity, not permission to merge unresolved code M/H/C
+  findings.
+- Low findings become deduplicated ideas because they are non-blocking but still useful maintenance
+  signals.
+- The direct OSE-private push is a user-authorized, plan-local delivery exception. It is deliberately
+  absent from the canonical policy propagation set.
+
+The retrofit pass treats every live plan as a consumer of the canonical workflow. A deterministic
+reference inventory identifies candidates in `plans/backlog/` and `plans/in-progress/`; each matching
+plan receives a semantic review, not a blind textual substitution. It updates only future-facing
+requirements, delivery steps, and merge instructions. Completed plans and append-only execution
+records retain historical facts, but an active plan's remaining unchecked steps must use the new rule.
+
+For non-eligible PRs, the specialist loop and surface tester gates are skipped. The orchestrator
+verifies the current-head run of the `pr-quality-gate` workflow defined at
+`.github/workflows/pr-quality-gate.yml`, then merges. Secret scanning and incident response remain
+universal and are never classified away.
+
+Every PR route uses the CI-monitoring contention rule. A queued or apparently stalled run first
+triggers a cross-repository runner-contention check, then cadence-based polling and root-cause
+investigation. It is not evidence that the current goal should be cancelled. The policy will extend
+the CI-monitoring workflow and every applicable agent-facing entry point in OSE-public, OSE-private,
+and OSE Primer without weakening the required-check gate.
+
+The OSE-private companion in this specific plan is the sole delivery exception: the user has
+authorized a worktree-based commit and direct push to `origin/main`, with no private PR or
+PR-quality wait. The executor still verifies the intended post-public base, secret-safety status, and
+public/private byte-identity manifest. The exception is written in this plan rather than in canonical
+governance so it expires with this plan and cannot alter other work.
+
+The concurrently active OSE-private PR-quality remediation is foreign work. This plan neither reads
+its uncommitted state nor waits for its checks; it provisions a separate, exact private worktree from
+`origin/main`. If foreign commits reach `origin/main` before this plan pushes, the plan follows the
+integration-diff-review rule before continuing.
+
+Every task in this plan has an AI-executable command path. No phase uses a `[HUMAN]` review, approval,
+or manual-check gate; provider operations that would normally need human involvement are either
+automated through the available repository/hosting interfaces or explicitly outside this plan's
+delivery scope.
+
+After a repository's final delivery unit has landed, cleanup is a direct terminal operation. The
+executor resolves the explicit plan worktree path, verifies that every delivery unit is complete and
+the worktree has no uncommitted or unpushed plan state, then runs `git worktree remove <exact-path>`.
+It never uses a broad path, glob, repository root, or `rm` command. The root checkout is excluded so
+the final `git fetch origin` and fast-forward to `origin/main` can still run.
+
+## Secret-Incident Algorithm
+
+1. Stop further distribution; revoke or rotate the credential through its owning service without
+   putting its value in tracked files, terminal output, comments, or evidence.
+2. Identify every reachable affected branch, tag, pull-request branch/ref, and hosting artifact using
+   a sanitized incident record.
+3. Rewrite all affected reachable refs, delete contaminated branches/tags where appropriate, and force
+   update the rewritten refs under the user's standing authorization.
+4. Close the contaminated PR, create a clean branch from sanitized history, and open a replacement PR.
+5. Request hosting-provider cache and object purge support; document only request/result status and
+   the limitation that external clones/forks cannot be erased.
+
+No secret value, matching substring, raw diff, private path, or service-specific credential detail is
+committed during any step.
+
+## Cross-Repository Propagation
+
+`ose-public` is the canonical content source. Before its PR merges, prepare the corresponding
+`ose-private` change and record a portable-file manifest of paths and byte hashes without private
+facts. Every manifest file is byte-identical in public and private; private-only operational files are
+explicitly excluded rather than silently allowed to drift. After the public merge, commit and push the
+private worktree directly to `origin/main` under this plan's user-authorized exception; record the
+temporary skew and closure.
+
+This plan also delivers an OSE Primer companion after public/private reconciliation. Its governed
+portable files must implement the same routing, convergence, and secret-response semantics; a separate
+manifest names any documented Primer-specific wording or path exceptions. It receives the same
+live-plan retrofit inventory so a future Primer plan cannot retain the retired fixed-cycle rule.
+
+## File-Impact Analysis
+
+```text
+.
+├── AGENTS.md [E] — make plan-independent routing and merge rules discoverable to every agent
+├── repo-governance/
+│   ├── development/workflow/pr-merge-protocol.md [E] — replace universal cycle precondition
+│   ├── workflows/pr/pr-review-quality-gate.md [E] — own classifier, bounded loop, exits, learnings
+│   ├── development/quality/pr-review-disciplines.md [E] — align specialist scope and severity use
+│   ├── development/workflow/git-push-safety.md [E] — reference incident rewrite authorization safely
+│   ├── development/workflow/ci-monitoring.md [E] — make patient contention investigation explicit
+│   ├── development/workflow/worktree-and-artifact-cleanup.md [E] — require direct exact-path cleanup
+│   ├── conventions/structure/plans.md [E] — apply routing to planned and ad-hoc execution rules
+│   └── workflows/plan/plan-execution.md [E] — remove plan worktrees after final repository delivery
+├── docs/reference/related-repositories.md [E] — state public-first private governance reconciliation
+├── .claude/agents/repo-rules-maker.md [E] — require manual canonical propagation and generated sync
+├── .opencode/agents/repo-rules-maker.md [G] — generated binding
+├── .cursor/agents/repo-rules-maker.md [G] — generated binding when emitted by the harness
+├── .amazonq/agents/repo-rules-maker.md [G] — generated binding when emitted by the harness
+├── plans/
+│   ├── in-progress/pr-review-rule-convergence/ [E] — this control plan and sanitized learnings
+│   ├── in-progress/repository-onboarding-readme-refresh/ [E] — amend only remaining forward delivery
+│   │   steps that encode the retired review rule
+│   ├── backlog/ayokoding-learning-path-{06..18}-*/ [E] — retrofit every matching future plan document
+│   ├── ideas/README.md [E] — index any new Low-finding or non-convergence idea
+│   └── ideas/<deduplicated-topic>.md [N] — only when no existing two-pager owns the learning
+├── ose-private manifest-matched canonical paths [E] — byte-identical real-time governance delivery
+│   in its own repo
+└── ose-primer applicable canonical paths and live plans [E] — companion policy delivery and retrofit
+    in its own repo
+```
+
+The execution discovery step may adjust this tree only after an exact reference search proves another
+canonical duplicate exists. Generated surfaces are never edited manually.
+
+## Dependencies
+
+- Git and GitHub CLI access for branches, PRs, workflow state, and exact worktree inspection.
+- The repository's existing `pr-quality-gate.yml`, `rhino-cli` gate registry, and binding generator.
+- Authorized local access to the OSE-private and OSE Primer repositories; their concurrent working
+  trees remain out of scope unless this plan explicitly creates its own worktree.
+
+## Testing Strategy
+
+- Use a documented path matrix containing executable, non-executable, ambiguous, and mixed-diff cases
+  to exercise the classifier's selected route.
+- Validate documentation and generated bindings with the exact registry commands recorded in
+  `delivery.md`.
+- Verify PR routes from GitHub's current head status; for the one-plan private direct push, verify the
+  post-push revision and manifest instead of a PR workflow.
+
+## Rollback
+
+Policy changes are Markdown and generated binding changes. Before each public/Primer merge, a failed
+delivery is rolled back by a follow-up corrective PR that restores the last known-good canonical text
+and regenerates bindings. The user-authorized private direct push is corrected by a new forward commit
+on `origin/main`; never rewrite history unless a confirmed secret incident invokes the separately
+defined secret-remediation algorithm.
+
+## Verification Strategy
+
+- Use path-matrix fixtures or a deterministic classifier test if an existing test harness supports it;
+  otherwise use checked-in documented examples and an audited dry-run command.
+- Run `npm run generate:bindings` followed by `npm run validate:sync` after canonical agent edits.
+- Verify Markdown structure, links, and Mermaid diagrams using the registry-selected commands.
+- Open a draft PR and confirm the named workflow is green on the final head SHA before merge.
+- Compare the public/private governed-path manifest before and after the private companion merge.
+- Validate the OSE Primer applicable-policy manifest and its own live-plan retrofit before its PR merges.
+- Simulate or inspect a queued CI state and verify that the documented response preserves the active
+  goal and uses the contention-monitoring cadence.
+- Verify each worktree path against `git worktree list` immediately before the direct removal command;
+  confirm the repository root is not a cleanup target.
+- Re-run the live-plan reference inventory and manually inspect every remaining match; only historical
+  execution evidence may retain a description of the retired behavior.

--- a/plans/in-progress/pr-review-rule-convergence/tech-docs.md
+++ b/plans/in-progress/pr-review-rule-convergence/tech-docs.md
@@ -4,7 +4,7 @@
 
 ```mermaid
 %% Color palette: Blue #0173B2, Teal #029E73, Orange #DE8F05, Purple #CC78BC
-flowchart LR
+flowchart TD
   D["PR diff classifier"]:::blue --> E{"Executable behavior?"}:::blue
   E -->|Yes| R["Sequential review: max 7\nexit when code M/H/C = 0"]:::orange
   E -->|No| Q["pr-quality-gate workflow"]:::teal


### PR DESCRIPTION
Adds the in-progress three-repository plan, its delivery DAG, resolved policy decisions, and plan-quality audit evidence.