### PR TITLE
feat(ports): resolve every listener port from flag, env var, then default

### DIFF
--- a/apps/ayokoding-www/.env.example
+++ b/apps/ayokoding-www/.env.example
@@ -10,8 +10,9 @@
 # OPTIONAL | boolean | Include draft posts in listing; set to "true" to enable (default: false)
 # AYOKODING_WEB_SHOW_DRAFTS=
 
-# OPTIONAL | u16 | Next.js dev-server port (framework-reserved name; default: 3101)
-# PORT=3101
-
 # OPTIONAL | string | Next.js dev-server hostname (framework-reserved name; default: 0.0.0.0)
 # HOSTNAME=0.0.0.0
+
+# OPTIONAL | u16 | Listener port. Resolution order: `--port` flag, then this variable,
+# then the 3101 default. A bare PORT is deliberately NOT honoured.
+# AYOKODING_WWW_PORT=3101

--- a/apps/ayokoding-www/.env.example
+++ b/apps/ayokoding-www/.env.example
@@ -13,6 +13,6 @@
 # OPTIONAL | string | Next.js dev-server hostname (framework-reserved name; default: 0.0.0.0)
 # HOSTNAME=0.0.0.0
 
-# OPTIONAL | u16 | Listener port. Resolution order: `--port` flag, then this variable,
-# then the 3101 default. A bare PORT is deliberately NOT honoured.
+# OPTIONAL | u16 | Listener port (default: 3101)
+# Format: `--port` flag first, then this variable, then the default; a bare PORT is not honoured
 # AYOKODING_WWW_PORT=3101

--- a/apps/ayokoding-www/Dockerfile
+++ b/apps/ayokoding-www/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOSTNAME=0.0.0.0
-ENV PORT=3101
+ENV AYOKODING_WWW_PORT=3101
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
@@ -50,11 +50,13 @@ COPY --from=builder --chown=nextjs:nodejs /workspace/apps/ayokoding-www/content 
 # the build context (not the `builder` stage) since it is never part of the Next.js build itself.
 COPY --chown=nextjs:nodejs apps/ayokoding-www-fe-e2e/fixtures/manifests ./apps/ayokoding-www-fe-e2e/fixtures/manifests
 
+COPY --chown=nextjs:nodejs scripts/next-with-port.mjs scripts/next-with-port.mjs
+COPY --chown=nextjs:nodejs libs/ts-env-loader/src/port-resolver.ts libs/ts-env-loader/src/port-resolver.ts
 USER nextjs
 EXPOSE 3101
 
 # server.js is at apps/ayokoding-www/server.js in standalone output
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3101/ || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://localhost:${AYOKODING_WWW_PORT}/ || exit 1
 
-CMD ["node", "apps/ayokoding-www/server.js"]
+CMD ["node", "scripts/next-with-port.mjs", "--env", "AYOKODING_WWW_PORT", "--default", "3101", "--server", "apps/ayokoding-www/server.js"]

--- a/apps/ayokoding-www/project.json
+++ b/apps/ayokoding-www/project.json
@@ -7,7 +7,7 @@
     "codegen": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "echo 'No codegen needed — ayokoding-www has no OpenAPI contract'",
+        "command": "echo 'No codegen needed \u2014 ayokoding-www has no OpenAPI contract'",
         "cwd": "{projectRoot}"
       }
     },
@@ -49,7 +49,7 @@
     "dev": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "npx tsx src/scripts/generate-indexes.ts && next dev --port 3101",
+        "command": "npx tsx src/scripts/generate-indexes.ts && node ../../scripts/next-with-port.mjs dev --env AYOKODING_WWW_PORT --default 3101",
         "cwd": "{projectRoot}"
       }
     },
@@ -65,7 +65,7 @@
     "start": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "next start --port 3101",
+        "command": "node ../../scripts/next-with-port.mjs start --env AYOKODING_WWW_PORT --default 3101",
         "cwd": "{projectRoot}"
       }
     },

--- a/apps/beavernest-be/project.json
+++ b/apps/beavernest-be/project.json
@@ -94,7 +94,7 @@
     "test:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "dotnet test apps/beavernest-be/tests/unit/BeaverNestBe.UnitTests.fsproj /p:CollectCoverage=true /p:Threshold=90 /p:ThresholdType=line \"/p:ExcludeByFile=**/Program.fs\""
+        "command": "dotnet test apps/beavernest-be/tests/unit/BeaverNestBe.UnitTests.fsproj /p:CollectCoverage=true /p:Threshold=90 /p:ThresholdType=line \"/p:ExcludeByFile=**/Program.fs\" \"/p:Include=[BeaverNestBe]*\""
       },
       "cache": true,
       "inputs": ["{projectRoot}/src/**/*.fs", "{projectRoot}/src/**/*.sql", "{projectRoot}/tests/unit/**/*.fs", "env"]
@@ -143,7 +143,7 @@
     "specs:domain:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "echo 'specs:domain:coverage: no-op (beavernest is not in specs.domain-areas — no domain/** bounded-context features)'"
+        "command": "echo 'specs:domain:coverage: no-op (beavernest is not in specs.domain-areas \u2014 no domain/** bounded-context features)'"
       },
       "cache": true
     },

--- a/apps/beavernest-be/src/BeaverNestBe/Domain/HttpConfiguration.fs
+++ b/apps/beavernest-be/src/BeaverNestBe/Domain/HttpConfiguration.fs
@@ -37,3 +37,30 @@ let parse (readEnvironment: string -> string) : Result<ListenerConfiguration, st
 
 let url configuration =
     $"http://%s{configuration.Address}:%d{configuration.Port}"
+
+/// True when argv carries nothing but a `--port` override, in either spelling.
+///
+/// `Program.commandMode` classifies argv as a subcommand (`backup`, `integrity`, `restore`) and
+/// rejects anything it does not recognise. Without this predicate it treated `--port 4000` as an
+/// unrecognised subcommand and refused to boot — the reason a port flag was previously impossible
+/// for this service.
+let isOnlyPortFlags (args: string[]) : bool =
+    match args with
+    | [||] -> true
+    | [| "--port"; _ |] -> true
+    | [| single |] -> single.StartsWith("--port=", StringComparison.Ordinal)
+    | _ -> false
+
+/// Applies the repo-wide `--port` flag on top of an already-parsed listener.
+///
+/// `parse` has resolved the env-var and default tiers already, so passing its port through as the
+/// fallback yields exactly the shared precedence — flag, then BEAVERNEST_BE_HTTP_LISTEN_PORT, then
+/// the 19300 default — without changing `parse`'s signature or weakening its loopback/wildcard
+/// guard, which still owns the address half of the decision.
+let applyPortFlag
+    (argv: string[])
+    (readEnvironment: string -> string)
+    (listener: ListenerConfiguration)
+    : Result<ListenerConfiguration, string> =
+    FsharpEnvLoader.PortResolver.resolvePort argv readEnvironment "BEAVERNEST_BE_HTTP_LISTEN_PORT" listener.Port
+    |> Result.map (fun port -> { listener with Port = port })

--- a/apps/beavernest-be/src/BeaverNestBe/Domain/HttpConfiguration.fs
+++ b/apps/beavernest-be/src/BeaverNestBe/Domain/HttpConfiguration.fs
@@ -5,11 +5,16 @@ open System.Globalization
 
 type ListenerConfiguration = { Address: string; Port: int }
 
+/// Mirrors FsharpEnvLoader.PortResolver's `presentValue`: trim first, then treat an
+/// empty result as absent. The trim is load-bearing now that the port tier parses under
+/// NumberStyles.None — a value read from a mounted secret usually carries a trailing
+/// newline, and the shared resolver accepts that, so this must too.
 let private environmentValue (readEnvironment: string -> string) key =
     match readEnvironment key with
-    | null
-    | "" -> None
-    | value -> Some value
+    | null -> None
+    | value ->
+        let trimmed = value.Trim()
+        if trimmed = "" then None else Some trimmed
 
 let private validPort value = value > 0 && value <= 65535
 

--- a/apps/beavernest-be/src/BeaverNestBe/Domain/HttpConfiguration.fs
+++ b/apps/beavernest-be/src/BeaverNestBe/Domain/HttpConfiguration.fs
@@ -1,6 +1,7 @@
 module BeaverNestBe.Domain.HttpConfiguration
 
 open System
+open System.Globalization
 
 type ListenerConfiguration = { Address: string; Port: int }
 
@@ -26,7 +27,10 @@ let parse (readEnvironment: string -> string) : Result<ListenerConfiguration, st
         environmentValue readEnvironment "BEAVERNEST_BE_HTTP_LISTEN_PORT"
         |> Option.defaultValue "19300"
 
-    match Int32.TryParse port with
+    // NumberStyles.None matches FsharpEnvLoader.PortResolver.parsePort exactly: plain digits only,
+    // so `+4000` and `0x1F4` are rejected here rather than passing this tier and then failing
+    // applyPortFlag's stricter re-parse of the same raw string. One variable, one grammar.
+    match Int32.TryParse(port, NumberStyles.None, CultureInfo.InvariantCulture) with
     | true, parsedPort when validPort parsedPort ->
         match address, runningInContainer with
         | "127.0.0.1", _ -> Ok { Address = address; Port = parsedPort }
@@ -38,7 +42,9 @@ let parse (readEnvironment: string -> string) : Result<ListenerConfiguration, st
 let url configuration =
     $"http://%s{configuration.Address}:%d{configuration.Port}"
 
-/// True when argv carries nothing but a `--port` override, in either spelling.
+/// True when argv carries nothing but a `--port` override, in either spelling — including a
+/// trailing bare `--port` with no value, which the shared resolver treats as "no flag supplied"
+/// and falls through to the env var rather than erroring.
 ///
 /// `Program.commandMode` classifies argv as a subcommand (`backup`, `integrity`, `restore`) and
 /// rejects anything it does not recognise. Without this predicate it treated `--port 4000` as an
@@ -48,7 +54,7 @@ let isOnlyPortFlags (args: string[]) : bool =
     match args with
     | [||] -> true
     | [| "--port"; _ |] -> true
-    | [| single |] -> single.StartsWith("--port=", StringComparison.Ordinal)
+    | [| single |] -> single = "--port" || single.StartsWith("--port=", StringComparison.Ordinal)
     | _ -> false
 
 /// Applies the repo-wide `--port` flag on top of an already-parsed listener.

--- a/apps/beavernest-be/src/BeaverNestBe/Program.fs
+++ b/apps/beavernest-be/src/BeaverNestBe/Program.fs
@@ -55,30 +55,6 @@ let prepareApplication readEnvironment =
         | Ok() -> Ok listener
         | Error error -> Error(safeMessage error)
 
-/// True when argv carries nothing but a `--port` override, in either spelling. Without this the
-/// catch-all below would classify `--port 4000` as an unrecognised SUBCOMMAND and refuse to boot —
-/// the reason a port flag was previously impossible here.
-let private isOnlyPortFlags (args: string[]) : bool =
-    match args with
-    | [||] -> true
-    | [| "--port"; _ |] -> true
-    | [| single |] -> single.StartsWith("--port=", System.StringComparison.Ordinal)
-    | _ -> false
-
-/// Applies the repo-wide `--port` flag on top of an already-parsed listener.
-///
-/// `parse` has resolved the env-var and default tiers already, so passing its port through as the
-/// fallback yields exactly the shared precedence — flag, then BEAVERNEST_BE_HTTP_LISTEN_PORT, then
-/// the 19300 default — without changing `parse`'s signature or weakening its loopback/wildcard
-/// guard, which still owns the address half of the decision.
-let private applyPortFlag
-    (argv: string[])
-    (readEnvironment: string -> string)
-    (listener: ListenerConfiguration)
-    : Result<ListenerConfiguration, string> =
-    FsharpEnvLoader.PortResolver.resolvePort argv readEnvironment "BEAVERNEST_BE_HTTP_LISTEN_PORT" listener.Port
-    |> Result.map (fun port -> { listener with Port = port })
-
 let private commandMode args databaseConfiguration =
     match args with
     | [| "backup"; "--name"; name |] ->

--- a/apps/beavernest-be/src/BeaverNestBe/Program.fs
+++ b/apps/beavernest-be/src/BeaverNestBe/Program.fs
@@ -55,6 +55,30 @@ let prepareApplication readEnvironment =
         | Ok() -> Ok listener
         | Error error -> Error(safeMessage error)
 
+/// True when argv carries nothing but a `--port` override, in either spelling. Without this the
+/// catch-all below would classify `--port 4000` as an unrecognised SUBCOMMAND and refuse to boot —
+/// the reason a port flag was previously impossible here.
+let private isOnlyPortFlags (args: string[]) : bool =
+    match args with
+    | [||] -> true
+    | [| "--port"; _ |] -> true
+    | [| single |] -> single.StartsWith("--port=", System.StringComparison.Ordinal)
+    | _ -> false
+
+/// Applies the repo-wide `--port` flag on top of an already-parsed listener.
+///
+/// `parse` has resolved the env-var and default tiers already, so passing its port through as the
+/// fallback yields exactly the shared precedence — flag, then BEAVERNEST_BE_HTTP_LISTEN_PORT, then
+/// the 19300 default — without changing `parse`'s signature or weakening its loopback/wildcard
+/// guard, which still owns the address half of the decision.
+let private applyPortFlag
+    (argv: string[])
+    (readEnvironment: string -> string)
+    (listener: ListenerConfiguration)
+    : Result<ListenerConfiguration, string> =
+    FsharpEnvLoader.PortResolver.resolvePort argv readEnvironment "BEAVERNEST_BE_HTTP_LISTEN_PORT" listener.Port
+    |> Result.map (fun port -> { listener with Port = port })
+
 let private commandMode args databaseConfiguration =
     match args with
     | [| "backup"; "--name"; name |] ->
@@ -69,7 +93,7 @@ let private commandMode args databaseConfiguration =
         match restore databaseConfiguration name with
         | Ok() -> Some 0
         | Error error -> Some(fail error)
-    | [||] -> None
+    | _ when isOnlyPortFlags args -> None
     | _ -> Some(fail "invalid command")
 
 [<EntryPoint>]
@@ -84,7 +108,10 @@ let main args =
         match commandMode args databaseConfiguration with
         | Some exitCode -> exitCode
         | None ->
-            match prepareApplication System.Environment.GetEnvironmentVariable with
+            match
+                prepareApplication System.Environment.GetEnvironmentVariable
+                |> Result.bind (applyPortFlag args System.Environment.GetEnvironmentVariable)
+            with
             | Error error -> fail error
             | Ok listener ->
                 match acquireDataDirectoryServiceLock databaseConfiguration with

--- a/apps/beavernest-be/tests/unit/Tests/HttpConfigurationTests.fs
+++ b/apps/beavernest-be/tests/unit/Tests/HttpConfigurationTests.fs
@@ -104,6 +104,17 @@ let ``applyPortFlag falls through to the env var when --port carries no value`` 
     )
 
 [<Theory>]
+[<InlineData("4000\n")>]
+[<InlineData(" 4000")>]
+[<InlineData("4000 ")>]
+let ``parse tolerates surrounding whitespace, as the shared resolver does`` (value: string) =
+    // A port read from a mounted secret file routinely carries a trailing newline. The shared
+    // resolver trims before parsing, so parse must too, or the two grammars diverge again.
+    match parse (environment (Map.ofList [ "BEAVERNEST_BE_HTTP_LISTEN_PORT", value ])) with
+    | Ok configuration -> Assert.Equal(4000, configuration.Port)
+    | Error message -> Assert.Fail($"expected %s{value} to be accepted, but got: %s{message}")
+
+[<Theory>]
 [<InlineData("+4000")>]
 [<InlineData("0x1F4")>]
 [<InlineData("1e3")>]

--- a/apps/beavernest-be/tests/unit/Tests/HttpConfigurationTests.fs
+++ b/apps/beavernest-be/tests/unit/Tests/HttpConfigurationTests.fs
@@ -88,6 +88,33 @@ let ``isOnlyPortFlags recognises a bare port override and nothing else``
 let ``isOnlyPortFlags treats empty argv as a plain server start`` () = Assert.True(isOnlyPortFlags [||])
 
 [<Fact>]
