### PR TITLE
fix(security): drop dead Write() deny rules from settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,14 +15,7 @@
       "Read(apps/*/content/**/*.env)",
       "Edit(apps/*/content/**/*.env)"
     ],
-    "deny": [
-      "Read(**/.env.prod)",
-      "Write(**/.env.prod)",
-      "Edit(**/.env.prod)",
-      "Read(**/.env.stag)",
-      "Write(**/.env.stag)",
-      "Edit(**/.env.stag)"
-    ]
+    "deny": ["Read(**/.env.prod)", "Edit(**/.env.prod)", "Read(**/.env.stag)", "Edit(**/.env.stag)"]
   },
   "hooks": {
     "PreToolUse": [


### PR DESCRIPTION
## Summary
- Permission checks only match `Edit()` rules for file-editing tools — the `Write()` deny entries for the two restricted-tier env files never matched anything.
- Drops the dead `Write()` rules; `Edit()` already covers `Write` per Claude Code's permission model.

## Test plan
- [x] `git push` pre-push gates passed (md-links, harness-bindings, env-validate, etc.)