### PR TITLE
docs(security): document .env.local test-tier gap and lib env-var CLI-only exception

### DIFF
--- a/docs/how-to/configure-app-environments.md
+++ b/docs/how-to/configure-app-environments.md
@@ -44,6 +44,13 @@ write, or edit either file directly — see
 below. Every other tier file (`.env.local`, `.env.test`, and the committed `.env.example`
 template) is agent-readable and agent-editable.
 
+The `test` tier exists as its own file rather than reusing `local` because Next.js deliberately
+skips `.env.local` whenever `NODE_ENV=test` — [documented
+upstream](https://nextjs.org/docs/pages/guides/environment-variables#test-environment-variables) as
+"you expect tests to produce the same results for everyone." There is no framework option to make
+tests read `.env.local` instead; `.env.test` is the only tier file Next.js's own loader will pick up
+during a test run.
+
 ## The `APP_ENV` contract
 
 Every loader in the repo — Next.js, F#, and Vite alike — implements the same five rules:

--- a/repo-governance/conventions/security/secrets-and-env-standards.md
+++ b/repo-governance/conventions/security/secrets-and-env-standards.md
@@ -137,6 +137,18 @@ Each app's env template lives in exactly one place: `apps/<app>/.env.example`.
 Relocating real gitignored `.env*` files (`.env.local` etc.) is a **[HUMAN]** task — the
 `guard-env-file-access` policy forbids agents from touching them directly.
 
+### Library env-var rule
+
+A `libs/` project never loads an env file itself — no `.env.example` template, no tier loader. If a
+library reads the process environment directly (`GetEnvironmentVariable`, `process.env`, `env::var`),
+each name it reads must be declared in the `.env.example` of every **tiered app** that consumes it
+(the app is what crosses the local/test/stag/prod tier boundary; the library does not). A library
+consumed only by out-of-scope CLI tooling (no `.env.example` by design — see §3's app-only scope) is
+an explicit exception: there is no tiered-app consumer to declare the name in, so none is required.
+Re-verify this exception whenever the library gains a new consumer — a name that was legitimately
+undeclared while the only consumer was a CLI tool must be declared the moment a tiered app starts
+consuming that library too.
+
 ## 4. `.env.example` Annotation Format
 
 Every env var line is preceded by a comment block:


### PR DESCRIPTION
## Summary

Two documentation-only follow-ups from `restrict-env-access-to-prod-and-stag`'s Phase 10 Knowledge Capture (plan archived in `ose-private` at `plans/done/2026-08-13__restrict-env-access-to-prod-and-stag/`):

- `docs/how-to/configure-app-environments.md` never explained why `.env.test` exists as its own file instead of reusing `.env.local` — added the framework fact (Next.js skips `.env.local` under `NODE_ENV=test`) with the upstream citation.
- `repo-governance/conventions/security/secrets-and-env-standards.md` never named the "lib rule"'s CLI-only-consumer exception (a library consumed only by out-of-scope CLI tooling has no tiered-app consumer to declare its env-var names in) — added a "Library env-var rule" subsection under §3, discovered while applying the rule to `libs/fsharp-crane-core`.

No behavior change — docs only.

## Test plan

- [x] `prettier --check` on both files
- [x] `markdownlint-cli2` on both files
- [x] Full pre-push gate suite (212/212 checks passed locally, including `md-links`)
- [ ] CI green on `pr-quality-gate.yml`