+let ``isOnlyPortFlags accepts a trailing bare --port with no value`` () =
+    // The shared resolver deliberately reads a valueless trailing `--port` as "no flag supplied" and
+    // falls through to the env var. Rejecting it here as an unknown subcommand would make that
+    // documented fallback unreachable for this service alone.
+    Assert.True(isOnlyPortFlags [| "--port" |])
+
+[<Fact>]
+let ``applyPortFlag falls through to the env var when --port carries no value`` () =
+    let listener = { Address = "127.0.0.1"; Port = 19300 }
+
+    Assert.Equal(
+        Ok { Address = "127.0.0.1"; Port = 4100 },
+        applyPortFlag [| "--port" |] (envWith [ "BEAVERNEST_BE_HTTP_LISTEN_PORT", "4100" ]) listener
+    )
+
+[<Theory>]
+[<InlineData("+4000")>]
+[<InlineData("0x1F4")>]
+[<InlineData("1e3")>]
+let ``parse admits plain digits only, matching the shared resolver's grammar`` (value: string) =
+    // parse and applyPortFlag both read BEAVERNEST_BE_HTTP_LISTEN_PORT. If parse admitted a wider
+    // grammar, a value could clear parse and then fail applyPortFlag's re-parse of the same string.
+    match parse (environment (Map.ofList [ "BEAVERNEST_BE_HTTP_LISTEN_PORT", value ])) with
+    | Ok configuration -> Assert.Fail($"expected %s{value} to be rejected, but resolved to %d{configuration.Port}")
+    | Error message -> Assert.Contains("between 1 and 65535", message)
+
+[<Fact>]
 let ``applyPortFlag lets an explicit --port outrank the parsed listener`` () =
     let listener = { Address = "127.0.0.1"; Port = 19300 }
 

--- a/apps/beavernest-be/tests/unit/Tests/HttpConfigurationTests.fs
+++ b/apps/beavernest-be/tests/unit/Tests/HttpConfigurationTests.fs
@@ -58,3 +58,57 @@ let ``listener URL is constructed only from validated configuration`` () =
         |> Result.defaultWith failwith
 
     Assert.Equal("http://127.0.0.1:19320", url configuration)
+
+// --- Runtime port override -------------------------------------------------
+
+let private envWith (pairs: (string * string) list) : string -> string =
+    fun key ->
+        pairs
+        |> List.tryFind (fun (name, _) -> name = key)
+        |> Option.map snd
+        |> Option.defaultValue null
+
+let private noEnvironment: string -> string = envWith []
+
+[<Theory>]
+[<InlineData(true, "--port", "4000")>]
+[<InlineData(true, "--port=4000", null)>]
+[<InlineData(false, "backup", "--name")>]
+[<InlineData(false, "integrity", null)>]
+[<InlineData(false, "--verbose", null)>]
+let ``isOnlyPortFlags recognises a bare port override and nothing else``
+    (expected: bool)
+    (first: string)
+    (second: string)
+    =
+    let args = if isNull second then [| first |] else [| first; second |]
+    Assert.Equal(expected, isOnlyPortFlags args)
+
+[<Fact>]
+let ``isOnlyPortFlags treats empty argv as a plain server start`` () = Assert.True(isOnlyPortFlags [||])
+
+[<Fact>]
+let ``applyPortFlag lets an explicit --port outrank the parsed listener`` () =
+    let listener = { Address = "127.0.0.1"; Port = 19300 }
+
+    Assert.Equal(Ok { Address = "127.0.0.1"; Port = 4000 }, applyPortFlag [| "--port"; "4000" |] noEnvironment listener)
+
+[<Fact>]
+let ``applyPortFlag keeps the parsed listener when no flag is given`` () =
+    let listener = { Address = "127.0.0.1"; Port = 19320 }
+    Assert.Equal(Ok listener, applyPortFlag [||] noEnvironment listener)
+
+[<Fact>]
+let ``applyPortFlag preserves the address half of the listener`` () =
+    // The loopback/wildcard guard belongs to parse; the port flag must not disturb it.
+    let listener = { Address = "0.0.0.0"; Port = 19300 }
+
+    Assert.Equal(Ok { Address = "0.0.0.0"; Port = 4000 }, applyPortFlag [| "--port=4000" |] noEnvironment listener)
+
+[<Fact>]
+let ``applyPortFlag rejects a malformed --port instead of falling back`` () =
+    let listener = { Address = "127.0.0.1"; Port = 19300 }
+
+    match applyPortFlag [| "--port"; "99999" |] noEnvironment listener with
+    | Ok configuration -> Assert.Fail($"expected an error, but resolved to %d{configuration.Port}")
+    | Error message -> Assert.Contains("--port", message)

--- a/apps/organiclever-app-web/.env.example
+++ b/apps/organiclever-app-web/.env.example
@@ -8,6 +8,6 @@
 # OPTIONAL | string | Next.js dev-server hostname (framework-reserved name; default: 0.0.0.0)
 # HOSTNAME=0.0.0.0
 
-# OPTIONAL | u16 | Listener port. Resolution order: `--port` flag, then this variable,
-# then the 3202 default. A bare PORT is deliberately NOT honoured.
+# OPTIONAL | u16 | Listener port (default: 3202)
+# Format: `--port` flag first, then this variable, then the default; a bare PORT is not honoured
 # ORGANICLEVER_APP_WEB_PORT=3202

--- a/apps/organiclever-app-web/.env.example
+++ b/apps/organiclever-app-web/.env.example
@@ -5,8 +5,9 @@
 # When unset, backend status page shows "Not configured".
 # ORGANICLEVER_BE_URL=
 
-# OPTIONAL | u16 | Next.js dev-server port (framework-reserved name; default: 3202)
-# PORT=3202
-
 # OPTIONAL | string | Next.js dev-server hostname (framework-reserved name; default: 0.0.0.0)
 # HOSTNAME=0.0.0.0
+
+# OPTIONAL | u16 | Listener port. Resolution order: `--port` flag, then this variable,
+# then the 3202 default. A bare PORT is deliberately NOT honoured.
+# ORGANICLEVER_APP_WEB_PORT=3202

--- a/apps/organiclever-app-web/Dockerfile
+++ b/apps/organiclever-app-web/Dockerfile
@@ -45,10 +45,12 @@ RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
 COPY --from=build --chown=app:app /app/.next/standalone ./
 COPY --from=build --chown=app:app /app/.next/static ./.next/static
+COPY --chown=app:app scripts/next-with-port.mjs scripts/next-with-port.mjs
+COPY --chown=app:app libs/ts-env-loader/src/port-resolver.ts libs/ts-env-loader/src/port-resolver.ts
 USER app
 EXPOSE 3202
-ENV PORT=3202 HOSTNAME="0.0.0.0" NODE_ENV=production NEXT_TELEMETRY_DISABLED=1
+ENV ORGANICLEVER_APP_WEB_PORT=3202 HOSTNAME="0.0.0.0" NODE_ENV=production NEXT_TELEMETRY_DISABLED=1
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3202/ || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://localhost:${ORGANICLEVER_APP_WEB_PORT}/ || exit 1
 
-CMD ["node", "server.js"]
+CMD ["node", "scripts/next-with-port.mjs", "--env", "ORGANICLEVER_APP_WEB_PORT", "--default", "3202", "--server", "server.js"]

--- a/apps/organiclever-app-web/project.json
+++ b/apps/organiclever-app-web/project.json
@@ -17,7 +17,7 @@
     "dev": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "node scripts/gen-migrations.mjs && next dev --port 3202",
+        "command": "node scripts/gen-migrations.mjs && node ../../scripts/next-with-port.mjs dev --env ORGANICLEVER_APP_WEB_PORT --default 3202",
         "cwd": "{projectRoot}"
       }
     },
@@ -33,7 +33,7 @@
     "start": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "next start --port 3202",
+        "command": "node ../../scripts/next-with-port.mjs start --env ORGANICLEVER_APP_WEB_PORT --default 3202",
         "cwd": "{projectRoot}"
       }
     },

--- a/apps/organiclever-be/.env.example
+++ b/apps/organiclever-be/.env.example
@@ -5,7 +5,8 @@
 # Format: postgres://<user>:<password>@<host>:<port>/<database>
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/organiclever
 
-# OPTIONAL | u16 | TCP port the server listens on (default: 8202)
+# OPTIONAL | u16 | TCP port the server listens on. Resolution order: `--port` flag, then
+# this variable, then the 8202 default. A bare PORT is deliberately NOT honoured.
 ORGANICLEVER_BE_PORT=8202
 
 # OPTIONAL | string | Comma-separated CORS origins or "*" to allow all (default: *)

--- a/apps/organiclever-be/.env.example
+++ b/apps/organiclever-be/.env.example
@@ -5,8 +5,8 @@
 # Format: postgres://<user>:<password>@<host>:<port>/<database>
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/organiclever
 
-# OPTIONAL | u16 | TCP port the server listens on. Resolution order: `--port` flag, then
-# this variable, then the 8202 default. A bare PORT is deliberately NOT honoured.
+# OPTIONAL | u16 | Listener port (default: 8202)
+# Format: `--port` flag first, then this variable, then the default; a bare PORT is not honoured
 ORGANICLEVER_BE_PORT=8202
 
 # OPTIONAL | string | Comma-separated CORS origins or "*" to allow all (default: *)

--- a/apps/organiclever-be/Dockerfile
+++ b/apps/organiclever-be/Dockerfile
@@ -29,7 +29,8 @@ WORKDIR /app
 
 COPY --from=build /app/publish .
 
-# Default port — override at runtime via ORGANICLEVER_BE_PORT.
+# Default port — override at runtime with `-e ORGANICLEVER_BE_PORT=<port>`, or with a `--port <port>`
+# argument appended to the entrypoint. Until this change the variable was read by nothing.
 ENV ORGANICLEVER_BE_PORT=8202
 EXPOSE 8202
 

--- a/apps/organiclever-be/docker-compose.e2e.yml
+++ b/apps/organiclever-be/docker-compose.e2e.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: organiclever
     ports:
-      - "5432:5432"
+      - "5436:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -17,4 +17,4 @@ services:
     image: nats:latest
     command: ["-js"]
     ports:
-      - "4222:4222"
+      - "4226:4222"

--- a/apps/organiclever-be/scripts/run-e2e.sh
+++ b/apps/organiclever-be/scripts/run-e2e.sh
@@ -10,8 +10,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 # test.skip() left in the e2e suite. test.skip(condition, reason) - the documented
 # Playwright environment-guard form - is intentionally allowed through.
 if grep -rn -E --include='*.ts' --exclude-dir=node_modules --exclude-dir=.features-gen --exclude-dir=test-results --exclude-dir=playwright-report '\$?test\.skip\([^,)]*\)' "${ROOT}/apps/organiclever-be-e2e"; then
-  echo "ERROR: unconditional test.skip() found in test files above - use test.skip(condition, reason) for legitimate environment guards, or remove" >&2
-  exit 1
+	echo "ERROR: unconditional test.skip() found in test files above - use test.skip(condition, reason) for legitimate environment guards, or remove" >&2
+	exit 1
 fi
 
 COMPOSE_FILE="${ROOT}/apps/organiclever-be/docker-compose.e2e.yml"
@@ -21,11 +21,11 @@ FSPROJ="${ROOT}/apps/organiclever-be/src/OrganicleverBe/OrganicleverBe.fsproj"
 BE_PID=""
 
 cleanup() {
-  if [[ -n "${BE_PID}" ]]; then
-    kill "${BE_PID}" 2>/dev/null || true
-    wait "${BE_PID}" 2>/dev/null || true
-  fi
-  docker compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}" down -v >/dev/null 2>&1 || true
+	if [[ -n "${BE_PID}" ]]; then
+		kill "${BE_PID}" 2>/dev/null || true
+		wait "${BE_PID}" 2>/dev/null || true
+	fi
+	docker compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}" down -v >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
@@ -37,11 +37,10 @@ docker compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}" up -d --wait
 dotnet build "${FSPROJ}" --configuration Release --nologo -v quiet
 
 # Start backend in background
-export DATABASE_URL="Host=localhost;Port=5432;Database=organiclever;Username=postgres;Password=postgres"
-export ASPNETCORE_URLS="http://localhost:${PORT}"
+export DATABASE_URL="Host=localhost;Port=5436;Database=organiclever;Username=postgres;Password=postgres"
 export ORGANICLEVER_BE_PORT="${PORT}"
 export ORGANICLEVER_BE_CORS_ORIGINS="*"
-export ORGANICLEVER_BE_NATS_URL="nats://localhost:4222"
+export ORGANICLEVER_BE_NATS_URL="nats://localhost:4226"
 
 dotnet run --project "${FSPROJ}" --no-build --configuration Release &
 BE_PID="$!"
@@ -49,15 +48,15 @@ BE_PID="$!"
 # Wait until the health endpoint responds (up to 60 s)
 echo "Waiting for organiclever-be on port ${PORT}..."
 for i in $(seq 1 60); do
-  if curl -sf "http://localhost:${PORT}/api/v1/health" >/dev/null 2>&1; then
-    echo "organiclever-be is ready (${i}s)"
-    break
-  fi
-  if [[ "${i}" -eq 60 ]]; then
-    echo "ERROR: organiclever-be did not start within 60 seconds" >&2
-    exit 1
-  fi
-  sleep 1
+	if curl -sf "http://localhost:${PORT}/api/v1/health" >/dev/null 2>&1; then
+		echo "organiclever-be is ready (${i}s)"
+		break
+	fi
+	if [[ "${i}" -eq 60 ]]; then
+		echo "ERROR: organiclever-be did not start within 60 seconds" >&2
+		exit 1
+	fi
+	sleep 1
 done
 
 # Run the Playwright e2e suite

--- a/apps/organiclever-be/src/OrganicleverBe/Program.fs
+++ b/apps/organiclever-be/src/OrganicleverBe/Program.fs
@@ -58,15 +58,12 @@ let main args =
     // 4. HTTP host (Giraffe routes for all bounded contexts + EF DbContext), bound to the port
     //    resolved by the repo-wide `--port` > ORGANICLEVER_BE_PORT > 8202 contract — see
     //    libs/fsharp-env-loader/src/PortResolver.fs, shared with every other port-binding app here.
+    let readEnvironment (key: string) =
+        System.Environment.GetEnvironmentVariable key
+
     let listenUrl =
-        match
-            FsharpEnvLoader.PortResolver.resolvePort
-                args
-                System.Environment.GetEnvironmentVariable
-                "ORGANICLEVER_BE_PORT"
-                8202
-        with
-        | Ok port -> FsharpEnvLoader.PortResolver.listenUrl System.Environment.GetEnvironmentVariable port
+        match FsharpEnvLoader.PortResolver.resolvePort args readEnvironment "ORGANICLEVER_BE_PORT" 8202 with
+        | Ok port -> FsharpEnvLoader.PortResolver.listenUrl readEnvironment port
         | Error message ->
             eprintfn "%s" message
             exit 1

--- a/apps/organiclever-be/src/OrganicleverBe/Program.fs
+++ b/apps/organiclever-be/src/OrganicleverBe/Program.fs
@@ -24,11 +24,11 @@ let private configureServices (connStr: string) (services: IServiceCollection) =
     services.AddDbContext<AppDbContext>(fun opts -> opts.UseNpgsql(connStr).UseSnakeCaseNamingConvention() |> ignore)
     |> ignore
 
-let private buildHost (args: string[]) (connStr: string) (handler: HttpHandler) =
+let private buildHost (args: string[]) (connStr: string) (handler: HttpHandler) (url: string) =
     Host
         .CreateDefaultBuilder(args)
         .ConfigureWebHostDefaults(fun webHostBuilder ->
-            webHostBuilder.Configure(configureApp handler).ConfigureServices(configureServices connStr)
+            webHostBuilder.UseUrls(url).Configure(configureApp handler).ConfigureServices(configureServices connStr)
             |> ignore)
         .Build()
 
@@ -55,8 +55,23 @@ let main args =
         status.Set outcome
     | None -> status.Set(Failed "NATS unavailable at startup")
 
-    // 4. HTTP host (Giraffe routes for all bounded contexts + EF DbContext).
-    let host = buildHost args connStr (buildWebApp status)
+    // 4. HTTP host (Giraffe routes for all bounded contexts + EF DbContext), bound to the port
+    //    resolved by the repo-wide `--port` > ORGANICLEVER_BE_PORT > 8202 contract — see
+    //    libs/fsharp-env-loader/src/PortResolver.fs, shared with every other port-binding app here.
+    let listenUrl =
+        match
+            FsharpEnvLoader.PortResolver.resolvePort
+                args
+                System.Environment.GetEnvironmentVariable
+                "ORGANICLEVER_BE_PORT"
+                8202
+        with
+        | Ok port -> FsharpEnvLoader.PortResolver.listenUrl System.Environment.GetEnvironmentVariable port
+        | Error message ->
+            eprintfn "%s" message
+            exit 1
+
+    let host = buildHost args connStr (buildWebApp status) listenUrl
 
     host.Run()
 

--- a/apps/organiclever-www/.env.example
+++ b/apps/organiclever-www/.env.example
@@ -4,8 +4,9 @@
 # No application-defined env vars in this app at this time.
 # All values are supplied at runtime by the Next.js framework or deployment platform.
 
-# OPTIONAL | u16 | Next.js dev-server port (framework-reserved name; default: 3200)
-# PORT=3200
-
 # OPTIONAL | string | Next.js dev-server hostname (framework-reserved name; default: 0.0.0.0)
 # HOSTNAME=0.0.0.0
+
+# OPTIONAL | u16 | Listener port. Resolution order: `--port` flag, then this variable,
+# then the 3200 default. A bare PORT is deliberately NOT honoured.
+# ORGANICLEVER_WWW_PORT=3200

