### PR TITLE
docs(plans): add optimize-governance-md plan

### DIFF
--- a/plans/in-progress/README.md
+++ b/plans/in-progress/README.md
@@ -13,6 +13,11 @@ execution checklist.
 
 - [beaver-flutter](./beaver-flutter/README.md) — Replaces the Vite/React BeaverNest client with a
   responsive Flutter Web application, establishing a future-ready core and safe diagnostics.
+- [optimize-governance-md](./optimize-governance-md/README.md) — Caps every governance Markdown
+  file at 500 words, replaces the byte budget with a word budget, requires annotated `README.md`
+  sibling indexes, and adds `when_to_use` frontmatter — across `ose-public` and `ose-private`.
+  545 files over the ceiling; remediation is progressive disclosure, enforced by rhino-cli at
+  pre-push and in the PR quality gate.
 - [repository-onboarding-readme-refresh](./repository-onboarding-readme-refresh/README.md) — Refreshes
   living reader-facing READMEs, onboarding journeys, related docs, and GitHub About metadata across
   `ose-public`, `ose-primer`, and `ose-private`, with product-first paths, fresh-checkout proof, and

--- a/plans/in-progress/optimize-governance-md/README.md
+++ b/plans/in-progress/optimize-governance-md/README.md
@@ -1,0 +1,262 @@
+# Optimize Governance Markdown
+
+## Context
+
+This repository's governance surfaces have grown without a size ceiling. [Repo-grounded,
+measured 2026-08-13, reproduced by this plan's own audit] Measured across the source
+(non-generated) governance Markdown in both repos:
+
+| Repo          | Governance `.md` | Over 500 words | Excess words   |
+| ------------- | ---------------- | -------------- | -------------- |
+| `ose-public`  | 347              | **298**        | ~594,000       |
+| `ose-private` | 287              | **247**        | ~523,000       |
+| **Total**     | **634**          | **545**        | **~1,117,000** |
+
+**This table is deliberately scoped to source (non-generated) content only** —
+`repo-governance/` + `.claude/`, excluding the `.cursor`/`.opencode`/`.amazonq` generated mirrors
+and root `AGENTS.md`/`CLAUDE.md`. It answers "how much is our own authored content," not "how
+many files will the gate flag." The `governance-word-budget` gate's actual **covered surface**
+is broader (see §Scope Boundaries below and `prd.md` FR-1.3) and its current live baseline is
+**464** for `ose-public` and **349** for `ose-private` [Repo-grounded, re-derived 2026-08-13 via
+`tech-docs.md` §7's census script]. `delivery.md`'s Phase 1/10 Gate acceptance criteria cite
+these full-surface numbers, not the 298/247 above.
+
+[Repo-grounded, verified byte-for-byte via `wc -w`] The median governance file is **1,451
+words** — roughly three times the ceiling this plan introduces. The largest are far worse:
+
+| File                                                 | Words      |
+| ---------------------------------------------------- | ---------- |
+| `repo-governance/development/agents/ai-agents.md`    | **14,720** |
+| `repo-governance/workflows/plan/plan-execution.md`   | **14,326** |
+| `repo-governance/conventions/structure/plans.md`     | **13,241** |
+| `repo-governance/conventions/formatting/diagrams.md` | **11,816** |
+| `.claude/agents/plan-checker.md`                     | **11,773** |
+| `AGENTS.md`                                          | 3,001      |
+| `CLAUDE.md`                                          | 907        |
+
+Size is not the only defect. Two adjacent gaps compound it:
+
+- **Reachability** [Repo-grounded]: 721 Markdown-bearing directories in `ose-public` have no
+  `README.md`. Splitting large files without an index rule would convert one unreadable file
+  into thirty unreachable ones.
+- **Retrieval** [Repo-grounded]: `repo-governance/**/*.md` carries `title`, `description`,
+  `category`, `subcategory`, `tags`, `created` — but nothing telling an agent _when_ to open the
+  file. 214/214 files have frontmatter, 187/214 carry `description`, **0** carry `when_to_use`.
+
+## What This Plan Changes
+
+Four changes, delivered together because each is load-bearing for the others.
+
+### 1. A 500-word ceiling on governance Markdown
+
+Every `.md` file under the governance surfaces gets a hard word ceiling. Over it, the sole
+sanctioned remediation is
+[Progressive Disclosure](../../../repo-governance/principles/content/progressive-disclosure.md):
+split into an index parent plus capped children — never delete the rule, never dense-compress,
+never move bytes into another auto-loaded file.
+
+- **≤ 400 words** — OK
+- **401–500 words** — warn (gate exits 0)
+- **> 500 words** — fail (gate exits 1)
+
+Counting is **raw whole-file word count**: YAML frontmatter, fenced code blocks, Mermaid
+blocks, tables, and link URLs all count. No exemptions, no allowlist, no waiver mechanism.
+
+**Size is new; reachability extends what's already live.** `governance-word-budget` has no
+predecessor. `governance readme-index validate` is a **rename-and-extend** of the already-armed
+`rhino-cli md readme-index validate` (gate id `md-readme-index`) — it already runs on every push
+and PR today, detecting `orphan`/`ghost` findings. This plan renames it in place (no enforcement
+gap) and adds two new finding kinds, `missing` and `unannotated`, via a second gate id that is
+dark-launched like `governance-word-budget`. Three gate ids in total, one per enforcement
+posture:
+
+| Gate                             | Command                                      | Finding kinds            | Fires when                                                                                                                          |
+| -------------------------------- | -------------------------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `governance-word-budget`         | `rhino-cli governance word-budget validate`  | size                     | a governance surface, `AGENTS.md`, `CLAUDE.md`, or `repo-config.yml` changed — path-gated, dark-launched Phase 1 → armed Phase 9/16 |
+| `governance-readme-index`        | `rhino-cli governance readme-index validate` | `orphan`, `ghost`        | unconditionally (`all-file-type`) — continuously armed since before this plan, renamed in place at Phase 1, no gap                  |
+| `governance-readme-completeness` | `rhino-cli governance readme-index validate` | `missing`, `unannotated` | a covered tree (no mirrors, no `plans/`) or `repo-config.yml` changed — path-gated, dark-launched Phase 1 → armed Phase 9/16        |
+
+`governance-readme-index` and `governance-readme-completeness` invoke the same binary; the split
+exists so the already-working orphan/ghost check never regresses to path-gated (and briefly
+weaker) coverage while the genuinely new checks go through the same safe dark-launch sequencing
+FR-4's frontmatter change uses. See `prd.md` §FR-3 "Repurpose, do not rebuild" and `tech-docs.md`
+§1.1/§4 for the full decision record.
+
+### 2. The byte budget is replaced
+
+`repo-governance/conventions/structure/instruction-file-size-budget.md` and the
+`instruction-size:` block in `repo-config.yml` are **replaced**, not supplemented. The word
+cap becomes the sole per-file size gate. The one thing a per-file cap cannot express — the
+**resolved-tree** aggregate (`CLAUDE.md` plus its `@`-imports) — is **ported from bytes to
+words** rather than dropped.
+
+### 3. `README.md` must index its siblings (extends an already-live gate)
+
+In the covered trees, a directory's `README.md` must link **every `*.md` directly beside it**
+(excluding itself) **plus every immediate subdirectory's `README.md`**. This is the
+machine-checkable reachability guarantee that makes change 1 safe: without it, ~1,800 new
+child files become orphans. This is **not built from scratch** — `md readme-index validate`
+already checks orphan/broken links today, unconditionally, on every push and PR; this plan
+renames it to `governance readme-index validate` and adds the `missing`-README and
+annotation-drift checks below as new, dark-launched capabilities.
+
+Entries are **annotated, not bare links** — each carries a one-line summary and a trigger:
+
+```markdown
+- [Governance Conventions](conventions/README.md) — shared standards for repository content
+  and practices. Use them when creating or reviewing work covered by a convention.
+```
+
+The annotation is **derived from the target file's own frontmatter** (`description` +
+`when_to_use`, change 4), so indexes are machine-generatable and cannot drift from what they
+describe. `rhino-cli governance readme-index generate` writes them; `validate` verifies them.
+
+### 4. `when_to_use` frontmatter
+
+Every `repo-governance/**/*.md` gains a required `when_to_use:` key — the retrieval trigger,
+the same job `.claude/skills/*/SKILL.md` frontmatter already performs for skill auto-loading.
+The 27 files missing `description:` are backfilled at the same time, and `description`'s
+_severity_ is also upgraded from WARN to FAIL for governance docs (an earlier draft of this plan
+assumed it already was FAIL; verified false against `frontmatter.rs`). Both severity flips land
+dark-launched at WARN in Phase 1 and are armed to FAIL only in Phase 9/16, once the backfill is
+complete — see `prd.md` §FR-4 "Dark-launch sequencing."
+
+## Decisions and Rationale
+
+Every decision below was resolved with the user before this plan was written — the "Choice"
+column is [Judgment call] throughout (user-approved design preference, not a checkable fact);
+the "Why" column's numeric callouts (545, 658/721, 87%) are [Repo-grounded], reproduced in the
+census above and in `brd.md` §Success Metrics.
+
+| Decision               | Choice                                                                                                                                                          | Why                                                                                                                                 |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Word metric            | Raw whole-file count                                                                                                                                            | Ungameable; no arguing about what is "prose"                                                                                        |
+| Thresholds             | 400 warn / 500 fail, zero exemptions                                                                                                                            | Matches the three-tier classification the repo already uses                                                                         |
+| Remediation shape      | Full — all 545 files fixed in this plan, hard gate flipped last                                                                                                 | An allowlist deferred past a plan boundary becomes permanent                                                                        |
+| vs. byte budget        | Word cap **replaces** it; resolved-tree ported to words                                                                                                         | Two overlapping size gates on the same files is worse than one                                                                      |
+| Gate implementation    | Repurpose `instruction_size.rs` in place                                                                                                                        | Globbing, three-tier classification, reporting, and all four enforcement points already exist                                       |
+| README-index gate      | Repurpose `readme_index_audit.rs`/`md_validate_readme_index.rs` in place; rename `md-readme-index` gate id to `governance-readme-index` with no enforcement gap | It already detects orphan/ghost links today, armed unconditionally; a from-scratch rebuild would leave two overlapping gates active |
+| Command name           | `rhino-cli governance word-budget validate`                                                                                                                     | Scope is governance surfaces, not just harness instruction files                                                                    |
+| Convention doc         | `git mv` to `governance-word-budget.md`, rewrite every inbound link (discovered live, not hardcoded — see `tech-docs.md` §6)                                    | Name must not lie about its unit or its scope                                                                                       |
+| Split pattern          | Index parent + sibling directory (`X.md` + `X/NN-slug.md`)                                                                                                      | Preserves every existing inbound link to `X.md`; `md links validate` gates hundreds of them                                         |
+| Agent bodies           | Bulk moves to `.claude/skills/<name>/reference/*.md`                                                                                                            | Agent `.md` bodies load **verbatim** — they are not `@`-import resolved                                                             |
+| README index authority | Parent `X.md` is the index; split dirs exempt from the README rule                                                                                              | One list to maintain, not two kept in sync by a gate                                                                                |
+| README rule scope      | Source governance surfaces + `docs/` + `specs/`                                                                                                                 | Excludes `apps/` (658 of 721 missing READMEs are content trees), `plans/`, and generated mirrors                                    |
+| Frontmatter            | Add `when_to_use` only; keep `description`                                                                                                                      | `description` is already required and 87% populated — it _is_ the tldr                                                              |
+| Repos                  | `ose-public` first, then `ose-private`                                                                                                                          | Private never inherits a pattern that later changes under it                                                                        |
+| `ose-primer`           | **Deferred**                                                                                                                                                    | See "Accepted divergence" below                                                                                                     |
+| Concurrency            | N=3 background agents                                                                                                                                           | Repo default; the splits are judgment-heavy content work, not mechanical                                                            |
+
+## Top Risks
+
+### `AGENTS.md` at 500 words is a real behavioural change
+
+[Repo-grounded — eight Tier-1 harnesses per `docs/reference/platform-bindings.md`] `AGENTS.md`
+is 3,001 words and is read **natively** by Cursor, Windsurf, JetBrains Junie, GitHub Copilot,
+OpenAI Codex CLI, Google Antigravity CLI, Pi, and OpenCode. At 500 words it becomes close to a
+pure directive index. Harnesses that do not eagerly follow links will hold fewer rules in
+context than they do today.
+
+**Mitigation**: `AGENTS.md` is rewritten as a directive index whose opening instruction
+requires reading the linked surfaces before acting, and the ported resolved-tree word budget
+keeps the `CLAUDE.md` → `AGENTS.md` chain measurable. This risk is **accepted, not
+eliminated**, and is called out here rather than buried.
+
+### Agent quality may degrade before it improves
+
+Moving `plan-checker.md` (11,773 words) into `.claude/skills/.../reference/*.md` converts
+prompt content the harness loads for free into content the agent must `Read` at runtime.
+Agents that fail to read their reference modules will behave as if the rules are gone.
+
+**Mitigation**: every migrated agent keeps a mandatory, unconditional "read all reference
+modules before acting" instruction in its ≤500-word charter, and Phase 6 verifies behaviour
+on a real invocation before the PR merges.
+
+### File-count explosion
+
+~1,117,000 excess words become an estimated **1,400–2,200 new files** across both repos.
+Every one is subject to Prettier, markdownlint, `md links validate`,
+`md heading-hierarchy validate`, and `md frontmatter validate`. CI wall-clock on the markdown
+gate group will grow measurably.
+
+### Accepted divergence: `ose-primer`
+
+`apps/rhino-cli` is byte-identical across `ose-public`, `ose-primer`, and `ose-private`
+(659 files pinned in `apps/rhino-cli/parity-manifest.sha256`). This plan changes rhino-cli in
+two repos only.
+
+**Verified consequence**: `parity manifest validate` reads _its own repo's_ committed manifest
+against _its own repo's_ tracked boundary
+(`apps/rhino-cli/src/application/parity.rs::validate_at_root`). It never fetches siblings.
+**No gate turns red in any repo.** The real cost is silent divergence — `ose-primer`'s
+rhino-cli forks from `ose-public`'s until a follow-up sync plan lands. Content parity
+(`ose-public` ↔ `ose-primer`) likewise accrues a debt across `repo-governance/`.
+
+This is a deliberate, user-approved deferral. A follow-up plan must close it.
+
+### `plans/` considered and excluded from the README rule scope
+
+`plans/` was considered for the README-index scope and excluded — see §Scope Boundaries below
+and `brd.md` §Out of Scope for the final decision and rationale (184 of 195 `plans/done/**`
+folders that would qualify under FR-3.1's own applicability rule — a sibling `*.md` besides
+`README.md`, or a subdirectory containing a `README.md` — already carry a README; retrofitting
+the remaining 11 archival folders was judged not worth the churn of editing completed plan
+history for no reader). [Repo-grounded, verified 2026-08-13 — counted with a `os.walk("plans/done")`
+sweep applying FR-3.1's applicability predicate per directory, excluding the `plans/done` root
+itself; reproducible via the equivalent shell form: for each directory under `plans/done`, it
+qualifies if `find <dir> -maxdepth 1 -name '*.md' ! -name README.md | grep -q .` or any immediate
+subdirectory contains a `README.md`, then check `test -e <dir>/README.md`]
+
+## Scope Boundaries
+
+**In scope** (word budget): `repo-governance/**/*.md`, `.claude/**/*.md`, `.cursor/**/*.md`,
+`.codex/**/*.md`, `.opencode/**/*.md`, `.pi/**/*.md`, `.amazonq/**/*.md`, root `AGENTS.md`,
+root `CLAUDE.md` — **including generated mirrors**.
+
+**In scope** (README index, `orphan`/`ghost` — `governance-readme-index`): the gate's current
+`DEFAULT_PATHS`, unchanged through the Phase 1 rename: `repo-governance/`, `.claude/agents/`,
+`.claude/skills/`, `docs/explanation/software-engineering/`.
+
+**In scope** (README completeness, `missing`/`unannotated` — `governance-readme-completeness`,
+new, dark-launched): the wider FR-3.7 list — `repo-governance/`, `.claude/`, `.codex/`, `.pi/`,
+`docs/`, `specs/`. **Not** the generated mirror trees — a 94-entry annotated index
+[Repo-grounded, verified 2026-08-13] fits no defensible ceiling, and nobody navigates
+`.opencode/agents/` by README. Mirrors stay fully inside the word budget.
+
+**In scope** (frontmatter `when_to_use`): `repo-governance/**/*.md` only.
+
+**Out of scope**: `plans/**` (all three gates), `apps/**`, `libs/**`, root
+`README.md`/`CONTRIBUTING.md`/`LICENSING-NOTICE.md`, `ose-primer`, and the plan documents in
+this folder.
+
+A generated mirror that violates the word budget is **never hand-edited** — the fix belongs in
+`.claude/` source or in the binding generator.
+
+## Repos and Delivery
+
+| Repo          | Worktree                           | Plan docs         | PRs                                |
+| ------------- | ---------------------------------- | ----------------- | ---------------------------------- |
+| `ose-public`  | `worktrees/optimize-governance-md` | **Authoritative** | 10 (2 executable, 8 markdown-only) |
+| `ose-private` | `worktrees/optimize-governance-md` | none (uses this)  | 7 (2 executable, 5 markdown-only)  |
+
+**17 PRs total, 4 executable.** Phase 0 opens none; the earliest PR is Phase 1 — see
+`delivery.md` §PR Map and §Delivery Boundaries for the full phase-to-PR mapping, including PR17
+(Phase 17's knowledge-capture and archival PR, added per Finding 9 of the 2026-08-13 plan audit).
+
+**Exactly one worktree named `optimize-governance-md` per repository** — the
+[one-worktree-per-repo-per-plan HARD RULE](../../../repo-governance/conventions/structure/plans.md#worktree-cap--one-worktree-per-repository-per-plan-hard-rule).
+The name matches the plan-folder identifier per the Worktree Specification's name-matching
+requirement — no exception needed (see `brd.md` §Constraints for the note on the `ose-public`
+worktree's mid-session rename from its original provisioning name).
+
+**Delivery mode**: `worktree-to-pr` in both repos. Markdown-only PRs are **noneligible static
+work** — they merge on a green `.github/workflows/pr-quality-gate.yml` run with no PR review
+cycle. Only the two rhino-cli PRs per repo carry changed executable behaviour and run the
+review cycle.
+
+## Documents
+
+- [brd.md](./brd.md) — business goal and impact
+- [prd.md](./prd.md) — requirements and Gherkin acceptance criteria
+- [tech-docs.md](./tech-docs.md) — gate design, split pattern, migration mechanics
+- [delivery.md](./delivery.md) — phased delivery checklist

--- a/plans/in-progress/optimize-governance-md/brd.md
+++ b/plans/in-progress/optimize-governance-md/brd.md
@@ -1,0 +1,136 @@
+# Business Requirements Document: Optimize Governance Markdown
+
+## Business Goal
+
+Make this repository's governance instructions **actually reach the agents and humans that
+depend on them** — by capping every governance Markdown file at a size a reader can hold,
+guaranteeing every file is reachable from an index, and telling every reader when a file
+applies.
+
+## Business Impact
+
+### Pain point 1 — Rules that exist but are never read
+
+[Repo-grounded, measured 2026-08-13] The median governance file in `ose-public` is **1,451
+words**; the largest is **14,720 words**
+(`repo-governance/development/agents/ai-agents.md`). `AGENTS.md`, the canonical instruction
+surface read natively by eight harnesses [Repo-grounded — all Tier-1 harnesses per
+`docs/reference/platform-bindings.md`: Cursor, Windsurf, JetBrains Junie, GitHub Copilot, OpenAI
+Codex CLI, Google Antigravity CLI, Pi, OpenCode], is **3,001 words**.
+
+A rule buried at word 12,000 of a 14,720-word file is, for practical purposes, not a rule.
+Agents and contributors skim; harnesses truncate. The repository is paying full maintenance
+cost on governance content that does not change behaviour.
+
+### Pain point 2 — Silent truncation, unquantified
+
+[Repo-grounded] The existing
+`repo-governance/conventions/structure/instruction-file-size-budget.md` documents the failure
+mode precisely: Codex CLI truncates a resolved `AGENTS.md` tree at 32,768 bytes; some agents
+warn at 40,000 characters; some editors hard-cap at 12,000 characters per file. Content past
+the limit **vanishes without warning** — the agent behaves as though the rule was never
+written.
+
+The byte budget was the first response to this. It gates only the handful of surfaces a
+harness auto-loads, in a unit (bytes) no author reasons in, and it has never constrained the
+bulk of `repo-governance/`, which agents read on demand and which is where 188 of the 298
+public violations live.
+
+### Pain point 3 — Orphaned and untriggerable content
+
+[Repo-grounded] **721** Markdown-bearing directories in `ose-public` have no `README.md`.
+And **0 of 214** `repo-governance/` files declare when they apply — an agent deciding whether
+to open `integration-diff-review.md` has `title`, `description`, `category`, `subcategory`,
+`tags`, and `created` to work with, none of which answer "does this apply to what I am doing
+right now?"
+
+Splitting large files without fixing both gaps would make the problem worse: one unread file
+becomes thirty unreachable ones.
+
+## Expected Benefit
+
+[Judgment call] Governance content that fits inside a reader's working attention, is reachable
+by walking any index, and announces its own trigger condition should be applied more
+consistently by both agents and contributors than content that is none of those things. This
+plan asserts **no numeric behavioural improvement as measured fact** — the verifiable outcomes
+are structural and are stated in `prd.md` §Acceptance Criteria:
+
+- Zero files over 500 words across the covered surfaces in both repos
+- Zero unreachable Markdown files in the covered trees
+- `when_to_use` present on 100% of `repo-governance/**/*.md`
+- One size gate instead of two, in a unit authors reason in
+
+## Stakeholders
+
+| Stakeholder               | Interest                                                                   |
+| ------------------------- | -------------------------------------------------------------------------- |
+| AI coding agents          | Primary consumer; the truncation and retrieval failures land here first    |
+| Repository maintainers    | Own the ~1,400–2,200 new files this plan creates and their ongoing upkeep  |
+| Contributors              | Gain navigable governance; pay a 500-word ceiling on everything they write |
+| `ose-primer` (downstream) | Accrues rhino-cli and content-parity debt until a follow-up plan closes it |
+
+## Success Metrics
+
+| Metric                                                         | Baseline (2026-08-13) | Target        |
+| -------------------------------------------------------------- | --------------------- | ------------- |
+| Governance `.md` over 500 words — `ose-public` (source-only)¹  | 298                   | **0**         |
+| Governance `.md` over 500 words — `ose-private` (source-only)¹ | 247                   | **0**         |
+| `repo-governance/**/*.md` with `when_to_use`                   | 0 / 214               | **214 / 214** |
+| `repo-governance/**/*.md` with `description`                   | 187 / 214             | **214 / 214** |
+| Covered directories with a compliant sibling index             | not measured          | **100%**      |
+| Per-file size gates in `repo-config.yml`                       | 1 (bytes)             | 1 (words)     |
+| Files exempted from the word budget                            | —                     | **0**         |
+
+Every metric is derived by running the gate itself, not by hand-counting.
+
+¹ **298/247 are the narrower "source (non-generated)" figures** — `repo-governance/` + `.claude/`
+only, per `README.md` §Context. The `governance-word-budget` gate's actual **covered surface**
+(FR-1.3: also `.cursor/`, `.codex/`, `.opencode/`, `.pi/`, `.amazonq/`, root `AGENTS.md`, root
+`CLAUDE.md` — generated mirrors are gated, not exempted, per FR-1.4) has a **larger** current
+baseline: **464** for `ose-public` and **349** for `ose-private` [Repo-grounded, re-derived
+2026-08-13 via `tech-docs.md` §7's census script against the full FR-1.3 surface]. 298/247 remain
+accurate and useful as the narrower "how much of this is our own authored content vs. derivative
+mirror copies" narrative in `README.md` §Context and in this document's Business Impact section
+above; they are not the number the `governance-word-budget:validation` gate run itself reports.
+FR-1.9's "zero files" target is scoped to the full covered surface (464/349 today), and
+`delivery.md`'s Phase 1/10 Gate acceptance criteria cite the full-surface figures accordingly.
+
+## Out of Scope
+
+- **`ose-primer`** — deliberate, user-approved deferral; requires a follow-up sync plan for
+  both the rhino-cli boundary and `repo-governance/` content parity
+- `apps/**` and `libs/**` — 658 of the 721 missing READMEs sit in course-content trees
+  where a sibling index has no reader
+- **Root `README.md`, `CONTRIBUTING.md`, `LICENSING-NOTICE.md`** — outward-facing documents
+  with different length requirements
+- `docs/**` word budget — `docs/` joins the README-index rule only; its tutorials and
+  reference specs are legitimately long
+- **`plans/`** — outside **both** gates by design. Plan documents (BRD, PRD, tech-docs,
+  delivery) routinely and legitimately exceed 500 words, and `plans/done/**` is archival:
+  retrofitting an index rule onto completed plans would edit history for no reader
+- **Generated mirror trees** (`.opencode/`, `.cursor/`, `.amazonq/`) — excluded from the
+  README-index rule only; they remain fully inside the word budget
+- **Rewriting governance _content_** — this plan relocates and indexes existing rules. It does
+  not change what any rule says. Any rule that must change gets its own plan.
+
+## Constraints
+
+- **No rule may be deleted to satisfy the budget.** Progressive disclosure is the sole
+  sanctioned remediation, per
+  [Progressive Disclosure](../../../repo-governance/principles/content/progressive-disclosure.md).
+- **No exemption mechanism ships.** No allowlist, no waiver key, no per-file override for the
+  word budget.
+- **Generated mirrors are never hand-edited.** A mirror violation is fixed in `.claude/`
+  source or in the binding generator.
+- **`ose-public` completes before `ose-private` begins** its content work.
+- **Exactly one worktree named `optimize-governance-md` per repository**, matching the
+  plan-folder identifier per the
+  [Worktree Specification HARD RULE](../../../repo-governance/conventions/structure/plans.md#worktree-specification)
+  — no exception needed. (An earlier session instruction had provisioned the `ose-public`
+  worktree under the shorter name `optimize-gov`; it was renamed via `git worktree move` +
+  `git branch -m` to `worktrees/optimize-governance-md` on branch
+  `worktree/optimize-governance-md` before any plan-quality-gate iteration closed, so the plan
+  is fully compliant, not exception-carrying.)
+
+- **Zero `[HUMAN]` steps.** The plan is fully AI-deliverable; see `delivery.md` §Fully
+  AI-Deliverable for the per-category grounding.

--- a/plans/in-progress/optimize-governance-md/delivery.md
+++ b/plans/in-progress/optimize-governance-md/delivery.md
@@ -1,0 +1,1105 @@
+# Delivery Checklist: Optimize Governance Markdown
+
+> **Legend** — `[AI]`: an agent performs the step (the default; unmarked steps are `[AI]`).
+> `[HUMAN]`: only a human can do it. `[AI+HUMAN]`: agent prepares, human approves.
+>
+> **This plan contains zero `[HUMAN]` steps.** See §Fully AI-Deliverable below.
+>
+> **Phase Gate** — every phase ends with a `### Phase N Gate` (must-pass verification) plus a
+> `> **Pause Safety**:` note. A phase is not complete until its gate is green; do not start
+> phase N+1 while any gate check fails.
+
+## Worktree
+
+| Repo          | Worktree path                      | Branch                            |
+| ------------- | ---------------------------------- | --------------------------------- |
+| `ose-public`  | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` |
+| `ose-private` | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` |
+
+**Exactly one worktree named `optimize-governance-md` per repository**, reused across every delivery unit
+landed there — the
+[one-worktree-per-repo-per-plan HARD RULE](../../../repo-governance/conventions/structure/plans.md#worktree-cap--one-worktree-per-repository-per-plan-hard-rule).
+Two repos, two worktrees, no more. Verify with `git worktree list` before creating anything.
+
+After `git worktree add` in `ose-private`, run `npm install` **and**
+`npm run doctor -- --fix` per
+[Worktree Toolchain Initialization](../../../repo-governance/development/workflow/worktree-setup.md).
+
+Optional manual pre-provisioning (run from each repo's root):
+
+```bash
+claude --worktree optimize-governance-md
+```
+
+Phase 0 enters this worktree by default; the command above only pre-provisions it. `optimize-governance-md`
+matches the plan-folder identifier per the
+[Worktree Specification HARD RULE](../../../repo-governance/conventions/structure/plans.md#worktree-specification)
+— no naming deviation. (See `brd.md` §Constraints for the note on the `ose-public` worktree's
+mid-session rename from its original shorter provisioning name.)
+
+## Delivery Mode: worktree-to-pr
+
+Mandatory in both repos — `main` is branch-protected. Each PR is behaviour-classified:
+
+| PR class                     | Classification      | Merge requirement                                                                        |
+| ---------------------------- | ------------------- | ---------------------------------------------------------------------------------------- |
+| rhino-cli gate PRs (4 total) | eligible executable | Up to seven CI-gated review cycles; exit at first clean code MEDIUM/HIGH/CRITICAL result |
+| Markdown-only PRs (13 total) | noneligible static  | Green `.github/workflows/pr-quality-gate.yml`, then merge                                |
+
+`[AI]` merges by default once all five hardened preconditions hold.
+
+## Fully AI-Deliverable
+
+Every step below is `[AI]`. Grounded per category:
+
+| Category               | Why no human is required                                                                       |
+| ---------------------- | ---------------------------------------------------------------------------------------------- |
+| Worktree create/remove | Git-mechanical steps are `[AI]` in all three OSE repos                                         |
+| Commits and pushes     | Push targets are plan branches and PRs, never `main`, never a `prod-*`/`stag-*` deploy ref     |
+| PR merges              | `[AI]` merges by default under Delivery Mode; markdown-only PRs need only a green quality gate |
+| Secrets                | No step reads, writes, or references `.env.prod`, `.env.stag`, or any real secret              |
+| Git identity           | No step runs `git config user.*` at any scope or edits `.git/config`                           |
+| Infrastructure         | No deploys, no runner provisioning, no external service calls                                  |
+| Verification           | Gate execution, log reading, and local agent invocation — all in-repo and reproducible         |
+| CI                     | Polled with `gh run view --json status,conclusion` every 2 minutes; never `gh run watch`       |
+
+## Quality Gate Discipline
+
+**Fix ALL failures found during any quality gate run in this plan, not just those caused by
+your own changes.** This is a standing instruction that applies to every "Verify" checkbox, every
+`### Phase N Gate`, and every pre-push/CI run across Phases 1–17 — not only Phase 0's baseline
+resolution. Hitting a preexisting failure mid-phase (e.g. during one of the repeated subtree
+"Verify" checkboxes in Phases 2–5/11–15) is not a reason to defer it; fix it in the same phase per
+the repo's Root Cause Orientation principle.
+
+### Commit Guidelines
+
+- Commit changes thematically — group related changes into logically cohesive commits, never one
+  giant commit per PR.
+- Follow Conventional Commits format: `<type>(<scope>): <description>` (e.g.,
+  `feat(rhino-cli): replace byte budget with word-count gate`,
+  `docs(governance): rewrite instruction-file-size-budget as governance-word-budget`).
+- Split different domains/concerns into separate commits — a Rust gate-implementation change, a
+  `repo-config.yml` edit, a convention-doc rename, and Gherkin spec changes (all present together
+  in Phase 1 and Phase 9) are each their own commit, not one bundled commit.
+- Do NOT bundle unrelated fixes into a single commit.
+
+## Parallelization Model
+
+**N=3** background agents plus one main-thread orchestrator (the N+1 model). The orchestrator
+stays vacant — it does not take a split subtree itself. Independent subtrees fan out; dependent
+phases serialize per the DAG below.
+
+Every agent maintains a **file-touch ledger**, reproduced in full through every compaction and
+handoff, reconciled against `git status` before staging. `git status` is the union of everyone's
+work — anything not on your ledger belongs to another actor.
+
+Cleanup (Phase 17's worktree-removal step) is the terminal node — it depends on every other
+delivery node (via the linear DAG below) so it never removes a worktree, branch, or artifact an
+in-flight node still needs.
+
+### DAG Registry
+
+```mermaid
+%% Color Palette: Blue #0173B2, Orange #DE8F05, Teal #029E73, Purple #CC78BC, Brown #CA9161
+graph TD
+  P0["Phase 0<br/>Baseline"]:::blue
+  P1["Phase 1<br/>Gate + convention<br/>PR1 executable"]:::orange
+  PG["Phases 2-5<br/>repo-governance/<br/>4 parallel PRs"]:::teal
+  P6["Phase 6<br/>.claude/agents/"]:::teal
+  P7["Phase 7<br/>.claude/skills/"]:::teal
+  P8["Phase 8<br/>Root files + mirrors"]:::teal
+  P9["Phase 9<br/>Flip to hard-fail<br/>PR9 executable"]:::purple
+  P10["Phase 10<br/>private: gate sync<br/>PR10 executable"]:::orange
+  P11["Phases 11-15<br/>private: content"]:::teal
+  P16["Phase 16<br/>private: flip<br/>PR16 executable"]:::purple
+  P17["Phase 17<br/>Knowledge capture"]:::brown
+
+  P0 --> P1
+  P1 --> PG
+  P1 --> P6
+  P6 --> P7
+  PG --> P8
+  P7 --> P8
+  P8 --> P9
+  P9 --> P10
+  P10 --> P11
+  P11 --> P16
+  P16 --> P17
+
+  style P0 fill:#0173B2,stroke:#000000,color:#FFFFFF,stroke-width:2px
+  style P1 fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+  style PG fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+  style P6 fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+  style P7 fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+  style P8 fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+  style P9 fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+  style P10 fill:#DE8F05,stroke:#000000,color:#FFFFFF,stroke-width:2px
+  style P11 fill:#029E73,stroke:#000000,color:#FFFFFF,stroke-width:2px
+  style P16 fill:#CC78BC,stroke:#000000,color:#FFFFFF,stroke-width:2px
+  style P17 fill:#CA9161,stroke:#000000,color:#FFFFFF,stroke-width:2px
+```
+
+**Fan-out windows**: Phases 2–6 are independent (N=3 concurrent). Phases 11–15 are independent
+within `ose-private`. Everything else serializes.
+
+### Delivery Boundaries
+
+[Repo-grounded — every phase from 1 onward is its own delivery unit; this plan's markdown-only
+phases are independent parallel splits (rule 5 of the PRs-Open-at-Delivery-Boundaries HARD RULE),
+so each opens its own PR rather than batching into a shared unit] Branch is the single
+`worktree/optimize-governance-md` branch declared in `## Worktree` above, reused sequentially — each PR
+merges before the next phase in the same repo begins its own commits.
+
+| Phase(s) | Delivery unit                                    | Worktree                           | Branch                            | PR opens                 |
+| -------- | ------------------------------------------------ | ---------------------------------- | --------------------------------- | ------------------------ |
+| 0        | — (setup and baseline, `ose-public`)             | —                                  | —                                 | no                       |
+| 1        | Gate implementation (`ose-public`)               | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 1 (PR1)   |
+| 2        | `repo-governance/conventions/` split             | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 2 (PR2)   |
+| 3        | `repo-governance/development/` split             | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 3 (PR3)   |
+| 4        | `repo-governance/workflows/` split               | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 4 (PR4)   |
+| 5        | `principles/`, `vision/`, architecture split     | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 5 (PR5)   |
+| 6        | `.claude/agents/` → skills migration             | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 6 (PR6)   |
+| 7        | `.claude/skills/` split                          | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 7 (PR7)   |
+| 8        | Root instruction files                           | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 8 (PR8)   |
+| 9        | Arm the gates (`ose-public`)                     | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 9 (PR9)   |
+| 10       | `ose-private` gate sync                          | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 10 (PR10) |
+| 11       | `repo-governance/conventions/` split (private)   | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 11 (PR11) |
+| 12       | `repo-governance/development/` split (private)   | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 12 (PR12) |
+| 13       | `workflows/`, `principles/`, `vision/` (private) | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 13 (PR13) |
+| 14       | `.claude/agents/` → skills (private)             | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 14 (PR14) |
+| 15       | `.claude/skills/`, root files (private)          | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 15 (PR15) |
+| 16       | Arm the gates (`ose-private`)                    | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 16 (PR16) |
+| 17       | Knowledge capture and archival (`ose-public`)    | `worktrees/optimize-governance-md` | `worktree/optimize-governance-md` | yes — at Phase 17 (PR17) |
+
+---
+
+## PR Map
+
+| PR   | Phase | Repo    | Class      | Contents                                                 |
+| ---- | ----- | ------- | ---------- | -------------------------------------------------------- |
+| PR1  | 1     | public  | executable | Gate impl, config, convention rename, specs, removals    |
+| PR2  | 2     | public  | markdown   | `repo-governance/conventions/`                           |
+| PR3  | 3     | public  | markdown   | `repo-governance/development/`                           |
+| PR4  | 4     | public  | markdown   | `repo-governance/workflows/`                             |
+| PR5  | 5     | public  | markdown   | `repo-governance/principles/`, `vision/`, architecture   |
+| PR6  | 6     | public  | markdown   | `.claude/agents/` → skills, mirrors                      |
+| PR7  | 7     | public  | markdown   | `.claude/skills/`, mirrors                               |
+| PR8  | 8     | public  | markdown   | `AGENTS.md`, `CLAUDE.md`, root indexes, final mirrors    |
+| PR9  | 9     | public  | executable | Flip to hard-fail; arm word-budget + readme-completeness |
+| PR10 | 10    | private | executable | Byte-identical rhino-cli sync, config, specs             |
+| PR11 | 11    | private | markdown   | `repo-governance/conventions/`                           |
+| PR12 | 12    | private | markdown   | `repo-governance/development/`                           |
+| PR13 | 13    | private | markdown   | `repo-governance/workflows/`, `principles/`, `vision/`   |
+| PR14 | 14    | private | markdown   | `.claude/agents/` → skills, mirrors                      |
+| PR15 | 15    | private | markdown   | `.claude/skills/`, `AGENTS.md`, `CLAUDE.md`, mirrors     |
+| PR16 | 16    | private | executable | Flip to hard-fail; arm word-budget + readme-completeness |
+| PR17 | 17    | public  | markdown   | Knowledge capture; plan-folder archival to `plans/done/` |
+
+**17 PRs, 4 executable.** No PR opens before Phase 1 — Phase 0 opens none. PR17 exists because
+Phase 17's archival diff (`git mv` of the plan folder, README updates) is a real, git-tracked
+change to `ose-public`, and `main` is branch-protected under `worktree-to-pr` — see Finding 9 of
+the 2026-08-13 plan audit.
+
+---
+
+## Phase 0 — Baseline (`ose-public`)
+
+No PR. Establishes a clean, known-good starting state.
+
+- [ ] `[AI]` Verify exactly one `optimize-governance-md` worktree exists: `git worktree list`
+- [ ] `[AI]` `npm install`
+- [ ] `[AI]` `npm run doctor -- --fix`
+- [ ] `[AI]` Record the violation census to `evidence/phase-0-census.txt`:
+      `find repo-governance .claude .cursor .codex .opencode .pi .amazonq -name '*.md' -type f -print0 | xargs -0 wc -w | grep -v ' total$' | sort -rn`
+- [ ] `[AI]` Record README-index coverage to `evidence/phase-0-readme-coverage.txt`
+- [ ] `[AI]` Record frontmatter coverage to `evidence/phase-0-frontmatter.txt`
+- [ ] `[AI]` Run the full pre-push surface and resolve every preexisting failure:
+      `apps/rhino-cli/scripts/rhino-bin.sh gate run --surface=pre-push`
+- [ ] `[AI]` **Cursor subdirectory-recursion research refresh** — the one open research gap, resolved
+      without a live IDE launch (no CLI/API exists for an agent to observe Cursor GUI behavior;
+      see [User Decisions Required — `cursor_smoke_test_tagging`, resolved `redesign_research_only`]).
+      Delegate to `web-researcher`: re-check [cursor.com/docs/subagents](https://cursor.com/docs/subagents),
+      the Cursor changelog, and the Cursor GitHub issue tracker for any newly-documented
+      `.cursor/agents/` subdirectory support. Record the result — cited findings + access date, or
+      "no new information found" — in `evidence/phase-0-cursor-recursion.md`. The plan proceeds with
+      flat mirrors either way (per `prd.md` §FR-3.16, which treats Cursor as unsupported until proven
+      otherwise), so this is informational, not blocking.
+
+### Phase 0 Gate
+
+- `git worktree list` shows exactly one `optimize-governance-md` entry
+- `gate run --surface=pre-push` exits 0 with no preexisting failures
+- All three census files exist and are non-empty
+- The Cursor research-refresh result is recorded in `evidence/phase-0-cursor-recursion.md`
+
+> **Pause Safety**: nothing has changed. Safe to stop indefinitely.
+
+---
+
+## Phase 1 — Gate implementation (`ose-public`, PR1, executable)
+
+### 1a. RED — failing tests first
+
+- [ ] `[AI]` Write unit tests in `apps/rhino-cli/src/application/governance/word_budget.rs`
+      covering every FR-1 and FR-2 scenario in `prd.md`
+
+  **Gherkin (underpins) →** "A file within target passes silently"; "A file between target and
+  fail warns without blocking"; "A file over the ceiling fails the gate"; "Every covered surface
+  is scanned"; "Non-prose content counts toward the budget"; "An out-of-scope file is never
+  scanned"; "The config schema rejects an exemption key"; "The old command is gone"; "The old
+  config block is gone"; "The old gate id is gone from the registry"; "The resolved tree is
+  measured in words"; "An oversized resolved tree fails"; "Import cycles terminate"; "No inbound
+  link to the renamed convention is left broken"
+
+- [ ] `[AI]` Write a dedicated unit test in `apps/rhino-cli/src/application/governance/
+word_budget.rs` asserting `check_instruction_sizes` resolves surface overlap by
+      **selecting the winning surface before classifying**, not by comparing candidate findings
+      after the fact: build a `BudgetConfig` with two surfaces matching the same path (a general
+      `fail: 500` surface declared first, a specific `fail: 900` surface declared second) against
+      a file sized to fail the general surface but only warn the specific one; assert the
+      returned findings contain exactly **one** finding for that path, with the specific
+      surface's `target`/`warn`/`fail`/severity — not two findings, and not the general surface's
+      `Fail`. This targets the precedence rule as new **selection logic** in code (`tech-docs.md`
+      §1.1/§1.3), not merely YAML declaration order
+
+  **Gherkin (binds) →** "A README.md file uses the wider README-specific glob threshold"
+
+  ```gherkin
+  Scenario: A README.md file uses the wider README-specific glob threshold
+    Given "repo-governance/development/quality/README.md" contains 850 words
+    When I run "rhino-cli governance word-budget validate"
+    Then the exit code is 0
+    And the output contains a "warn" finding naming that file, not a "fail" finding
+  ```
+
+- [ ] `[AI]` Write a second dedicated unit test in the same file covering the **Ok-winner case**:
+      build a `BudgetConfig` with the same two overlapping surfaces (general `fail: 500` declared
+      first, specific `fail: 900` declared second) against a fixture file sized at 670 words —
+      large enough that the general surface alone would classify it `Fail`, but within the
+      specific surface's own `target: 700` (so the specific surface's own verdict is `Ok`); assert
+      `check_instruction_sizes` returns **zero** findings for that path. This is the case
+      iteration 7's remediation missed: a "keep the more severe of the candidate findings"
+      design produces no candidate to keep when the winning surface's own verdict is Ok, so it
+      silently leaves the general surface's `Fail` unfiltered — this test targets that specific
+      failure mode
+
+  **Gherkin (binds) →** "A README.md file under the specific-surface target produces zero
+  findings"
+
+  ```gherkin
+  Scenario: A README.md file under the specific-surface target produces zero findings
+    Given "repo-governance/development/quality/README.md" contains 670 words
+    When I run "rhino-cli governance word-budget validate"
+    Then the exit code is 0
+    And the output contains no finding naming that file
+    And this holds even though 670 words exceeds the general surface's 500-word fail ceiling,
+      because the winning README-specific surface classifies 670 words as "ok" against its own
+      700-word target
+  ```
+
+- [ ] `[AI]` Write unit tests for the README-index gate covering every FR-3 scenario
+
+  **Gherkin (underpins) →** "A complete index passes"; "A missing sibling link fails"; "A missing
+  subdirectory README link fails"; "A missing README fails when siblings exist"; "The rule does
+  not reach grandchildren"; "A split directory is exempt and its parent indexes it"; "A split
+  directory whose parent omits a child fails"; "An uncovered tree is not scanned"; "A generated
+  mirror directory is not scanned"; "A generated mirror is still subject to the word budget"; "The
+  Phase 1 rename introduces no enforcement gap for orphan or ghost"; "The unannotated finding kind
+  is dark-launched, not enforced, before Phase 9"; "The unannotated finding kind fails once armed
+  and in scope"
+
+- [ ] `[AI]` Write unit tests in `apps/rhino-cli/src/commands/governance_validate_readme_index.rs`
+      for the FR-5.8 mechanism: `--paths` overrides `DEFAULT_PATHS` when given and leaves it
+      unchanged when absent; `--fail-kinds` restricts which discovered finding kinds contribute to
+      the nonzero exit code while every kind is still discovered and printed regardless
+
+  **Gherkin (underpins) →** "The --paths flag overrides the default scan scope"; "The
+  --fail-kinds flag restricts which findings contribute to the exit code"
+
+- [ ] `[AI]` Write a unit test in `apps/rhino-cli/src/application/docs/frontmatter.rs` asserting
+      `validate_governance_schema` reports a `KIND_MISSING_WHEN_TO_USE` finding at **WARN**
+      severity for a governance file missing `when_to_use` — the dark-launched, not-yet-armed
+      FR-4.1 behavior (see `tech-docs.md` §5 "Dark-launch sequencing"). The FAIL-severity
+      end-state scenarios in `prd.md` §FR-4 (including "A missing description now fails, not
+      warns") are Phase 9's RED target, not Phase 1's
+
+  **Gherkin (binds) →** "A missing when_to_use warns during Phase 1's dark-launch, before
+  enforcement is armed"
+
+  ```gherkin
+  Scenario: A missing when_to_use warns during Phase 1's dark-launch, before enforcement is armed
+    Given "repo-governance/conventions/formatting/linking.md" frontmatter has no "when_to_use"
+    And Phase 1 has registered the check but not yet armed it to FAIL severity
+    When I run "rhino-cli md frontmatter validate"
+    Then the exit code is 0
+    And the output contains a "when_to_use" finding at "warn" severity
+  ```
+
+- [ ] `[AI]` Write the companion Gherkin under
+      `specs/apps/rhino/behavior/rhino-cli/gherkin/governance/`
+- [ ] **Command**: `npx nx run rhino-cli:test:unit`
+- [ ] **Acceptance**: the run fails, and the failures are the new tests — not compilation errors
+      in unrelated modules
+
+### 1b. GREEN — make them pass
+
+- [ ] `[AI]` `git mv` `instruction_size.rs` → `application/governance/word_budget.rs`; replace
+      the byte metric with `split_whitespace().count()`
+- [ ] `[AI]` Implement per-path overlap precedence in `word_budget.rs`'s `check_instruction_sizes`
+      by restructuring the iteration order — **select the winning surface for each path before
+      classifying it, never classify-then-compare**. Concretely: replace the current "for each
+      surface, classify every matching file and push a candidate if non-Ok" loop with two passes.
+      Pass 1: for each surface in declaration order, glob-match its files and record, per
+      resolved path, the **most recently matched surface** in a `path -> &Surface` map (a plain
+      `HashMap::insert` per match is sufficient — because surfaces are iterated in
+      `config.surfaces` declaration order, a later-declared surface's match always overwrites an
+      earlier one for the same path, so the map holds the last-declared — i.e. winning — surface
+      per path with no extra index bookkeeping needed). Pass 2: for each `(path, winning_surface)`
+      entry, call `classify()` **exactly once**, using only the winning surface's
+      `target`/`warn`/`fail`, and push a `Finding` **only if that single classification is not
+      `Severity::Ok`**. This is new selection logic — the current `instruction_size.rs` has none
+      (`tech-docs.md` §1.1) — required for both dedicated unit tests above (the Warn/Fail-winner
+      case and the Ok-winner case) and for FR-1.6/FR-3.15's three README-glob Gherkin scenarios in
+      `prd.md` to pass. The prior design (dedup over the results of the existing Ok-filtered
+      per-surface loop) is insufficient: it never generates a candidate to keep when the winning
+      surface's own verdict is Ok, so a stray Fail from a less-specific, earlier-declared surface
+      survives unfiltered for that path — this restructured select-then-classify order removes
+      that failure mode structurally, because the earlier-declared surface's classification is
+      never computed for a path a later surface also matches
+- [ ] `[AI]` `git mv` `commands/harness_validate_instruction_size.rs` →
+      `commands/governance_validate_word_budget.rs`; then fold
+      `commands/convention_validate_instruction_size.rs`'s implementation body (the `SCHEMA`
+      const, `run_for_root`, finding construction, and text/JSON/markdown formatters — the real
+      logic the thin wrapper delegated to) directly into that same file, and `git rm`
+      `convention_validate_instruction_size.rs` — per `tech-docs.md` §1.4's Command file merge
+      note
+- [ ] `[AI]` Update `apps/rhino-cli/src/commands.rs`: remove the `pub mod
+convention_validate_instruction_size;` declaration entirely (its file is merged away) and rename
+      `pub mod harness_validate_instruction_size;` to `pub mod governance_validate_word_budget;`
+- [ ] `[AI]` Update `apps/rhino-cli/src/cli.rs`: rewrite the `#[command(name =
+"instruction-size", subcommand)]` command tree and the `Validate(...)` dispatch to
+      `governance word-budget validate`, and rewrite the two unit tests that assert the OLD
+      command structure — `verb_last_harness_instruction_size_validate_parses` and
+      `verb_middle_convention_validate_instruction_size_no_longer_parses`
+- [ ] `[AI]` Update `apps/rhino-cli/src/application/repo_governance/audit_orchestrator.rs`:
+      rename the `"instruction-size"` category name, command-name mapping, and `match` arm
+      dispatching to `audit_instruction_size` (which calls `merged_budget_config` directly — see
+      the corrected FR-1.15 framing in `prd.md`) to `"governance-word-budget"`, and update its
+      five unit test assertions referencing the literal string `"instruction-size"`
+- [ ] `[AI]` Update `apps/rhino-cli/src/commands/harness_audit.rs`: rename its separate
+      `"validate-instruction-size"` member, `match` arm, and unit test
+      (`MEMBERS.contains(&"validate-instruction-size")`) to the new command name
+- [ ] `[AI]` In `apps/rhino-cli/src/application/repo_governance/mod.rs`, remove `pub mod
+instruction_size;` (the module moves to a new parent, not a sibling rename); in
+      `apps/rhino-cli/src/application/mod.rs`, add a new `pub mod governance;` line — the
+      `application/governance/` directory does not exist yet and needs this declaration
+- [ ] `[AI]` Update `apps/rhino-cli/src/application/repo_config/mod.rs`: rename the
+      `#[serde(rename = "instruction-size", default)] pub instruction_size: Option<BudgetConfig>`
+      field to `governance-word-budget`, and repoint its `use` of `BudgetConfig` to
+      `application::governance::word_budget`
+- [ ] `[AI]` **Rename, do not rebuild** (per `prd.md` §FR-3 "Repurpose, do not rebuild" and
+      `tech-docs.md` §1.1): `git mv
+apps/rhino-cli/src/application/repo_governance/readme_index_audit.rs` →
+      `apps/rhino-cli/src/application/governance/readme_index.rs`, and `git mv
+apps/rhino-cli/src/commands/md_validate_readme_index.rs` →
+      `apps/rhino-cli/src/commands/governance_validate_readme_index.rs`. Preserve the existing
+      `orphan`/`ghost` detection logic and the current `DEFAULT_PATHS` (4 entries) unchanged —
+      that behavior stays exactly as it is today
+- [ ] `[AI]` In `apps/rhino-cli/src/cli.rs`, remove `ReadmeIndex(MdReadmeIndexCommands)` from
+      `MdCommands` and add it under a new `#[command(name = "governance", subcommand)]` tree
+      alongside `word-budget`, so the CLI surface becomes `governance readme-index validate`
+      (was `md readme-index validate`)
+- [ ] `[AI]` In `apps/rhino-cli/src/commands.rs`, rename `pub mod md_validate_readme_index;` to
+      `pub mod governance_validate_readme_index;`
+- [ ] `[AI]` Add a `generate` path (FR-3.12) and two new finding kinds to the renamed module:
+      `missing` (a covered directory needing an index has none — FR-3.1) and `unannotated` (an
+      entry lacks the derived-annotation format or has drifted from the target's frontmatter —
+      FR-3.10/FR-3.11/FR-3.14). Widen the module's internal covered-tree constant to FR-3.7's
+      full 6-entry list (`repo-governance/`, `.claude/`, `.codex/`, `.pi/`, `docs/`, `specs/` —
+      never `plans/`, `apps/`, `libs/`, or the generated mirror trees) for use by the
+      `governance-readme-completeness` gate (below) — the continuity-preserving
+      `governance-readme-index` gate keeps the original, unwidened `DEFAULT_PATHS`
+- [ ] `[AI]` Add two repeatable CLI flags to `ReadmeIndexAuditArgs` in
+      `apps/rhino-cli/src/commands/governance_validate_readme_index.rs` (per `tech-docs.md` §4
+      "The mechanism" and `prd.md` FR-5.8/FR-1.10/FR-1.11): `--paths <path>` (when given, replaces
+      `DEFAULT_PATHS` for this invocation; when absent, `DEFAULT_PATHS` is used exactly as today)
+      and `--fail-kinds <kind>` (when given, restricts which discovered finding kinds contribute
+      to the nonzero exit code; every kind is still discovered and printed regardless — when
+      absent, all kinds fail, preserving today's standalone-CLI behavior). Both flags map onto
+      `repo-config.yml`'s existing `args:` → `fixed_arguments()` repeated-`--<key> <value>`
+      mechanism (`apps/rhino-cli/src/application/repo_config/mod.rs::fixed_arguments`) — no
+      change to that mechanism is needed
+- [ ] `[AI]` In `repo-config.yml`, rename the `md-readme-index` gate entry **in place** to
+      `governance-readme-index` — same `command:` update, same `scope: all-file-type` on both
+      `pre-push` and `ci`, plus one new `args: { fail-kinds: [orphan, ghost] }` block (`prd.md`
+      FR-1.10/FR-1.11's YAML) so a `missing`/`unannotated` finding surfacing inside this gate's
+      unchanged scan scope is reported but never fails the build. No `paths:` override is added —
+      omitting it keeps this gate scanning the original, unwidened `DEFAULT_PATHS`. This is still
+      a straight rename, not a delete-then-re-add: the gate stays continuously armed through this
+      commit (FR-3.19 — no enforcement gap)
+- [ ] `[AI]` **Teach `harness bindings generate` to flatten** (FR-3.18). A grouped source at
+      `.claude/agents/<group>/<file>.md` must still emit `.opencode/agents/<name>.md` and
+      `.cursor/agents/<name>.md` at the top level, filename derived from the `name` frontmatter
+      key. **This must land before Phase 6 groups the source** — OpenCode declined subdirectory
+      support ("not planned"), so a 1:1 mirrored subfolder silently orphans 94 agents.
+- [ ] `[AI]` Add a unit test asserting a grouped source produces a flat mirror path, and a test
+      asserting two agents with the same `name` in different groups is a hard error
+- [ ] `[AI]` Replace `instruction-size:` with `governance-word-budget:` in `repo-config.yml`;
+      extend the schema to reject any exemption key
+- [ ] `[AI]` Add a `**/README.md` glob entry (`target: 700, warn: 900, fail: 900`) to the new
+      `governance-word-budget:` block in `repo-config.yml`, declared **after** the general surface
+      globs so the last-declared-surface-wins logic added above selects it on overlap, per
+      FR-1.6/FR-3.15's precedence rule (`tech-docs.md` §1.3). This, combined with that selection
+      logic, is the mechanism `repo-governance/development/quality/README.md` (~670 words per
+      `tech-docs.md` §4.4's table) needs to pass the word budget once Phase 9 arms enforcement —
+      without both the glob entry and the select-then-classify selection logic, the general
+      500-word ceiling's `Fail` finding for that file would still trip the gate, because at 670
+      words the file's `Fail` verdict comes only from the general surface's tighter `fail: 500`
+      ceiling — the README-specific surface's own verdict at 670 words is `Ok` (670 ≤ its
+      `target: 700`), not `Warn`, so there is no "specific surface warns" to fall back on; the
+      selection logic must resolve this by classifying only against the winning (README-specific)
+      surface, which correctly yields zero findings, not by comparing an Ok surface's absence of
+      a candidate against the general surface's Fail candidate
+- [ ] `[AI]` Add `when_to_use` to the frontmatter validator (`KIND_MISSING_WHEN_TO_USE`),
+      scoped to `repo-governance/**/*.md`, reported at **WARN** severity (the same
+      `SEVERITY_WARN` construction `description` already uses) — dark-launched, not yet armed;
+      Phase 9 flips it to FAIL. `description`'s severity is **not** changed in this phase —
+      FR-4.2's `mk_fail()` upgrade is deferred to Phase 9's GREEN step. See `tech-docs.md` §5
+      "Dark-launch sequencing"
+- [ ] `[AI]` Add both Nx targets to `apps/rhino-cli/project.json`
+- [ ] `[AI]` `git mv` the convention doc to `governance-word-budget.md`, rewrite it, and split it
+      so it satisfies its own 500-word ceiling
+- [ ] `[AI]` Rewrite every inbound link to the old convention path — discover the set live with
+      `grep -rl "instruction-size\|instruction-file-size-budget" repo-governance .claude docs
+AGENTS.md` (10 files as of 2026-08-13, excluding the convention doc itself; **do not** use
+      a fixed count) and rewrite each hit
+- [ ] `[AI]` Separately, discover every `specs/` file naming the old gate — `grep -rl
+"instruction-size" specs` (9 files as of 2026-08-13, **do not** use a fixed count; a distinct
+      sweep from the inbound-link grep above, since it targets Gherkin scenario/README text naming
+      the gate, not markdown links to the convention doc) — and rewrite each hit: the 3
+      `harness/repo-governance-instruction-size*.feature` files' scenario text (gate name, Step 0.5
+      preflight category, skip-set category, Nx-target references), the already-planned
+      `harness/repo-governance-agents-md-size.feature` rewrite, the 3 index READMEs
+      (`gherkin/README.md`, `gherkin/harness/README.md`, `gherkin/repo-governance/README.md`), and
+      the command-name mentions in `gherkin/specs/harness-registry-driven.feature` and
+      `gherkin/specs/harness-bindings.feature`
+- [ ] `[AI]` Delete the 12 obsolete `*instruction-size*`-named golden-master fixtures (4
+      commands × `.exit`/`.stderr`/`.stdout`); regenerate under the new gate ids. Also regenerate
+      the 4 golden-master snapshots whose _content_ references the string without being named
+      for it — `harness-help.stderr`, `convention-validate.stderr`, `harness-validate.stderr`,
+      `manifest.json` — their `--help`/manifest output changes once the command is renamed
+- [ ] `[AI]` Delete the 9 obsolete `*readme-index*`-named golden-master fixtures
+      (`md-readme-index.{exit,stderr,stdout}`, `md-readme-index-validate.{exit,stderr,stdout}`,
+      `md-validate-readme-index.{exit,stderr,stdout}`); regenerate under the
+      `governance-readme-index` naming
+- [ ] **Command**: `npx nx run rhino-cli:test:unit && npx nx run rhino-cli:test:quick && npx nx
+run rhino-cli:specs:behavior:coverage`
+- [ ] **Acceptance**: exit 0 on all three; every new test passes; no `instruction-size` string
+      remains outside `plans/done/`; `specs:behavior:coverage` confirms the new Gherkin under
+      `specs/apps/rhino/behavior/rhino-cli/gherkin/governance/` stays in sync with the
+      implementation (NFR-4)
+
+### 1c. REFACTOR
+
+- [ ] `[AI]` Extract shared glob/threshold handling used by the word-budget and readme-index
+      modules
+- [ ] `[AI]` `cargo clippy` clean at warning level; `cargo fmt`
+- [ ] **Command**: `apps/rhino-cli/scripts/rhino-bin.sh gate run --surface=pre-push`
+- [ ] **Acceptance**: exit 0
+
+### 1d. Register, but do not arm (word budget and readme-completeness only)
+
+- [ ] `[AI]` Confirm the `gates:` registry does **not** yet contain
+      `governance-word-budget` or `governance-readme-completeness` — Phase 9 arms them
+- [ ] `[AI]` Confirm the `instruction-size` gate entry **is** removed
+- [ ] `[AI]` Confirm `governance-readme-index` **is** present and armed (`scope:
+all-file-type`, both `pre-push` and `ci`) immediately after this commit — it is the
+      continuity-preserving rename of the already-armed `md-readme-index`, not a dark-launched
+      gate; confirm `md-readme-index` no longer appears anywhere in `repo-config.yml`
+- [ ] `[AI]` **Prove `path-gated` works on the `ci` surface** before Phase 9 depends on it.
+      `governance-word-budget` and `governance-readme-completeness` are the first `ci`-surface
+      users of that scope — all six pre-existing path-gated declarations are `pre-push`.
+      Register a throwaway path-gated `ci` gate, run `gate run --surface=ci` once with a
+      matching changed path and once without, confirm it executes then skips, and remove the
+      fixture. Record both runs in `evidence/phase-1-ci-path-gated.txt`.
+- [ ] `[AI]` If `ci` path-gating does **not** work, stop and re-plan Phase 9 wiring — do not
+      fall back to `all-file-type` for `governance-word-budget` or `governance-readme-completeness`,
+      which would run a whole-tree scan on every PR
+
+### 1e. Parity and PR
+
+- [ ] `[AI]` `rhino-cli parity manifest generate && git add apps/rhino-cli/parity-manifest.sha256`
+- [ ] `[AI]` `rhino-cli parity manifest validate`
+- [ ] `[AI]` Commit thematically (per §Commit Guidelines), push, open PR1, run the PR review
+      cycle to a clean result, merge
+- [ ] `[AI]` Poll `gh run view --json status,conclusion` for PR1's `pr-quality-gate.yml` run
+      every 2 minutes until conclusion — acceptance: `conclusion == success`; never `gh run watch`
+
+### Phase 1 Gate
+
+- `npx nx run rhino-cli:governance-word-budget:validation` runs and reports failures matching a
+  live re-run of `tech-docs.md` §7's census script against the full FR-1.3-scoped covered surface
+  (measured 2026-08-13: **464** files for `ose-public` — not the narrower 298 "source
+  (non-generated)" figure in `README.md` §Context/`brd.md` §Success Metrics, which excludes the
+  `.cursor`/`.opencode`/`.amazonq` mirrors and root `AGENTS.md`/`CLAUDE.md`; re-verify live, since
+  the count drifts as governance content changes on this continuously-edited repo)
+  [Repo-grounded — re-derived directly against FR-1.3's declared glob list]
+- `npx nx run rhino-cli:governance-readme-index:validation` runs, reports **zero** `orphan`/
+  `ghost` findings (unchanged behavior from the `md-readme-index` baseline it replaces), and
+  reports **none** under `plans/`, `apps/`, `.opencode/`, `.cursor/`, or `.amazonq/`
+- A grouped-source fixture emits flat mirror paths; `npm run validate:sync` exits 0
+- `rhino-cli gate list --surface=pre-push --format=text` shows `governance-readme-index`
+  (`all-file-type`, armed) but **neither** `governance-word-budget` **nor**
+  `governance-readme-completeness` — those two stay dark-launched until Phase 9
+- `rhino-cli md frontmatter validate` reports `when_to_use` findings at **WARN** severity
+  (dark-launched, not yet armed) and `description` unchanged at WARN — CI does not fail on
+  either check yet; see `tech-docs.md` §5 "Dark-launch sequencing"
+- `rhino-cli md links validate` exits 0
+- `rhino-cli parity manifest validate` exits 0
+- The dedicated overlap-precedence unit test (Phase 1a) passes: a path matched by two surfaces
+  produces exactly one finding, taken from the last-declared matching surface
+- PR1 merged
+
+> **Pause Safety**: `governance-word-budget` and `governance-readme-completeness` exist as
+> reporting tools and block nothing yet. The byte budget is gone. `governance-readme-index`
+> (orphan/ghost) is the one exception — it is already armed and blocking, exactly as
+> `md-readme-index` was before this PR, so nothing regresses. Safe to stop — see `tech-docs.md`
+> §6.2 on the accepted (word-budget-only) enforcement gap.
+
+---
+
+## Phases 2–5 — `repo-governance/` splits (`ose-public`, PR2–PR5, markdown-only)
+
+Independent of each other; fan out up to N=3.
+
+| Phase | Subtree                                                                           | PR  |
+| ----- | --------------------------------------------------------------------------------- | --- |
+| 2     | `repo-governance/conventions/`                                                    | PR2 |
+| 3     | `repo-governance/development/`                                                    | PR3 |
+| 4     | `repo-governance/workflows/`                                                      | PR4 |
+| 5     | `repo-governance/principles/`, `vision/`, `repository-governance-architecture.md` | PR5 |
+
+Each phase performs the same four operations on its subtree (`<subtree>` = the phase's own
+`repo-governance/...` path from the table above):
+
+- [ ] `[AI]` **Split**: every file over 500 words in `<subtree>` becomes an index parent plus a
+      sibling directory of capped children, per `tech-docs.md` §2. No rule text is changed —
+      content is relocated only. Acceptance:
+      `npx nx run rhino-cli:governance-word-budget:validation` reports 0 failures under
+      `<subtree>`
+- [ ] `[AI]` **Frontmatter**: add `when_to_use` to every file in `<subtree>`, including new
+      children; backfill `description` where missing. Acceptance:
+      `rhino-cli md frontmatter validate` exits 0 for `<subtree>`
+- [ ] `[AI]` **Index**: create or update every `README.md` in `<subtree>` with annotated entries
+      derived from target frontmatter; split directories are indexed by their parent. Acceptance:
+      `npx nx run rhino-cli:governance-readme-index:validation` reports 0 `orphan`/`ghost`
+      failures under `<subtree>` (this Nx target maps to the already-armed
+      `governance-readme-index` gate), **and** `rhino-cli governance readme-index validate
+<subtree>` (direct invocation — `governance-readme-completeness` is not armed until Phase 9, so
+      this must be run directly, not via its Nx target) reports 0 `missing`/`unannotated`
+      findings under `<subtree>`
+- [ ] `[AI]` **Verify**: `rhino-cli md links validate && rhino-cli md heading-hierarchy validate
+&& npm run lint:md`. Acceptance: all three exit 0
+- [ ] `[AI]` Commit thematically (per §Commit Guidelines), push, open this phase's PR, wait for
+      a green `pr-quality-gate.yml` run (markdown-only, no review cycle), merge
+- [ ] `[AI]` Poll `gh run view --json status,conclusion` for this phase's `pr-quality-gate.yml`
+      run every 2 minutes until conclusion — acceptance: `conclusion == success`; never
+      `gh run watch`
+
+### Phase 2–5 Gate (each)
+
+- `npx nx run rhino-cli:governance-word-budget:validation` reports **zero** failures within the
+  phase's subtree
+- `npx nx run rhino-cli:governance-readme-index:validation` reports zero `orphan`/`ghost`
+  failures within it (armed gate)
+- `rhino-cli governance readme-index validate <subtree>` (direct invocation) reports zero
+  `missing`/`unannotated` findings — not yet CI-enforced, but must already be clean so Phase 9's
+  arming step is a no-op flip, not a scramble
+- `rhino-cli md frontmatter validate` exits 0 for the subtree
+- `rhino-cli md links validate` exits 0 repo-wide — no inbound link broken
+- `rhino-cli md heading-hierarchy validate` exits 0
+- `npm run lint:md` exits 0
+- Rule-preservation check: every heading present before the split is present after it
+- PR merged on a green `pr-quality-gate.yml`
+
+> **Pause Safety**: each merged subtree is self-consistent. Stopping between phases leaves the
+> repo readable and every link resolving.
+
+---
+
+## Phase 6 — `.claude/agents/` → skills (`ose-public`, PR6, markdown-only)
+
+78 of 94 agent files exceed the ceiling [Repo-grounded, verified 2026-08-13]. This phase carries
+the plan's highest behavioural risk.
+
+- [ ] `[AI]` For each oversized agent, create or extend `.claude/skills/<skill-name>/` with
+      `SKILL.md` plus `reference/NN-*.md` modules, per `tech-docs.md` §3.2
+- [ ] `[AI]` Reduce each agent body to a ≤500-word charter ending in the **mandatory read
+      directive** from `tech-docs.md` §3.3
+- [ ] `[AI]` **Group** `.claude/agents/` into role subfolders so its annotated index fits the
+      ceiling. Claude Code discovery is unaffected — identity comes from the `name` frontmatter
+      key, not the path. Verify every `name` is unique across the whole tree first; duplicates
+      load non-deterministically.
+- [ ] `[AI]` Build the grouped, annotated `.claude/agents/README.md` — group entries only, each
+      group's own README annotating its members
+- [ ] `[AI]` `npm run generate:bindings` — regenerate `.opencode/`, `.cursor/`, `.amazonq/`
+- [ ] `[AI]` **Confirm the mirrors came out flat**: `/bin/ls .opencode/agents/` shows no
+      subdirectories and the same 94 filenames as before grouping
+- [ ] `[AI]` `npm run validate:sync`
+- [ ] `[AI]` **Behavioural verification**: invoke at least five migrated agents on real tasks and
+      confirm each reads its reference modules and applies a rule that lives only in a module.
+      Record transcripts under `evidence/phase-6-agent-verification/`.
+- [ ] `[AI]` Commit thematically (per §Commit Guidelines), push, open PR6, wait for a green
+      `pr-quality-gate.yml` run (markdown-only, no review cycle), merge
+- [ ] `[AI]` Poll `gh run view --json status,conclusion` for PR6's `pr-quality-gate.yml` run
+      every 2 minutes until conclusion — acceptance: `conclusion == success`; never
+      `gh run watch`
+
+### Phase 6 Gate
+
+- Zero word-budget failures under `.claude/agents/` **and** under every generated mirror
+- `.opencode/agents/` and `.cursor/agents/` are **flat** — no subdirectory, no lost agent
+- Every agent `name` is unique across the grouped tree
+- `npm run validate:sync` exits 0
+- No mirror was hand-edited (`git diff` on mirrors matches generator output exactly)
+- Five behavioural verifications recorded, all passing
+- PR merged
+
+> **Pause Safety**: if a verification fails, revert PR6 and re-split that agent. Agents are
+> restored wholesale by the revert.
+
+---
+
+## Phase 7 — `.claude/skills/` (`ose-public`, PR7, markdown-only)
+
+Depends on Phase 6 (which creates new skills).
+
+- [ ] `[AI]` Split the 29 oversized skill files [Repo-grounded, verified 2026-08-13 via
+      `find .claude/skills -mindepth 2 -maxdepth 2 -name 'SKILL.md' -print0 | xargs -0 wc -w |
+      awk '$1>500'`] into `SKILL.md` + `reference/NN-*.md`. Acceptance:
+      `npx nx run rhino-cli:governance-word-budget:validation` reports 0 failures under
+      `.claude/skills/`
+- [ ] `[AI]` Index every `reference/` directory per FR-3. Acceptance:
+      `npx nx run rhino-cli:governance-readme-index:validation` reports 0 failures under
+      `.claude/skills/`
+- [ ] `[AI]` `npm run generate:bindings && npm run validate:sync`. Acceptance: both exit 0
+- [ ] `[AI]` Confirm no stale `.opencode/skill/` or `.opencode/skills/<claude-name>` mirror
+      reappeared. Acceptance: `validate:sync`'s `No Synced Skill Mirror` check passes
+- [ ] `[AI]` Commit thematically (per §Commit Guidelines), push, open PR7, wait for a green
+      `pr-quality-gate.yml` run (markdown-only, no review cycle), merge
+- [ ] `[AI]` Poll `gh run view --json status,conclusion` for PR7's `pr-quality-gate.yml` run
+      every 2 minutes until conclusion — acceptance: `conclusion == success`; never
+      `gh run watch`
+
+### Phase 7 Gate
+
+- Zero word-budget failures under `.claude/skills/`
+- `validate:sync` `No Synced Skill Mirror` check passes
+- PR merged
+
+> **Pause Safety**: `.claude/agents/` (Phase 6) and `.claude/skills/` (this phase) are both split,
+> indexed, and green. Safe to stop before Phase 8's root-instruction-file rewrite. To resume:
+> `npx nx run rhino-cli:governance-word-budget:validation` on `.claude/` should report zero
+> failures.
+
+---
+
+## Phase 8 — Root instruction files (`ose-public`, PR8, markdown-only)
+
+- [ ] `[AI]` Rewrite `AGENTS.md` (3,001 → ≤500 words) as a directive index whose opening
+      instruction requires reading the linked surfaces before acting
+- [ ] `[AI]` Rewrite `CLAUDE.md` (907 → ≤500 words), preserving the
+      `Platform Binding Examples` heading the vendor-audit scanner depends on, and the
+      `<!-- nx configuration -->` / `<!-- rtk-instructions -->` marker pairs
+- [ ] `[AI]` Verify the resolved-tree word budget: `CLAUDE.md` + `@AGENTS.md` ≤ 1,500 words
+- [ ] `[AI]` Update `repo-governance/README.md` and every top-level index
+- [ ] `[AI]` Final `npm run generate:bindings && npm run validate:sync`
+- [ ] `[AI]` Commit thematically (per §Commit Guidelines), push, open PR8, wait for a green
+      `pr-quality-gate.yml` run (markdown-only, no review cycle), merge
+- [ ] `[AI]` Poll `gh run view --json status,conclusion` for PR8's `pr-quality-gate.yml` run
+      every 2 minutes until conclusion — acceptance: `conclusion == success`; never
+      `gh run watch`
+
+### Phase 8 Gate
+
+- `governance-word-budget:validation` reports **zero failures repo-wide**
+- `governance-readme-index:validation` reports **zero** `orphan`/`ghost` failures repo-wide
+  (armed gate)
+- `rhino-cli governance readme-index validate` (direct invocation, full FR-3.7 6-tree scope)
+  reports **zero** `missing`/`unannotated` findings — `governance-readme-completeness` is not
+  armed until Phase 9, but must already be clean
+- Resolved-tree check passes
+- `rhino-cli harness vendor-audit` (or equivalent) still exits 0 — the scanner's
+  `Platform Binding Examples` skip still works
+- PR merged
+
+> **Pause Safety**: this is the last content phase. `ose-public` is fully compliant but not yet
+> enforced for `governance-word-budget`/`governance-readme-completeness`.
+> `governance-readme-index` (orphan/ghost) has been enforcing throughout. Safe to stop here for
+> an extended period.
+
+---
+
+## Phase 9 — Arm the gates (`ose-public`, PR9, executable)
+
+### 9a. RED
+
+- [ ] `[AI]` Add a fixture file over the ceiling; confirm `gate run --surface=pre-push` fails
+
+  **Gherkin (binds) →** "A triggered gate validates the whole covered tree, not just changed
+  files"
+
+  ```gherkin
+  Scenario: A triggered gate validates the whole covered tree, not just changed files
+    Given the changed paths include only "repo-governance/conventions/formatting/linking.md"
+    And "repo-governance/development/agents/ai-agents.md" contains 900 words
+    When I run "rhino-cli gate run --surface=pre-push"
+    Then the exit code is 1
+    And the finding names "repo-governance/development/agents/ai-agents.md"
+  ```
+
+- [ ] `[AI]` Confirm `rhino-cli md frontmatter validate` currently reports `when_to_use` and
+      `description` findings at WARN (not FAIL) for a deliberately incomplete fixture file — the
+      pre-arm baseline this phase's GREEN step must change (see `prd.md` §FR-4 "Dark-launch
+      sequencing")
+
+  **Gherkin (underpins) →** "A missing when_to_use fails"; "A missing description now fails, not
+  warns"
+
+- [ ] **Acceptance**: the pre-push surface exits 1 and names the fixture
+
+### 9b. GREEN
+
+- [ ] `[AI]` Register `governance-word-budget` in `gates:` with **`pre-push` and `ci` only**,
+      both `scope: path-gated`, `ci-group: governance`, and the 10-entry trigger list from
+      `prd.md` §FR-1.10. **No `pre-commit` surface.**
+- [ ] `[AI]` Register `governance-readme-completeness` (a **new** entry — do not touch the
+      already-armed `governance-readme-index`) with **`pre-push` and `ci` only**, both
+      `scope: path-gated`, `ci-group: governance`, the narrower 7-entry trigger list from
+      `prd.md` §FR-1.11 — no mirror trees, no `plans/` — and the `args: { paths: [...6-entry
+FR-3.7 list], fail-kinds: [missing, unannotated] }` block from `prd.md` FR-1.11's YAML (the
+      mechanism that makes this gate scan the widened scope and fail only on the two new finding
+      kinds — `tech-docs.md` §4 "The mechanism"). This gate flips `missing`/`unannotated`
+      from dark-launched to enforced (FR-3.20); `governance-readme-index` (`orphan`/`ghost`) is
+      untouched by this step — it has been armed since Phase 1
+- [ ] `[AI]` Register `governance-word-budget` (only) as a `repo-governance audit` category
+- [ ] `[AI]` **Arm FR-4** (register-then-arm for the already-active `md-frontmatter` gate): run
+      `rhino-cli md frontmatter validate` against `repo-governance/**/*.md` and confirm zero
+      files are missing `when_to_use` or `description` — true only once Phases 2–5 have merged.
+      Then, in `apps/rhino-cli/src/application/docs/frontmatter.rs::validate_governance_schema`,
+      change both the `KIND_MISSING_WHEN_TO_USE` finding and the `description` finding from
+      `SEVERITY_WARN` to `mk_fail()`, scoped to `GOVERNANCE_DOC_PREFIXES` — satisfies the "A
+      missing description now fails, not warns" Gherkin scenario in `prd.md` §FR-4
+- [ ] `[AI]` Remove the fixture
+- [ ] **Command**: `apps/rhino-cli/scripts/rhino-bin.sh gate validate`
+- [ ] **Acceptance**: exit 0 — shim, generated-artifact, and CI conformance all agree
+
+### 9b-2. Prove the gating both ways
+
+A trigger list that never fires is worse than no gate — it reads as green. Prove both
+directions on both surfaces, per the falsifiability rule that an acceptance clause must be
+checkable in both directions. Every case below also confirms `governance-readme-index`
+(`all-file-type`, unconditional) executes regardless of path — it is not part of this
+path-gating proof, since it was never dark-launched:
+
+- [ ] `[AI]` Touch `repo-governance/README.md` → `governance-word-budget` and
+      `governance-readme-completeness` **execute** on `pre-push` and `ci`;
+      `governance-readme-index` executes too (as always)
+- [ ] `[AI]` Touch only `apps/ayokoding-www/content/en/lesson-01.md` →
+      `governance-word-budget` and `governance-readme-completeness` **skip**;
+      `governance-readme-index` still executes (as always)
+- [ ] `[AI]` Touch only `.opencode/agents/<any>.md` → `governance-word-budget` **executes**,
+      `governance-readme-completeness` **skips**
+- [ ] `[AI]` Touch only `plans/in-progress/<any>/delivery.md` → `governance-word-budget` and
+      `governance-readme-completeness` **skip**
+- [ ] `[AI]` Touch only `repo-config.yml` → `governance-word-budget` and
+      `governance-readme-completeness` **execute**
+- [ ] `[AI]` Record every run in `evidence/phase-9-trigger-matrix.txt`
+
+### 9c. Parity and PR
+
+- [ ] `[AI]` `rhino-cli parity manifest generate && git add` + `validate`
+- [ ] `[AI]` Commit thematically (per §Commit Guidelines), push, open PR9, run the PR review
+      cycle to a clean result, merge
+- [ ] `[AI]` Poll `gh run view --json status,conclusion` for PR9's CI run every 2 minutes until
+      conclusion — acceptance: `conclusion == success`; never `gh run watch`
+
+### Phase 9 Gate
+
+- `rhino-cli gate list --surface=pre-push --format=text` shows all three gate ids:
+  `governance-word-budget` (`path-gated`), `governance-readme-completeness` (`path-gated`,
+  newly armed this phase), and `governance-readme-index` (`all-file-type`, armed since Phase 1)
+- `rhino-cli gate list --surface=ci --format=text` shows all three, with the same scopes
+- None of the three appears on the `pre-commit` surface
+- `gate validate` exits 0
+- `rhino-cli md frontmatter validate` reports `when_to_use` and `description` findings at
+  **FAIL** severity for `repo-governance/**/*.md` — FR-4 is armed; zero WARN-only downgrades
+  remain
+- A deliberately oversized file fails pre-push, then is removed
+- The 5-case trigger matrix in `evidence/phase-9-trigger-matrix.txt` matches expectations —
+  every **execute** case ran and every **skip** case skipped
+- `ose-public` census: **0 files over 500 words**
+- PR9 merged
+
+> **Pause Safety**: `ose-public` is complete and enforced. `ose-private` work has not started.
+> This is the natural long-pause point.
+
+---
+
+## Phase 10 — `ose-private` gate sync (PR10, executable)
+
+- [ ] `[AI]` `git worktree add worktrees/optimize-governance-md` in `ose-private`; verify exactly one
+- [ ] `[AI]` `npm install && npm run doctor -- --fix`
+- [ ] `[AI]` Baseline: `gate run --surface=pre-push` green; record the census to `evidence/`
+- [ ] `[AI]` Copy the rhino-cli boundary **byte-for-byte** from `ose-public` — `src`, `tests`,
+      `Cargo.toml`, `Cargo.lock`, `project.json`, `LICENSE`, and the Gherkin tree. Do not
+      reimplement.
+- [ ] `[AI]` Apply the equivalent `repo-config.yml` changes, adjusted for private's surfaces
+      (**no `.pi/`**; `.amazonq/` has one file). This includes renaming `ose-private`'s own
+      already-armed `md-readme-index` entry **in place** to `governance-readme-index`
+      (`scope: all-file-type` unchanged, no gap — same FR-3.19 guarantee as `ose-public`
+      Phase 1) and adding the new `governance-word-budget`/`governance-readme-completeness`
+      entries unarmed, exactly mirroring `ose-public`'s Phase 1 registration state
+- [ ] `[AI]` `git mv` and rewrite the convention doc; rewrite inbound links — discover the set
+      live with `grep -rl "instruction-size\|instruction-file-size-budget" repo-governance
+.claude docs AGENTS.md` in the `ose-private` checkout; do not reuse the `ose-public` count
+- [ ] `[AI]` `rhino-cli parity manifest generate && git add` + `validate`
+- [ ] **Command**: `npx nx run rhino-cli:test:quick && npx nx run
+rhino-cli:specs:behavior:coverage`
+- [ ] **Acceptance**: both exit 0; the rhino-cli boundary diff against `ose-public` is empty;
+      `specs:behavior:coverage` confirms the copied Gherkin stays in sync (NFR-4)
+- [ ] `[AI]` Commit thematically (per §Commit Guidelines), push, open PR10, run the PR review
+      cycle to a clean result, merge
+- [ ] `[AI]` Poll `gh run view --json status,conclusion` for PR10's CI run every 2 minutes until
+      conclusion — acceptance: `conclusion == success`; never `gh run watch`
+
+### Phase 10 Gate
+
+- Boundary diff versus `ose-public` is empty for all seven boundary paths
+- `parity manifest validate` exits 0
+- `governance-word-budget` runs and reports failures matching a live re-run of `tech-docs.md`
+  §7's census script (adjusted for `ose-private`'s checkout — no `.pi/` there) against the full
+  FR-1.3-scoped covered surface (measured 2026-08-13: **349** files for `ose-private` — not the
+  narrower 247 "source (non-generated)" figure in `README.md` §Context/`brd.md` §Success
+  Metrics; re-verify live, since the count drifts)
+  [Repo-grounded — re-derived directly against FR-1.3's declared glob list]
+- `governance-readme-index` (`orphan`/`ghost`) is armed and reports **zero** failures — renamed
+  in place from `ose-private`'s own already-armed `md-readme-index`, no gap
+- `governance-word-budget` and `governance-readme-completeness` are **not** armed yet;
+  `missing`/`unannotated` findings against the not-yet-split content are expected and not a
+  gate failure — Phases 11–15 are what clear them, before Phase 16 arms enforcement
+- PR10 merged
+
+> **Pause Safety**: `ose-private`'s rhino-cli boundary is byte-for-byte synced with `ose-public`
+> and its new gates are registered-but-unarmed, mirroring `ose-public`'s Phase 1 state. Safe to
+> stop before Phases 11–15's content splitting begins. To resume: re-run
+> `rhino-cli parity manifest validate` and confirm the boundary diff against `ose-public` is
+> still empty.
+
+---
+
+## Phases 11–15 — `ose-private` content (PR11–PR15, markdown-only)
+
+Same four operations as Phases 2–8, applied to private's surfaces (`<subtree>` = the phase's own
+path from the table below). Independent within the repo; fan out up to N=3.
+
+| Phase | Subtree                                                                  | PR   |
+| ----- | ------------------------------------------------------------------------ | ---- |
+| 11    | `repo-governance/conventions/`                                           | PR11 |
+| 12    | `repo-governance/development/`                                           | PR12 |
+| 13    | `repo-governance/workflows/`, `principles/`, `vision/`                   | PR13 |
+| 14    | `.claude/agents/` → skills, mirrors                                      | PR14 |
+| 15    | `.claude/skills/`, `AGENTS.md`, `CLAUDE.md`, root indexes, final mirrors | PR15 |
+
+Each phase performs:
+
+- [ ] `[AI]` **Split**: every file over 500 words in `<subtree>` becomes an index parent plus a
+      sibling directory of capped children, per `tech-docs.md` §2. Acceptance:
+      `npx nx run rhino-cli:governance-word-budget:validation` reports 0 failures under
+      `<subtree>`
+- [ ] `[AI]` **Frontmatter**: add `when_to_use` to every file in `<subtree>`, including new
+      children; backfill `description` where missing. Acceptance:
+      `rhino-cli md frontmatter validate` exits 0 for `<subtree>`
+- [ ] `[AI]` **Index**: create or update every `README.md` in `<subtree>` with annotated entries
+      derived from target frontmatter; split directories are indexed by their parent. Acceptance:
+      `npx nx run rhino-cli:governance-readme-index:validation` reports 0 `orphan`/`ghost`
+      failures under `<subtree>` (armed Nx target), **and** `rhino-cli governance readme-index
+validate <subtree>` (direct invocation — `governance-readme-completeness` is not armed until
+      Phase 16) reports 0 `missing`/`unannotated` findings under `<subtree>`
+- [ ] `[AI]` **Verify**: `rhino-cli md links validate && rhino-cli md heading-hierarchy validate
+&& npm run lint:md`. Acceptance: all three exit 0
+- [ ] `[AI]` **Phase 14 only** — behavioural verification: invoke at least five migrated agents
+      on real tasks and confirm each reads its reference modules and applies a rule that lives
+      only in a module. Record transcripts under `evidence/phase-14-agent-verification/`.
+- [ ] `[AI]` **Phase 15 only** — verify the resolved-tree word budget: `CLAUDE.md` + `@AGENTS.md`
+      ≤ 1,500 words
+- [ ] `[AI]` Commit thematically (per §Commit Guidelines), push, open this phase's PR, wait for
+      a green `pr-quality-gate.yml` run (markdown-only, no review cycle), merge
+- [ ] `[AI]` Poll `gh run view --json status,conclusion` for this phase's `pr-quality-gate.yml`
+      run every 2 minutes until conclusion — acceptance: `conclusion == success`; never
+      `gh run watch`
+
+### Phase 11–15 Gate (each)
+
+Identical to the Phase 2–5 gate, scoped to the phase's subtree. Phase 14 additionally requires
+five recorded behavioural verifications. Phase 15 additionally requires the resolved-tree check.
+
+> **Pause Safety**: each merged subtree is self-consistent in `ose-private`.
+
+---
+
+## Phase 16 — Arm the gates in `ose-private` (PR16, executable)
+
+Identical structure to Phase 9, applied to `ose-private` (steps 16a–16c mirror 9a–9c 1:1;
+substitute `ose-private`'s own 349-failure full-covered-surface baseline (see Phase 10 Gate) and
+trigger list for `ose-public`'s).
+
+### 16a. RED
+
+- [ ] `[AI]` Add a fixture file over the ceiling in `ose-private`; confirm
+      `gate run --surface=pre-push` fails
+
+  **Gherkin (binds) →** "A triggered gate validates the whole covered tree, not just changed
+  files"
+
+  ```gherkin
+  Scenario: A triggered gate validates the whole covered tree, not just changed files
+    Given the changed paths include only "repo-governance/conventions/formatting/linking.md"
+    And "repo-governance/development/agents/ai-agents.md" contains 900 words
+    When I run "rhino-cli gate run --surface=pre-push"
+    Then the exit code is 1
+    And the finding names "repo-governance/development/agents/ai-agents.md"
+  ```
+
+- [ ] `[AI]` Confirm `rhino-cli md frontmatter validate` currently reports `when_to_use` and
+      `description` findings at WARN (not FAIL) in `ose-private` — the pre-arm baseline this
+      phase's GREEN step must change (see `prd.md` §FR-4 "Dark-launch sequencing")
+
+  **Gherkin (underpins) →** "A missing when_to_use fails"; "A missing description now fails, not
+  warns"
+
+- [ ] **Acceptance**: the pre-push surface exits 1 and names the fixture
+
+### 16b. GREEN
+
+- [ ] `[AI]` Register `governance-word-budget` in `ose-private`'s `gates:` with `pre-push` and
+      `ci` only, both `scope: path-gated`, `ci-group: governance`, and the 10-entry trigger list
+      from `prd.md` §FR-1.10 adjusted for private's surfaces (no `.pi/`; one `.amazonq/` file).
+      No `pre-commit` surface.
+- [ ] `[AI]` Register `governance-readme-completeness` (a **new** entry — `governance-readme-index`
+      is already armed since Phase 10 and untouched by this step) the same way with the narrower
+      7-entry trigger list from `prd.md` §FR-1.11, adjusted for private's surfaces (no `.pi/`),
+      plus the same `args: { paths: [...], fail-kinds: [missing, unannotated] }` block from
+      Phase 9b's GREEN step, paths list adjusted identically (no `.pi/`)
+- [ ] `[AI]` Register `governance-word-budget` (only) as a `repo-governance audit` category
+- [ ] `[AI]` **Arm FR-4** in `ose-private` (register-then-arm for the already-active
+      `md-frontmatter` gate): run `rhino-cli md frontmatter validate` against
+      `repo-governance/**/*.md` and confirm zero files are missing `when_to_use` or
+      `description` — true only once Phases 11–13 have merged. Then apply the identical
+      `frontmatter.rs::validate_governance_schema` severity flip from Phase 9b's GREEN step —
+      the rhino-cli boundary is byte-identical across repos, so this is the same code change
+      copied, not reimplemented
+- [ ] `[AI]` Remove the fixture
+- [ ] **Command**: `apps/rhino-cli/scripts/rhino-bin.sh gate validate`
+- [ ] **Acceptance**: exit 0
+
+### 16b-2. Prove the gating both ways
+
+- [ ] `[AI]` Repeat the 5-case trigger matrix from Phase 9's §9b-2, adjusted for `ose-private`'s
+      surfaces, and record every run in `evidence/phase-16-trigger-matrix.txt`
+
+### 16c. Parity and PR
+
+- [ ] `[AI]` `rhino-cli parity manifest generate && git add` + `validate`
+- [ ] `[AI]` Commit thematically (per §Commit Guidelines), push, open PR16, run the PR review
+      cycle to a clean result, merge
+- [ ] `[AI]` Poll `gh run view --json status,conclusion` for PR16's CI run every 2 minutes until
+      conclusion — acceptance: `conclusion == success`; never `gh run watch`
+
+### Phase 16 Gate
+
+- All three gate ids registered and armed (`governance-word-budget`,
+  `governance-readme-completeness` newly armed this phase; `governance-readme-index` armed
+  since Phase 10); `gate validate` exits 0
+- `rhino-cli md frontmatter validate` reports `when_to_use` and `description` findings at
+  **FAIL** severity for `repo-governance/**/*.md` in `ose-private` — FR-4 is armed
+- `ose-private` census: **0 files over 500 words**
+- `governance-readme-index` reports **zero** `orphan`/`ghost` failures;
+  `governance-readme-completeness` reports **zero** `missing`/`unannotated` failures
+- The 5-case trigger matrix in `evidence/phase-16-trigger-matrix.txt` matches expectations
+- `parity manifest validate` exits 0
+- PR16 merged
+
+> **Pause Safety**: both repos are complete and enforced. Safe to stop before Phase 17's
+> archival work.
+
+---
+
+## Phase 17 — Knowledge capture, archival, and cleanup (`ose-public`, PR17, markdown-only, terminal node)
+
+### 17a. Knowledge capture
+
+- [ ] `[AI]` Apply the litmus test to every `learnings.md` entry — keep only if a durable
+      surface would catch this automatically next time; discard the rest with a one-line reason
+- [ ] `[AI]` Apply the **secret/sensitivity gate** — sanitize any secret, credential, token, or
+      private hostname to a `<placeholder>` token, or discard if unsanitizable
+- [ ] `[AI]` Apply the **repo-relevance gate** — infra-private content stays in `ose-private`
+      only and is NEVER cross-routed into `ose-public`/`ose-primer`
+- [ ] `[AI]` Route each surviving learning to exactly one durable home per the open-ended routing
+      matrix; code homes (`apps/`, `libs/`, tests) are ALWAYS filed as a separate
+      `plans/backlog/<slug>/` plan, NEVER landed inline (the only carve-out is a genuine blocker
+      required to finish this plan's own scope)
+- [ ] `[AI]` For any entry routed to `plans/ideas/`, scan `plans/ideas/README.md` and the
+      existing two-pagers FIRST for a brief already covering the same area — fold in rather than
+      creating a new file
+- [ ] `[AI]` Record the terminal state of every entry (routed inline / filed as backlog at
+      `<path>` / discarded with reason) directly in `learnings.md`, or record the explicit
+      `No generalizable learnings — <reason>` escape if none surfaced
+
+### 17b. Follow-up and archival
+
+- [ ] `[AI]` File a follow-up backlog plan for `ose-primer`: rhino-cli boundary sync **and**
+      `repo-governance/` content parity. This plan does not close until that plan exists.
+- [ ] `[AI]` Record the final census for both repos in `evidence/`
+- [ ] `[AI]` `git mv` this plan folder to `plans/done/YYYY-MM-DD__optimize-governance-md/`
+- [ ] `[AI]` Update `plans/in-progress/README.md` and `plans/done/README.md`
+
+### 17c. PR and cleanup
+
+- [ ] `[AI]` Commit thematically (per §Commit Guidelines), push, open PR17, wait for a green
+      `pr-quality-gate.yml` run (markdown-only, no review cycle), merge
+- [ ] `[AI]` Poll `gh run view --json status,conclusion` for PR17's `pr-quality-gate.yml` run
+      every 2 minutes until conclusion — acceptance: `conclusion == success`; never
+      `gh run watch`
+- [ ] `[AI]` Fast-forward local `main` in both repos after all PRs (including PR17) have merged —
+      side-worktree pushes advance `origin`, not local `main`
+- [ ] `[AI]` Remove both `optimize-governance-md` worktrees, but only after reading each dirty diff first —
+      a merged PR does not imply an empty working tree
+
+### Phase 17 Gate
+
+- Every `learnings.md` entry is terminal (routed inline / filed as backlog / discarded with
+  reason), or the explicit "none" escape is recorded
+- No code-homed learning landed inline in this plan's own commits/PRs
+- Both repos: 0 word-budget failures, 0 README-index failures, `gate validate` exits 0
+- `ose-primer` follow-up plan exists in `plans/backlog/`
+- PR17 merged
+- Both worktrees removed; `git worktree list` shows only the primary checkout
+- Local `main` matches `origin/main` in both repos
+- Plan folder archived under `plans/done/`
+
+> **Pause Safety**: plan complete.
+
+---
+
+## Rollback Positions
+
+| Position            | Effect                                                                    |
+| ------------------- | ------------------------------------------------------------------------- |
+| Revert PR9 / PR16   | Disarms enforcement; all split content stays. **Safest partial rollback** |
+| Revert a content PR | Restores that subtree's pre-split files; nothing else breaks              |
+| Revert PR1 / PR10   | Restores the byte budget wholesale in that repo                           |
+
+Reverts must run in dependency order — a content PR cannot be reverted after Phase 9 arms the
+gates without also reverting the flip, or the restored oversized files fail pre-push.

--- a/plans/in-progress/optimize-governance-md/learnings.md
+++ b/plans/in-progress/optimize-governance-md/learnings.md
@@ -1,0 +1,82 @@
+# Learnings: Optimize Governance Markdown
+
+Captured during execution; triaged to a permanent home or explicitly discarded at Phase 17 per
+the [Knowledge Capture Convention](../../../repo-governance/development/quality/knowledge-capture.md).
+
+## Planning-Phase Learnings
+
+### Harness agent-directory recursion differs per harness
+
+[Web-cited] Claude Code scans `.claude/agents/` **recursively** and derives agent identity from
+the `name` frontmatter key, not the path
+([docs](https://code.claude.com/docs/en/sub-agents)). OpenCode does **not** — its maintainers
+closed the subdirectory feature request as _not planned_
+([opencode#6635](https://github.com/anomalyco/opencode/issues/6635)). Cursor's
+`.cursor/agents/` behaviour is undocumented in either direction.
+
+**Why it matters**: reorganizing a source directory that has generated mirrors is only safe if
+every mirror consumer tolerates the new shape. The generator must flatten.
+
+**Candidate home**: `docs/reference/platform-bindings.md`, or the
+[Multi-Harness Binding Convention](../../../repo-governance/conventions/structure/multi-harness-binding.md).
+
+### `parity manifest validate` is repo-local, not cross-repo
+
+[Repo-grounded — `apps/rhino-cli/src/application/parity.rs::validate_at_root`] The gate compares
+a repo's committed manifest against that same repo's tracked boundary. It never fetches siblings.
+Deferring a rhino-cli change in one of the three repos therefore produces **silent divergence**,
+not a red gate.
+
+**Why it matters**: the risk of a partial cross-repo rollout was previously described as
+"breakage". It is not. It is undetected drift, which is arguably worse because nothing surfaces it.
+
+**Candidate home**: [Related Repositories reference](../../../docs/reference/related-repositories.md).
+
+### `path-gated` was never exercised on the `ci` surface
+
+[Repo-grounded — `repo-config.yml`, `commands/gate/run.rs`] All six existing `path-gated`
+declarations are on `pre-push`. Reading the runner shows the scope is surface-agnostic and CI
+changed-paths are computed from `RHINO_GATE_CHANGED_BASE` or `git merge-base origin/main HEAD` —
+but no gate had proven it in practice.
+
+**Why it matters**: `candidate_paths` must classify the gate as needing changed paths, otherwise
+`changed_paths` is `None` and the skip predicate silently skips **every** run. A gate that never
+fires reads as green.
+
+**Candidate home**: the gate-registry documentation in `repo-config.yml`'s header comment.
+
+### `merged_budget_config` merges harness-registry globs, undocumented anywhere else
+
+[Repo-grounded — `instruction_size.rs::merged_budget_config`] The byte-budget gate silently
+extends itself with every `harness:` registry entry's `instruction:` glob list, applying
+default thresholds to globs with no explicit surface entry. Nothing outside that one function
+consumes `harness.instruction` (verified by grep), and none of the four surfaces it would cover
+exist in either repo yet. The word-budget gate deliberately drops this behaviour rather than
+port it.
+
+**Why it matters**: a "repurpose this module" plan can miss a secondary behaviour that isn't
+visible from the primary code path unless the full file is read.
+
+**Candidate home**: `prd.md` FR-1.15 already carries the decision record; no further doc needed.
+
+### Governance-schema `description` was WARN-severity, not FAIL
+
+[Repo-grounded — `frontmatter.rs::validate_governance_schema` vs. `validate_software_schema`]
+Only `title` was FAIL for governance docs; `description` used a plain `SEVERITY_WARN`
+construction. The software-engineering schema, by contrast, already used `mk_fail()` for both
+fields. A first draft of this plan assumed the two schemas already agreed and wrote a Gherkin
+scenario claiming software-engineering docs "still only warn" — factually wrong, caught only by
+reading `validate_software_schema` directly.
+
+**Why it matters**: assuming two similarly-named validators behave the same without reading both
+produces confidently-wrong acceptance criteria.
+
+**Candidate home**: `prd.md` FR-4.2/FR-4.8 already carries the decision record; no further doc needed.
+
+## Execution-Phase Learnings
+
+_Populated during Phases 0-16._
+
+## Discarded
+
+_Observations considered and deliberately not promoted, with the reason._

--- a/plans/in-progress/optimize-governance-md/prd.md
+++ b/plans/in-progress/optimize-governance-md/prd.md
@@ -1,0 +1,905 @@
+# Product Requirements Document: Optimize Governance Markdown
+
+Four functional requirements. FR-1 and FR-2 ship together (one gate replaces another); FR-3
+and FR-4 are independent gates that make FR-1's output usable.
+
+## Product Overview
+
+[Repo-grounded] This product is **one new** `rhino-cli` gate (`governance word-budget validate`)
+plus a **rename-and-extend** of an existing gate (`governance readme-index validate`, split
+across two `repo-config.yml` registrations — `governance-readme-index` for the
+continuity-preserving `orphan`/`ghost` checks and the new, dark-launched
+`governance-readme-completeness` for `missing`/`unannotated`) — plus the migration work needed to
+bring both repos' governance Markdown into compliance with all three gate ids. It replaces the
+existing byte-based `instruction-size` gate (FR-2) with a word-based ceiling that covers the
+whole governance surface, not just the handful of files a harness auto-loads, and adds a
+machine-checkable reachability guarantee (README indexing, FR-3) plus a retrieval-trigger
+frontmatter key (`when_to_use`, FR-4). See `brd.md` §Business Goal for the "why"; this document
+covers "what."
+
+## Personas
+
+[Judgment call — this is a solo-maintainer repo; personas are consumption modes, not
+organizational roles]
+
+- **The repo maintainer** — authors and reviews governance content, runs the gates locally
+  before pushing, and is the sole human decision-maker for this plan.
+- **The consuming AI coding agent** — reads governance Markdown at runtime (on demand via
+  `Read`, or natively via a harness's `AGENTS.md`/`CLAUDE.md` resolution) to decide how to act.
+  This is the primary beneficiary of the word ceiling and the `when_to_use` retrieval trigger —
+  see `brd.md` §Business Impact "Pain point 1" and "Pain point 3."
+
+## User Stories
+
+[Repo-grounded — derived directly from the FR/NFR set below, not new scope]
+
+- As an AI coding agent, I want every governance file under 500 words, so that I can hold the
+  whole rule in context without silent truncation (FR-1).
+- As an AI coding agent, I want a single word-based size gate instead of two overlapping gates
+  in different units, so that I reason about size in the same unit I author in (FR-2).
+- As an AI coding agent or a contributor, I want every governance directory's `README.md` to
+  link every file beside it, so that splitting a large file never creates an orphaned child
+  (FR-3).
+- As an AI coding agent, I want every `repo-governance/**/*.md` file to declare `when_to_use`,
+  so that I can decide whether a file applies to my current task without opening it (FR-4).
+- As a repo maintainer, I want size and reachability enforced as two independent gates with
+  their own triggers, so that a failure in one never masks a failure in the other (FR-5).
+
+## Product Scope
+
+**In scope**: the new `governance word-budget validate` gate command, the rename-and-extend of
+`governance readme-index validate` (split across the `governance-readme-index` and
+`governance-readme-completeness` registrations), and their `repo-config.yml` wiring (FR-1, FR-5);
+removal of the byte-based `instruction-size` gate and porting of its resolved-tree check to words
+(FR-2); the README sibling-index gate and generator (FR-3); the `when_to_use` frontmatter
+requirement (FR-4); the content migration in both `ose-public` and `ose-private` needed to make
+all three gate ids pass at zero failures.
+
+**Out of scope**: rewriting what any governance rule says (relocation and indexing only);
+`ose-primer` (deferred — see `brd.md` §Out of Scope); `apps/`, `libs/`, and `plans/` content;
+the root `README.md`/`CONTRIBUTING.md`/`LICENSING-NOTICE.md` files. See `brd.md` §Out of Scope
+for the full business-level list; this section covers only the product-scope boundary that
+follows from it.
+
+## Product Risks
+
+[Judgment call, cross-referenced against `brd.md` §Top Risks for the business framing]
+
+- **A migrated agent silently loses a rule.** Moving content from an agent's body into
+  `.claude/skills/<name>/reference/*.md` only helps if the agent actually reads those files at
+  runtime. Mitigated by the mandatory read directive (`tech-docs.md` §3.3) and Phase 6's
+  behavioural verification requirement.
+- **`AGENTS.md` truncated to an index loses effectiveness for harnesses that do not eagerly
+  follow links.** Accepted, not eliminated — see `brd.md` §Top Risks.
+- **The README-index annotation drifts from the target's frontmatter** if the gate's
+  `generate`/`validate` split ever diverges. Mitigated by FR-3.14 (drift fails the gate).
+
+---
+
+## FR-1 — Governance word budget
+
+### Description
+
+A new gate, `rhino-cli governance word-budget validate`, classifies every Markdown file in the
+covered surfaces against a three-tier word threshold and fails the build on any file over the
+hard ceiling.
+
+### Requirements
+
+| ID      | Requirement                                                                                                                                                                                        |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FR-1.1  | Word count is the **raw whole-file** count — YAML frontmatter, fenced code blocks, Mermaid blocks, tables, and link URLs all count                                                                 |
+| FR-1.2  | Classification is `≤ 400` OK (silent), `401–500` Warn (message, exit 0), `> 500` Fail (message, exit 1)                                                                                            |
+| FR-1.3  | Covered surfaces are `repo-governance/**/*.md`, `.claude/**/*.md`, `.cursor/**/*.md`, `.codex/**/*.md`, `.opencode/**/*.md`, `.pi/**/*.md`, `.amazonq/**/*.md`, root `AGENTS.md`, root `CLAUDE.md` |
+| FR-1.4  | Generated mirrors (`.opencode/`, `.cursor/`, `.amazonq/`) are **gated**, not exempted                                                                                                              |
+| FR-1.5  | There is **no** exemption list, allowlist, waiver key, or per-file override — the config schema must not admit one                                                                                 |
+| FR-1.6  | Thresholds and surface globs live in `repo-config.yml`, not in Rust constants                                                                                                                      |
+| FR-1.7  | A Fail message names the file, its word count, the ceiling, and links the remediation convention                                                                                                   |
+| FR-1.8  | The gate is enforced at **pre-push** and in the **PR quality gate (CI)**, both `scope: path-gated` — it runs only when a trigger path changed                                                      |
+| FR-1.9  | Zero files in `ose-public` and `ose-private` covered surfaces exceed 500 words when the plan closes                                                                                                |
+| FR-1.15 | The gate does **not** port `merged_budget_config`'s harness-registry `instruction:` merge — see "Registry-merge scope decision" below                                                              |
+
+### Registry-merge scope decision
+
+[Repo-grounded — `apps/rhino-cli/src/application/repo_governance/instruction_size.rs::merged_budget_config`]
+The byte gate has a second config source beyond the explicit `instruction-size:` YAML block: it
+also folds in every `harness:` registry entry's `instruction:` glob list, applying default
+byte thresholds (10,000/13,000/16,000 B) to any glob not already covered by an explicit surface.
+The `harness.instruction` registry field this merge reads has **no other consumer** in the
+codebase (verified via `grep`) — it exists solely to guarantee every harness-declared instruction
+surface is size-gated even without an explicit entry. `merged_budget_config` itself **does** have
+a second caller, though: `audit_orchestrator.rs::audit_instruction_size` calls it directly and
+consumes its registry-merged output for the `repo-governance audit --category=instruction-size`
+command's own results. Dropping the merge is still the right call (FR-1.3's explicit glob list
+already supersedes every registry-declared `.md`-extension surface that resolves to an existing
+file today — see below), but
+`audit_orchestrator.rs` is a real, functionally-coupled call site this plan touches, not an
+unaffected bystander — its rename is tracked explicitly in `tech-docs.md`'s File-Impact Analysis
+tree.
+
+**FR-1.15 drops this merge.** FR-1.3's explicit glob list is a superset of every harness
+`instruction:` entry that resolves to an **existing** `.md` file in either repo today — verified
+against the live `harness:` registry (`repo-config.yml` lines 32–62, all 11 harness entries). Six
+registry-declared surfaces are **not** covered by FR-1.3 and would lose gating if ever created:
+`.cursor/rules/*.mdc` (extension `.mdc`, not `.md` — outside a word-count gate's remit
+regardless), `.windsurf/rules/*.md`, `.junie/guidelines.md`, `.github/copilot-instructions.md`,
+`GEMINI.md` (the `antigravity` harness's second instruction surface), and `CONVENTIONS.md` (the
+`aider` harness's second instruction surface). **All six are absent in both `ose-public` and
+`ose-private` as of 2026-08-13** (`/bin/ls` confirms), so this drop changes zero observable
+behavior today. It is a scoped, accepted future gap, not a silent regression — introducing any
+of the five `.md`-extension surfaces (`.windsurf/rules/*.md`, `.junie/guidelines.md`,
+`.github/copilot-instructions.md`, `GEMINI.md`, `CONVENTIONS.md`) is new scope for whichever
+future plan adds that harness's instruction file, the same way it would have been new scope to
+add the `.md` glob explicitly.
+
+### Enforcement: path-gated, not repo-wide (word budget and the new completeness gate only)
+
+`governance-word-budget` and `governance-readme-completeness` are net-new enforcement — neither
+has a pre-existing armed gate to preserve — so both are dark-launched and declare
+`scope: path-gated` with an explicit `trigger:` list on **both** the `pre-push` and `ci`
+surfaces. `governance-readme-index` (orphan/ghost — the rename-and-extend of the
+already-armed `md-readme-index` gate, FR-3.19) is the one exception: it stays `scope:
+all-file-type`, unchanged from its current live registration, with no dark-launch and no trigger
+list — see the callout after FR-1.11 below.
+
+**FR-1.10 — Word-budget triggers**:
+
+```yaml
+- id: governance-word-budget
+  type: check
+  command: governance word-budget validate
+  kind: rhino-cli
+  ci-group: governance
+  surfaces:
+    pre-push: &word-budget-triggers
+      scope: path-gated
+      trigger:
+        - repo-governance/
+        - .claude/
+        - .cursor/
+        - .codex/
+        - .opencode/
+        - .pi/
+        - .amazonq/
+        - AGENTS.md
+        - CLAUDE.md
+        - repo-config.yml
+    ci: *word-budget-triggers
+```
+
+**FR-1.11 — README-completeness triggers** are narrower, matching FR-3.7's covered trees. Mirror
+trees and `plans/` are absent from both the scope and the triggers. This trigger list belongs to
+the **new** `governance-readme-completeness` gate id (FR-3.20 — `missing` + `unannotated`), not
+to `governance-readme-index` (`orphan` + `ghost`). The two gate ids share one implementation
+(FR-5.8) but scan and fail differently, and the difference is carried entirely by each
+registration's `args:` block — the same mechanism `md-mermaid`'s `args: { exclude: [...] }}` and
+`md-links`'s `args: { exclude: [...] }}` already use (`repo-config.yml:743`, `:914`), which
+`fixed_arguments()` turns into repeated `--<key> <value>` flags
+(`apps/rhino-cli/src/application/repo_config/mod.rs::fixed_arguments`). Two new repeatable flags
+are added to `ReadmeIndexAuditArgs`:
+
+- **`--paths <path>`** (repeatable) — overrides the module's `DEFAULT_PATHS` scan scope for this
+  invocation. Omitted entirely on `governance-readme-index`, so it keeps scanning the original,
+  unwidened 4-entry `DEFAULT_PATHS` with zero config change — the continuity guarantee (FR-3.19)
+  falls out of "don't pass the flag," not a second constant to keep in sync. Set explicitly on
+  `governance-readme-completeness` to FR-3.7's widened 6-entry list.
+- **`--fail-kinds <kind>`** (repeatable; values `orphan`/`ghost`/`missing`/`unannotated`) — the
+  command still discovers and reports every finding kind on the scanned scope, but only a finding
+  whose kind appears in `--fail-kinds` contributes to the nonzero exit code (mirroring FR-1.2's
+  existing Warn-vs-Fail severity split, applied per finding-kind instead of per word-count band).
+  `governance-readme-index` sets `--fail-kinds orphan --fail-kinds ghost` so a `missing`/
+  `unannotated` finding inside its unchanged 4-entry scope (`repo-governance/` overlaps both
+  scopes) is still detected and printed, but never fails the build — preserving FR-3.19's
+  guarantee even though both gates scan overlapping directories. `governance-readme-completeness`
+  sets `--fail-kinds missing --fail-kinds unannotated`.
+
+```yaml
+- id: governance-readme-completeness
+  type: check
+  command: governance readme-index validate
+  kind: rhino-cli
+  ci-group: governance
+  args:
+    paths:
+      - repo-governance/
+      - .claude/
+      - .codex/
+      - .pi/
+      - docs/
+      - specs/
+    fail-kinds:
+      - missing
+      - unannotated
+  surfaces:
+    pre-push: &readme-completeness-triggers
+      scope: path-gated
+      trigger:
+        - repo-governance/
+        - .claude/
+        - .codex/
+        - .pi/
+        - docs/
+        - specs/
+        - repo-config.yml
+    ci: *readme-completeness-triggers
+```
+
+`governance-readme-index` (orphan/ghost) is registered separately and is **not**
+path-gated:
+
+```yaml
+- id: governance-readme-index
+  type: check
+  command: governance readme-index validate
+  kind: rhino-cli
+  ci-group: governance
+  args:
+    fail-kinds:
+      - orphan
+      - ghost
+  surfaces:
+    pre-push: { scope: all-file-type }
+    ci: { scope: all-file-type }
+```
+
+**FR-1.12 — Trigger gates execution; validation stays whole-tree.** A matched trigger runs the
+command against the entire covered surface, not only the changed files. This is deliberate:
+adding one file can invalidate its directory's index, and changing a threshold in
+`repo-config.yml` invalidates every file. Per NFR-1 a full-tree run costs under 10 seconds, so
+narrowing validation scope would buy nothing and would miss real violations.
+
+**FR-1.13 — `repo-config.yml` is a trigger for `governance-word-budget` and
+`governance-readme-completeness`**, so a threshold or scope edit re-validates everything even
+when no Markdown changed. `governance-readme-index` needs no such trigger — it already runs
+unconditionally on every push and PR.
+
+**FR-1.14** — None of the three gates is declared on the `pre-commit` surface. Pre-push and CI
+are the enforcement points; adding pre-commit would run a whole-tree scan on every commit for no
+additional coverage.
+
+**Known limitation, consistent with every existing path-gated gate**: on the `ci` surface,
+changed paths come from `RHINO_GATE_CHANGED_BASE` when set, otherwise
+`git merge-base origin/main HEAD`. On a direct push to `main` that merge base is `HEAD`, so the
+diff is empty and path-gated gates skip. This is preexisting repo-wide behaviour, not a defect
+introduced here; PR runs — the merge-blocking path — always have a real base.
+
+### Acceptance Criteria
+
+```gherkin
+Feature: Governance word budget
+
+  Background:
+    Given repo-config.yml declares a governance-word-budget section
+    And the section sets target 400, warn 500, fail 500
+
+  Scenario: A file within target passes silently
+    Given "repo-governance/conventions/formatting/linking.md" contains 380 words
+    When I run "rhino-cli governance word-budget validate"
+    Then the exit code is 0
+    And the output contains no finding for that file
+
+  Scenario: A file between target and fail warns without blocking
+    Given "repo-governance/conventions/formatting/linking.md" contains 450 words
+    When I run "rhino-cli governance word-budget validate"
+    Then the exit code is 0
+    And the output contains a "warn" finding naming that file
+
+  Scenario: A file over the ceiling fails the gate
+    Given "repo-governance/development/agents/ai-agents.md" contains 14720 words
+    When I run "rhino-cli governance word-budget validate"
+    Then the exit code is 1
+    And the output contains a "fail" finding naming that file
+    And the finding states the word count 14720 and the ceiling 500
+    And the finding links the governance word budget convention
+
+  Scenario Outline: Every covered surface is scanned
+    Given a file "<path>" contains 900 words
+    When I run "rhino-cli governance word-budget validate"
+    Then the exit code is 1
+    And the output contains a "fail" finding naming "<path>"
+
+    Examples:
+      | path                                     |
+      | repo-governance/principles/example.md    |
+      | .claude/agents/example.md                |
+      | .claude/skills/example/SKILL.md          |
+      | .opencode/agents/example.md              |
+      | .cursor/agents/example.md                |
+      | .amazonq/rules/example.md                |
+      | AGENTS.md                                |
+      | CLAUDE.md                                |
+
+  Scenario: A README.md file under the specific-surface target produces zero findings
+    Given "repo-governance/development/quality/README.md" contains 670 words
+    When I run "rhino-cli governance word-budget validate"
+    Then the exit code is 0
+    And the output contains no finding naming that file
+    And this holds even though 670 words exceeds the general surface's 500-word fail ceiling,
+      because the winning README-specific surface classifies 670 words as "ok" against its own
+      700-word target
+
+  Scenario: A README.md file uses the wider README-specific glob threshold
+    Given "repo-governance/development/quality/README.md" contains 850 words
+    When I run "rhino-cli governance word-budget validate"
+    Then the exit code is 0
+    And the output contains a "warn" finding naming that file, not a "fail" finding
+
+  Scenario: A README.md file over the wider ceiling still fails
+    Given "repo-governance/development/quality/README.md" contains 950 words
+    When I run "rhino-cli governance word-budget validate"
+    Then the exit code is 1
+    And the output contains a "fail" finding naming that file
+
+  Scenario: Non-prose content counts toward the budget
+    Given "repo-governance/conventions/formatting/diagrams.md" contains 200 prose words
+    And it contains a Mermaid block of 400 words
+    When I run "rhino-cli governance word-budget validate"
+    Then the exit code is 1
+    And the reported word count is 600
+
+  Scenario: An out-of-scope file is never scanned
+    Given "apps/ayokoding-www/content/lesson.md" contains 5000 words
+    When I run "rhino-cli governance word-budget validate"
+    Then the exit code is 0
+    And the output contains no finding for that file
+
+  Scenario: The config schema rejects an exemption key
+    Given repo-config.yml adds "exempt: [AGENTS.md]" under governance-word-budget
+    When I run "rhino-cli repo-config schema validate"
+    Then the exit code is 1
+```
+
+---
+
+## FR-2 — Byte budget replaced; resolved tree ported to words
+
+### Description
+
+The `instruction-size` byte gate is removed in its entirety and superseded by FR-1. Its one
+irreplaceable capability — the aggregate size of the resolved `CLAUDE.md` `@`-import tree — is
+re-expressed in words and carried forward into the new gate.
+
+### Requirements
+
+| ID     | Requirement                                                                                                                              |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| FR-2.1 | `rhino-cli harness instruction-size validate` no longer exists                                                                           |
+| FR-2.2 | The `instruction-size:` block is removed from `repo-config.yml` in both repos                                                            |
+| FR-2.3 | The `instruction-size` entry is removed from the `gates:` registry and replaced by `governance-word-budget`                              |
+| FR-2.4 | `repo-governance/conventions/structure/instruction-file-size-budget.md` is `git mv`-renamed to `governance-word-budget.md` and rewritten |
+| FR-2.5 | Every inbound link to the old convention path is rewritten in the same commit                                                            |
+| FR-2.6 | The resolved-tree check survives, measured in **words**, rooted at `CLAUDE.md`, depth ≤ 4, cycle-guarded                                 |
+| FR-2.7 | The resolved-tree budget is `1200` target / `1500` warn / `1500` fail words                                                              |
+| FR-2.8 | Obsolete Gherkin features and golden-master fixtures for `instruction-size` are deleted, not left orphaned                               |
+| FR-2.9 | No repository is left with two per-file size gates at any commit                                                                         |
+
+### Acceptance Criteria
+
+```gherkin
+Feature: Byte budget replacement
+
+  Scenario: The old command is gone
+    When I run "rhino-cli harness instruction-size validate"
+    Then the exit code is non-zero
+    And the output reports an unknown subcommand
+
+  Scenario: The old config block is gone
+    When I read repo-config.yml
+    Then it contains no "instruction-size:" section
+    And it contains a "governance-word-budget:" section
+
+  Scenario: The old gate id is gone from the registry
+    When I run "rhino-cli gate list --surface=pre-push --format=text"
+    Then the output contains no gate id "instruction-size"
+    And the output contains gate id "governance-word-budget"
+
+  Scenario: The resolved tree is measured in words
+    Given "CLAUDE.md" contains 480 words
+    And "CLAUDE.md" imports "AGENTS.md" via an @-directive
+    And "AGENTS.md" contains 490 words
+    When I run "rhino-cli governance word-budget validate"
+    Then the exit code is 0
+    And the reported resolved-tree word count is 970
+
+  Scenario: An oversized resolved tree fails
+    Given the resolved CLAUDE.md tree totals 1600 words
+    When I run "rhino-cli governance word-budget validate"
+    Then the exit code is 1
+    And the output contains a "fail" finding for the resolved tree
+
+  Scenario: Import cycles terminate
+    Given "CLAUDE.md" imports "AGENTS.md"
+    And "AGENTS.md" imports "CLAUDE.md"
+    When I run "rhino-cli governance word-budget validate"
+    Then the command terminates
+    And each file is counted at most once
+
+  Scenario: No inbound link to the renamed convention is left broken
+    When I run "rhino-cli md links validate"
+    Then the exit code is 0
+```
+
+---
+
+## FR-3 — README sibling index
+
+### Description
+
+`rhino-cli governance readme-index validate` asserts that each covered directory's `README.md`
+links every Markdown file beside it and every immediate subdirectory's `README.md`. **This is
+not a new gate.** It is a rename-and-extend of the already-existing, already-armed
+`rhino-cli md readme-index validate` command (`repo-config.yml` gate id `md-readme-index`,
+implementation `apps/rhino-cli/src/application/repo_governance/readme_index_audit.rs` +
+`apps/rhino-cli/src/commands/md_validate_readme_index.rs`), which today already detects `orphan`
+(unlinked sibling) and `ghost` (broken link) findings, unconditionally, on every `pre-push` and
+`ci` run. See "Repurpose, do not rebuild" below for the full decision record — the same pattern
+FR-1 applies to `instruction_size.rs`.
+
+### Repurpose, do not rebuild
+
+[Repo-grounded, verified 2026-08-13] `readme_index_audit.rs::audit_readme_index` already
+implements the exact walk-and-audit mechanic FR-3.1–FR-3.4 describe: it walks each covered
+directory, computes the sibling `.md` files and subdirectory `README.md`s, and reports orphan
+(unlinked) and ghost (broken-link) findings. `md_validate_readme_index.rs` wires it to the CLI
+as `md readme-index validate` and defaults to scanning `repo-governance/`, `.claude/agents/`,
+`.claude/skills/`, and `docs/explanation/software-engineering/` when no path argument is given.
+This command is registered in `repo-config.yml` as gate id `md-readme-index`, armed at
+`surfaces: { pre-push: { scope: all-file-type }, ci: { scope: all-file-type } }` — it already
+runs on every push and every PR touching any tracked Markdown file, today, with zero findings.
+
+The rename-and-extend is:
+
+1. `git mv apps/rhino-cli/src/application/repo_governance/readme_index_audit.rs` →
+   `apps/rhino-cli/src/application/governance/readme_index.rs` (mirrors FR-1's
+   `instruction_size.rs` → `governance/word_budget.rs` destination pattern).
+2. `git mv apps/rhino-cli/src/commands/md_validate_readme_index.rs` →
+   `apps/rhino-cli/src/commands/governance_validate_readme_index.rs`; the CLI command moves from
+   the `md` top-level group (`md readme-index validate`) to the new `governance` top-level group
+   (`governance readme-index validate`), mirroring FR-1's `harness`/`convention` → `governance`
+   move.
+3. `repo-config.yml` gate id `md-readme-index` is **renamed in place** to `governance-readme-index`
+   — never removed and re-added, because that would leave a window with no README-index
+   enforcement at all. See FR-3.19 below for the continuity guarantee this implies.
+4. `DEFAULT_PATHS` widens from its current 4-entry list to FR-3.7's full 6-entry covered-tree
+   list (`repo-governance/`, `.claude/`, `.codex/`, `.pi/`, `docs/`, `specs/`).
+5. Two genuinely new capabilities are added to the same module: a `missing` finding kind
+   (FR-3.1's "must contain a README.md" — the existing implementation only audits READMEs that
+   already exist, so it cannot today catch a directory that lacks one entirely) and an
+   `unannotated` finding kind (FR-3.10/FR-3.11/FR-3.14's annotation-derivation requirement — the
+   existing implementation accepts a bare `[Name](target.md)` link with no annotation text). A
+   `generate` subcommand is added per FR-3.12 — `md readme-index` has no generator today.
+
+What is **not** re-implemented: the orphan/ghost walk-and-audit core, the split-directory
+exemption's file-discovery mechanics, and the Markdown-link-extraction regex — all carried
+forward unchanged from `readme_index_audit.rs`.
+
+### Requirements
+
+| ID      | Requirement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| FR-3.1  | A covered directory containing at least one `*.md` besides `README.md`, or at least one subdirectory containing a `README.md`, **must** contain a `README.md`                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| FR-3.2  | That `README.md` must contain a Markdown link to every `*.md` directly in the same directory, excluding itself                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| FR-3.3  | That `README.md` must contain a Markdown link to every immediate subdirectory's `README.md`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| FR-3.4  | The rule is **not** recursive — a README never indexes a grandchild                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| FR-3.5  | A directory `X/` whose **sibling file `X.md` exists** is a _split directory_ and is exempt from FR-3.1–FR-3.3                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| FR-3.6  | For a split directory, the parent `X.md` is the index and must link every `*.md` inside `X/`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| FR-3.7  | Covered trees: `repo-governance/`, `.claude/`, `.codex/`, `.pi/`, `docs/`, `specs/`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| FR-3.8  | **Not** covered: `plans/`, `apps/`, `libs/`, the repository root, and the generated mirror trees (FR-3.17)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| FR-3.9  | Link targets are validated for existence by the existing `md links validate` gate, not re-implemented here                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| FR-3.10 | Every entry is **annotated**, in the form `- [<title>](<path>) — <description> <when_to_use>`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| FR-3.11 | The annotation is **derived from the target file's frontmatter**; the gate asserts the entry matches the target's `description` and `when_to_use`                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| FR-3.12 | `rhino-cli governance readme-index generate` writes conforming indexes; `validate` verifies them. Indexes are generated, not hand-authored                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| FR-3.13 | For targets outside `repo-governance/` — which do not carry `when_to_use` under FR-4.6 — only the `— <description>` half is required                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| FR-3.14 | An index whose annotation text has drifted from the target's frontmatter **fails**, and the finding names both texts                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| FR-3.19 | **Continuity guarantee**: the `orphan` and `ghost` finding kinds stay registered at `governance-readme-index`, `scope: all-file-type`, its current `DEFAULT_PATHS` (unwidened), on both `pre-push` and `ci`, throughout Phase 1 — the rename introduces **no enforcement gap**, unlike the word budget's accepted Phase 1–9 gap (`tech-docs.md` §6.2), because this gate is already armed today and the rename must not silently disarm it                                                                                                                                                                         |
+| FR-3.20 | The `missing` and `unannotated` finding kinds are **not** covered by FR-3.19's continuity guarantee — both are new, and unconditionally arming either against a repo not yet compliant (721 directories lack a `README.md`; zero files carry `when_to_use`) would break CI on day one. Both are dark-launched (registered but excluded from enforcement, Phase 1) at the widened FR-3.7 6-entry scope, then armed via a **second**, separately-registered gate id, `governance-readme-completeness`, `scope: path-gated` with the FR-1.11 trigger list, armed at Phase 9 (`ose-public`) / Phase 16 (`ose-private`) |
+
+### Index size versus the word budget
+
+[Repo-grounded, verified 2026-08-13] An annotated entry costs ~25–35 words. After excluding
+`plans/` (FR-3.8) and the generated mirror trees (FR-3.17), only two covered directories exceed
+the 500-word ceiling on their index alone. Entry counts are the indexable `*.md` files, excluding
+each directory's own `README.md`:
+
+| Directory                              | Entries | Estimated index | Status                   |
+| -------------------------------------- | ------- | --------------- | ------------------------ |
+| `.claude/agents/`                      | 94      | ~2,650 words    | covered — needs grouping |
+| `repo-governance/development/quality/` | 23      | ~670 words      | covered — glob threshold |
+| `.opencode/agents/`                    | 94      | ~2,650 words    | excluded (mirror)        |
+| `.cursor/agents/`                      | 94      | ~2,650 words    | excluded (mirror)        |
+| `plans/done/`                          | 185     | ~5,200 words    | excluded (`plans/`)      |
+
+**FR-3.15** — This collision is resolved by **both** mechanisms, and neither is an exemption:
+
+1. A dedicated `**/README.md` glob threshold, declared after the general glob (700 target / 900
+   fail), backed by new **select-then-classify** precedence logic in the ported
+   `word_budget.rs`: the last-declared matching surface is chosen for a path _before_
+   classification, and `classify()` runs exactly once against only that surface's thresholds —
+   so an earlier, less-specific surface never contributes a finding, even when the winning
+   surface's own verdict is `Ok`. Full mechanism and rationale: `tech-docs.md` §1.1/§1.3; RED/
+   GREEN steps: `delivery.md` Phase 1a/1b. Every README stays gated; none is waived.
+2. **Grouping for directories that still overflow.** A directory whose annotated index exceeds
+   900 words is reorganized into subfolders, each with its own index, and the parent annotates
+   the group READMEs instead of the leaves.
+
+**FR-3.16** — Grouping may only be applied to a harness-scanned directory once recursive
+subdirectory discovery is **confirmed** for every harness that reads it.
+
+- **Claude Code — CONFIRMED**: "Claude Code scans `.claude/agents/` and `~/.claude/agents/`
+  recursively, so you can organize definitions into subfolders... The subdirectory path doesn't
+  affect how a subagent is identified or invoked, because identity comes only from the `name`
+  frontmatter field." Constraint: `name` values must stay unique across the whole tree — already
+  true in both repos.
+- **OpenCode — CONFIRMED UNSUPPORTED**. The maintainers closed
+  [sst/opencode#6635 "support subdirectories in agent folder"](https://github.com/anomalyco/opencode/issues/6635)
+  as **not planned**; [the docs](https://opencode.ai/docs/agents/) describe only flat placement
+  in `.opencode/agents/`. Mirroring a grouped source 1:1 would **silently orphan 94 agents**
+  [Repo-grounded — the current indexable count, excluding `README.md`].
+- **Cursor — UNDOCUMENTED**. [cursor.com/docs/subagents](https://cursor.com/docs/subagents)
+  documents `.cursor/agents/` but is silent on subdirectory recursion, and no issue settles it.
+  Treated as unsupported; Phase 0 delegates a documentation/changelog/issue-tracker research
+  refresh (not a live IDE test — no CLI/API exists for an agent to observe Cursor GUI behavior) to
+  confirm this stays current before the plan proceeds with flat mirrors. (Note: `.cursor/rules/*.mdc`
+  _is_ documented as nestable — a different mechanism, not in this plan's scope.)
+- **Amazon Q — NOT APPLICABLE**. Its surface is a generated JSON bridge
+  (`.amazonq/cli-agents/ose-default.json`) referencing `AGENTS.md` and
+  `.amazonq/rules/**/*.md`; it never mirrors `.claude/agents/*.md`. Recursion there is explicit
+  via the `**` glob already in use.
+- **Codex — NOT APPLICABLE**. Its agents live in `.codex/config.toml` sub-tables. Separately
+  confirmed [Repo-grounded — carried forward from
+  `repo-governance/conventions/structure/instruction-file-size-budget.md`, the convention this
+  plan replaces (FR-2.4)]: `AGENTS.md` has a **32 KiB combined-size cap**
+  (`project_doc_max_bytes`) with root-to-cwd concatenation — which the ported resolved-tree word
+  budget (FR-2.6) keeps far inside.
+
+**FR-3.17 — Generated mirror directories are excluded from FR-3.** `.opencode/`, `.cursor/`,
+and `.amazonq/` trees are machine-consumed; no human navigates them by README. They remain
+**fully in scope for the word budget** (FR-1.4). If the generator emits a mirror `README.md`,
+it must be a **pointer** to the `.claude/` source index, not an enumeration of 94 siblings —
+which could not fit any sane ceiling.
+
+**FR-3.18 — The bindings generator must flatten grouped sources.** When `.claude/agents/` is
+grouped into subfolders, `rhino-cli harness bindings generate` must continue emitting
+`.opencode/agents/<name>.md` and `.cursor/agents/<name>.md` as **flat files**, deriving the
+filename from the agent's `name` frontmatter. This is a rhino-cli behaviour change and
+therefore lands in **Phase 1 (PR1, executable)** — before Phase 6 groups the source. Shipping
+the grouping first would break OpenCode discovery between merges.
+
+### Acceptance Criteria
+
+```gherkin
+Feature: README sibling index
+
+  Scenario: A complete index passes
+    Given directory "repo-governance/conventions/formatting/" contains "README.md", "linking.md", "emoji.md"
+    And "README.md" links "./linking.md" and "./emoji.md"
+    When I run "rhino-cli governance readme-index validate"
+    Then the exit code is 0
+
+  Scenario: A missing sibling link fails
+    Given directory "repo-governance/conventions/formatting/" contains "README.md", "linking.md", "emoji.md"
+    And "README.md" links "./linking.md" only
+    When I run "rhino-cli governance readme-index validate"
+    Then the exit code is 1
+    And the finding names "emoji.md" as unindexed
+
+  Scenario: A missing subdirectory README link fails
+    Given directory "repo-governance/conventions/" contains "README.md"
+    And it contains subdirectory "structure/" containing "README.md"
+    And "conventions/README.md" does not link "./structure/README.md"
+    When I run "rhino-cli governance readme-index validate"
+    Then the exit code is 1
+    And the finding names "structure/README.md" as unindexed
+
+  Scenario: A missing README fails when siblings exist
+    Given directory ".claude/skills/grill-me/reference/" contains "01-options.md"
+    And it contains no "README.md"
+    When I run "rhino-cli governance readme-index validate"
+    Then the exit code is 1
+    And the finding reports a missing index for that directory
+
+  Scenario: The rule does not reach grandchildren
+    Given "repo-governance/README.md" links "./conventions/README.md"
+    And it does not link "./conventions/structure/plans.md"
+    When I run "rhino-cli governance readme-index validate"
+    Then the exit code is 0
+
+  Scenario: A split directory is exempt and its parent indexes it
+    Given file "repo-governance/development/agents/ai-agents.md" exists
+    And directory "repo-governance/development/agents/ai-agents/" contains "01-catalog.md" and "02-naming.md"
+    And "ai-agents/" contains no "README.md"
+    And "ai-agents.md" links "./ai-agents/01-catalog.md" and "./ai-agents/02-naming.md"
+    When I run "rhino-cli governance readme-index validate"
+    Then the exit code is 0
+
+  Scenario: A split directory whose parent omits a child fails
+    Given file "repo-governance/development/agents/ai-agents.md" exists
+    And directory "repo-governance/development/agents/ai-agents/" contains "01-catalog.md" and "02-naming.md"
+    And "ai-agents.md" links "./ai-agents/01-catalog.md" only
+    When I run "rhino-cli governance readme-index validate"
+    Then the exit code is 1
+    And the finding names "02-naming.md" as unindexed
+
+  Scenario Outline: An uncovered tree is not scanned
+    Given directory "<dir>" contains "<file>" and no "README.md"
+    When I run "rhino-cli governance readme-index validate"
+    Then the exit code is 0
+
+    Examples:
+      | dir                                | file          |
+      | apps/ayokoding-www/content/en/     | lesson-01.md  |
+      | plans/backlog/some-plan/           | brd.md        |
+      | plans/done/2026-01-01__a-plan/     | delivery.md   |
+
+  Scenario: A generated mirror directory is not scanned
+    Given directory ".opencode/agents/" contains 95 agent files
+    And it contains no "README.md"
+    When I run "rhino-cli governance readme-index validate"
+    Then the exit code is 0
+
+  Scenario: A generated mirror is still subject to the word budget
+    Given ".opencode/agents/plan-checker.md" contains 900 words
+    When I run "rhino-cli governance word-budget validate"
+    Then the exit code is 1
+    And the finding names ".opencode/agents/plan-checker.md"
+
+  Scenario: The Phase 1 rename introduces no enforcement gap for orphan or ghost
+    Given gate id "md-readme-index" is armed at "scope: all-file-type" before Phase 1
+    When Phase 1's rename lands and gate id "governance-readme-index" replaces it
+    Then "governance-readme-index" is armed at "scope: all-file-type" immediately, not deferred
+    And "rhino-cli gate list --surface=pre-push --format=text" never shows both ids at once
+
+  Scenario: The unannotated finding kind is dark-launched, not enforced, before Phase 9
+    Given "repo-governance/conventions/README.md" links "./linking.md" with no annotation text
+    And Phase 9 has not yet armed "governance-readme-completeness"
+    When I run "rhino-cli governance readme-index validate"
+    Then the exit code is 0
+    And no finding of kind "unannotated" causes a failure
+
+  Scenario: The unannotated finding kind fails once armed and in scope
+    Given "repo-governance/conventions/README.md" links "./linking.md" with no annotation text
+    And Phase 9 has armed "governance-readme-completeness" at "scope: path-gated"
+    And the changed paths include "repo-governance/conventions/README.md"
+    When I run "rhino-cli gate run --surface=pre-push"
+    Then the exit code is 1
+    And the finding names "linking.md" as unannotated
+
+  Scenario: The --paths flag overrides the default scan scope
+    Given "rhino-cli governance readme-index validate" is invoked with "--paths repo-governance/"
+    When the command runs
+    Then it scans only "repo-governance/", not the unmodified DEFAULT_PATHS list
+    And running it again with no "--paths" flag scans the unmodified DEFAULT_PATHS list
+
+  Scenario: The --fail-kinds flag restricts which findings contribute to the exit code
+    Given a scanned directory has one "orphan" finding and one "missing" finding
+    When I run "rhino-cli governance readme-index validate --fail-kinds orphan"
+    Then the exit code reflects only the "orphan" finding
+    And the "missing" finding is still printed in the output
+```
+
+---
+
+## FR-4 — `when_to_use` frontmatter
+
+### Description
+
+`repo-governance/**/*.md` gains a required `when_to_use:` frontmatter key — the retrieval
+trigger. The existing `rhino-cli md frontmatter validate` gate is extended rather than
+duplicated.
+
+### Requirements
+
+| ID     | Requirement                                                                                                                                                                                                                                                                                                           |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FR-4.1 | `when_to_use` is a **required (FAIL-severity once armed)**, non-empty string on every `repo-governance/**/*.md` — lands at WARN in Phase 1 (dark-launched), armed to FAIL at Phase 9/16; see "Dark-launch sequencing" below                                                                                           |
+| FR-4.2 | `description` is **upgraded from its current WARN severity to required (FAIL)**, scoped to governance docs only; it is the tldr. **No `tldr:` key is introduced**. The flip is deferred to Phase 9/16 ("Dark-launch sequencing" below) — **not** implemented in Phase 1 — see "Description severity correction" below |
+| FR-4.3 | The 27 `repo-governance` files currently missing `description` are backfilled                                                                                                                                                                                                                                         |
+| FR-4.4 | `when_to_use` states a trigger condition, not a restatement of the title                                                                                                                                                                                                                                              |
+| FR-4.5 | Enforcement extends `rhino-cli md frontmatter validate` (gate `md-frontmatter`); no new gate id                                                                                                                                                                                                                       |
+| FR-4.6 | The requirement applies to `repo-governance/**/*.md` only — `docs/`, `.claude/`, and `apps/` unaffected                                                                                                                                                                                                               |
+| FR-4.7 | Frontmatter words count toward the FR-1 budget; no carve-out                                                                                                                                                                                                                                                          |
+| FR-4.8 | `title` stays FAIL-severity (unchanged) for governance docs; only `description`'s severity changes                                                                                                                                                                                                                    |
+
+### Description severity correction
+
+[Repo-grounded — `apps/rhino-cli/src/application/docs/frontmatter.rs::validate_governance_schema`,
+verified 2026-08-13] The governance frontmatter schema today enforces `title` at FAIL and
+`description` only at **WARN** ("recommended field"). An earlier draft of this plan stated
+"`description` remains required," which was inaccurate — it has never been FAIL-severity for
+governance docs.
+
+**FR-4.2 corrects this going forward**, not just backfilling the 27 files. Adding `when_to_use`
+at FAIL while leaving `description` at WARN would enforce the _trigger_ harder than the field
+describing _what the file is_ — an inconsistent gate. Both are upgraded to FAIL, scoped to
+`GOVERNANCE_DOC_PREFIXES` only (`repo-governance/{conventions,principles,development,workflows}/`);
+the software-engineering schema (`docs/explanation/software-engineering/`) is untouched.
+
+### Dark-launch sequencing (register-then-arm)
+
+[Repo-grounded — `repo-config.yml:774-781` scopes `md-frontmatter`'s `ci` surface as
+`{ scope: all-file-type }`, resolved by `ScopeKind::AllFileType => CandidateScope::TrackedFiles`
+in `apps/rhino-cli/src/commands/gate/run.rs:441`] Unlike FR-1/FR-3's two brand-new gate ids —
+which Phase 1 can register in `gates:` without arming, because an unregistered gate id runs
+nowhere — `md-frontmatter` is an **already-armed, whole-tree-scanning gate that runs on every
+CI run today**. Landing FR-4.1/FR-4.2 as FAIL-severity in the same PR that adds them would fail
+the `markdown` CI job for every contributor, in either repo, from the moment Phase 1's PR merges
+until the content-backfill phases finish (0/214 `repo-governance/**/*.md` files currently carry
+`when_to_use`; 27/214 are missing `description`).
+
+FR-4 therefore follows the same register-then-arm shape as FR-1/FR-3, adapted to an
+already-active gate rather than a new one:
+
+- **Phase 1 (register, `ose-public`)**: `KIND_MISSING_WHEN_TO_USE` lands using the same
+  `SEVERITY_WARN` construction `description` already uses — the check exists and is tested, but
+  does not fail the gate. `description`'s construction is left unchanged (already
+  `SEVERITY_WARN`); FR-4.2's `mk_fail()` upgrade is **not** implemented in Phase 1.
+- **Phase 9 (arm, `ose-public`)**: after `rhino-cli md frontmatter validate` confirms zero
+  `repo-governance/**/*.md` files are missing `when_to_use` or `description` (true only once
+  Phases 2–5 have merged), both findings' construction in `validate_governance_schema` switches
+  to `mk_fail()`, scoped to `GOVERNANCE_DOC_PREFIXES`, in the same commit that arms
+  `governance-word-budget`/`governance-readme-index`.
+- **Phase 10 (register, `ose-private`) / Phase 16 (arm, `ose-private`)**: identical sequencing,
+  gated on Phases 11–13 instead of 2–5.
+
+This keeps NFR-5 ("No commit in the plan leaves `main` with a red gate in either repo")
+satisfied for `md-frontmatter` the same way Phase 1's "register, but do not arm" step already
+satisfies it for the two brand-new gates. The Gherkin scenarios below describe FR-4's **armed
+end-state** (post-Phase-9/16) — Phase 1 only needs to satisfy the WARN-severity interim behavior
+described above.
+
+### Acceptance Criteria
+
+```gherkin
+Feature: when_to_use frontmatter
+
+  Scenario: A compliant governance file passes
+    Given "repo-governance/conventions/formatting/linking.md" frontmatter has a non-empty "description"
+    And it has a non-empty "when_to_use"
+    When I run "rhino-cli md frontmatter validate"
+    Then the exit code is 0
+
+  Scenario: A missing when_to_use fails
+    Given "repo-governance/conventions/formatting/linking.md" frontmatter has no "when_to_use"
+    When I run "rhino-cli md frontmatter validate"
+    Then the exit code is 1
+    And the finding kind is "missing-when-to-use"
+
+  Scenario: An empty when_to_use fails
+    Given "repo-governance/conventions/formatting/linking.md" has "when_to_use: \"\""
+    When I run "rhino-cli md frontmatter validate"
+    Then the exit code is 1
+
+  Scenario: A missing description now fails, not warns
+    Given "repo-governance/principles/content/progressive-disclosure.md" has no "description"
+    When I run "rhino-cli md frontmatter validate"
+    Then the exit code is 1
+    And the finding kind is "missing-description"
+    And the finding severity is "fail"
+
+  Scenario: The software-engineering schema is unaffected — it was already fail-severity
+    Given "docs/explanation/software-engineering/programming-languages/typescript/index.md" has no "description"
+    When I run "rhino-cli md frontmatter validate"
+    Then the exit code is 1
+    And the finding severity is "fail"
+    # unchanged by this plan — validate_software_schema has always used mk_fail for description
+
+  Scenario: A tldr key is not required anywhere
+    Given no repo-governance file declares "tldr"
+    When I run "rhino-cli md frontmatter validate"
+    Then the exit code is 0
+
+  Scenario: Files outside repo-governance are not required to declare when_to_use
+    Given "docs/reference/monorepo-structure.md" has no "when_to_use"
+    When I run "rhino-cli md frontmatter validate"
+    Then the exit code is 0
+
+  Scenario: A missing when_to_use warns during Phase 1's dark-launch, before enforcement is armed
+    Given "repo-governance/conventions/formatting/linking.md" frontmatter has no "when_to_use"
+    And Phase 1 has registered the check but not yet armed it to FAIL severity
+    When I run "rhino-cli md frontmatter validate"
+    Then the exit code is 0
+    And the output contains a "when_to_use" finding at "warn" severity
+```
+
+---
+
+## FR-5 — Two separate concerns, never combined into one checker
+
+### Description
+
+Size and reachability are distinct concerns with distinct trigger sets, distinct failure modes,
+and distinct remediations. They ship as two commands, never as one combined checker.
+Reachability (`governance readme-index validate`) is itself split across **two** `gates:`
+registrations — `governance-readme-index` (orphan/ghost, continuously armed, FR-3.19)
+and `governance-readme-completeness` (the new `missing` + `unannotated` checks, dark-launched
+then armed, FR-3.20) — because one is a continuity-preserving rename of an already-armed gate and the
+other is genuinely new, path-gated work; folding them into a single registration would either
+reintroduce the enforcement gap FR-3.19 forbids, or path-gate (and thus temporarily weaken)
+orphan/ghost detection that is armed unconditionally today. Size (`governance word-budget
+validate`) remains a single gate id, `governance-word-budget`, since it has no pre-existing
+armed gate to preserve.
+
+### Requirements
+
+| ID     | Requirement                                                                                                                                                                                                                                                                                                                                                                         |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FR-5.1 | `rhino-cli governance word-budget validate` and `rhino-cli governance readme-index validate` are separate leaf commands                                                                                                                                                                                                                                                             |
+| FR-5.2 | Gate ids `governance-word-budget`, `governance-readme-index`, and `governance-readme-completeness` are registered independently in `gates:`                                                                                                                                                                                                                                         |
+| FR-5.3 | `governance-word-budget` and `governance-readme-index` each have their own Nx target: `rhino-cli:governance-word-budget:validation`, `rhino-cli:governance-readme-index:validation` (FR-3.20)                                                                                                                                                                                       |
+| FR-5.4 | `governance-word-budget` and `governance-readme-completeness` each declare their **own** `trigger:` list (FR-1.10, FR-1.11); `governance-readme-index` declares none — it is `scope: all-file-type`                                                                                                                                                                                 |
+| FR-5.5 | Any gate may fail without the others running; none short-circuits another                                                                                                                                                                                                                                                                                                           |
+| FR-5.6 | `readme-index` additionally exposes a `generate` subcommand; `word-budget` has no generator — an oversized file needs a human-authored split, not codegen                                                                                                                                                                                                                           |
+| FR-5.7 | Only `governance-word-budget` is registered as a `repo-governance audit` category                                                                                                                                                                                                                                                                                                   |
+| FR-5.8 | `governance-readme-index` and `governance-readme-completeness` invoke the **same** underlying `governance readme-index validate` binary; each `repo-config.yml` registration passes its own `args:` block — `--paths` selects the scan scope and `--fail-kinds` selects which finding kinds cause a nonzero exit — per the mechanism in FR-1.10/FR-1.11 below and `tech-docs.md` §4 |
+
+### Acceptance Criteria
+
+```gherkin
+Feature: Gate separation and path-gated execution
+
+  Scenario: Both gates are registered independently
+    When I run "rhino-cli gate list --surface=pre-push --format=text"
+    Then the output contains gate id "governance-word-budget"
+    And the output contains gate id "governance-readme-index"
+
+  Scenario: A governance Markdown change triggers both gates
+    Given the changed paths include "repo-governance/conventions/formatting/linking.md"
+    When I run "rhino-cli gate run --surface=pre-push"
+    Then "governance-word-budget" executes
+    And "governance-readme-index" executes
+
+  Scenario: An application change triggers neither gate
+    Given the changed paths include only "apps/ayokoding-www/content/en/lesson-01.md"
+    When I run "rhino-cli gate run --surface=pre-push"
+    Then "governance-word-budget" is skipped
+    And "governance-readme-index" is skipped
+
+  Scenario: A mirror-only change triggers the word budget but not the index gate
+    Given the changed paths include only ".opencode/agents/plan-checker.md"
+    When I run "rhino-cli gate run --surface=pre-push"
+    Then "governance-word-budget" executes
+    And "governance-readme-index" is skipped
+
+  Scenario: A config change re-validates everything
+    Given the changed paths include only "repo-config.yml"
+    When I run "rhino-cli gate run --surface=pre-push"
+    Then "governance-word-budget" executes
+    And "governance-readme-index" executes
+
+  Scenario: A plans-only change triggers neither gate
+    Given the changed paths include only "plans/in-progress/some-plan/delivery.md"
+    When I run "rhino-cli gate run --surface=pre-push"
+    Then "governance-word-budget" is skipped
+    And "governance-readme-index" is skipped
+
+  Scenario: The same triggers apply on the CI surface
+    Given the changed paths include "AGENTS.md"
+    When I run "rhino-cli gate run --surface=ci"
+    Then "governance-word-budget" executes
+
+  Scenario: A triggered gate validates the whole covered tree, not just changed files
+    Given the changed paths include only "repo-governance/conventions/formatting/linking.md"
+    And "repo-governance/development/agents/ai-agents.md" contains 900 words
+    When I run "rhino-cli gate run --surface=pre-push"
+    Then the exit code is 1
+    And the finding names "repo-governance/development/agents/ai-agents.md"
+
+  Scenario: One gate failing does not suppress the other
+    Given "governance-word-budget" fails
+    When I run "rhino-cli gate run --surface=ci --group=governance"
+    Then "governance-readme-index" still executes
+    And both outcomes appear in the group summary
+```
+
+---
+
+## Non-Functional Requirements
+
+| ID    | Requirement                                                                                                                                        |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| NFR-1 | Both new gates complete in under 10 seconds on a warm checkout of either repo                                                                      |
+| NFR-2 | Every gate finding is deterministic and order-stable, so golden-master fixtures do not flake                                                       |
+| NFR-3 | `apps/rhino-cli` changes land byte-identically in `ose-public` and `ose-private`; the parity manifest is regenerated and staged in the same commit |
+| NFR-4 | Every rhino-cli behaviour change lands with companion Gherkin under `specs/apps/rhino/behavior/rhino-cli/gherkin/` in the same PR                  |
+| NFR-5 | No commit in the plan leaves `main` with a red gate in either repo                                                                                 |
+| NFR-6 | Generated bindings are regenerated and committed **with** their `.claude/` source, never in a follow-up commit                                     |

--- a/plans/in-progress/optimize-governance-md/tech-docs.md
+++ b/plans/in-progress/optimize-governance-md/tech-docs.md
@@ -1,0 +1,871 @@
+# Technical Documentation: Optimize Governance Markdown
+
+## 1. Gate Design
+
+### 1.1 Repurpose, do not rebuild
+
+`apps/rhino-cli/src/application/repo_governance/instruction_size.rs` already provides
+everything this plan needs except the metric:
+
+- glob-driven surface matching against repo-relative paths
+- a three-tier `Severity` enum (`Ok` / `Warn` / `Fail`) with `severity_label`
+- deserialized per-surface thresholds (`Surface { glob, target, warn, fail }`)
+- transitive `@`-import resolution with depth limit and cycle guard (`ResolvedTree`)
+- a `Finding` type and reporter already wired into four enforcement points
+
+The change is therefore narrow: swap the measured quantity from bytes to words, widen the
+globs, and rename the module and its command surface. The `Fs` port abstraction stays, so the
+existing unit tests keep their fixture style.
+
+**Overlap-precedence gap — new selection logic, not a config-only change** [Repo-grounded — read
+`check_instruction_sizes` in full, `apps/rhino-cli/src/application/repo_governance/
+instruction_size.rs:273-318`]: today's `check_instruction_sizes` iterates every configured
+surface in declaration order and, for each one, evaluates **every matching file independently
+against that surface's own thresholds**, pushing a `Finding` per surface a file matches (skipping
+only that surface's own `Ok` verdicts — a file within one surface's thresholds simply produces no
+candidate from that surface, while a different surface matching the same file can still push its
+own candidate). There is no deduplication and no "later-declared-surface-wins" logic — a file
+matched by two surfaces (e.g. a `README.md` matched by both the general
+`repo-governance/**/*.md` surface and the new `**/README.md` surface) can produce **two
+independent findings** today, one per surface, whenever both surfaces independently classify it
+non-`Ok`. The caller, `convention_validate_instruction_size.rs::run_for_root`, computes
+`has_fail = findings.iter().any(|f| f.severity == Severity::Fail)`, so the less-specific
+surface's `Fail` trips the gate even when the more-specific surface classifies the same file
+`Warn` — or, in the common case where the more-specific surface classifies the file `Ok`, even
+when the more-specific surface has nothing to say about the file at all.
+
+§1.3's "later globs win on overlap" and FR-1.6/FR-3.15's precedence rule are therefore **genuinely
+new selection logic this plan adds during the port**. The design is **select the winning surface
+per path first, then classify once against only that surface's thresholds** — not "classify
+against every surface, then filter/compare the resulting findings." The second shape is
+insufficient: because `Ok` verdicts never produce a candidate finding, a design that only compares
+already-produced candidates has nothing to compare against when the winning (more specific)
+surface's own verdict is `Ok` — the earlier-declared, less-specific surface's stray `Fail`/`Warn`
+candidate then survives unfiltered, exactly the bug this section exists to close, just triggered
+by the surface that was supposed to fix it. The select-then-classify order removes this failure
+mode structurally: an earlier-declared surface's `classify()` call is never made at all for a path
+a later-declared surface also matches, so it can never contribute a stray candidate in the first
+place. See §1.3 below and `delivery.md` Phase 1a/1b for the RED/GREEN steps that add it.
+
+**Registry-merge scope decision** [Repo-grounded — `merged_budget_config()`]: today's
+`instruction_size.rs` also merges every `harness:` registry entry's `instruction:` glob list
+into the budget, applying default byte thresholds to any glob not already covered by an
+explicit surface. This behaviour is **not ported**. The `harness.instruction` registry field
+this merge reads has no consumer besides `merged_budget_config` (verified by grep) — but
+`merged_budget_config` the _function_ has a second call site:
+`application/repo_governance/audit_orchestrator.rs::audit_instruction_size` calls it directly
+and consumes its registry-merged output for the `repo-governance audit --category=instruction-size`
+command. Dropping the merge is still the right call (FR-1.3's explicit glob list already
+supersedes every registry-declared `.md`-extension surface that resolves to an existing file
+today), but `audit_orchestrator.rs` is a real, functionally-coupled call site this plan touches,
+not an unaffected bystander — its rename is tracked in the File-Impact Analysis tree below. The
+six surfaces the merge would otherwise auto-cover (`.cursor/rules/*.mdc`, `.windsurf/rules/*.md`,
+`.junie/guidelines.md`, `.github/copilot-instructions.md`, `GEMINI.md`, `CONVENTIONS.md`) do not
+exist in either repo today (verified via `ls`). See `prd.md` FR-1.15 for the full decision
+record.
+
+**The same principle applies to FR-3's README-index gate — it is not exempt.**
+[Repo-grounded, verified 2026-08-13] `apps/rhino-cli/src/application/repo_governance/
+readme_index_audit.rs` already provides the walk-and-audit mechanic FR-3.1–FR-3.4 need:
+recursive `README.md` discovery, sibling `.md`/subdirectory-`README.md` computation, and
+`orphan`/`ghost` finding emission. It is wired to the CLI via
+`apps/rhino-cli/src/commands/md_validate_readme_index.rs` as `md readme-index validate`, and
+registered in `repo-config.yml` as gate id `md-readme-index`, **already armed** at
+`surfaces: { pre-push: { scope: all-file-type }, ci: { scope: all-file-type } }` — it runs on
+every push and every PR today, unconditionally, and currently passes with zero findings.
+
+The change is a **rename-and-extend**, mirroring word-budget's pattern exactly:
+`git mv` the module to `application/governance/readme_index.rs` and the command file to
+`commands/governance_validate_readme_index.rs`; rename the CLI surface from `md readme-index` to
+`governance readme-index`; and add two genuinely new finding kinds (`missing` — FR-3.1's
+README-must-exist rule, which the current implementation cannot check because it only audits
+READMEs that already exist — and `unannotated` — FR-3.10/FR-3.11/FR-3.14's annotation-derivation
+requirement, which the current implementation does not check at all) plus a `generate`
+subcommand (FR-3.12; `md readme-index` has no generator today). `DEFAULT_PATHS` for the
+continuity-preserving gate stays at its current 4-entry list — see below for why the scope
+widening to FR-3.7's full 6-entry list is deferred, not immediate.
+
+**The rename must not disarm what is already enforced, and a new capability must not arm itself
+against a currently-noncompliant repo.** These are two separate risks, handled two separate ways:
+
+1. **No enforcement gap** — because `md-readme-index` is armed today, the `repo-config.yml`
+   entry is renamed **in place** to `governance-readme-index` within the same Phase 1 commit
+   that performs the `git mv`. It is never removed and re-registered later, which would open an
+   enforcement gap FR-1's own byte→word transition explicitly accepts (§6.2) but FR-3's rename
+   does not need to. `governance-readme-index` keeps its current `orphan`/`ghost` behavior, its
+   current `DEFAULT_PATHS`, and its current `scope: all-file-type` surfaces — unchanged.
+2. **No day-one breakage from new capabilities** — `missing` (a directory lacking a required
+   `README.md`) and `unannotated` (a link lacking the derived-annotation format) are both
+   genuinely new checks against a repo that is not compliant with either today (`README.md`
+   §Context: 721 Markdown-bearing directories in `ose-public` lack a `README.md`; zero files
+   carry `when_to_use` yet). Arming either unconditionally at Phase 1 would fail CI immediately,
+   for reasons this plan's own Phases 2–8 exist to fix. Both therefore follow the **same
+   register-then-arm dark-launch sequencing FR-4 already uses** for `when_to_use`/`description`
+   (§5 below): registered but not enforced at Phase 1, via a **second**, separately-registered,
+   `path-gated` gate id, `governance-readme-completeness`, scoped to FR-3.7's full 6-entry
+   covered-tree list (the scope widening lives here, not in the continuity gate) — armed once
+   Phases 2–8 (`ose-public`) / 11–15 (`ose-private`) have populated the missing indexes and
+   annotations. See `prd.md` FR-3.19/FR-3.20 and §4 below for the full design.
+
+### 1.2 Word counting
+
+Word count is **raw and whole-file**, defined as the number of whitespace-separated tokens in
+the file's full UTF-8 contents — identical to `wc -w`. Frontmatter, fenced code, Mermaid,
+tables, and URLs all count.
+
+This definition is chosen because it is unarguable. Any "prose-only" definition requires a
+Markdown parser, invites per-file disputes about what counts, and can be gamed by moving
+content into a fenced block.
+
+```rust
+fn word_count(contents: &str) -> u64 {
+    contents.split_whitespace().count() as u64
+}
+```
+
+The counter must be byte-safe for non-ASCII content (Arabic, Indonesian) — `split_whitespace`
+operates on `char` boundaries and satisfies this without extra handling.
+
+### 1.3 Configuration
+
+`repo-config.yml` gains a `governance-word-budget:` block and loses `instruction-size:`.
+
+```yaml
+governance-word-budget:
+  surfaces:
+    - glob: "repo-governance/**/*.md"
+      target: 400
+      warn: 500
+      fail: 500
+    - glob: ".claude/**/*.md"
+      target: 400
+      warn: 500
+      fail: 500
+    # ... .cursor, .codex, .opencode, .pi, .amazonq
+    - glob: "AGENTS.md"
+      target: 400
+      warn: 500
+      fail: 500
+    - glob: "CLAUDE.md"
+      target: 400
+      warn: 500
+      fail: 500
+    - glob: "**/README.md"
+      target: 700
+      warn: 900
+      fail: 900
+  resolved-tree:
+    root: "CLAUDE.md"
+    target: 1200
+    warn: 1500
+    fail: 1500
+```
+
+**Schema constraints** (enforced by the existing `repo-config-schema` gate):
+
+- No `exempt`, `allow`, `ignore`, `waiver`, or `override` key is permitted anywhere in the
+  block. The schema must reject them explicitly so a future contributor cannot quietly add one.
+- `warn` and `fail` are equal on every surface. The three-tier machinery is retained so the
+  `Warn` band is expressible, but `Warn` here means `target < words ≤ fail`. A file at 450
+  words warns; a file at 501 fails.
+- Later globs win on overlap: when a file matches more than one surface,
+  `word_budget.rs`'s ported `check_instruction_sizes` first determines, per matched path, the
+  **last-declared matching surface**, then calls `classify()` exactly once for that path using
+  only that surface's own `target`/`warn`/`fail` — an earlier-declared surface matching the same
+  path is never classified at all, so it can never contribute a finding, regardless of whether
+  the winning surface's own verdict is `Ok`, `Warn`, or `Fail`. This is new per-path
+  select-then-classify logic added during the port (see §1.1 above and `delivery.md` Phase
+  1a/1b), not merely a YAML-ordering convention, and not a "compare the more severe of two
+  candidate findings" step — the latter shape silently fails whenever the winning surface's own
+  verdict is `Ok`, because an `Ok` verdict produces no candidate to compare. Declaration order in
+  this block is therefore load-bearing: a more specific glob (for example `**/README.md`) must be
+  declared **after** the general one it overlaps.
+
+### 1.4 Naming map
+
+| Artifact       | Before                                                  | After                                             |
+| -------------- | ------------------------------------------------------- | ------------------------------------------------- |
+| Command        | `rhino-cli harness instruction-size validate`           | `rhino-cli governance word-budget validate`       |
+| Module         | `application/repo_governance/instruction_size.rs`       | `application/governance/word_budget.rs`           |
+| Command file   | `commands/harness_validate_instruction_size.rs`         | `commands/governance_validate_word_budget.rs`     |
+| Config block   | `instruction-size:`                                     | `governance-word-budget:`                         |
+| Gate id        | `instruction-size`                                      | `governance-word-budget`                          |
+| Nx target      | `rhino-cli:instruction-size:validation`                 | `rhino-cli:governance-word-budget:validation`     |
+| Convention doc | `conventions/structure/instruction-file-size-budget.md` | `conventions/structure/governance-word-budget.md` |
+| Audit category | `instruction-size` (category 4)                         | `governance-word-budget`                          |
+
+**Command file merge note** [Repo-grounded, verified by reading both files]:
+`commands/harness_validate_instruction_size.rs` is a thin wrapper — its doc comment states it
+delegates to `convention_validate_instruction_size::run_for_root`, and its `run()` body is a
+single delegating call. The real implementation (the `SCHEMA` const, `run_for_root`, finding
+construction, and all text/JSON/markdown formatters) lives in the separate, pre-existing
+`commands/convention_validate_instruction_size.rs`, whose module is used nowhere else in the
+codebase (`grep -rn convention_validate_instruction_size apps/rhino-cli/src` shows only the
+`commands.rs` mod declaration and this one wrapper's `use`). The "Command file" row above is
+therefore a **two-source merge, not a single rename**: both
+`harness_validate_instruction_size.rs` and `convention_validate_instruction_size.rs` are deleted,
+and `commands/governance_validate_word_budget.rs` is created as their merged replacement —
+`convention_validate_instruction_size.rs`'s body becomes the new file's implementation, and
+`harness_validate_instruction_size.rs`'s CLI-arg-parsing entry point (`ValidateInstructionSizeArgs`
+→ renamed args struct, `run()`) is folded in directly, removing the delegation indirection. See
+the File-Impact Analysis tree below and §6's Migration and Removal Map for the full destination
+statement.
+
+A second command, `rhino-cli governance readme-index validate`, is a **rename-and-extend**, not
+a new command from scratch — see §1.1 above and §4 below for the full decision record. It splits
+across two gate ids: `governance-readme-index` (continuity-preserving rename of the already-armed
+`md-readme-index`) and `governance-readme-completeness` (new capabilities, dark-launched).
+
+| Artifact (readme-index) | Before                                              | After                                                                                   |
+| ----------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Command                 | `rhino-cli md readme-index validate`                | `rhino-cli governance readme-index validate`                                            |
+| Module                  | `application/repo_governance/readme_index_audit.rs` | `application/governance/readme_index.rs`                                                |
+| Command file            | `commands/md_validate_readme_index.rs`              | `commands/governance_validate_readme_index.rs`                                          |
+| Gate id                 | `md-readme-index`                                   | `governance-readme-index` (unchanged behavior) + `governance-readme-completeness` (new) |
+
+### 1.5 Enforcement points
+
+Three enforcement points — declared in the `gates:` registry in `repo-config.yml`, never
+hand-written into `.husky/` hooks, which are registry shims:
+
+| Gate                             | Pre-push                                                          | CI                              | Audit category |
+| -------------------------------- | ----------------------------------------------------------------- | ------------------------------- | -------------- |
+| `governance-word-budget`         | `path-gated`, 10 triggers                                         | `path-gated`, same 10 triggers  | yes            |
+| `governance-readme-index`        | `all-file-type` (unconditional, unchanged from `md-readme-index`) | `all-file-type` (unconditional) | no             |
+| `governance-readme-completeness` | `path-gated`, 7 triggers                                          | `path-gated`, same 7 triggers   | no             |
+
+Trigger lists are in `prd.md` §FR-1.10 and §FR-1.11. None of the three declares a `pre-commit`
+surface — a whole-tree scan on every commit adds cost without adding coverage.
+
+**`path-gated` on `ci` is already supported**, verified by reading the runner rather than
+assumed. Three facts settle it:
+
+- `commands/gate/run.rs::candidate_scope` maps `ScopeKind::PathGated → CandidateScope::PathTriggers`
+  with no surface condition.
+- `candidate_paths` computes changed paths whenever any selected gate resolves to
+  `StagedFiles` **or** `PathTriggers`, so `changed_paths` is `Some(..)` on CI — important,
+  because the skip predicate treats `None` as "no match" and would otherwise skip silently.
+- `changed_paths` handles `GateSurface::Ci` explicitly: `RHINO_GATE_CHANGED_BASE` when set,
+  otherwise `git merge-base origin/main HEAD`.
+
+[Repo-grounded, verified via `grep -c "scope: path-gated"` and surface inspection] Today there
+are six `path-gated` declarations in `repo-config.yml` and **all six are on `pre-push`** — these
+gates are the first to use it on `ci`. Phase 1 proves it with a live run rather than trusting the
+code read.
+
+`repo_config_validate.rs` already enforces the schema invariants both ways: `trigger` is
+rejected on a non-`path-gated` scope, and a `path-gated` scope with an empty `trigger` list is
+rejected.
+
+Verify wiring with `apps/rhino-cli/scripts/rhino-bin.sh gate validate`, never by reading the
+hook files.
+
+---
+
+## File-Impact Analysis
+
+[Repo-grounded] Root-relative tree of concrete, enumerable targets this plan touches directly,
+plus bounded glob patterns for the bulk content splits. Counts are re-derived from the current
+commit (2026-08-13); `ose-private` paths are a byte-for-byte mirror of the `ose-public` rhino-cli
+boundary, landed separately in Phase 10.
+
+```text
+apps/rhino-cli/src/
+├── application/repo_governance/instruction_size.rs        [D] git mv -> governance/word_budget.rs (Phase 1)
+├── application/governance/word_budget.rs                  [N] byte metric -> raw word metric (Phase 1)
+├── application/repo_governance/readme_index_audit.rs      [D] git mv -> governance/readme_index.rs (Phase 1)
+├── application/governance/readme_index.rs                 [N] git-mv destination of readme_index_audit.rs
+│                                                                (orphan/ghost logic carried forward unchanged);
+│                                                                extended with `missing` + `unannotated` finding
+│                                                                kinds and a `generate` path — NOT built from
+│                                                                scratch; see tech-docs.md §1.1/§4 (Phase 1)
+├── application/docs/frontmatter.rs                        [E] add KIND_MISSING_WHEN_TO_USE at WARN
+│                                                                (dark-launched; armed Phase 9/16) (Phase 1)
+├── application/repo_governance/mod.rs                      [E] remove `pub mod instruction_size;` —
+│                                                                module moves to a new parent (Phase 1)
+├── application/repo_governance/audit_orchestrator.rs       [E] rename "instruction-size" category name,
+│                                                                command mapping, match arm, and 5 unit
+│                                                                test assertions to "governance-word-budget"
+│                                                                (Phase 1)
+├── application/repo_config/mod.rs                          [E] rename the `#[serde(rename =
+│                                                                "instruction-size")] instruction_size:
+│                                                                Option<BudgetConfig>` struct field to
+│                                                                `governance-word-budget`; repoint its
+│                                                                `use` of `BudgetConfig` (Phase 1)
+├── application/mod.rs                                      [E] add `pub mod governance;` — the
+│                                                                `application/governance/` directory does
+│                                                                not exist yet (Phase 1)
+├── commands/harness_validate_instruction_size.rs           [D] merged into governance_validate_word_budget.rs
+│                                                                (Phase 1)
+├── commands/convention_validate_instruction_size.rs         [D] merged into governance_validate_word_budget.rs —
+│                                                                this file (not the thin harness_validate_instruction_size.rs
+│                                                                wrapper) holds the real implementation (SCHEMA, run_for_root,
+│                                                                formatters); it becomes the new file's body (Phase 1)
+├── commands/governance_validate_word_budget.rs              [N] merged command file: absorbs
+│                                                                convention_validate_instruction_size.rs's implementation
+│                                                                plus harness_validate_instruction_size.rs's CLI arg-parsing
+│                                                                entry point; the delegation wrapper is removed (Phase 1)
+├── commands/md_validate_readme_index.rs                     [D] git mv -> governance_validate_readme_index.rs
+│                                                                (Phase 1)
+├── commands/governance_validate_readme_index.rs             [N] git-mv destination of
+│                                                                md_validate_readme_index.rs; add `missing` +
+│                                                                `unannotated` finding kinds and a `generate`
+│                                                                verb (FR-3.12) (Phase 1)
+├── commands/harness_audit.rs                                [E] rename the separate
+│                                                                "validate-instruction-size" member, match
+│                                                                arm, and unit test
+│                                                                (`MEMBERS.contains(&"validate-instruction-size")`)
+│                                                                (Phase 1)
+├── commands.rs                                              [E] remove `pub mod
+│                                                                convention_validate_instruction_size;` entirely
+│                                                                (its file is merged away); rename `pub mod
+│                                                                harness_validate_instruction_size;` to `pub mod
+│                                                                governance_validate_word_budget;`; rename `pub mod
+│                                                                md_validate_readme_index;` to `pub mod
+│                                                                governance_validate_readme_index;` (Phase 1)
+└── cli.rs                                                   [E] rewrite the `#[command(name =
+                                                                 "instruction-size", subcommand)]` tree and
+                                                                 dispatch; rewrite the 2 unit tests asserting
+                                                                 the OLD command structure —
+                                                                 `verb_last_harness_instruction_size_validate_parses`,
+                                                                 `verb_middle_convention_validate_instruction_size_no_longer_parses`;
+                                                                 remove `ReadmeIndex(MdReadmeIndexCommands)` from
+                                                                 `MdCommands` and add it under a new
+                                                                 `#[command(name = "governance", subcommand)]`
+                                                                 tree alongside `word-budget` (Phase 1)
+
+apps/rhino-cli/project.json                                 [E] add governance-word-budget + governance-readme-index Nx targets (Phase 1)
+apps/rhino-cli/tests/golden-master/*instruction-size*        [D] 12 fixtures deleted, regenerated under new gate ids (Phase 1)
+apps/rhino-cli/tests/golden-master/*readme-index*            [D] 9 fixtures (`md-readme-index*`,
+                                                                   `md-validate-readme-index*` —
+                                                                   `.exit`/`.stderr`/`.stdout` triples) deleted,
+                                                                   regenerated under `governance-readme-index`
+                                                                   naming (Phase 1)
+apps/rhino-cli/tests/golden-master/{harness-help,convention-validate,
+  harness-validate}.stderr, manifest.json                    [E] content references "instruction-size"
+                                                                   without being named for it; regenerated
+                                                                   once the command is renamed (Phase 1)
+
+specs/apps/rhino/behavior/rhino-cli/gherkin/
+├── harness/repo-governance-instruction-size.feature          [D] git mv -> governance/ (Phase 1)
+├── harness/repo-governance-instruction-size-governance.feature [E] rewritten in place — 3
+│                                                               scenarios reference the deterministic
+│                                                               "instruction-size" gate name, the
+│                                                               Step 0.5 preflight category, and the
+│                                                               skip-set category by name; all 3
+│                                                               rewritten to "governance-word-budget"
+│                                                               (Phase 1)
+├── harness/repo-governance-instruction-size-pre-push.feature [E] rewritten in place — scenarios
+│                                                               assert "the instruction-size gate
+│                                                               runs" / "the instruction-size
+│                                                               validation target" by name; both
+│                                                               rewritten to the renamed gate/Nx
+│                                                               target (Phase 1)
+├── harness/repo-governance-agents-md-size.feature            [E] rewritten for word metric (Phase 1)
+└── governance/*.feature                                      [N] new word-budget + readme-index scenarios (Phase 1)
+
+repo-config.yml                                               [E] instruction-size: removed; governance-word-budget: added,
+                                                                    unarmed at registration (Phase 1), armed (Phase 9);
+                                                                    md-readme-index: renamed in place to
+                                                                    governance-readme-index, scope/surfaces unchanged,
+                                                                    continuously armed (Phase 1 — no gap);
+                                                                    governance-readme-completeness: added, unarmed at
+                                                                    registration (Phase 1), armed (Phase 9)
+
+repo-governance/conventions/structure/
+├── instruction-file-size-budget.md                            [D] git mv -> governance-word-budget.md (Phase 1)
+└── governance-word-budget.md                                  [N] renamed, rewritten, split to fit its own ceiling (Phase 1)
+
+<inbound links to the renamed convention doc>                  [E] discovered via
+    `grep -rl "instruction-size\|instruction-file-size-budget" repo-governance .claude docs AGENTS.md`
+    at Phase-1 execution time — never a hardcoded file list (see §6 below and Finding 4 of the
+    2026-08-13 plan audit)
+
+<specs/ scenario files referencing the old gate name>          [E] discovered separately via
+    `grep -rl "instruction-size" specs` at Phase-1 execution time (a distinct sweep from the
+    inbound-link grep above — it targets Gherkin scenario/README text naming the gate, not markdown
+    links to the convention doc, and is intentionally not merged into that grep's file count). As
+    of 2026-08-13 this returns 9 files: the 3 `harness/repo-governance-instruction-size*.feature`
+    files and 1 `harness/repo-governance-agents-md-size.feature` file already tracked above, plus 5
+    not otherwise tracked in this tree — 3 index READMEs (`gherkin/README.md`,
+    `gherkin/harness/README.md`, `gherkin/repo-governance/README.md`) and 2 unrelated-domain feature
+    files that name the old command in passing (`gherkin/specs/harness-registry-driven.feature`,
+    `gherkin/specs/harness-bindings.feature`) — never a hardcoded list; rewrite whatever the live
+    grep returns (Finding 1 of the 2026-08-13 plan audit)
+
+repo-governance/**/*.md                                        [E] [G] 188 files over 500 words in
+    `ose-public` (Phases 2–5) — the `repo-governance/`-only slice of the 298 combined
+    `repo-governance/` + `.claude/` "source (non-generated)" total in `README.md` §Context
+    (`.claude/`'s 110 are handled separately below); each becomes an index parent + capped
+    sibling directory, gains `when_to_use` frontmatter, and a README index entry
+.claude/agents/**/*.md                                          [E] [G] 78 of 94 files over 500 words;
+    migrated to a ≤500-word charter + `.claude/skills/<name>/reference/*.md` (Phase 6)
+.claude/skills/**/SKILL.md                                      [E] [G] 29 of 32 files over 500 words,
+    split into `SKILL.md` + `reference/NN-*.md` (Phase 7)
+.opencode/, .cursor/, .amazonq/                                 [G] regenerated via
+    `npm run generate:bindings` after every `.claude/` edit — never hand-edited (Phases 1, 6–8)
+AGENTS.md                                                        [E] rewritten as a directive index,
+    3,001 → ≤500 words (Phase 8)
+CLAUDE.md                                                         [E] rewritten, 907 → ≤500 words (Phase 8)
+repo-governance/README.md + every top-level index                [E] updated to reflect splits (Phase 8)
+
+ose-private/ (mirrored root; Phases 10–16)
+├── apps/rhino-cli/                                             [E] byte-for-byte copy of the ose-public
+│                                                                     rhino-cli boundary (Phase 10)
+├── repo-config.yml                                              [E] equivalent changes, adjusted for
+│                                                                     private's surfaces — no `.pi/`,
+│                                                                     one `.amazonq/` file (Phase 10)
+├── repo-governance/conventions/structure/instruction-file-size-budget.md [D] git mv + rewrite (Phase 10)
+├── repo-governance/**/*.md                                       [E] [G] 176 files over 500 words split
+│                                                                     (Phases 11–13) — the
+│                                                                     `repo-governance/`-only slice of the
+│                                                                     247 combined `repo-governance/` +
+│                                                                     `.claude/` "source (non-generated)"
+│                                                                     total in `README.md` §Context
+│                                                                     (`.claude/`'s 71 handled in Phase 14)
+├── .claude/agents/**/*.md, .claude/skills/**/SKILL.md            [E] [G] split + migrate (Phase 14)
+└── AGENTS.md, CLAUDE.md, mirrors                                 [E] [G] rewritten (Phase 15)
+
+plans/backlog/<ose-primer-sync-slug>/                             [N] follow-up plan: rhino-cli boundary
+                                                                        sync + content parity for
+                                                                        `ose-primer` (Phase 17)
+plans/done/YYYY-MM-DD__optimize-governance-md/                     [N] this plan folder, archived
+                                                                        (Phase 17)
+```
+
+`[E]` edited, `[N]` new, `[D]` deleted (git mv counts as delete-plus-new at its old path), `[G]`
+generated (never hand-edited; regenerated).
+
+### More Detail
+
+The full per-artifact action table, cross-repo parity mechanics, and rollback positions live in
+§6 "Migration and Removal Map" below — this tree is the scannable index; §6 is the narrative.
+The inbound-link count is deliberately not restated as a number here: see §6 and Finding 4 of the
+2026-08-13 audit for why a hardcoded count drifted from the live repo state.
+
+---
+
+## 2. Split Pattern
+
+### 2.1 Shape
+
+A file `X.md` over the ceiling becomes an index parent plus a sibling directory:
+
+```text
+repo-governance/development/agents/
+  ai-agents.md              <= 500 words — index, links every child
+  ai-agents/
+    01-agent-catalog.md     <= 500 words
+    02-naming.md            <= 500 words
+    ...
+```
+
+**Why the parent keeps its path**: `ai-agents.md` is linked from `AGENTS.md` and from many
+governance documents. `rhino-cli md links validate` gates every one of them. Moving the parent
+to `ai-agents/README.md` would break all inbound links; keeping it preserves them at zero cost.
+
+**Consequence for FR-3**: `ai-agents/` is a _split directory_ — it has a sibling file named
+`ai-agents.md` — and is therefore exempt from the README-index rule. The parent is the index.
+This exemption is **structural and machine-decidable**: `is_split_dir(X) := exists(X + ".md")`.
+It is not a waiver list.
+
+### 2.2 Child naming and ordering
+
+- Kebab-case, `NN-` numeric prefix for reading order: `01-agent-catalog.md`
+- The prefix defines narrative sequence, not category — no lookup table to memorize, per the
+  [File Naming Convention](../../../repo-governance/conventions/structure/file-naming.md)
+- Each child is self-contained: a complete section, never a mid-sentence continuation
+- Each child carries full frontmatter, including `when_to_use` (FR-4)
+
+### 2.3 Heading hierarchy
+
+`rhino-cli md heading-hierarchy validate` requires a single `H1` and correct nesting. Each
+child therefore gets its own `H1` matching its title; the parent's `H2` sections become child
+`H1`s, and their `H3`s promote to `H2`. Promotion is mechanical but must be applied — a child
+that keeps `H2` as its top heading fails the gate.
+
+### 2.4 Content integrity
+
+The split relocates content. It does not rewrite rules. A phase is not complete unless:
+
+- every rule present before the split is present after it, verbatim or with only heading-level
+  changes
+- every inbound link still resolves (`md links validate` exits 0)
+- the parent index links every child (FR-3.6)
+
+---
+
+## 3. Agent-to-Skill Migration
+
+### 3.1 The constraint
+
+A `.claude/agents/<name>.md` body **becomes the subagent's system prompt verbatim**.
+[Web-cited, accessed 2026-08-13, `https://code.claude.com/docs/en/sub-agents`]: "The frontmatter
+defines the subagent's metadata and configuration. The body becomes the system prompt that
+guides the subagent's behavior. Subagents receive only this system prompt plus basic environment
+details like the working directory, not the full Claude Code system prompt."
+
+There is no `@`-import resolution inside an agent body. Splitting an agent into linked modules
+does not make the harness load them — the agent must `Read` them at runtime. Content moved out
+of the body is content the agent will not have unless it is instructed to fetch it.
+
+### 3.2 Target shape
+
+```text
+.claude/agents/plan-checker.md          <= 500 words
+  frontmatter: name, description, tools, model, color
+  body: charter, non-negotiables, and a MANDATORY read directive
+
+.claude/skills/plan-checking/
+  SKILL.md                              <= 500 words — procedure skeleton
+  reference/
+    01-requirements-completeness.md     <= 500 words
+    02-delivery-executability.md        <= 500 words
+    ...
+```
+
+### 3.3 The mandatory read directive
+
+Every migrated agent body ends with an unconditional instruction — not a suggestion, not
+conditional on task type:
+
+```markdown
+## Required Reading
+
+Before taking any action, read every file in
+`.claude/skills/plan-checking/reference/`. These modules carry rules this
+charter does not restate. Do not begin work until you have read them.
+```
+
+### 3.4 Verification
+
+Phase 6 does not merge on a green gate alone. For each migrated agent, invoke it on a real
+task and confirm it reads its reference modules and applies at least one rule that lives only
+in a module. An agent that passes the word budget but silently lost its rules is a regression,
+not a delivery.
+
+### 3.5 Binding regeneration
+
+`.claude/agents/` is the only hand-authored surface. After every agent edit:
+
+```bash
+npm run generate:bindings
+npm run validate:sync
+```
+
+The regenerated `.opencode/`, `.cursor/`, and `.amazonq/` mirrors go on the file-touch ledger
+and land in the **same commit** as their `.claude/` source. Never a follow-up sync commit,
+never a hand-edit.
+
+Because mirrors are gated (FR-1.4), a mirror over the ceiling means either the source is too
+large or the generator adds too much boilerplate. Both fixes are upstream of the mirror.
+
+---
+
+## 4. README Index Gate
+
+This gate is a **rename-and-extend** of the pre-existing, already-armed `md readme-index
+validate` command (gate id `md-readme-index`) — see §1.1 above for the full repurpose-vs-rebuild
+decision record. It splits into two `repo-config.yml` registrations sharing one implementation
+(`application/governance/readme_index.rs`, `commands/governance_validate_readme_index.rs`):
+
+| Gate id                          | Finding kinds            | Scope                                                                             | Arming                                                                          |
+| -------------------------------- | ------------------------ | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `governance-readme-index`        | `orphan`, `ghost`        | `all-file-type`, current `DEFAULT_PATHS` (4 entries, unwidened)                   | Continuously armed — renamed in place at Phase 1, no gap                        |
+| `governance-readme-completeness` | `missing`, `unannotated` | `path-gated`, FR-1.11's 7-entry trigger list, FR-3.7's 6-entry covered-tree scope | Dark-launched Phase 1 → armed Phase 9 (`ose-public`) / Phase 16 (`ose-private`) |
+
+**The mechanism** [Repo-grounded — `apps/rhino-cli/src/application/repo_config/mod.rs::fixed_arguments`]:
+one binary, two `repo-config.yml` registrations, differentiated entirely by each entry's `args:`
+block — the same pattern `md-mermaid` and `md-links` already use for `args: { exclude: [...] }}`
+(`repo-config.yml:743`, `:914`). `fixed_arguments()` turns every `args:` key into repeated
+`--<key> <value>` flags, so two new repeatable flags on `ReadmeIndexAuditArgs` carry the split:
+
+- **`--paths <path>`** overrides `DEFAULT_PATHS` for this invocation.
+  `governance-readme-index` passes none, so it keeps scanning the original, unwidened 4-entry
+  list unchanged. `governance-readme-completeness` passes FR-3.7's widened 6-entry list.
+- **`--fail-kinds <kind>`** restricts which discovered finding kinds contribute to the nonzero
+  exit code; every kind is still discovered and printed regardless. `governance-readme-index`
+  sets `orphan`/`ghost` only, so a `missing`/`unannotated` finding surfacing inside its unchanged
+  scope (`repo-governance/` is inside both gates' scope) is reported but never fails the build —
+  this is how FR-3.19's continuity guarantee survives the two scopes overlapping.
+  `governance-readme-completeness` sets `missing`/`unannotated` only.
+
+See `prd.md` FR-1.10/FR-1.11 for the full `args:` YAML for both registrations and FR-5.8 for the
+requirement statement.
+
+### 4.1 Entry format
+
+Each index entry is a Markdown list item with a link and an annotation:
+
+```markdown
+- [Governance Conventions](conventions/README.md) — shared standards for repository
+  content and practices. Use them when creating or reviewing work covered by a convention.
+```
+
+Formally: `- [<title>](<path>) — <description> <when_to_use>`
+
+### 4.2 Derivation
+
+The annotation is **derived from the target file's frontmatter**, not hand-written:
+
+| Entry part      | Source                                 |
+| --------------- | -------------------------------------- |
+| `<title>`       | target's `title` frontmatter key       |
+| `<path>`        | relative path from the index file      |
+| `<description>` | target's `description` frontmatter key |
+| `<when_to_use>` | target's `when_to_use` frontmatter key |
+
+This makes indexes **generatable and drift-proof**: the gate reads the target's frontmatter and
+asserts the index entry matches. `rhino-cli governance readme-index generate` writes them;
+`validate` verifies them.
+
+**Known gap**: FR-4 requires `when_to_use` on `repo-governance/**` only. Index entries in
+`docs/`, `specs/`, `plans/`, and `.claude/` therefore have no `when_to_use` to derive from.
+Resolution: for targets outside `repo-governance/`, the gate requires the `— <description>`
+half and treats the when-to-use half as optional until those trees adopt the key. This is
+recorded as a deliberate, documented asymmetry, not an oversight.
+
+### 4.3 Traversal rule
+
+For each covered directory `D`:
+
+- **Applicability**: `D` needs an index if it contains at least one `*.md` other than
+  `README.md`, or at least one immediate subdirectory containing a `README.md`
+- **Exemption**: if a file `D + ".md"` exists beside `D`, then `D` is a split directory —
+  its parent is the index and `D` needs no `README.md`
+- **Required links**: every `*.md` directly in `D` except `README.md`, plus every immediate
+  subdirectory's `README.md`
+- **Not recursive**: an index never references a grandchild
+
+**Finding kinds** — four total, split across the two gate ids in the table above:
+
+- `orphan` **[existing]** — a sibling `.md` or subdirectory `README.md` exists on disk but is
+  not linked from `D`'s `README.md`
+- `ghost` **[existing]** — `D`'s `README.md` links a `.md` target that does not exist
+- `missing` **[new]** — `D` satisfies the Applicability rule above but has no `README.md` at
+  all; the existing implementation cannot detect this because it only audits READMEs that
+  already exist
+- `unannotated` **[new]** — a link exists and its target exists, but the entry lacks the
+  derived-annotation format (§4.1/§4.2) or the annotation text has drifted from the target's
+  frontmatter (FR-3.14)
+
+### 4.4 Interaction with the word budget
+
+[Repo-grounded, verified 2026-08-13] An annotated index costs roughly 25–35 words per entry.
+Measured worst cases (entry counts are the indexable `*.md` files, excluding each directory's
+own `README.md`):
+
+| Directory                              | Entries | Estimated index size |
+| -------------------------------------- | ------- | -------------------- |
+| `.claude/agents/`                      | 94      | ~2,650 words         |
+| `.opencode/agents/` (mirror)           | 94      | ~2,650 words         |
+| `.cursor/agents/` (mirror)             | 94      | ~2,650 words         |
+| `plans/done/`                          | 185     | ~5,200 words         |
+| `repo-governance/development/quality/` | 23      | ~670 words           |
+
+Every one of these exceeds the 500-word ceiling. The resolution is recorded in [prd.md](./prd.md)
+§FR-3.15 — **both** mechanisms apply, and neither is an exemption: a dedicated `**/README.md`
+glob threshold (700 target / 900 fail, the entry §1.3's config sample above declares last so it
+wins on overlap per the "later globs win" rule) covers `repo-governance/development/quality/`
+(~670 words, under the 900-word grouping trigger), and grouping into subfolders with per-group
+indexes covers directories that still overflow the 900-word glob ceiling
+(`.claude/agents/` at ~2,650 words — see §3 "Split Pattern" for the grouping mechanics; the
+mirror trees and `plans/done/` are excluded from this gate entirely, FR-3.8/FR-3.17).
+
+**Research status — RESOLVED 2026-08-13.** See `prd.md` §FR-3.16–FR-3.18 for the full
+citations. Summary of what the harnesses actually do:
+
+| Harness     | Subfolder discovery in its agent dir   | Effect on this plan                                              |
+| ----------- | -------------------------------------- | ---------------------------------------------------------------- |
+| Claude Code | **Yes** (documented)                   | `.claude/agents/` may be grouped; identity is frontmatter `name` |
+| OpenCode    | **No** — declined "not planned"        | `.opencode/agents/` **must stay flat**; generator flattens       |
+| Cursor      | **Undocumented**                       | Treated as flat until a smoke test proves otherwise              |
+| Amazon Q    | N/A — JSON bridge, not an agent mirror | Unaffected                                                       |
+| Codex       | N/A — agents live in `config.toml`     | Unaffected                                                       |
+
+Two consequences the design must carry:
+
+1. **`harness bindings generate` must flatten.** A grouped `.claude/agents/checkers/docs-checker.md`
+   still emits `.opencode/agents/docs-checker.md` and `.cursor/agents/docs-checker.md` at the
+   top level, filename derived from the `name` frontmatter key. This is a rhino-cli behaviour
+   change and lands in **Phase 1**, before Phase 6 groups the source. Grouping first would
+   break OpenCode discovery for 94 agents between merges.
+2. **Mirror trees are excluded from the README-index gate** (FR-3.17) but stay inside the word
+   budget. A 94-entry annotated index cannot fit any defensible ceiling, and nobody navigates a
+   generated tree by README. If a mirror `README.md` is emitted at all, it is a pointer to the
+   `.claude/` source index.
+
+Skills are architecturally safer than agents here: OpenCode reads
+`.claude/skills/<name>/SKILL.md` natively, and `reference/*.md` modules are fetched on demand by
+the agent's own file tools rather than by any directory-scanning logic — so nested `reference/`
+folders are not exposed to the recursion question at all.
+
+---
+
+## 5. Frontmatter Extension
+
+`when_to_use` is added to the existing schema in
+`apps/rhino-cli/src/application/docs/frontmatter.rs`, which already defines
+`KIND_MISSING_TITLE`, `KIND_MISSING_DESCRIPTION`, `KIND_MISSING_CATEGORY`,
+`KIND_MISSING_SUBCATEGORY`, and `KIND_MISSING_TAGS`. A new `KIND_MISSING_WHEN_TO_USE` follows
+the same pattern and reports through the same gate (`md-frontmatter`).
+
+The requirement is scoped to `repo-governance/**/*.md`. `docs/` retains the lighter schema
+described in that module's header comment.
+
+**Description severity correction** [Repo-grounded —
+`validate_governance_schema`/`validate_software_schema`]: `validate_governance_schema` today
+builds its `description` finding via a plain `SEVERITY_WARN` construction, not `mk_fail()` —
+missing `description` on a governance doc is a WARN, not a FAIL. This is inconsistent with the
+new `when_to_use` requirement being FAIL from day one, so `description`'s construction in
+`validate_governance_schema` is changed to `mk_fail()` alongside it, scoped to
+`GOVERNANCE_DOC_PREFIXES` only. `title` is unaffected (already `mk_fail()`).
+`validate_software_schema` is untouched — it already builds `description` via `mk_fail()`, so
+software-engineering docs see no severity change. See `prd.md` FR-4.2/FR-4.8 and "Description
+severity correction" for the full decision record.
+
+**Dark-launch sequencing (register-then-arm)** [Repo-grounded — `repo-config.yml:774-781` scopes
+`md-frontmatter`'s `ci` surface as `{ scope: all-file-type }`, resolved by
+`ScopeKind::AllFileType => CandidateScope::TrackedFiles` in
+`apps/rhino-cli/src/commands/gate/run.rs:441`]: this gate scans every tracked `.md` file on
+every CI run, unconditionally, unlike the two brand-new `governance-word-budget`/
+`governance-readme-index` gates that Phase 1 registers in `gates:` without arming (an
+unregistered gate id runs nowhere, so "register but don't arm" is free for a new gate). Because
+`md-frontmatter` is already armed and already running repo-wide, FR-4's two FAIL-severity checks
+cannot land as FAIL in the same PR that adds them — doing so would fail CI for every contributor
+the moment PR1 merges, since 0/214 `repo-governance/**/*.md` files currently carry `when_to_use`
+and the backfill only completes across Phases 2–5 (`ose-public`) / 11–13 (`ose-private`).
+
+FR-4 therefore follows the same register-then-arm shape as FR-1/FR-3, adapted to an
+already-active gate:
+
+1. **Phase 1 (register)**: `KIND_MISSING_WHEN_TO_USE` lands using the same `SEVERITY_WARN`
+   construction `description` already uses — the check exists, is tested, and reports, but does
+   not fail the gate. `description`'s construction is left unchanged (it is already
+   `SEVERITY_WARN`; FR-4.2's `mk_fail()` upgrade is deferred, not implemented, in Phase 1).
+2. **Phase 9 / Phase 16 (arm)**: after confirming via a `md frontmatter validate` run that every
+   file in the repo's covered surface already carries both `when_to_use` and `description`, both
+   `KIND_MISSING_WHEN_TO_USE` and `description`'s finding in `validate_governance_schema` are
+   switched to `mk_fail()` in the same commit — mirroring Phase 9/16's existing "arm the gates"
+   GREEN step for `governance-word-budget`/`governance-readme-index` exactly.
+
+This keeps NFR-5 ("No commit in the plan leaves `main` with a red gate in either repo") satisfied
+for `md-frontmatter`, the same way Phase 1's "register, but do not arm" step already satisfies it
+for the two brand-new gates. See `prd.md` §FR-4 "Dark-launch sequencing" for the requirement-level
+record.
+
+**Content rule**: `when_to_use` states a trigger, not a summary. `"Use when adding or editing
+any Markdown link."` is correct; `"About markdown linking."` is a restatement of `description`
+and fails review even though it passes the gate.
+
+**Budget interaction** [Judgment call — the 20–30-word-per-file estimate is not independently
+measured]: two frontmatter lines cost roughly 20–30 words per file across the 214
+`repo-governance/**/*.md` files [Repo-grounded, matches the frontmatter census in `brd.md`]. This
+is counted, not exempted, and is accounted for when sizing splits.
+
+---
+
+## 6. Migration and Removal Map
+
+Everything removed in Phase 1, per repo:
+
+| Artifact                                                                        | Action                                                                                                                                                                                                           |
+| ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/application/repo_governance/instruction_size.rs`                           | `git mv` + rewrite metric                                                                                                                                                                                        |
+| `src/commands/harness_validate_instruction_size.rs`                             | deleted; merged into `commands/governance_validate_word_budget.rs` (new)                                                                                                                                         |
+| `src/commands/convention_validate_instruction_size.rs`                          | deleted; its implementation body becomes `commands/governance_validate_word_budget.rs` (new)                                                                                                                     |
+| `instruction-size:` block in `repo-config.yml`                                  | delete                                                                                                                                                                                                           |
+| `instruction-size` entry in `gates:`                                            | replace                                                                                                                                                                                                          |
+| 12 `tests/golden-master/*instruction-size*` fixtures                            | delete, regenerate under new id                                                                                                                                                                                  |
+| `specs/.../gherkin/harness/repo-governance-instruction-size.feature`            | `git mv` + rewrite                                                                                                                                                                                               |
+| `specs/.../gherkin/harness/repo-governance-instruction-size-governance.feature` | rewrite in place — 3 scenarios asserting the "instruction-size" gate name/category/skip-set by name, renamed to `governance-word-budget`                                                                         |
+| `specs/.../gherkin/harness/repo-governance-instruction-size-pre-push.feature`   | rewrite in place — 2 scenarios asserting the "instruction-size gate"/validation target by name, renamed to the new gate/Nx target                                                                                |
+| `specs/.../gherkin/harness/repo-governance-agents-md-size.feature`              | rewrite for words                                                                                                                                                                                                |
+| `conventions/structure/instruction-file-size-budget.md`                         | `git mv` + rewrite                                                                                                                                                                                               |
+| Every inbound link to the old convention path                                   | rewrite — discovered live, not a hardcoded list (below)                                                                                                                                                          |
+| `src/application/repo_governance/readme_index_audit.rs`                         | `git mv` -> `application/governance/readme_index.rs`; extend with `missing`/`unannotated` + `generate`                                                                                                           |
+| `src/commands/md_validate_readme_index.rs`                                      | `git mv` -> `commands/governance_validate_readme_index.rs`                                                                                                                                                       |
+| `md-readme-index` entry in `gates:`                                             | **renamed in place** to `governance-readme-index` — never deleted-then-re-added; scope/surfaces unchanged (FR-3.19); `governance-readme-completeness` is a **new**, additional entry for `missing`/`unannotated` |
+| 9 `tests/golden-master/*readme-index*` fixtures                                 | delete, regenerate under `governance-readme-index` naming                                                                                                                                                        |
+| `cli.rs`'s `MdCommands::ReadmeIndex` variant                                    | removed from the `md` group; re-added under a new `governance` top-level command group                                                                                                                           |
+
+[Repo-grounded, verified 2026-08-13] The inbound-link count is **not hardcoded** in this plan.
+An earlier draft named 8 files; live verification found that list wrong in both directions — two
+named files (`code.md`, `ci-conventions.md`) contain zero actual references, and two real
+referrers (`docs/reference/rhino-cli-command-triage.md`, `docs/reference/sdlc-gate-standard.md`)
+were omitted. The true count is 10 files, excluding the convention doc itself. Phase 1 discovers
+the set live instead of trusting a list written into the plan text:
+
+```bash
+grep -rl "instruction-size\|instruction-file-size-budget" repo-governance .claude docs AGENTS.md
+```
+
+Rewrite whatever this command returns.
+
+The renamed convention doc must itself satisfy the 500-word ceiling — it becomes an index
+parent with a `governance-word-budget/` child directory. This is the plan's own dogfooding
+check.
+
+### 6.1 Cross-repo parity
+
+`apps/rhino-cli/src`, `tests`, `Cargo.toml`, `Cargo.lock`, `project.json`, `LICENSE`, and
+`specs/apps/rhino/behavior/rhino-cli/gherkin` are byte-identical across repos. In `ose-private`
+the rhino-cli change is a **byte-for-byte copy** of the `ose-public` change, not a
+reimplementation. After copying:
+
+```bash
+rhino-cli parity manifest generate
+git add apps/rhino-cli/parity-manifest.sha256
+rhino-cli parity manifest validate
+```
+
+The manifest must be staged before validation — `validate_at_root` compares the working-tree
+manifest against the Git index and errors if they differ.
+
+`ose-primer` is deliberately excluded. Its parity gate stays green because
+`validate_at_root` only ever compares a repo against its own committed manifest; it never
+fetches siblings. The debt is divergence, not breakage.
+
+### 6.2 Rollback
+
+Each PR is independently revertible.
+
+- Reverting a content PR restores the pre-split files; the gate is not yet blocking during
+  Phases 2–8, so nothing else breaks.
+- Reverting the Phase 1 gate PR restores the byte budget wholesale.
+- Reverting the Phase 9 flip PR disarms enforcement while leaving all split content in place —
+  the safe partial-rollback position.
+
+**Enforcement gap, stated plainly**: between Phase 1 (byte budget removed) and Phase 9 (word
+budget wired as a blocking gate), **no per-file size gate is active**. This is accepted: the
+word cap is strictly tighter than every byte threshold it replaces, so no file can pass Phase 9
+while violating what the byte budget would have caught.
+
+---
+
+## 7. Verification Commands
+
+```bash
+# Word budget, both new gates
+npx nx run rhino-cli:governance-word-budget:validation
+npx nx run rhino-cli:governance-readme-index:validation
+
+# Full markdown gate group
+npm run lint:md
+apps/rhino-cli/scripts/rhino-bin.sh gate run --surface=pre-push
+
+# Binding sync after any .claude/ edit
+npm run generate:bindings && npm run validate:sync
+
+# Cross-repo parity after any rhino-cli edit
+rhino-cli parity manifest generate && git add apps/rhino-cli/parity-manifest.sha256
+rhino-cli parity manifest validate
+
+# Ad-hoc violation census (matches the gate's raw whole-file metric, full FR-1.3 covered surface
+# — repo-governance/.claude/.cursor/.codex/.opencode/.pi/.amazonq plus root AGENTS.md/CLAUDE.md;
+# this is the number the Phase 1/10 Gate acceptance criteria cite, not the narrower
+# "source (non-generated)" repo-governance+.claude-only figure in README.md §Context)
+{ find repo-governance .claude .cursor .codex .opencode .pi .amazonq -name '*.md' -type f \
+    -print0; printf '%s\0' AGENTS.md CLAUDE.md; } \
+  | xargs -0 wc -w | grep -v ' total$' | awk '$1 > 500' | sort -rn
+```


### PR DESCRIPTION
## Summary
- Adds a new plan at `plans/in-progress/optimize-governance-md/` introducing a word-based governance-doc size gate (`governance-word-budget`), replacing the byte-based `instruction-size` gate
- Extends the already-live `md-readme-index` gate (rename to `governance-readme-index`) with two new, dark-launched checks (`missing`, `unannotated`) via a second gate id `governance-readme-completeness`
- Adds `when_to_use` frontmatter for `repo-governance/**/*.md` and upgrades `description`'s severity from WARN to FAIL for governance docs, both dark-launched
- Plan covers `ose-public` and `ose-private` via `worktree-to-pr`; `ose-primer` is deliberately deferred
- This PR is plan-docs-only (markdown, noneligible static work) — the plan-quality-gate loop ran 17 iterations to convergence (two consecutive zero-finding checker passes) before this commit

## Test plan
- [x] `plan-quality-gate` workflow run to convergence (17 iterations, plan-checker/plan-fixer cycle)
- [x] `md mermaid validate`, `md heading-hierarchy validate`, `md links validate` clean on the plan folder
- [x] `prettier --check` and `markdownlint-cli2` clean on all 6 plan files
- [x] Pre-push gates passed (env-validate, md-links, md-readme-index, harness-duplication, parity-manifest, harness-bindings)
- [ ] CI `.github/workflows/pr-quality-gate.yml` green (docs-only PR — merges automatically on green, no PR review cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)