### PR TITLE
chore(vscode): point dart.flutterSdkPath at the repository's FVM cache

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
     "buildFlags": ["-tags=integration"]
   },
   "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "dart.flutterSdkPath": ".fvm-cache/versions/3.41.5"
 }


### PR DESCRIPTION
## What

Adds one key to `.vscode/settings.json`:

```json
"dart.flutterSdkPath": ".fvm-cache/versions/3.41.5"
```

## Why the path is not `.fvm/`

The Flutter VS Code extension writes `.fvm/versions/<v>` by default. That directory does not exist in this repository. The SDK lives under `.fvm-cache`, which is what the build actually uses:

- `apps/beavernest-app/project.json` — `FVM_CACHE_PATH=.fvm-cache` and `FLUTTER_ROOT=../../.fvm-cache/versions/3.41.5`
- `.gitignore` ignores both `.fvm/` and `.fvm-cache/`
- Only `.fvm-cache/versions/3.41.5` exists on disk — a git checkout tagged `3.41.5` with an executable `bin/flutter`

The version matches `.fvmrc` (`3.41.5`).

## Provenance

Recovered from an uncommitted edit the extension had left in the `optimize-gov` worktree, which was removed after [#227](https://github.com/wahidyankf/ose-public/pull/227) merged. The extension's default `.fvm/…` value was corrected to the path that resolves; the edit's incidental `gopls` whitespace churn and lost trailing newline were dropped.

## Safety

`.vscode/settings.json` is tracked, so the committed blob was scanned: no absolute path, no home reference, no username, no hostname. The added value is workspace-relative. The diff is one key and nothing else.