--- a/apps/organiclever-www/.env.example
+++ b/apps/organiclever-www/.env.example
@@ -7,6 +7,6 @@
 # OPTIONAL | string | Next.js dev-server hostname (framework-reserved name; default: 0.0.0.0)
 # HOSTNAME=0.0.0.0
 
-# OPTIONAL | u16 | Listener port. Resolution order: `--port` flag, then this variable,
-# then the 3200 default. A bare PORT is deliberately NOT honoured.
+# OPTIONAL | u16 | Listener port (default: 3200)
+# Format: `--port` flag first, then this variable, then the default; a bare PORT is not honoured
 # ORGANICLEVER_WWW_PORT=3200

--- a/apps/organiclever-www/Dockerfile
+++ b/apps/organiclever-www/Dockerfile
@@ -42,10 +42,12 @@ WORKDIR /app
 COPY --from=build --chown=app:app /app/.next ./.next
 COPY --from=build --chown=app:app /app/node_modules ./node_modules
 COPY --from=build --chown=app:app /app/package.json ./package.json
+COPY --chown=app:app scripts/next-with-port.mjs scripts/next-with-port.mjs
+COPY --chown=app:app libs/ts-env-loader/src/port-resolver.ts libs/ts-env-loader/src/port-resolver.ts
 USER app
 EXPOSE 3200
-ENV PORT=3200 HOSTNAME="0.0.0.0" NODE_ENV=production NEXT_TELEMETRY_DISABLED=1
+ENV ORGANICLEVER_WWW_PORT=3200 HOSTNAME="0.0.0.0" NODE_ENV=production NEXT_TELEMETRY_DISABLED=1
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3200/ || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://localhost:${ORGANICLEVER_WWW_PORT}/ || exit 1
 
-CMD ["node_modules/.bin/next", "start", "-p", "3200", "-H", "0.0.0.0"]
+CMD ["node", "scripts/next-with-port.mjs", "start", "--env", "ORGANICLEVER_WWW_PORT", "--default", "3200", "-H", "0.0.0.0"]

--- a/apps/organiclever-www/project.json
+++ b/apps/organiclever-www/project.json
@@ -7,7 +7,7 @@
     "dev": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "next dev --port 3200",
+        "command": "node ../../scripts/next-with-port.mjs dev --env ORGANICLEVER_WWW_PORT --default 3200",
         "cwd": "{projectRoot}"
       }
     },
@@ -22,7 +22,7 @@
     "start": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "next start --port 3200",
+        "command": "node ../../scripts/next-with-port.mjs start --env ORGANICLEVER_WWW_PORT --default 3200",
         "cwd": "{projectRoot}"
       }
     },

--- a/apps/ose-app-web/.env.example
+++ b/apps/ose-app-web/.env.example
@@ -4,8 +4,9 @@
 # No application-defined env vars in this app at this time.
 # All values are supplied at runtime by the Next.js framework or deployment platform.
 
-# OPTIONAL | u16 | Next.js dev-server port (framework-reserved name; default: 3300)
-# PORT=3300
-
 # OPTIONAL | string | Next.js dev-server hostname (framework-reserved name; default: 0.0.0.0)
 # HOSTNAME=0.0.0.0
+
+# OPTIONAL | u16 | Listener port. Resolution order: `--port` flag, then this variable,
+# then the 3300 default. A bare PORT is deliberately NOT honoured.
+# OSE_APP_WEB_PORT=3300

--- a/apps/ose-app-web/.env.example
+++ b/apps/ose-app-web/.env.example
@@ -7,6 +7,6 @@
 # OPTIONAL | string | Next.js dev-server hostname (framework-reserved name; default: 0.0.0.0)
 # HOSTNAME=0.0.0.0
 
-# OPTIONAL | u16 | Listener port. Resolution order: `--port` flag, then this variable,
-# then the 3300 default. A bare PORT is deliberately NOT honoured.
+# OPTIONAL | u16 | Listener port (default: 3300)
+# Format: `--port` flag first, then this variable, then the default; a bare PORT is not honoured
 # OSE_APP_WEB_PORT=3300

--- a/apps/ose-app-web/Dockerfile
+++ b/apps/ose-app-web/Dockerfile
@@ -29,7 +29,7 @@ COPY apps/ose-app-web/package.json apps/ose-app-web/tsconfig.json apps/ose-app-w
 # RUN npx @hey-api/openapi-ts -i specs/apps/ose-app/containers/contracts/generated/openapi-bundled.yaml -o src/generated-contracts -s
 
 ENV NEXT_TELEMETRY_DISABLED=1
-ARG OSE_BE_URL=http://ose-be:8202
+ARG OSE_BE_URL=http://ose-be:8302
 ENV OSE_BE_URL=${OSE_BE_URL}
 RUN npx next build
 
@@ -42,10 +42,12 @@ RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
 COPY --from=build --chown=app:app /app/.next/standalone ./
 COPY --from=build --chown=app:app /app/.next/static ./.next/static
+COPY --chown=app:app scripts/next-with-port.mjs scripts/next-with-port.mjs
+COPY --chown=app:app libs/ts-env-loader/src/port-resolver.ts libs/ts-env-loader/src/port-resolver.ts
 USER app
 EXPOSE 3300
-ENV PORT=3300 HOSTNAME="0.0.0.0" NODE_ENV=production NEXT_TELEMETRY_DISABLED=1
+ENV OSE_APP_WEB_PORT=3300 HOSTNAME="0.0.0.0" NODE_ENV=production NEXT_TELEMETRY_DISABLED=1
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3300/ || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://localhost:${OSE_APP_WEB_PORT}/ || exit 1
 
-CMD ["node", "server.js"]
+CMD ["node", "scripts/next-with-port.mjs", "--env", "OSE_APP_WEB_PORT", "--default", "3300", "--server", "server.js"]

--- a/apps/ose-app-web/project.json
+++ b/apps/ose-app-web/project.json
@@ -17,7 +17,7 @@
     "dev": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "next dev --port 3300",
+        "command": "node ../../scripts/next-with-port.mjs dev --env OSE_APP_WEB_PORT --default 3300",
         "cwd": "{projectRoot}"
       }
     },
@@ -32,7 +32,7 @@
     "start": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "next start --port 3300",
+        "command": "node ../../scripts/next-with-port.mjs start --env OSE_APP_WEB_PORT --default 3300",
         "cwd": "{projectRoot}"
       }
     },

--- a/apps/ose-be/.env.example
+++ b/apps/ose-be/.env.example
@@ -5,8 +5,8 @@
 # Format: postgres://<user>:<password>@<host>:<port>/<database>
 DATABASE_URL=postgres://ose_app:ose_app@localhost:5432/ose_app
 
-# OPTIONAL | u16 | TCP port the server listens on. Resolution order: `--port` flag, then
-# this variable, then the 8302 default. A bare PORT is deliberately NOT honoured.
+# OPTIONAL | u16 | Listener port (default: 8302)
+# Format: `--port` flag first, then this variable, then the default; a bare PORT is not honoured
 OSE_BE_PORT=8302
 
 # OPTIONAL | string | Comma-separated CORS origins or "*" to allow all (default: *)

--- a/apps/ose-be/.env.example
+++ b/apps/ose-be/.env.example
@@ -5,7 +5,8 @@
 # Format: postgres://<user>:<password>@<host>:<port>/<database>
 DATABASE_URL=postgres://ose_app:ose_app@localhost:5432/ose_app
 
-# OPTIONAL | u16 | TCP port the server listens on (default: 8302)
+# OPTIONAL | u16 | TCP port the server listens on. Resolution order: `--port` flag, then
+# this variable, then the 8302 default. A bare PORT is deliberately NOT honoured.
 OSE_BE_PORT=8302
 
 # OPTIONAL | string | Comma-separated CORS origins or "*" to allow all (default: *)

--- a/apps/ose-be/Dockerfile
+++ b/apps/ose-be/Dockerfile
@@ -28,7 +28,8 @@ WORKDIR /app
 
 COPY --from=build /app/publish .
 
-# Default port — override at runtime via OSE_BE_PORT.
+# Default port — override at runtime with `-e OSE_BE_PORT=<port>`, or with a `--port <port>`
+# argument appended to the entrypoint. Until this change the variable was read by nothing.
 ENV OSE_BE_PORT=8302
 EXPOSE 8302
 

--- a/apps/ose-be/docker-compose.e2e.yml
+++ b/apps/ose-be/docker-compose.e2e.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: ose_app
     ports:
-      - "5432:5432"
+      - "5435:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
@@ -17,4 +17,4 @@ services:
     image: nats:latest
     command: ["-js"]
     ports:
-      - "4222:4222"
+      - "4225:4222"

--- a/apps/ose-be/scripts/run-e2e.sh
+++ b/apps/ose-be/scripts/run-e2e.sh
@@ -10,8 +10,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 # test.skip() left in the e2e suite. test.skip(condition, reason) - the documented
 # Playwright environment-guard form - is intentionally allowed through.
 if grep -rn -E --include='*.ts' --exclude-dir=node_modules --exclude-dir=.features-gen --exclude-dir=test-results --exclude-dir=playwright-report '\$?test\.skip\([^,)]*\)' "${ROOT}/apps/ose-be-e2e"; then
-  echo "ERROR: unconditional test.skip() found in test files above - use test.skip(condition, reason) for legitimate environment guards, or remove" >&2
-  exit 1
+	echo "ERROR: unconditional test.skip() found in test files above - use test.skip(condition, reason) for legitimate environment guards, or remove" >&2
+	exit 1
 fi
 
 COMPOSE_FILE="${ROOT}/apps/ose-be/docker-compose.e2e.yml"
@@ -21,11 +21,11 @@ FSPROJ="${ROOT}/apps/ose-be/src/OseBe/OseBe.fsproj"
 BE_PID=""
 
 cleanup() {
-  if [[ -n "${BE_PID}" ]]; then
-    kill "${BE_PID}" 2>/dev/null || true
-    wait "${BE_PID}" 2>/dev/null || true
-  fi
-  docker compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}" down -v >/dev/null 2>&1 || true
+	if [[ -n "${BE_PID}" ]]; then
+		kill "${BE_PID}" 2>/dev/null || true
+		wait "${BE_PID}" 2>/dev/null || true
+	fi
+	docker compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}" down -v >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
@@ -37,11 +37,10 @@ docker compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}" up -d --wait
 dotnet build "${FSPROJ}" --configuration Release --nologo -v quiet
 
 # Start backend in background
-export DATABASE_URL="Host=localhost;Port=5432;Database=ose_app;Username=postgres;Password=postgres"
-export ASPNETCORE_URLS="http://localhost:${PORT}"
+export DATABASE_URL="Host=localhost;Port=5435;Database=ose_app;Username=postgres;Password=postgres"
 export OSE_BE_PORT="${PORT}"
 export OSE_BE_CORS_ORIGINS="*"
-export OSE_BE_NATS_URL="nats://localhost:4222"
+export OSE_BE_NATS_URL="nats://localhost:4225"
 export OSE_BE_OPENROUTER_API_KEY=""
 export OSE_BE_OPENROUTER_MODEL="openrouter/auto"
 export OSE_BE_OPENROUTER_BASE_URL="https://openrouter.ai/api/v1"
@@ -52,15 +51,15 @@ BE_PID="$!"
 # Wait until the health endpoint responds (up to 60 s)
 echo "Waiting for ose-be on port ${PORT}..."
 for i in $(seq 1 60); do
-  if curl -sf "http://localhost:${PORT}/api/v1/health" >/dev/null 2>&1; then
-    echo "ose-be is ready (${i}s)"
-    break
-  fi
-  if [[ "${i}" -eq 60 ]]; then
-    echo "ERROR: ose-be did not start within 60 seconds" >&2
-    exit 1
-  fi
-  sleep 1
+	if curl -sf "http://localhost:${PORT}/api/v1/health" >/dev/null 2>&1; then
+		echo "ose-be is ready (${i}s)"
+		break
+	fi
+	if [[ "${i}" -eq 60 ]]; then
+		echo "ERROR: ose-be did not start within 60 seconds" >&2
+		exit 1
+	fi
+	sleep 1
 done
 
 # Run the Playwright e2e suite

--- a/apps/ose-be/src/OseBe/Program.fs
+++ b/apps/ose-be/src/OseBe/Program.fs
@@ -24,11 +24,11 @@ let private configureServices (connStr: string) (services: IServiceCollection) =
     services.AddDbContext<AppDbContext>(fun opts -> opts.UseNpgsql(connStr).UseSnakeCaseNamingConvention() |> ignore)
     |> ignore
 
-let private buildHost (args: string[]) (connStr: string) (handler: HttpHandler) =
+let private buildHost (args: string[]) (connStr: string) (handler: HttpHandler) (url: string) =
     Host
         .CreateDefaultBuilder(args)
         .ConfigureWebHostDefaults(fun webHostBuilder ->
-            webHostBuilder.Configure(configureApp handler).ConfigureServices(configureServices connStr)
+            webHostBuilder.UseUrls(url).Configure(configureApp handler).ConfigureServices(configureServices connStr)
             |> ignore)
         .Build()
 
@@ -56,8 +56,19 @@ let main args =
         status.Set outcome
     | None -> status.Set(Failed "NATS unavailable at startup")
 
-    // 5. HTTP host (Giraffe routes for all bounded contexts + EF DbContext).
-    let host = buildHost args connStr (buildWebApp status)
+    // 5. HTTP host (Giraffe routes for all bounded contexts + EF DbContext), bound to the port
+    //    resolved by the repo-wide `--port` > OSE_BE_PORT > 8302 contract — see
+    //    libs/fsharp-env-loader/src/PortResolver.fs, shared with every other port-binding app here.
+    let listenUrl =
+        match
+            FsharpEnvLoader.PortResolver.resolvePort args System.Environment.GetEnvironmentVariable "OSE_BE_PORT" 8302
+        with
+        | Ok port -> FsharpEnvLoader.PortResolver.listenUrl System.Environment.GetEnvironmentVariable port
+        | Error message ->
+            eprintfn "%s" message
+            exit 1
+
+    let host = buildHost args connStr (buildWebApp status) listenUrl
 
     host.Run()
 

--- a/apps/ose-be/src/OseBe/Program.fs
+++ b/apps/ose-be/src/OseBe/Program.fs
@@ -59,11 +59,12 @@ let main args =
     // 5. HTTP host (Giraffe routes for all bounded contexts + EF DbContext), bound to the port
     //    resolved by the repo-wide `--port` > OSE_BE_PORT > 8302 contract — see
     //    libs/fsharp-env-loader/src/PortResolver.fs, shared with every other port-binding app here.
+    let readEnvironment (key: string) =
+        System.Environment.GetEnvironmentVariable key
+
     let listenUrl =
-        match
-            FsharpEnvLoader.PortResolver.resolvePort args System.Environment.GetEnvironmentVariable "OSE_BE_PORT" 8302
-        with
-        | Ok port -> FsharpEnvLoader.PortResolver.listenUrl System.Environment.GetEnvironmentVariable port
+        match FsharpEnvLoader.PortResolver.resolvePort args readEnvironment "OSE_BE_PORT" 8302 with
+        | Ok port -> FsharpEnvLoader.PortResolver.listenUrl readEnvironment port
         | Error message ->
             eprintfn "%s" message
             exit 1

--- a/apps/ose-www/.env.example
+++ b/apps/ose-www/.env.example
@@ -10,6 +10,6 @@
 # OPTIONAL | string | Next.js dev-server hostname (framework-reserved name; default: 0.0.0.0)
 # HOSTNAME=0.0.0.0
 
-# OPTIONAL | u16 | Listener port. Resolution order: `--port` flag, then this variable,
-# then the 3100 default. A bare PORT is deliberately NOT honoured.
+# OPTIONAL | u16 | Listener port (default: 3100)
+# Format: `--port` flag first, then this variable, then the default; a bare PORT is not honoured
 # OSE_WWW_PORT=3100

--- a/apps/ose-www/.env.example
+++ b/apps/ose-www/.env.example
@@ -7,8 +7,9 @@
 # OPTIONAL | boolean | Include draft posts in listing; set to "true" to enable (default: false)
 # OSE_WEB_SHOW_DRAFTS=
 
-# OPTIONAL | u16 | Next.js dev-server port (framework-reserved name; default: 3100)
-# PORT=3100
-
 # OPTIONAL | string | Next.js dev-server hostname (framework-reserved name; default: 0.0.0.0)
 # HOSTNAME=0.0.0.0
+
+# OPTIONAL | u16 | Listener port. Resolution order: `--port` flag, then this variable,
+# then the 3100 default. A bare PORT is deliberately NOT honoured.
+# OSE_WWW_PORT=3100

--- a/apps/ose-www/Dockerfile
+++ b/apps/ose-www/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /workspace
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOSTNAME=0.0.0.0
-ENV PORT=3100
+ENV OSE_WWW_PORT=3100
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 COPY --from=builder --chown=nextjs:nodejs /workspace/apps/ose-www/.next/standalone ./
@@ -37,9 +37,11 @@ COPY --from=builder --chown=nextjs:nodejs /workspace/apps/ose-www/.next/static a
 COPY --from=builder --chown=nextjs:nodejs /workspace/apps/ose-www/public apps/ose-www/public
 COPY --from=builder --chown=nextjs:nodejs /workspace/apps/ose-www/content apps/ose-www/content
 COPY --from=builder --chown=nextjs:nodejs /workspace/apps/ose-www/generated apps/ose-www/generated
+COPY --chown=nextjs:nodejs scripts/next-with-port.mjs scripts/next-with-port.mjs
+COPY --chown=nextjs:nodejs libs/ts-env-loader/src/port-resolver.ts libs/ts-env-loader/src/port-resolver.ts
 USER nextjs
 EXPOSE 3100
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3100/ || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://localhost:${OSE_WWW_PORT}/ || exit 1
 
-CMD ["node", "apps/ose-www/server.js"]
+CMD ["node", "scripts/next-with-port.mjs", "--env", "OSE_WWW_PORT", "--default", "3100", "--server", "apps/ose-www/server.js"]

--- a/apps/ose-www/project.json
+++ b/apps/ose-www/project.json
@@ -10,7 +10,7 @@
       }
     },
     "dev": {
-      "command": "next dev --port 3100",
+      "command": "node ../../scripts/next-with-port.mjs dev --env OSE_WWW_PORT --default 3100",
       "options": {
         "cwd": "apps/ose-www"
       },
@@ -33,7 +33,7 @@
       "cache": true
     },
     "start": {
-      "command": "next start --port 3100",
+      "command": "node ../../scripts/next-with-port.mjs start --env OSE_WWW_PORT --default 3100",
       "options": {
         "cwd": "apps/ose-www"
       }

--- a/apps/wahidyankf-www/.env.example
+++ b/apps/wahidyankf-www/.env.example
@@ -7,6 +7,6 @@
 # OPTIONAL | string | Next.js dev-server hostname (framework-reserved name; default: 0.0.0.0)
 # HOSTNAME=0.0.0.0
 
-# OPTIONAL | u16 | Listener port. Resolution order: `--port` flag, then this variable,
-# then the 3201 default. A bare PORT is deliberately NOT honoured.
+# OPTIONAL | u16 | Listener port (default: 3201)
+# Format: `--port` flag first, then this variable, then the default; a bare PORT is not honoured
 # WAHIDYANKF_WWW_PORT=3201

--- a/apps/wahidyankf-www/.env.example
+++ b/apps/wahidyankf-www/.env.example
@@ -4,8 +4,9 @@
 # No application-defined env vars in this app at this time.
 # All values are supplied at runtime by the Next.js framework or deployment platform.
 
-# OPTIONAL | u16 | Next.js dev-server port (framework-reserved name; default: 3201)
-# PORT=3201
-
 # OPTIONAL | string | Next.js dev-server hostname (framework-reserved name; default: 0.0.0.0)
 # HOSTNAME=0.0.0.0
+
+# OPTIONAL | u16 | Listener port. Resolution order: `--port` flag, then this variable,
+# then the 3201 default. A bare PORT is deliberately NOT honoured.
+# WAHIDYANKF_WWW_PORT=3201

--- a/apps/wahidyankf-www/Dockerfile
+++ b/apps/wahidyankf-www/Dockerfile
@@ -37,10 +37,12 @@ COPY --from=build --chown=app:app /app/.next ./.next
 COPY --from=build --chown=app:app /app/public ./public
 COPY --from=build --chown=app:app /app/node_modules ./node_modules
 COPY --from=build --chown=app:app /app/package.json ./package.json
+COPY --chown=app:app scripts/next-with-port.mjs scripts/next-with-port.mjs
+COPY --chown=app:app libs/ts-env-loader/src/port-resolver.ts libs/ts-env-loader/src/port-resolver.ts
 USER app
 EXPOSE 3201
-ENV PORT=3201 HOSTNAME="0.0.0.0" NODE_ENV=production NEXT_TELEMETRY_DISABLED=1
+ENV WAHIDYANKF_WWW_PORT=3201 HOSTNAME="0.0.0.0" NODE_ENV=production NEXT_TELEMETRY_DISABLED=1
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3201/ || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://localhost:${WAHIDYANKF_WWW_PORT}/ || exit 1
 
-CMD ["node_modules/.bin/next", "start", "-p", "3201", "-H", "0.0.0.0"]
+CMD ["node", "scripts/next-with-port.mjs", "start", "--env", "WAHIDYANKF_WWW_PORT", "--default", "3201", "-H", "0.0.0.0"]

--- a/apps/wahidyankf-www/project.json
+++ b/apps/wahidyankf-www/project.json
@@ -7,7 +7,7 @@
     "dev": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "next dev --port 3201",
+        "command": "node ../../scripts/next-with-port.mjs dev --env WAHIDYANKF_WWW_PORT --default 3201",
         "cwd": "{projectRoot}"
       }
     },
@@ -22,7 +22,7 @@
     "start": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "next start --port 3201",
+        "command": "node ../../scripts/next-with-port.mjs start --env WAHIDYANKF_WWW_PORT --default 3201",
         "cwd": "{projectRoot}"
       }
     },

--- a/docs/explanation/standardize-secrets-and-env-parity-decisions.md
+++ b/docs/explanation/standardize-secrets-and-env-parity-decisions.md
@@ -117,16 +117,25 @@ an explicitly-blessed unprefixed shared name, not an oversight.
 
 **Deviation**: None.
 
-### 6. Next.js `PORT` exempt vs backend `PORT` prefixed
+### 6. Next.js `PORT` exempt vs backend `PORT` prefixed — SUPERSEDED
 
-**Decision**: In Next.js webs (`ose-www`, `ayokoding-www`, etc.), `PORT` stays unprefixed — it is a
-framework-reserved name the Next.js dev server reads natively. In F# backends (`organiclever-be`,
-`ose-be`), the port var takes the full prefix (`ORGANICLEVER_BE_PORT`, `OSE_BE_PORT`).
+> **Superseded.** The asymmetry recorded below no longer holds. Every port-binding app, web tier
+> included, now takes the app prefix and resolves its port through one shared contract — `--port`
+> flag, then the prefixed variable, then the compiled-in default. The premise that renaming `PORT`
+> "would break `nx dev ose-www`" was retired by `scripts/next-with-port.mjs`, which resolves the port
+> before Next.js starts and assigns `process.env.PORT` itself. See the
+> [Environment Variable Naming Standard](../../repo-governance/conventions/security/secrets-and-env-standards/environment-variable-naming-standard.md)
+> for the rule now in force. The text below is kept as the historical record of what was decided.
 
-**Why**: This asymmetry follows from who owns the binding. The Next.js dev server reads `PORT` from
-the platform (PaaS or OS) with no indirection through app code — renaming it to `OSE_WWW_PORT` would
-break `nx dev ose-www`. ASP.NET/Giraffe backends bind whatever value _our own code_ reads from the
-environment, so the backend port is app-defined and takes the prefix.
+**Decision (historical)**: In Next.js webs (`ose-www`, `ayokoding-www`, etc.), `PORT` stays
+unprefixed — it is a framework-reserved name the Next.js dev server reads natively. In F# backends
+(`organiclever-be`, `ose-be`), the port var takes the full prefix (`ORGANICLEVER_BE_PORT`,
+`OSE_BE_PORT`).
+
+**Why (historical)**: This asymmetry follows from who owns the binding. The Next.js dev server reads
+`PORT` from the platform (PaaS or OS) with no indirection through app code. ASP.NET/Giraffe backends
+bind whatever value _our own code_ reads from the environment, so the backend port is app-defined and
+takes the prefix.
 
 **Deviation from ose-private**: `ose-private` has no Next.js applications, so the web exemption is
 structural rather than a policy divergence — the underlying rule (framework-reserved names stay

--- a/docs/how-to/add-new-app.md
+++ b/docs/how-to/add-new-app.md
@@ -88,7 +88,7 @@ Create `apps/[app-name]/project.json`:
     "dev": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "next dev",
+        "command": "node ../../scripts/next-with-port.mjs dev --env [APP_NAME]_PORT --default [port]",
         "cwd": "apps/[app-name]"
       }
     },
@@ -103,7 +103,7 @@ Create `apps/[app-name]/project.json`:
     "start": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "next start",
+        "command": "node ../../scripts/next-with-port.mjs start --env [APP_NAME]_PORT --default [port]",
         "cwd": "apps/[app-name]"
       },
       "dependsOn": ["build"]
@@ -118,6 +118,14 @@ Create `apps/[app-name]/project.json`:
   }
 }
 ```
+
+> **Ports are not optional here.** Every Next.js app in this repository starts through
+> `scripts/next-with-port.mjs`, which resolves the listener port as `--port` flag, then the app's own
+> `[APP_NAME]_PORT` variable, then the `--default` baked into the target. Wiring `next dev`/`next start`
+> directly would silently opt the new app out of that contract. The same wrapper belongs in the app's
+> `Dockerfile` `CMD`, which must also `COPY` both `scripts/next-with-port.mjs` and
+> `libs/ts-env-loader/src/port-resolver.ts`, preserving their relative layout. Pick a `[port]` that no
+> other app claims — see [web-sites.md](../reference/web-sites.md).
 
 **Express API Example**:
 

--- a/docs/reference/monorepo-structure.md
+++ b/docs/reference/monorepo-structure.md
@@ -290,7 +290,7 @@ Location: `apps/[app-name]/project.json` or `libs/[lib-name]/project.json`
     "dev": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "next dev --port 3100",
+        "command": "node ../../scripts/next-with-port.mjs dev --env OSE_WWW_PORT --default 3100",
         "cwd": "apps/ose-www"
       }
     },

--- a/docs/reference/nx-configuration.md
+++ b/docs/reference/nx-configuration.md
@@ -271,7 +271,7 @@ Per-project:
     "dev": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "next dev --port 3100",
+        "command": "node ../../scripts/next-with-port.mjs dev --env OSE_WWW_PORT --default 3100",
         "cwd": "apps/ose-www"
       }
     },

--- a/docs/reference/web-sites.md
+++ b/docs/reference/web-sites.md
@@ -24,6 +24,49 @@ created: 2026-08-14
 | beavernest-app       | TBD (Flutter Web, same-origin combined runtime)          | 19300 | —                           |
 | beavernest-be        | TBD (F# / Giraffe / ASP.NET 10, combined runtime 19300)  | 19320 | —                           |
 
+## Overriding a port
+
+Every app in the table above resolves its listener port the same way: an explicit `--port` flag,
+then the app's prefixed variable, then the default shown. A malformed value fails at startup rather
+than falling back silently.
+
+| App                  | Variable                         |
+| -------------------- | -------------------------------- |
+| ose-www              | `OSE_WWW_PORT`                   |
+| ayokoding-www        | `AYOKODING_WWW_PORT`             |
+| organiclever-www     | `ORGANICLEVER_WWW_PORT`          |
+| wahidyankf-www       | `WAHIDYANKF_WWW_PORT`            |
+| organiclever-app-web | `ORGANICLEVER_APP_WEB_PORT`      |
+| ose-app-web          | `OSE_APP_WEB_PORT`               |
+| organiclever-be      | `ORGANICLEVER_BE_PORT`           |
+| ose-be               | `OSE_BE_PORT`                    |
+| beavernest-be        | `BEAVERNEST_BE_HTTP_LISTEN_PORT` |
+
+```bash
+nx dev ose-www --port=4000          # flag
+OSE_WWW_PORT=4000 nx dev ose-www    # variable
+docker run -e OSE_WWW_PORT=4000 …   # same variable inside a container
+```
+
+A bare `PORT` is deliberately not honoured — one exported `PORT` would otherwise retarget every app
+at once. See the
+[Environment Variable Naming Standard](../../repo-governance/conventions/security/secrets-and-env-standards/environment-variable-naming-standard.md).
+
+## Supporting Service Ports
+
+Every backend test stack publishes its PostgreSQL and NATS containers on distinct host ports so two
+stacks can run at the same time (Nx runs affected projects in parallel).
+
+| Stack                       | PostgreSQL | NATS |
+| --------------------------- | ---------- | ---- |
+| ose-be integration          | 5433       | 4223 |
+| organiclever-be integration | 5434       | 4224 |
+| ose-be e2e                  | 5435       | 4225 |
+| organiclever-be e2e         | 5436       | 4226 |
+
+Host ports 5432 and 4222 stay unclaimed — they remain the defaults in each backend's `.env.example`
+for a developer-run PostgreSQL or NATS shared across apps by database name, not by port.
+
 Each app README at `apps/[app-name]/README.md` covers framework, deployment, E2E tests, and content
 details. Staging branches: `stag-organiclever-app-web`, `stag-ose-app-web`.
 

--- a/libs/fsharp-env-loader/fsharp-env-loader.fsproj
+++ b/libs/fsharp-env-loader/fsharp-env-loader.fsproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Compile Include="src/EnvTier.fs" />
+    <Compile Include="src/PortResolver.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/libs/fsharp-env-loader/src/PortResolver.fs
+++ b/libs/fsharp-env-loader/src/PortResolver.fs
@@ -5,9 +5,16 @@ open System.Globalization
 
 /// The repo-wide runtime port contract for this repo's F# backends (`ose-be`,
 /// `organiclever-be`, `beavernest-be`). Mirrors the sibling TypeScript
-/// resolver at `libs/ts-env-loader/src/index.ts` (`resolvePort`) case for
-/// case, so a TypeScript service and an F# service resolve their listener
-/// port by identical rules rather than by two lookalike implementations.
+/// resolver at `libs/ts-env-loader/src/port-resolver.ts` (`resolvePort`), so a
+/// TypeScript service and an F# service accept and reject exactly the same
+/// port values.
+///
+/// Mirrored: the three-tier precedence below, the grammar of a valid port
+/// (plain decimal digits, 1-65535), blank-falls-through, and
+/// fail-loudly-on-malformed. Not mirrored: the exact error wording, and
+/// `beavernest-be`, which owns the env-var and default tiers in its own
+/// `HttpConfiguration.parse` (under the same grammar) and uses this module for
+/// the flag tier alone.
 ///
 /// Precedence, highest first:
 ///   1. CLI flag  — an explicit `--port` passed at start time, in either
@@ -15,7 +22,7 @@ open System.Globalization
 ///   2. Env var   — the app's own prefixed variable (e.g. `OSE_BE_PORT`),
 ///                  never a bare `PORT`. A prefixed name is what lets one
 ///                  shell hold every app's port at once; see
-///                  `repo-governance/conventions/security/secrets-and-env-standards/naming-standard.md`.
+///                  `repo-governance/conventions/security/secrets-and-env-standards/environment-variable-naming-standard.md`.
 ///   3. Fallback  — the app's compiled-in default, which is also the value
 ///                  documented in `docs/reference/web-sites.md`.
 ///

--- a/libs/fsharp-env-loader/src/PortResolver.fs
+++ b/libs/fsharp-env-loader/src/PortResolver.fs
@@ -1,0 +1,125 @@
+namespace FsharpEnvLoader
+
+open System
+open System.Globalization
+
+/// The repo-wide runtime port contract for this repo's F# backends (`ose-be`,
+/// `organiclever-be`, `beavernest-be`). Mirrors the sibling TypeScript
+/// resolver at `libs/ts-env-loader/src/index.ts` (`resolvePort`) case for
+/// case, so a TypeScript service and an F# service resolve their listener
+/// port by identical rules rather than by two lookalike implementations.
+///
+/// Precedence, highest first:
+///   1. CLI flag  — an explicit `--port` passed at start time, in either
+///                  `--port 4000` or `--port=4000` form.
+///   2. Env var   — the app's own prefixed variable (e.g. `OSE_BE_PORT`),
+///                  never a bare `PORT`. A prefixed name is what lets one
+///                  shell hold every app's port at once; see
+///                  `repo-governance/conventions/security/secrets-and-env-standards/naming-standard.md`.
+///   3. Fallback  — the app's compiled-in default, which is also the value
+///                  documented in `docs/reference/web-sites.md`.
+///
+/// An empty or whitespace-only value at a tier is treated as absent and falls
+/// through to the next tier, matching `EnvTier`'s treatment of an empty
+/// `APP_ENV`. A PRESENT but malformed value is a hard error rather than a
+/// silent fall-through: a typo'd `--port 80800` must not quietly boot the
+/// service on its default port, because the operator asked for something
+/// specific and did not get it.
+///
+/// The environment is read through a caller-supplied `readEnvironment`
+/// function rather than `Environment.GetEnvironmentVariable` directly, so the
+/// unit suite can drive every scenario without touching the real process
+/// environment — the same seam `BeaverNestBe.Domain.HttpConfiguration` uses.
+module PortResolver =
+
+    /// Lowest legal TCP port. Port 0 means "let the OS choose", which is never
+    /// what an operator naming a port intends, so it is rejected.
+    let private minPort: int = 1
+
+    /// Highest legal TCP port (16-bit unsigned ceiling).
+    let private maxPort: int = 65535
+
+    /// Treats absent, empty, and whitespace-only alike as "not supplied", so a
+    /// blank tier falls through instead of erroring.
+    let private presentValue (value: string) : string option =
+        match value with
+        | null -> None
+        | text ->
+            let trimmed = text.Trim()
+            if trimmed = "" then None else Some trimmed
+
+    /// Parses one tier's value, naming that tier in the error so the message
+    /// says which knob was wrong.
+    ///
+    /// `NumberStyles.None` is deliberate: it admits only plain digits, so
+    /// `-1`, `31.5`, and `3100abc` are all rejected outright rather than
+    /// partially parsed. That matches the TypeScript twin's use of `Number()`
+    /// over `parseInt()`, which would silently accept `parseInt("3100abc")` as
+    /// 3100.
+    let private parsePort (text: string) (source: string) : Result<int, string> =
+        match Int32.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture) with
+        | true, parsed when parsed >= minPort && parsed <= maxPort -> Ok parsed
+        | _ ->
+            Error
+                $"env-loader: %s{source} supplied an invalid port \"%s{text}\". A port must be an integer between %d{minPort} and %d{maxPort}."
+
+    /// Finds an explicit `--port` in `argv`, accepting both the space-separated
+    /// (`--port 4000`) and the joined (`--port=4000`) spellings. A trailing
+    /// bare `--port` with no following value yields None, so it falls through
+    /// to the env var rather than erroring on an empty string.
+    let private flagValue (argv: string[]) : string option =
+        let rec scan (index: int) : string option =
+            if index >= argv.Length then
+                None
+            else
+                let current = argv.[index]
+
+                if current.StartsWith("--port=", StringComparison.Ordinal) then
+                    Some(current.Substring("--port=".Length))
+                elif current = "--port" && index + 1 < argv.Length then
+                    Some argv.[index + 1]
+                else
+                    scan (index + 1)
+
+        scan 0
+
+    /// Resolves a listener port by the flag > env var > fallback precedence
+    /// documented above. Returns Error when a tier is present but does not
+    /// hold a valid port, or when the app's own compiled-in fallback is itself
+    /// out of range (a programming error, caught at startup rather than
+    /// shipped).
+    let resolvePort
+        (argv: string[])
+        (readEnvironment: string -> string)
+        (envVar: string)
+        (fallback: int)
+        : Result<int, string> =
+        match flagValue argv |> Option.bind presentValue with
+        | Some value -> parsePort value "--port"
+        | None ->
+            match presentValue (readEnvironment envVar) with
+            | Some value -> parsePort value envVar
+            | None ->
+                if fallback >= minPort && fallback <= maxPort then
+                    Ok fallback
+                else
+                    Error
+                        $"env-loader: the compiled-in fallback for %s{envVar} is an invalid port %d{fallback}. A port must be an integer between %d{minPort} and %d{maxPort}."
+
+    /// Shapes the ASP.NET listener URL for a resolved port.
+    ///
+    /// Loopback (`localhost`) on a developer machine, wildcard (`+`) only inside a container. The
+    /// distinction is load-bearing in both directions: binding wildcard on a laptop exposes a
+    /// development service to the local network, while binding loopback inside a container makes
+    /// the service unreachable from outside it — the published port would connect to nothing.
+    ///
+    /// `DOTNET_RUNNING_IN_CONTAINER` is the same signal
+    /// `BeaverNestBe.Domain.HttpConfiguration` already gates its own wildcard guard on, and the
+    /// official `mcr.microsoft.com/dotnet/aspnet` images set it to "true" themselves.
+    let listenUrl (readEnvironment: string -> string) (port: int) : string =
+        let host =
+            match readEnvironment "DOTNET_RUNNING_IN_CONTAINER" with
+            | "true" -> "+"
+            | _ -> "localhost"
+
+        $"http://%s{host}:%d{port}"

--- a/libs/fsharp-env-loader/tests/unit/Tests/PortResolverTests.fs
+++ b/libs/fsharp-env-loader/tests/unit/Tests/PortResolverTests.fs
@@ -1,0 +1,142 @@
+module FsharpEnvLoader.Tests.Unit.Tests.PortResolverTests
+
+open Xunit
+open FsharpEnvLoader.PortResolver
+
+/// These cases mirror, one for one, the scenarios in
+/// `specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature`
+/// and their TypeScript step definitions in
+/// `libs/ts-env-loader/src/port-resolver.unit.test.ts`. The two
+/// implementations are only "the same mechanism" if they agree case by case,
+/// so the pairing is load-bearing: a case added on one side without its twin
+/// on the other means the repo has two port contracts, not one.
+/// Builds a `readEnvironment` seam over an in-memory pair list, returning null
+/// for anything unset — exactly what `Environment.GetEnvironmentVariable`
+/// does for an absent variable. No test here touches the real process
+/// environment.
+let private envFrom (pairs: (string * string) list) : string -> string =
+    fun key ->
+        pairs
+        |> List.tryFind (fun (name, _) -> name = key)
+        |> Option.map snd
+        |> Option.defaultValue null
+
+let private noEnv: string -> string = envFrom []
+
+// --- Precedence ------------------------------------------------------------
+
+// @covers port-resolver.feature:The CLI flag outranks every other source
+[<Fact>]
+let ``the CLI flag outranks every other source`` () =
+    let readEnvironment = envFrom [ "OSE_WWW_PORT", "4000" ]
+    let actual = resolvePort [| "--port"; "5000" |] readEnvironment "OSE_WWW_PORT" 3100
+    Assert.Equal(Ok 5000, actual)
+
+// @covers port-resolver.feature:The prefixed variable outranks the fallback
+[<Fact>]
+let ``the prefixed variable outranks the fallback`` () =
+    let readEnvironment = envFrom [ "OSE_WWW_PORT", "4000" ]
+    let actual = resolvePort [||] readEnvironment "OSE_WWW_PORT" 3100
+    Assert.Equal(Ok 4000, actual)
+
+// @covers port-resolver.feature:The fallback applies when nothing else supplies a port
+[<Fact>]
+let ``the fallback applies when nothing else supplies a port`` () =
+    let actual = resolvePort [||] noEnv "OSE_WWW_PORT" 3100
+    Assert.Equal(Ok 3100, actual)
+
+// @covers port-resolver.feature:A bare PORT variable never moves the listener
+[<Fact>]
+let ``a bare PORT variable never moves the listener`` () =
+    // A bare PORT is Next.js's own knob; this repo deliberately does NOT honour
+    // it as a port source, so one exported PORT cannot silently retarget every
+    // app at once.
+    let readEnvironment = envFrom [ "PORT", "4000" ]
+    let actual = resolvePort [||] readEnvironment "OSE_WWW_PORT" 3100
+    Assert.Equal(Ok 3100, actual)
+
+// --- Blank values fall through ---------------------------------------------
+
+// @covers port-resolver.feature:A blank value at a tier falls through to the next tier
+[<Theory>]
+[<InlineData("", "4000", 4000)>]
+[<InlineData("", "", 3100)>]
+[<InlineData("5000", "", 5000)>]
+[<InlineData("   ", "  ", 3100)>]
+let ``a blank value at a tier falls through to the next tier`` (flagValue: string) (envValue: string) (expected: int) =
+    let argv = if flagValue = "" then [||] else [| "--port"; flagValue |]
+    let readEnvironment = envFrom [ "OSE_WWW_PORT", envValue ]
+    let actual = resolvePort argv readEnvironment "OSE_WWW_PORT" 3100
+    Assert.Equal(Ok expected, actual)
+
+// --- Malformed values fail loudly ------------------------------------------
+
+// @covers port-resolver.feature:A present but malformed port fails loudly instead of falling through
+[<Theory>]
+[<InlineData("0")>]
+[<InlineData("65536")>]
+[<InlineData("abc")>]
+[<InlineData("3100abc")>]
+[<InlineData("31.5")>]
+[<InlineData("-1")>]
+let ``a present but malformed port fails loudly instead of falling through`` (flagValue: string) =
+    match resolvePort [| "--port"; flagValue |] noEnv "OSE_WWW_PORT" 3100 with
+    | Ok port -> Assert.Fail($"expected an error, but resolved to %d{port}")
+    | Error message ->
+        Assert.Contains("--port", message)
+        Assert.Contains("65535", message)
+
+// @covers port-resolver.feature:A malformed prefixed variable names that variable in the error
+[<Fact>]
+let ``a malformed prefixed variable names that variable in the error`` () =
+    let readEnvironment = envFrom [ "OSE_WWW_PORT", "not-a-port" ]
+
+    match resolvePort [||] readEnvironment "OSE_WWW_PORT" 3100 with
+    | Ok port -> Assert.Fail($"expected an error, but resolved to %d{port}")
+    | Error message ->
+        Assert.Contains("OSE_WWW_PORT", message)
+        Assert.Contains("65535", message)
+
+// --- F#-side flag spellings ------------------------------------------------
+// The TypeScript twin receives an already-parsed flag value from its wrapper,
+// so argv spelling is this side's own concern and has no Gherkin counterpart.
+
+[<Fact>]
+let ``the joined --port=N spelling is accepted`` () =
+    let actual = resolvePort [| "--port=4000" |] noEnv "OSE_WWW_PORT" 3100
+    Assert.Equal(Ok 4000, actual)
+
+[<Fact>]
+let ``a --port flag among other arguments is found`` () =
+    let actual = resolvePort [| "backup"; "--port"; "4000" |] noEnv "OSE_WWW_PORT" 3100
+    Assert.Equal(Ok 4000, actual)
+
+[<Fact>]
+let ``a trailing bare --port with no value falls through to the env var`` () =
+    let readEnvironment = envFrom [ "OSE_WWW_PORT", "4000" ]
+    let actual = resolvePort [| "--port" |] readEnvironment "OSE_WWW_PORT" 3100
+    Assert.Equal(Ok 4000, actual)
+
+[<Fact>]
+let ``an out-of-range compiled-in fallback is caught at startup`` () =
+    match resolvePort [||] noEnv "OSE_WWW_PORT" 70000 with
+    | Ok port -> Assert.Fail($"expected an error, but resolved to %d{port}")
+    | Error message -> Assert.Contains("fallback", message)
+
+// --- Listener URL shaping --------------------------------------------------
+
+[<Fact>]
+let ``listenUrl binds loopback outside a container`` () =
+    Assert.Equal("http://localhost:8302", listenUrl noEnv 8302)
+
+[<Fact>]
+let ``listenUrl binds the wildcard inside a container`` () =
+    // Without this, a published container port would connect to a loopback-only
+    // listener and the service would be unreachable from outside the container.
+    let readEnvironment = envFrom [ "DOTNET_RUNNING_IN_CONTAINER", "true" ]
+    Assert.Equal("http://+:8302", listenUrl readEnvironment 8302)
+
+[<Fact>]
+let ``listenUrl treats any non-true container flag as not-a-container`` () =
+    let readEnvironment = envFrom [ "DOTNET_RUNNING_IN_CONTAINER", "false" ]
+    Assert.Equal("http://localhost:8302", listenUrl readEnvironment 8302)

--- a/libs/fsharp-env-loader/tests/unit/Tests/PortResolverTests.fs
+++ b/libs/fsharp-env-loader/tests/unit/Tests/PortResolverTests.fs
@@ -25,27 +25,27 @@ let private noEnv: string -> string = envFrom []
 
 // --- Precedence ------------------------------------------------------------
 
-// @covers port-resolver.feature:The CLI flag outranks every other source
+// @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:The CLI flag outranks every other source
 [<Fact>]
 let ``the CLI flag outranks every other source`` () =
     let readEnvironment = envFrom [ "OSE_WWW_PORT", "4000" ]
     let actual = resolvePort [| "--port"; "5000" |] readEnvironment "OSE_WWW_PORT" 3100
     Assert.Equal(Ok 5000, actual)
 
-// @covers port-resolver.feature:The prefixed variable outranks the fallback
+// @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:The prefixed variable outranks the fallback
 [<Fact>]
 let ``the prefixed variable outranks the fallback`` () =
     let readEnvironment = envFrom [ "OSE_WWW_PORT", "4000" ]
     let actual = resolvePort [||] readEnvironment "OSE_WWW_PORT" 3100
     Assert.Equal(Ok 4000, actual)
 
-// @covers port-resolver.feature:The fallback applies when nothing else supplies a port
+// @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:The fallback applies when nothing else supplies a port
 [<Fact>]
 let ``the fallback applies when nothing else supplies a port`` () =
     let actual = resolvePort [||] noEnv "OSE_WWW_PORT" 3100
     Assert.Equal(Ok 3100, actual)
 
-// @covers port-resolver.feature:A bare PORT variable never moves the listener
+// @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:A bare PORT variable never moves the listener
 [<Fact>]
 let ``a bare PORT variable never moves the listener`` () =
     // A bare PORT is Next.js's own knob; this repo deliberately does NOT honour
@@ -57,7 +57,7 @@ let ``a bare PORT variable never moves the listener`` () =
 
 // --- Blank values fall through ---------------------------------------------
 
-// @covers port-resolver.feature:A blank value at a tier falls through to the next tier
+// @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:A blank value at a tier falls through to the next tier
 [<Theory>]
 [<InlineData("", "4000", 4000)>]
 [<InlineData("", "", 3100)>]
@@ -71,7 +71,7 @@ let ``a blank value at a tier falls through to the next tier`` (flagValue: strin
 
 // --- Malformed values fail loudly ------------------------------------------
 
-// @covers port-resolver.feature:A present but malformed port fails loudly instead of falling through
+// @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:A present but malformed port fails loudly instead of falling through
 [<Theory>]
 [<InlineData("0")>]
 [<InlineData("65536")>]
@@ -86,7 +86,7 @@ let ``a present but malformed port fails loudly instead of falling through`` (fl
         Assert.Contains("--port", message)
         Assert.Contains("65535", message)
 
-// @covers port-resolver.feature:A malformed prefixed variable names that variable in the error
+// @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:A malformed prefixed variable names that variable in the error
 [<Fact>]
 let ``a malformed prefixed variable names that variable in the error`` () =
     let readEnvironment = envFrom [ "OSE_WWW_PORT", "not-a-port" ]
@@ -117,6 +117,7 @@ let ``a trailing bare --port with no value falls through to the env var`` () =
     let actual = resolvePort [| "--port" |] readEnvironment "OSE_WWW_PORT" 3100
     Assert.Equal(Ok 4000, actual)
 
+// @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:An out-of-range compiled-in fallback is caught at startup
 [<Fact>]
 let ``an out-of-range compiled-in fallback is caught at startup`` () =
     match resolvePort [||] noEnv "OSE_WWW_PORT" 70000 with

--- a/libs/fsharp-env-loader/tests/unit/fsharp-env-loader-unit-tests.fsproj
+++ b/libs/fsharp-env-loader/tests/unit/fsharp-env-loader-unit-tests.fsproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Compile Include="Tests/EnvTierTests.fs" />
+    <Compile Include="Tests/PortResolverTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/libs/ts-env-loader/package.json
+++ b/libs/ts-env-loader/package.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@open-sharia-enterprise/ts-env-loader",
   "version": "0.1.0",
+  "type": "module",
   "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/libs/ts-env-loader/src/index.ts
+++ b/libs/ts-env-loader/src/index.ts
@@ -113,3 +113,10 @@ export function loadTierEnv(options: LoadTierEnvOptions = {}): void {
     processEnv: env as unknown as Record<string, string>,
   });
 }
+
+/**
+ * The runtime port contract lives in its own dependency-free module so a container entrypoint can
+ * import it without dragging `dotenv` (and therefore `node_modules`) along — see
+ * `./port-resolver.ts` for why that matters. Re-exported here so app code has one import site.
+ */
+export { resolvePort, type ResolvePortOptions } from "./port-resolver";

--- a/libs/ts-env-loader/src/next-with-port-wrapper.unit.test.ts
+++ b/libs/ts-env-loader/src/next-with-port-wrapper.unit.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Contract tests for `scripts/next-with-port.mjs`.
+ *
+ * The wrapper lives at the repository root, outside any Nx project, so nothing would otherwise
+ * execute it. It is tested from here because it exists solely to apply this library's `resolvePort`
+ * to a Next.js server, and this is the target that already runs on every change to that resolver.
+ *
+ * Only the `--server` form is exercised. It is the branch four of the six container images use, and
+ * unlike the `dev`/`start` form it needs no Next.js installation — the wrapper simply sets
+ * `process.env.PORT` and imports whatever path it is handed, so a few lines of fixture stand in for
+ * the generated standalone server faithfully.
+ */
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const wrapper = path.join(repoRoot, "scripts/next-with-port.mjs");
+
+let fixtureDir: string;
+let fixtureServer: string;
+
+beforeAll(() => {
+  fixtureDir = mkdtempSync(path.join(tmpdir(), "next-with-port-"));
+  fixtureServer = path.join(fixtureDir, "server.js");
+  // Mirrors Next's standalone server: parses no flags, reads only process.env.PORT.
+  writeFileSync(fixtureServer, 'console.log("PORT=" + process.env.PORT);\n');
+});
+
+afterAll(() => {
+  rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+interface RunResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runWrapper(args: string[], env: Record<string, string> = {}): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn("node", [wrapper, ...args, "--server", fixtureServer], {
+      cwd: repoRoot,
+      env: { ...process.env, ...env },
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += String(chunk)));
+    child.stderr.on("data", (chunk) => (stderr += String(chunk)));
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+describe("next-with-port.mjs", () => {
+  it("falls back to --default when nothing overrides it", async () => {
+    const result = await runWrapper(["--env", "PROBE_PORT", "--default", "3100"], { PROBE_PORT: "" });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("PORT=3100");
+  });
+
+  it("lets the prefixed variable outrank the default", async () => {
+    const result = await runWrapper(["--env", "PROBE_PORT", "--default", "3100"], { PROBE_PORT: "4321" });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("PORT=4321");
+  });
+
+  it("lets an explicit --port outrank the variable", async () => {
+    const result = await runWrapper(["--env", "PROBE_PORT", "--default", "3100", "--port", "5000"], {
+      PROBE_PORT: "4321",
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("PORT=5000");
+  });
+
+  it("accepts the joined --port=N spelling", async () => {
+    const result = await runWrapper(["--env", "PROBE_PORT", "--default", "3100", "--port=5001"]);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("PORT=5001");
+  });
+
+  it("exits non-zero on a malformed value instead of falling back to the default", async () => {
+    const result = await runWrapper(["--env", "PROBE_PORT", "--default", "3100"], { PROBE_PORT: "notaport" });
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("PROBE_PORT");
+    expect(result.stdout).not.toContain("PORT=3100");
+  });
+
+  it("rejects the numeric-literal forms the F# resolver also rejects", async () => {
+    for (const value of ["0x10", "1e3", "+3100", "0b1010"]) {
+      const result = await runWrapper(["--env", "PROBE_PORT", "--default", "3100"], { PROBE_PORT: value });
+
+      expect(result.code, `${value} should be rejected`).toBe(1);
+      expect(result.stderr).toContain("PROBE_PORT");
+    }
+  });
+});

--- a/libs/ts-env-loader/src/port-resolver.ts
+++ b/libs/ts-env-loader/src/port-resolver.ts
@@ -1,0 +1,90 @@
+/**
+ * The repo-wide runtime port contract, shared by every port-binding app in this repository and
+ * mirrored one-for-one by `libs/fsharp-env-loader`'s `PortResolver` module so the TypeScript and
+ * F# services resolve their listener port by identical rules.
+ *
+ * Precedence, highest first:
+ *   1. CLI flag  — an explicit `--port` passed at start time.
+ *   2. Env var   — the app's own prefixed variable (e.g. `OSE_WWW_PORT`), never a bare `PORT`.
+ *                  A prefixed name is what lets one shell hold every app's port at once; see
+ *                  `repo-governance/conventions/security/secrets-and-env-standards/naming-standard.md`.
+ *   3. Fallback  — the app's compiled-in default, which is also the value documented in
+ *                  `docs/reference/web-sites.md`.
+ *
+ * An empty or whitespace-only value at a tier is treated as absent and falls through to the next
+ * tier, matching `./index.ts`'s treatment of an empty `APP_ENV`. A PRESENT but malformed value is a
+ * hard error rather than a silent fall-through: a typo'd `--port 80800` must not quietly boot the
+ * service on its default port, because the operator asked for something specific and did not get
+ * it. That is the same "fail loudly on bad config" posture as the loader's rule 5.
+ *
+ * THIS MODULE MUST STAY DEPENDENCY-FREE — no `dotenv`, no `node:fs`, nothing outside the language.
+ * `scripts/next-with-port.mjs` imports it directly by relative path from inside a built container
+ * image, where Next's standalone output has pruned `node_modules` down to what the app traced at
+ * build time. `./index.ts` pulls `dotenv`, so importing the port resolver through the package
+ * entry point would crash the container at boot. Keeping this file free-standing is what makes the
+ * same resolver usable in local development and in the image.
+ */
+
+/** A `process.env`-shaped record. Structurally identical to `./index.ts`'s `EnvRecord`, redeclared
+ * here so this module imports nothing at all. */
+type EnvLike = Record<string, string | undefined>;
+
+const MIN_PORT = 1;
+const MAX_PORT = 65535;
+
+export interface ResolvePortOptions {
+  /** Value of an explicit `--port` flag, if one was passed. Highest precedence. */
+  flag?: string | number | undefined;
+  /** Name of this app's prefixed port variable, e.g. `"OSE_WWW_PORT"`. */
+  envVar: string;
+  /** The app's compiled-in default, used when neither flag nor env var supplies a value. */
+  fallback: number;
+  /** Record to read `envVar` from. Defaults to `process.env`. */
+  env?: EnvLike;
+}
+
+/** Treats empty/whitespace-only as absent, so a blank env var falls through instead of erroring. */
+function presentValue(value: string | number | undefined): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const text = String(value).trim();
+  return text.length > 0 ? text : undefined;
+}
+
+/** Parses one tier's value, throwing with the tier's name so the error says which knob was wrong. */
+function parsePort(text: string, source: string): number {
+  // Number() is deliberate over parseInt(): parseInt("3100abc") returns 3100, silently accepting a
+  // typo'd value, whereas Number("3100abc") is NaN and gets rejected below.
+  const parsed = Number(text);
+
+  if (!Number.isInteger(parsed) || parsed < MIN_PORT || parsed > MAX_PORT) {
+    throw new Error(
+      `env-loader: ${source} supplied an invalid port "${text}". A port must be an integer ` +
+        `between ${MIN_PORT} and ${MAX_PORT}.`,
+    );
+  }
+
+  return parsed;
+}
+
+/**
+ * Resolves a listener port by the flag > env var > fallback precedence documented above.
+ *
+ * @throws if a tier is present but does not hold a valid port number.
+ */
+export function resolvePort(options: ResolvePortOptions): number {
+  const env = options.env ?? process.env;
+
+  const flagValue = presentValue(options.flag);
+  if (flagValue !== undefined) {
+    return parsePort(flagValue, "--port");
+  }
+
+  const envValue = presentValue(env[options.envVar]);
+  if (envValue !== undefined) {
+    return parsePort(envValue, options.envVar);
+  }
+
+  return parsePort(String(options.fallback), `fallback for ${options.envVar}`);
+}

--- a/libs/ts-env-loader/src/port-resolver.ts
+++ b/libs/ts-env-loader/src/port-resolver.ts
@@ -1,13 +1,20 @@
 /**
  * The repo-wide runtime port contract, shared by every port-binding app in this repository and
- * mirrored one-for-one by `libs/fsharp-env-loader`'s `PortResolver` module so the TypeScript and
- * F# services resolve their listener port by identical rules.
+ * mirrored by `libs/fsharp-env-loader`'s `PortResolver` module, so a TypeScript service and an F#
+ * service accept and reject exactly the same port values.
+ *
+ * What is mirrored: the three-tier precedence below, the grammar of a valid port (plain decimal
+ * digits, 1-65535 — see `parsePort`), blank-falls-through, and fail-loudly-on-malformed. What is
+ * NOT mirrored: the exact error wording, and `beavernest-be`, which composes the contract
+ * differently — its own `HttpConfiguration.parse` owns the env-var and default tiers (under the
+ * same grammar) and layers `PortResolver` on top for the flag tier alone, because its listener
+ * address carries a loopback-versus-wildcard guard the shared resolver knows nothing about.
  *
  * Precedence, highest first:
  *   1. CLI flag  — an explicit `--port` passed at start time.
  *   2. Env var   — the app's own prefixed variable (e.g. `OSE_WWW_PORT`), never a bare `PORT`.
  *                  A prefixed name is what lets one shell hold every app's port at once; see
- *                  `repo-governance/conventions/security/secrets-and-env-standards/naming-standard.md`.
+ *                  `repo-governance/conventions/security/secrets-and-env-standards/environment-variable-naming-standard.md`.
  *   3. Fallback  — the app's compiled-in default, which is also the value documented in
  *                  `docs/reference/web-sites.md`.
  *
@@ -52,11 +59,17 @@ function presentValue(value: string | number | undefined): string | undefined {
   return text.length > 0 ? text : undefined;
 }
 
+/** Matches plain decimal digits only — the same grammar F#'s `NumberStyles.None` admits. */
+const DECIMAL_ONLY = /^[0-9]+$/;
+
 /** Parses one tier's value, throwing with the tier's name so the error says which knob was wrong. */
 function parsePort(text: string, source: string): number {
-  // Number() is deliberate over parseInt(): parseInt("3100abc") returns 3100, silently accepting a
-  // typo'd value, whereas Number("3100abc") is NaN and gets rejected below.
-  const parsed = Number(text);
+  // The digits-only gate comes first because Number() alone is too permissive for a port: it accepts
+  // "0x10" (16), "0b1010" (10), "1e3" (1000) and "+3100", none of which is a port designation anyone
+  // means to write. F#'s twin rejects all four via NumberStyles.None, so admitting them here would
+  // give the two resolvers different notions of a valid port. Number() is still preferred over
+  // parseInt() for the conversion itself: parseInt("3100abc") silently returns 3100.
+  const parsed = DECIMAL_ONLY.test(text) ? Number(text) : Number.NaN;
 
   if (!Number.isInteger(parsed) || parsed < MIN_PORT || parsed > MAX_PORT) {
     throw new Error(

--- a/libs/ts-env-loader/src/port-resolver.unit.test.ts
+++ b/libs/ts-env-loader/src/port-resolver.unit.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Step definitions for ts-env-loader's runtime port resolution feature.
+ *
+ * Covers: specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature
+ *
+ * Every scenario drives `resolvePort()` with an isolated `env` record (a plain object, never the
+ * real `process.env`) so the suite cannot be perturbed by, or perturb, this process's environment.
+ *
+ * These scenarios are deliberately mirrored one-for-one by
+ * `libs/fsharp-env-loader/tests/unit/Tests/PortResolverTests.fs`. The two implementations are only
+ * "the same mechanism" if they agree case by case, so the pairing is load-bearing — a scenario
+ * added here without its F# twin means the repo has two port contracts, not one.
+ */
+import path from "path";
+import { loadFeature, describeFeature } from "@amiceli/vitest-cucumber";
+import { expect } from "vitest";
+import { resolvePort, type EnvRecord } from "./index";
+
+const feature = await loadFeature(
+  path.resolve(__dirname, "../../../specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature"),
+);
+
+describeFeature(feature, ({ Scenario, ScenarioOutline }) => {
+  Scenario("The CLI flag outranks every other source", ({ Given, And, When, Then }) => {
+    let env: EnvRecord = {};
+    let envVar = "";
+    let fallback = 0;
+    let resolved = 0;
+
+    Given('the app declares the prefixed variable "OSE_WWW_PORT" with fallback 3100', () => {
+      envVar = "OSE_WWW_PORT";
+      fallback = 3100;
+    });
+
+    And('the environment sets "OSE_WWW_PORT" to "4000"', () => {
+      env = { OSE_WWW_PORT: "4000" };
+    });
+
+    When('the port resolves with a "--port" flag of "5000"', () => {
+      resolved = resolvePort({ flag: "5000", envVar, fallback, env });
+    });
+
+    // @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:The CLI flag outranks every other source
+    Then("the resolved port is 5000", () => {
+      expect(resolved).toBe(5000);
+    });
+  });
+
+  Scenario("The prefixed variable outranks the fallback", ({ Given, And, When, Then }) => {
+    let env: EnvRecord = {};
+    let envVar = "";
+    let fallback = 0;
+    let resolved = 0;
+
+    Given('the app declares the prefixed variable "OSE_WWW_PORT" with fallback 3100', () => {
+      envVar = "OSE_WWW_PORT";
+      fallback = 3100;
+    });
+
+    And('the environment sets "OSE_WWW_PORT" to "4000"', () => {
+      env = { OSE_WWW_PORT: "4000" };
+    });
+
+    When('the port resolves with no "--port" flag', () => {
+      resolved = resolvePort({ envVar, fallback, env });
+    });
+
+    // @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:The prefixed variable outranks the fallback
+    Then("the resolved port is 4000", () => {
+      expect(resolved).toBe(4000);
+    });
+  });
+
+  Scenario("The fallback applies when nothing else supplies a port", ({ Given, And, When, Then }) => {
+    let env: EnvRecord = {};
+    let envVar = "";
+    let fallback = 0;
+    let resolved = 0;
+
+    Given('the app declares the prefixed variable "OSE_WWW_PORT" with fallback 3100', () => {
+      envVar = "OSE_WWW_PORT";
+      fallback = 3100;
+    });
+
+    And('the environment does not set "OSE_WWW_PORT"', () => {
+      env = {};
+    });
+
+    When('the port resolves with no "--port" flag', () => {
+      resolved = resolvePort({ envVar, fallback, env });
+    });
+
+    // @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:The fallback applies when nothing else supplies a port
+    Then("the resolved port is 3100", () => {
+      expect(resolved).toBe(3100);
+    });
+  });
+
+  Scenario("A bare PORT variable never moves the listener", ({ Given, And, When, Then }) => {
+    let env: EnvRecord = {};
+    let envVar = "";
+    let fallback = 0;
+    let resolved = 0;
+
+    Given('the app declares the prefixed variable "OSE_WWW_PORT" with fallback 3100', () => {
+      envVar = "OSE_WWW_PORT";
+      fallback = 3100;
+    });
+
+    And('the environment sets "PORT" to "4000"', () => {
+      env = { PORT: "4000" };
+    });
+
+    And('the environment does not set "OSE_WWW_PORT"', () => {
+      expect(env["OSE_WWW_PORT"]).toBeUndefined();
+    });
+
+    When('the port resolves with no "--port" flag', () => {
+      resolved = resolvePort({ envVar, fallback, env });
+    });
+
+    // @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:A bare PORT variable never moves the listener
+    // A bare PORT is Next.js's own knob; this repo deliberately does NOT honour it as a port
+    // source, so that one exported PORT cannot silently retarget every app at once.
+    Then("the resolved port is 3100", () => {
+      expect(resolved).toBe(3100);
+    });
+  });
+
+  ScenarioOutline("A blank value at a tier falls through to the next tier", ({ Given, And, When, Then }, examples) => {
+    const flagValue = String(examples["flagValue"] ?? "");
+    const envValue = String(examples["envValue"] ?? "");
+    const expected = Number(examples["expected"]);
+
+    let env: EnvRecord = {};
+    let envVar = "";
+    let fallback = 0;
+    let resolved = 0;
+
+    Given('the app declares the prefixed variable "OSE_WWW_PORT" with fallback 3100', () => {
+      envVar = "OSE_WWW_PORT";
+      fallback = 3100;
+    });
+
+    And('the environment sets "OSE_WWW_PORT" to "<envValue>"', () => {
+      env = { OSE_WWW_PORT: envValue };
+    });
+
+    When('the port resolves with a "--port" flag of "<flagValue>"', () => {
+      resolved = resolvePort({ flag: flagValue, envVar, fallback, env });
+    });
+
+    // @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:A blank value at a tier falls through to the next tier
+    Then("the resolved port is <expected>", () => {
+      expect(resolved).toBe(expected);
+    });
+  });
+
+  ScenarioOutline(
+    "A present but malformed port fails loudly instead of falling through",
+    ({ Given, And, When, Then }, examples) => {
+      const flagValue = String(examples["flagValue"] ?? "");
+
+      let env: EnvRecord = {};
+      let envVar = "";
+      let fallback = 0;
+      let thrown: unknown;
+
+      Given('the app declares the prefixed variable "OSE_WWW_PORT" with fallback 3100', () => {
+        envVar = "OSE_WWW_PORT";
+        fallback = 3100;
+      });
+
+      And('the environment does not set "OSE_WWW_PORT"', () => {
+        env = {};
+      });
+
+      When('the port resolves with a "--port" flag of "<flagValue>"', () => {
+        thrown = undefined;
+        try {
+          resolvePort({ flag: flagValue, envVar, fallback, env });
+        } catch (error) {
+          thrown = error;
+        }
+      });
+
+      // @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:A present but malformed port fails loudly instead of falling through
+      Then('resolution throws, naming "--port" and the valid range', () => {
+        expect(thrown).toBeInstanceOf(Error);
+        expect((thrown as Error).message).toContain("--port");
+        expect((thrown as Error).message).toContain("65535");
+      });
+    },
+  );
+
+  Scenario("A malformed prefixed variable names that variable in the error", ({ Given, And, When, Then }) => {
+    let env: EnvRecord = {};
+    let envVar = "";
+    let fallback = 0;
+    let thrown: unknown;
+
+    Given('the app declares the prefixed variable "OSE_WWW_PORT" with fallback 3100', () => {
+      envVar = "OSE_WWW_PORT";
+      fallback = 3100;
+    });
+
+    And('the environment sets "OSE_WWW_PORT" to "not-a-port"', () => {
+      env = { OSE_WWW_PORT: "not-a-port" };
+    });
+
+    When('the port resolves with no "--port" flag', () => {
+      thrown = undefined;
+      try {
+        resolvePort({ envVar, fallback, env });
+      } catch (error) {
+        thrown = error;
+      }
+    });
+
+    // @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:A malformed prefixed variable names that variable in the error
+    Then('resolution throws, naming "OSE_WWW_PORT" and the valid range', () => {
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as Error).message).toContain("OSE_WWW_PORT");
+      expect((thrown as Error).message).toContain("65535");
+    });
+  });
+});

--- a/libs/ts-env-loader/src/port-resolver.unit.test.ts
+++ b/libs/ts-env-loader/src/port-resolver.unit.test.ts
@@ -193,6 +193,38 @@ describeFeature(feature, ({ Scenario, ScenarioOutline }) => {
     },
   );
 
+  Scenario("An out-of-range compiled-in fallback is caught at startup", ({ Given, And, When, Then }) => {
+    let env: EnvRecord = {};
+    let envVar = "";
+    let fallback = 0;
+    let thrown: unknown;
+
+    Given('the app declares the prefixed variable "OSE_WWW_PORT" with fallback 70000', () => {
+      envVar = "OSE_WWW_PORT";
+      fallback = 70000;
+    });
+
+    And('the environment does not set "OSE_WWW_PORT"', () => {
+      env = {};
+    });
+
+    When('the port resolves with no "--port" flag', () => {
+      thrown = undefined;
+      try {
+        resolvePort({ envVar, fallback, env });
+      } catch (error) {
+        thrown = error;
+      }
+    });
+
+    // @covers specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature:An out-of-range compiled-in fallback is caught at startup
+    Then('resolution throws, naming "OSE_WWW_PORT" and the valid range', () => {
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as Error).message).toContain("OSE_WWW_PORT");
+      expect((thrown as Error).message).toContain("65535");
+    });
+  });
+
   Scenario("A malformed prefixed variable names that variable in the error", ({ Given, And, When, Then }) => {
     let env: EnvRecord = {};
     let envVar = "";

--- a/repo-config.yml
+++ b/repo-config.yml
@@ -298,7 +298,7 @@ env-contract:
       kind: app
       lang: typescript
       allowlist:
-        - PORT # framework-reserved Next.js dev-server port
+        - PORT # set by scripts/next-with-port.mjs after resolution; not an override source
         # Resolved by scripts/next-with-port.mjs before the app process starts, so it
         # is read by the launcher rather than by this app's own source.
         - OSE_WWW_PORT
@@ -308,7 +308,7 @@ env-contract:
       kind: app
       lang: typescript
       allowlist:
-        - PORT
+        - PORT # set by scripts/next-with-port.mjs after resolution; not an override source
         # Resolved by scripts/next-with-port.mjs before the app process starts, so it
         # is read by the launcher rather than by this app's own source.
         - AYOKODING_WWW_PORT
@@ -319,7 +319,7 @@ env-contract:
       kind: app
       lang: typescript
       allowlist:
-        - PORT # framework-reserved Next.js dev-server port
+        - PORT # set by scripts/next-with-port.mjs after resolution; not an override source
         # Resolved by scripts/next-with-port.mjs before the app process starts, so it
         # is read by the launcher rather than by this app's own source.
         - ORGANICLEVER_WWW_PORT
@@ -329,7 +329,7 @@ env-contract:
       kind: app
       lang: typescript
       allowlist:
-        - PORT
+        - PORT # set by scripts/next-with-port.mjs after resolution; not an override source
         # Resolved by scripts/next-with-port.mjs before the app process starts, so it
         # is read by the launcher rather than by this app's own source.
         - ORGANICLEVER_APP_WEB_PORT
@@ -339,7 +339,7 @@ env-contract:
       kind: app
       lang: typescript
       allowlist:
-        - PORT
+        - PORT # set by scripts/next-with-port.mjs after resolution; not an override source
         # Resolved by scripts/next-with-port.mjs before the app process starts, so it
         # is read by the launcher rather than by this app's own source.
         - OSE_APP_WEB_PORT
@@ -349,7 +349,7 @@ env-contract:
       kind: app
       lang: typescript
       allowlist:
-        - PORT
+        - PORT # set by scripts/next-with-port.mjs after resolution; not an override source
         # Resolved by scripts/next-with-port.mjs before the app process starts, so it
         # is read by the launcher rather than by this app's own source.
         - WAHIDYANKF_WWW_PORT

--- a/repo-config.yml
+++ b/repo-config.yml
@@ -271,7 +271,8 @@ env-contract:
       allowlist:
         # Forward-declared config not yet consumed by the Phase 1 F# shell
         # (wired in later phases); declared in .env.example ahead of use.
-        - ORGANICLEVER_BE_PORT
+        # ORGANICLEVER_BE_PORT is no longer listed here: it is now genuinely
+        # read, via PortResolver in Program.fs.
         - ORGANICLEVER_BE_CORS_ORIGINS
         # Tier-selection control var (which .env.<tier> file to load), not an
         # app config value — same treatment as PORT/HOSTNAME for the TS apps.
@@ -282,8 +283,9 @@ env-contract:
       lang: fsharp
       allowlist:
         # Forward-declared config not yet consumed by the Phase 1 F# shell
-        # (port/CORS + OpenRouter wired in later phases); declared ahead of use.
-        - OSE_BE_PORT
+        # (CORS + OpenRouter wired in later phases); declared ahead of use.
+        # OSE_BE_PORT is no longer listed here: it is now genuinely read, via
+        # PortResolver in Program.fs.
         - OSE_BE_CORS_ORIGINS
         - OSE_BE_OPENROUTER_API_KEY
         - OSE_BE_OPENROUTER_MODEL
@@ -297,6 +299,9 @@ env-contract:
       lang: typescript
       allowlist:
         - PORT # framework-reserved Next.js dev-server port
+        # Resolved by scripts/next-with-port.mjs before the app process starts, so it
+        # is read by the launcher rather than by this app's own source.
+        - OSE_WWW_PORT
         - HOSTNAME # framework-reserved Next.js dev-server hostname
 
     - root: apps/ayokoding-www
@@ -304,6 +309,9 @@ env-contract:
       lang: typescript
       allowlist:
         - PORT
+        # Resolved by scripts/next-with-port.mjs before the app process starts, so it
+        # is read by the launcher rather than by this app's own source.
+        - AYOKODING_WWW_PORT
         - HOSTNAME
         - NODE_ENV # Node-reserved; read by static client-data refresh test guard
 
@@ -312,6 +320,9 @@ env-contract:
       lang: typescript
       allowlist:
         - PORT # framework-reserved Next.js dev-server port
+        # Resolved by scripts/next-with-port.mjs before the app process starts, so it
+        # is read by the launcher rather than by this app's own source.
+        - ORGANICLEVER_WWW_PORT
         - HOSTNAME # framework-reserved Next.js dev-server hostname
 
     - root: apps/organiclever-app-web
@@ -319,6 +330,9 @@ env-contract:
       lang: typescript
       allowlist:
         - PORT
+        # Resolved by scripts/next-with-port.mjs before the app process starts, so it
+        # is read by the launcher rather than by this app's own source.
+        - ORGANICLEVER_APP_WEB_PORT
         - HOSTNAME
 
     - root: apps/ose-app-web
@@ -326,6 +340,9 @@ env-contract:
       lang: typescript
       allowlist:
         - PORT
+        # Resolved by scripts/next-with-port.mjs before the app process starts, so it
+        # is read by the launcher rather than by this app's own source.
+        - OSE_APP_WEB_PORT
         - HOSTNAME
 
     - root: apps/wahidyankf-www
@@ -333,6 +350,9 @@ env-contract:
       lang: typescript
       allowlist:
         - PORT
+        # Resolved by scripts/next-with-port.mjs before the app process starts, so it
+        # is read by the launcher rather than by this app's own source.
+        - WAHIDYANKF_WWW_PORT
         - HOSTNAME
 
     - root: apps/beavernest-be

--- a/repo-governance/conventions/security/secrets-and-env-standards/environment-variable-naming-standard.md
+++ b/repo-governance/conventions/security/secrets-and-env-standards/environment-variable-naming-standard.md
@@ -51,20 +51,15 @@ resolves its listener port by one precedence rule:
 A value that is present but malformed is a hard startup error, never a silent fall back to the
 default: an operator who asked for a specific port must not get a different one quietly.
 
-**A port variable therefore takes the app prefix — including on the web tier.** This reverses the
-older rule that treated `PORT` as framework-reserved for webs. Next's CLI does read a bare `PORT`
-natively, and for that reason a single exported `PORT` used to retarget every app in the shell at
-once; the prefixed name is what lets one shell hold all nine ports without collision. The
-frameworks are bridged rather than fought:
+**A port variable takes the app prefix — including on the web tier**, reversing the older rule that
+treated `PORT` as framework-reserved for webs. A single exported `PORT` used to retarget every app
+at once; the prefixed name is what lets one shell hold all nine ports. The frameworks are bridged,
+not fought: `scripts/next-with-port.mjs` resolves the port and then sets `process.env.PORT` itself
+before starting Next, and `libs/fsharp-env-loader`'s `PortResolver` shapes the `UseUrls` value for
+the F# backends. A bare `PORT` is **not** an override source for either. `HOSTNAME` is unaffected.
 
-- **Next.js** — `scripts/next-with-port.mjs` resolves the port and then assigns `process.env.PORT`
-  before handing off to `next` or to the standalone `server.js`. Next still sees the `PORT` it
-  wants; nothing in the repo has to be configured with it.
-- **F#/ASP.NET** — `libs/fsharp-env-loader`'s `PortResolver` resolves the port and shapes the
-  listener URL for `UseUrls`.
-
-The two resolvers are deliberate mirrors of each other, and their scenarios are paired one-for-one
-so the contract cannot drift into two lookalike implementations. A bare `PORT` is **not** honoured
-as a port source by either.
-
-`HOSTNAME` remains framework-reserved and is unaffected.
+A valid port is plain decimal digits in 1-65535. The TypeScript and F# resolvers are deliberate
+mirrors with scenarios paired one-for-one, so both accept and reject exactly the same values.
+`beavernest-be` composes them differently — its own `HttpConfiguration` owns the variable and default
+tiers under that same grammar and calls `PortResolver` for the flag tier alone, because its listener
+address carries a loopback-versus-wildcard guard.

--- a/repo-governance/conventions/security/secrets-and-env-standards/environment-variable-naming-standard.md
+++ b/repo-governance/conventions/security/secrets-and-env-standards/environment-variable-naming-standard.md
@@ -21,7 +21,7 @@ created: 2026-06-10
 | Class                      | Rule                                        | Example                                           |
 | -------------------------- | ------------------------------------------- | ------------------------------------------------- |
 | App-defined value          | `SCREAMING_SNAKE`, per-app prefix           | `ORGANICLEVER_BE_PORT`, `OSE_BE_OPENROUTER_MODEL` |
-| Framework-reserved         | Keep the framework's required name          | `NEXT_PUBLIC_*`, Next.js `PORT`                   |
+| Framework-reserved         | Keep the framework's required name          | `NEXT_PUBLIC_*`, `NODE_ENV`                       |
 | Shared service connection  | Unprefixed, conventional name               | `DATABASE_URL`                                    |
 | Environment tier in a name | **Forbidden** (keys identical across tiers) | not `PROD_DATABASE_URL`                           |
 
@@ -33,12 +33,38 @@ The **per-app prefix** is the app's Nx project name upcased with `_` separators:
 | Name            | Why exempt                                                                    |
 | --------------- | ----------------------------------------------------------------------------- |
 | `NEXT_PUBLIC_*` | Framework-required (Next.js browser-exposure prefix)                          |
-| `PORT`          | Platform convention (host/PaaS injects it) — **webs only**                    |
 | `NODE_ENV`      | Node reserved                                                                 |
 | `DATABASE_URL`  | Cross-ecosystem convention; prefixing breaks every tool that reads it by name |
 | `HOSTNAME`      | Platform convention for Next.js dev server                                    |
 
-**Critical asymmetry**: The **Next.js dev server** reads `PORT` natively — renaming it to
-`OSE_WWW_PORT` would break `nx dev ose-www`. Rust **backend** ports are app-defined code, so they
-**do** take the prefix (`ORGANICLEVER_BE_PORT`, `OSE_BE_PORT`). This is the single most
-error-prone point of the naming standard.
+## Runtime port contract
+
+Every port-binding app in this repository — the six Next.js sites and the three F# backends alike —
+resolves its listener port by one precedence rule:
+
+1. An explicit **`--port` flag** passed at start time.
+2. The app's **prefixed variable** (`OSE_WWW_PORT`, `AYOKODING_WWW_PORT`, `OSE_BE_PORT`,
+   `BEAVERNEST_BE_HTTP_LISTEN_PORT`, …), formed by the per-app prefix rule above.
+3. The app's **compiled-in default**, which is also the value recorded in
+   [web-sites.md](../../../../docs/reference/web-sites.md).
+
+A value that is present but malformed is a hard startup error, never a silent fall back to the
+default: an operator who asked for a specific port must not get a different one quietly.
+
+**A port variable therefore takes the app prefix — including on the web tier.** This reverses the
+older rule that treated `PORT` as framework-reserved for webs. Next's CLI does read a bare `PORT`
+natively, and for that reason a single exported `PORT` used to retarget every app in the shell at
+once; the prefixed name is what lets one shell hold all nine ports without collision. The
+frameworks are bridged rather than fought:
+
+- **Next.js** — `scripts/next-with-port.mjs` resolves the port and then assigns `process.env.PORT`
+  before handing off to `next` or to the standalone `server.js`. Next still sees the `PORT` it
+  wants; nothing in the repo has to be configured with it.
+- **F#/ASP.NET** — `libs/fsharp-env-loader`'s `PortResolver` resolves the port and shapes the
+  listener URL for `UseUrls`.
+
+The two resolvers are deliberate mirrors of each other, and their scenarios are paired one-for-one
+so the contract cannot drift into two lookalike implementations. A bare `PORT` is **not** honoured
+as a port source by either.
+
+`HOSTNAME` remains framework-reserved and is unaffected.

--- a/scripts/next-with-port.mjs
+++ b/scripts/next-with-port.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * Single entrypoint that gives every Next.js app in this repo the same runtime port contract as
+ * the F# backends: an explicit `--port` flag wins, then the app's own prefixed environment
+ * variable, then its compiled-in default.
+ *
+ * Why a wrapper exists at all: Next's CLI resolves its port from `--port` or a bare `PORT`, and an
+ * explicit `--port` on the command line always outranks `PORT`. Every app's `project.json` used to
+ * pass `--port <literal>`, which meant no environment variable could ever move the listener. Worse,
+ * four of the six container images run Next's STANDALONE `server.js`, which reads `process.env.PORT`
+ * and parses no flags at all. One wrapper that resolves first and then hands the answer to whichever
+ * server shape follows is what makes local development and the image behave identically.
+ *
+ * Usage:
+ *   node scripts/next-with-port.mjs dev   --env OSE_WWW_PORT --default 3100 [--port 4000]
+ *   node scripts/next-with-port.mjs start --env OSE_WWW_PORT --default 3100 [--port 4000]
+ *   node scripts/next-with-port.mjs --env OSE_WWW_PORT --default 3100 --server apps/ose-www/server.js
+ *
+ * The `--server` form is the standalone-image path: it sets `process.env.PORT` and then imports the
+ * generated server, which is the only knob that server exposes.
+ *
+ * CONTAINER REQUIREMENT: the resolver is imported by a path relative to THIS file, so any image
+ * using this wrapper must COPY both `scripts/next-with-port.mjs` and
+ * `libs/ts-env-loader/src/port-resolver.ts`, preserving their relative layout. `port-resolver.ts`
+ * is deliberately dependency-free (no `dotenv`, no `node:fs`) so it needs no `node_modules` — see
+ * its own header. Node strips the TypeScript types natively, so there is no build step.
+ */
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { resolvePort } from "../libs/ts-env-loader/src/port-resolver.ts";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Reads `--name value` out of argv. Deliberately minimal: this wrapper takes a fixed, known set of
+ * options from project.json and Dockerfiles, not arbitrary user input, so a full parser would be
+ * more machinery than the job needs.
+ */
+function option(argv, name) {
+  const index = argv.indexOf(`--${name}`);
+  if (index !== -1 && index + 1 < argv.length) {
+    return argv[index + 1];
+  }
+  const joined = argv.find((arg) => arg.startsWith(`--${name}=`));
+  return joined === undefined ? undefined : joined.slice(`--${name}=`.length);
+}
+
+function fail(message) {
+  process.stderr.write(`next-with-port: ${message}\n`);
+  process.exit(1);
+}
+
+const argv = process.argv.slice(2);
+const mode = argv[0] !== undefined && !argv[0].startsWith("--") ? argv[0] : undefined;
+const envVar = option(argv, "env");
+const fallbackRaw = option(argv, "default");
+const serverPath = option(argv, "server");
+const flag = option(argv, "port");
+
+if (envVar === undefined) {
+  fail("missing required --env <PREFIXED_PORT_VARIABLE>");
+}
+if (fallbackRaw === undefined) {
+  fail("missing required --default <port>");
+}
+
+let port;
+try {
+  port = resolvePort({ flag, envVar, fallback: Number(fallbackRaw) });
+} catch (error) {
+  // resolvePort's message already names the offending knob and the legal range.
+  fail(error instanceof Error ? error.message : String(error));
+}
+
+// Next's standalone server and `next start` both read PORT; setting it here means the resolved
+// value reaches either shape without the caller caring which one it got.
+process.env.PORT = String(port);
+
+if (serverPath !== undefined) {
+  // Standalone image path: no child process, no Next CLI — just boot the generated server with the
+  // environment it expects.
+  await import(path.resolve(process.cwd(), serverPath));
+} else {
+  if (mode === undefined) {
+    fail("missing mode: expected `dev` or `start` (or --server <path> for a standalone image)");
+  }
+
+  // Prefer the workspace-local binary so the wrapper does not depend on PATH being set up the way
+  // Nx happens to set it up, and falls back to PATH resolution when there is no local install.
+  const localNext = path.join(process.cwd(), "node_modules", ".bin", "next");
+  const workspaceNext = path.join(scriptDir, "..", "node_modules", ".bin", "next");
+  const nextBin = existsSync(localNext) ? localNext : existsSync(workspaceNext) ? workspaceNext : "next";
+
+  // Everything after the recognised options is forwarded to Next untouched, so app-specific flags
+  // (--turbopack, --experimental-https, -H) keep working.
+  const recognised = new Set(["--env", "--default", "--server", "--port"]);
+  const passthrough = [];
+  for (let index = mode === undefined ? 0 : 1; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (recognised.has(arg)) {
+      index += 1;
+      continue;
+    }
+    if ([...recognised].some((name) => arg.startsWith(`${name}=`))) {
+      continue;
+    }
+    passthrough.push(arg);
+  }
+
+  const child = spawn(nextBin, [mode, "--port", String(port), ...passthrough], {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  // Forward the signals a developer (Ctrl-C) or a container runtime (docker stop) actually sends,
+  // so the Next server shuts down instead of being orphaned when this wrapper exits.
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    process.on(signal, () => child.kill(signal));
+  }
+
+  child.on("exit", (code, signal) => {
+    process.exit(signal !== null ? 1 : (code ?? 0));
+  });
+}

--- a/scripts/next-with-port.mjs
+++ b/scripts/next-with-port.mjs
@@ -19,6 +19,14 @@
  * The `--server` form is the standalone-image path: it sets `process.env.PORT` and then imports the
  * generated server, which is the only knob that server exposes.
  *
+ * PROCESS SHAPE: the `--server` form stays single-process — it imports the standalone server into
+ * this very process. The `dev`/`start` form must spawn, because Next's CLI is a separate binary and
+ * Node has no `execve`, so the wrapper stays resident as the child's parent for the process's whole
+ * life. Only `organiclever-www` and `wahidyankf-www` take that path in a container image (they are
+ * the two apps without `output: "standalone"`), so only those two images carry a second resident
+ * Node process. Signals are forwarded and re-raised so an orchestrator still sees the conventional
+ * 128+N status rather than a synthesised exit code.
+ *
  * CONTAINER REQUIREMENT: the resolver is imported by a path relative to THIS file, so any image
  * using this wrapper must COPY both `scripts/next-with-port.mjs` and
  * `libs/ts-env-loader/src/port-resolver.ts`, preserving their relative layout. `port-resolver.ts`
@@ -122,6 +130,14 @@ if (serverPath !== undefined) {
   }
 
   child.on("exit", (code, signal) => {
-    process.exit(signal !== null ? 1 : (code ?? 0));
+    if (signal !== null) {
+      // Re-raise the same signal against this process rather than exiting 1, so the wrapper reports
+      // the conventional 128+N status. Collapsing every signal to 1 would make a normal `docker
+      // stop` (SIGTERM) look like a crash to any orchestrator reading the container's exit code.
+      process.removeAllListeners(signal);
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 0);
   });
 }

--- a/specs/libs/ts-env-loader/README.md
+++ b/specs/libs/ts-env-loader/README.md
@@ -11,6 +11,11 @@ These specs define the **observable behavior** of the loader: how it resolves th
 variable always wins over a file value, why a missing tier file is not an error, and why a stray
 auto-loaded env file beside a non-local tier file must fail loudly.
 
+They also define the repo-wide **runtime port contract** the loader exposes alongside tier
+loading: how a listener port resolves from an explicit `--port` flag, then the app's prefixed
+variable, then its compiled-in fallback — and why a present-but-malformed value fails loudly
+instead of silently falling back.
+
 ## Structure
 
 ```
@@ -22,7 +27,8 @@ specs/libs/ts-env-loader/
 ├── components/            # C4 L3 component catalogue
 └── behavior/
     └── gherkin/           # Gherkin feature files
-        └── env-loader/
+        ├── env-loader/
+        └── port-resolver/
 ```
 
 ## Status
@@ -30,7 +36,9 @@ specs/libs/ts-env-loader/
 `test:unit` and `test:coverage` are real, already-wired `vitest` targets (see
 `libs/ts-env-loader/project.json`) — every scenario in
 [behavior/gherkin/env-loader/env-loader.feature](./behavior/gherkin/env-loader/env-loader.feature)
-is exercised by `libs/ts-env-loader/src/env-loader.unit.test.ts` via `@amiceli/vitest-cucumber`.
+is exercised by `libs/ts-env-loader/src/env-loader.unit.test.ts`, and every scenario in
+[behavior/gherkin/port-resolver/port-resolver.feature](./behavior/gherkin/port-resolver/port-resolver.feature)
+by `libs/ts-env-loader/src/port-resolver.unit.test.ts` — both via `@amiceli/vitest-cucumber`.
 
 - [Behavior — ts-env-loader](./behavior/README.md)
 - [Components — ts-env-loader](./components/README.md)

--- a/specs/libs/ts-env-loader/behavior/README.md
+++ b/specs/libs/ts-env-loader/behavior/README.md
@@ -29,3 +29,12 @@ feature file, and duplicating it under `specs/libs/fsharp-env-loader/` would cre
 second source of truth the pairing exists to prevent. The F# suite adds a few argv-spelling cases
 (`--port=N`, a trailing bare `--port`) that have no Gherkin counterpart because they concern F#'s
 own `argv` array rather than the shared resolution rule.
+
+**Known gap: the F# markers are not mechanically enforced.** `libs/fsharp-env-loader` has no
+`specs:behavior:coverage` target, so nothing fails if a scenario here is renamed and the F# side goes
+stale — the pairing above was verified by hand. Simply adding the target does not work:
+`behavior-coverage validate` matches Gherkin _step text_ against step definitions, and these xUnit
+tests carry only scenario-level `@covers` markers, so it reports every step as a gap. Closing this
+properly means giving the library a step-definition harness in the shape of
+`libs/fsharp-crane-core/tests/unit/Tests/PdfToMarkdownRoutingSteps.fs` (`[<Given>]`-attributed
+steps), which is its own piece of work rather than a spec-file edit.

--- a/specs/libs/ts-env-loader/behavior/README.md
+++ b/specs/libs/ts-env-loader/behavior/README.md
@@ -2,18 +2,25 @@
 
 Gherkin behavioral specifications for
 [ts-env-loader](../../../../libs/ts-env-loader/README.md), the shared `APP_ENV` tier env-file
-loader.
+loader and the repo-wide runtime port contract it exposes.
 
 ## Structure
 
 ```
 specs/libs/ts-env-loader/behavior/
 └── gherkin/
-    └── env-loader/
-        └── env-loader.feature
+    ├── env-loader/
+    │   └── env-loader.feature
+    └── port-resolver/
+        └── port-resolver.feature
 ```
 
 ## Status
 
-`test:unit` runs the real `vitest` suite (`libs/ts-env-loader/src/env-loader.unit.test.ts`) against
-these scenarios via `@amiceli/vitest-cucumber` — see the top-level [README.md](../README.md).
+`test:unit` runs the real `vitest` suites (`libs/ts-env-loader/src/env-loader.unit.test.ts` and
+`libs/ts-env-loader/src/port-resolver.unit.test.ts`) against these scenarios via
+`@amiceli/vitest-cucumber` — see the top-level [README.md](../README.md).
+
+The port-resolver scenarios are mirrored one-for-one by
+`libs/fsharp-env-loader/tests/unit/Tests/PortResolverTests.fs`, so the TypeScript and F# services
+provably share one port contract rather than two lookalikes.

--- a/specs/libs/ts-env-loader/behavior/README.md
+++ b/specs/libs/ts-env-loader/behavior/README.md
@@ -23,4 +23,9 @@ specs/libs/ts-env-loader/behavior/
 
 The port-resolver scenarios are mirrored one-for-one by
 `libs/fsharp-env-loader/tests/unit/Tests/PortResolverTests.fs`, so the TypeScript and F# services
-provably share one port contract rather than two lookalikes.
+provably accept and reject the same port values. That F# suite carries `@covers` markers pointing at
+the feature file in **this** directory on purpose: the port contract is one contract, so it gets one
+feature file, and duplicating it under `specs/libs/fsharp-env-loader/` would create exactly the
+second source of truth the pairing exists to prevent. The F# suite adds a few argv-spelling cases
+(`--port=N`, a trailing bare `--port`) that have no Gherkin counterpart because they concern F#'s
+own `argv` array rather than the shared resolution rule.

--- a/specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature
+++ b/specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature
@@ -1,0 +1,62 @@
+Feature: Runtime listener port resolution
+  As an operator starting a service
+  I want one precedence rule for the listener port across every app in the repository
+  So that the same flag and the same prefixed variable move the port in local development and in a container alike
+
+  Scenario: The CLI flag outranks every other source
+    Given the app declares the prefixed variable "OSE_WWW_PORT" with fallback 3100
+    And the environment sets "OSE_WWW_PORT" to "4000"
+    When the port resolves with a "--port" flag of "5000"
+    Then the resolved port is 5000
+
+  Scenario: The prefixed variable outranks the fallback
+    Given the app declares the prefixed variable "OSE_WWW_PORT" with fallback 3100
+    And the environment sets "OSE_WWW_PORT" to "4000"
+    When the port resolves with no "--port" flag
+    Then the resolved port is 4000
+
+  Scenario: The fallback applies when nothing else supplies a port
+    Given the app declares the prefixed variable "OSE_WWW_PORT" with fallback 3100
+    And the environment does not set "OSE_WWW_PORT"
+    When the port resolves with no "--port" flag
+    Then the resolved port is 3100
+
+  Scenario: A bare PORT variable never moves the listener
+    Given the app declares the prefixed variable "OSE_WWW_PORT" with fallback 3100
+    And the environment sets "PORT" to "4000"
+    And the environment does not set "OSE_WWW_PORT"
+    When the port resolves with no "--port" flag
+    Then the resolved port is 3100
+
+  Scenario Outline: A blank value at a tier falls through to the next tier
+    Given the app declares the prefixed variable "OSE_WWW_PORT" with fallback 3100
+    And the environment sets "OSE_WWW_PORT" to "<envValue>"
+    When the port resolves with a "--port" flag of "<flagValue>"
+    Then the resolved port is <expected>
+
+    Examples:
+      | flagValue | envValue | expected |
+      |           | 4000     | 4000     |
+      |           |          | 3100     |
+      | 5000      |          | 5000     |
+
+  Scenario Outline: A present but malformed port fails loudly instead of falling through
+    Given the app declares the prefixed variable "OSE_WWW_PORT" with fallback 3100
+    And the environment does not set "OSE_WWW_PORT"
+    When the port resolves with a "--port" flag of "<flagValue>"
+    Then resolution throws, naming "--port" and the valid range
+
+    Examples:
+      | flagValue |
+      | 0         |
+      | 65536     |
+      | abc       |
+      | 3100abc   |
+      | 31.5      |
+      | -1        |
+
+  Scenario: A malformed prefixed variable names that variable in the error
+    Given the app declares the prefixed variable "OSE_WWW_PORT" with fallback 3100
+    And the environment sets "OSE_WWW_PORT" to "not-a-port"
+    When the port resolves with no "--port" flag
+    Then resolution throws, naming "OSE_WWW_PORT" and the valid range

--- a/specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature
+++ b/specs/libs/ts-env-loader/behavior/gherkin/port-resolver/port-resolver.feature
@@ -54,9 +54,19 @@ Feature: Runtime listener port resolution
       | 3100abc   |
       | 31.5      |
       | -1        |
+      | 0x10      |
+      | 0b1010    |
+      | 1e3       |
+      | +3100     |
 
   Scenario: A malformed prefixed variable names that variable in the error
     Given the app declares the prefixed variable "OSE_WWW_PORT" with fallback 3100
     And the environment sets "OSE_WWW_PORT" to "not-a-port"
+    When the port resolves with no "--port" flag
+    Then resolution throws, naming "OSE_WWW_PORT" and the valid range
+
+  Scenario: An out-of-range compiled-in fallback is caught at startup
+    Given the app declares the prefixed variable "OSE_WWW_PORT" with fallback 70000
+    And the environment does not set "OSE_WWW_PORT"
     When the port resolves with no "--port" flag
     Then resolution throws, naming "OSE_WWW_PORT" and the valid range


### PR DESCRIPTION
## What

Every port-binding app in this repo now resolves its listener port through one identical contract:

```
--port <n>   >   <APP>_PORT env var   >   compiled-in default
```

A malformed value is a hard startup error at every layer — never a silent fallback to the default.

Nine apps, one mechanism:

| App | Variable | Default |
| --- | --- | --- |
| ose-www | `OSE_WWW_PORT` | 3100 |
| ayokoding-www | `AYOKODING_WWW_PORT` | 3101 |
| organiclever-www | `ORGANICLEVER_WWW_PORT` | 3200 |
| wahidyankf-www | `WAHIDYANKF_WWW_PORT` | 3201 |
| organiclever-app-web | `ORGANICLEVER_APP_WEB_PORT` | 3202 |
| ose-app-web | `OSE_APP_WEB_PORT` | 3300 |
| organiclever-be | `ORGANICLEVER_BE_PORT` | 8202 |
| ose-be | `OSE_BE_PORT` | 8302 |
| beavernest-be | `BEAVERNEST_BE_HTTP_LISTEN_PORT` | 19300 |

## How

Two resolvers, mirrored signatures, living in the libraries that already own env loading — no new
projects:

- `libs/ts-env-loader/src/port-resolver.ts` — deliberately dependency-free, so a container
  entrypoint can import it without `dotenv` present (Next.js standalone output prunes
  `node_modules`).
- `libs/fsharp-env-loader/src/PortResolver.fs` — plus `listenUrl`, which shapes the bind host from
  `DOTNET_RUNNING_IN_CONTAINER` (`localhost` on a dev box, `+` inside an image).

`scripts/next-with-port.mjs` is the single entrypoint for all six Next.js apps, used identically in
`nx dev`, `nx start`, and every `Dockerfile` `CMD`. That uniformity is what makes the flag work in a
container at all: standalone `server.js` parses no arguments and reads only `process.env.PORT`, so
the wrapper resolves the port first and sets `PORT` before importing the server. Each image now
COPYs the wrapper and the resolver, preserving their relative layout.

Both F# backends pass the resolved URL to `.UseUrls()`, which outranks `ASPNETCORE_URLS`;
`beavernest-be`'s command dispatcher learned to treat a bare `--port` as "serve", so its
`backup`/`integrity`/`restore` subcommands still parse unchanged.

## Also in here

- Fixes two genuine host-port collisions between this repo's e2e Compose stacks (`ose-be` and
  `organiclever-be` both mapped Postgres 5433 and NATS 4223).
- Corrects `apps/ose-app-web/Dockerfile`, which pointed at `ose-be:8202` — `organiclever-be`'s port.
- Documents this repo's own ports in `docs/reference/web-sites.md` and the naming contract in
  `repo-governance/conventions/security/secrets-and-env-standards/`.

## Tests

- 7 new TS unit scenarios and 27 new F# unit cases, all traced to new Gherkin under
  `specs/libs/*/behavior/gherkin/`.
- `beavernest-be` coverage helpers moved out of the `ExcludeByFile`'d `Program.fs` into
  `Domain/HttpConfiguration.fs` so they are reachable; coverage scoped to `[BeaverNestBe]*` and
  passing at 92.27% over 96 tests.
- Pre-push gate green: `test:quick` across 23 affected projects, plus lint, `compat:min-version`,
  spec structure/behaviour coverage, and `rhino-cli env validate` with no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
