### PR TITLE
docs(governance): rank Playwright MCP first for browser verification

### DIFF
--- a/.claude/skills/web-testing-design-fidelity/reference/browser-driving.md
+++ b/.claude/skills/web-testing-design-fidelity/reference/browser-driving.md
@@ -3,8 +3,8 @@
 ## How to Drive the Browser
 
 Before browser-facing verification, discover the real-browser integrations installed on the machine
-and confirm which are healthy and callable in the current harness. Prefer Chrome/Chromium through
-Chrome DevTools MCP or Playwright MCP; if neither is available, use an equivalent installed
+and confirm which are healthy and callable in the current harness. Prefer Playwright MCP; if it is
+unavailable, use Chrome DevTools MCP; if neither is available, use an equivalent installed
 browser-driving tool. Record the selected tool, any fallback, browser/version when available, and
 capability gaps in the verification evidence. Static source, fetched HTML, WebFetch, and curl
 inspection are useful baselines, but do not count as live-browser verification when a working browser

--- a/.claude/skills/web-testing-exploratory-methodology/reference/browser-driving.md
+++ b/.claude/skills/web-testing-exploratory-methodology/reference/browser-driving.md
@@ -1,8 +1,8 @@
 # How to Drive the Browser
 
 Before browser-facing verification, discover the real-browser integrations installed on the machine
-and confirm which are healthy and callable in the current harness. Prefer Chrome/Chromium through
-Chrome DevTools MCP or Playwright MCP; if neither is available, use an equivalent installed
+and confirm which are healthy and callable in the current harness. Prefer Playwright MCP; if it is
+unavailable, use Chrome DevTools MCP; if neither is available, use an equivalent installed
 browser-driving tool. Record the selected tool, any fallback, browser/version when available, and
 capability gaps in the verification evidence. Static source, fetched HTML, WebFetch, and curl
 inspection are useful baselines, but do not count as live-browser verification when a working browser

--- a/.claude/skills/web-testing-usability-heuristics/reference/browser-driving.md
+++ b/.claude/skills/web-testing-usability-heuristics/reference/browser-driving.md
@@ -1,8 +1,8 @@
 # How to Drive the Browser
 
 Before browser-facing verification, discover the real-browser integrations installed on the machine
-and confirm which are healthy and callable in the current harness. Prefer Chrome/Chromium through
-Chrome DevTools MCP or Playwright MCP; if neither is available, use an equivalent installed
+and confirm which are healthy and callable in the current harness. Prefer Playwright MCP; if it is
+unavailable, use Chrome DevTools MCP; if neither is available, use an equivalent installed
 browser-driving tool. Record the selected tool, any fallback, browser/version when available, and
 capability gaps in the verification evidence. Static source, fetched HTML, WebFetch, and curl
 inspection are useful baselines, but do not count as live-browser verification when a working browser

--- a/repo-governance/development/quality/manual-behavioral-verification/tools-and-automation.md
+++ b/repo-governance/development/quality/manual-behavioral-verification/tools-and-automation.md
@@ -16,7 +16,7 @@ when_to_use: "Use when locating a manual-verification tool."
 
 # Tools and Automation
 
-- **Browser MCP tools**: Discover installed integrations first; prefer Chrome DevTools MCP or
-  Playwright MCP, then equivalent available real-browser tooling
+- **Browser MCP tools**: Discover installed integrations first; prefer Playwright MCP, then Chrome
+  DevTools MCP, then equivalent available real-browser tooling
 - **curl**: Available via Bash for API verification
 - **jq**: Available via Bash for JSON response inspection

--- a/repo-governance/development/quality/manual-behavioral-verification/ui-verification.md
+++ b/repo-governance/development/quality/manual-behavioral-verification/ui-verification.md
@@ -17,8 +17,8 @@ when_to_use: "Use when preparing to manually verify a UI change."
 # UI Verification
 
 Before browser-facing verification, discover the real-browser integrations installed on the machine
-and confirm which are healthy and callable in the current harness. Prefer Chrome/Chromium through
-Chrome DevTools MCP or Playwright MCP; if neither is available, use an equivalent installed
+and confirm which are healthy and callable in the current harness. Prefer Playwright MCP; if it is
+unavailable, use Chrome DevTools MCP; if neither is available, use an equivalent installed
 browser-driving tool. Record the selected tool, any fallback, browser/version when available, and
 capability gaps in the verification evidence. Static source, fetched HTML, WebFetch, and curl
 inspection are useful baselines, but do not count as live-browser verification when a working browser

--- a/repo-governance/workflows/web/web-ux-test-fixing-planning/phase-0-pre-flight.md
+++ b/repo-governance/workflows/web/web-ux-test-fixing-planning/phase-0-pre-flight.md
@@ -13,7 +13,7 @@ when_to_use: "Use when checking exactly what pre-flight verifies and compiles be
   the user to start it — the testers cannot run against a dead target.
 - **Browser-tool preflight** — before browser-facing verification, discover the real-browser
   integrations installed on the machine and confirm which are healthy and callable in the current
-  harness. Prefer Chrome/Chromium through Chrome DevTools MCP or Playwright MCP; if neither is
+  harness. Prefer Playwright MCP; if it is unavailable, use Chrome DevTools MCP; if neither is
   available, use an equivalent installed browser-driving tool. Record the selected tool, any fallback,
   browser/version when available, and capability gaps in the verification evidence. Static source,
   fetched HTML, WebFetch, and curl inspection are useful baselines, but do not count as live-browser


### PR DESCRIPTION
## What

Reorders the browser-tool preference so **Playwright MCP is first**.

| Rank | Before | After |
| --- | --- | --- |
| 1 | Chrome DevTools MCP | **Playwright MCP** |
| 2 | Playwright MCP | **Chrome DevTools MCP** |
| 3 | Equivalent installed browser integration | unchanged |
| 4 | Static source / fetched HTML / WebFetch / curl — *not* browser verification | unchanged |

## Why this repo needed more than a swap

ose-public did not actually rank the top two. Every site read
`Chrome DevTools MCP **or** Playwright MCP` — an unordered pair. Making Playwright first therefore
required introducing the explicit order that was missing, not just transposing two names.

## Sites covered (6)

All six sentences that state the preference, so the rule is fixed as a class rather than at the
locations that happened to be noticed first:

- `repo-governance/development/quality/manual-behavioral-verification/ui-verification.md`
- `repo-governance/development/quality/manual-behavioral-verification/tools-and-automation.md`
- `repo-governance/workflows/web/web-ux-test-fixing-planning/phase-0-pre-flight.md`
- `.claude/skills/web-testing-exploratory-methodology/reference/browser-driving.md`
- `.claude/skills/web-testing-design-fidelity/reference/browser-driving.md`
- `.claude/skills/web-testing-usability-heuristics/reference/browser-driving.md`

The three `.claude/skills` files are the ones that carry this preference to `web-exploratory-tester`,
`web-usability-tester`, and `web-design-tester`. Those agents' `tools:` arrays contain no MCP entries,
so the skills are the only place the rank reaches them.

## Verification

- `grep` for `Chrome DevTools MCP or Playwright` / `Chrome/Chromium through` / `prefer Chrome` across
  `repo-governance/` and `.claude/` returns **zero** hits after the change.
- Word budget on every touched `repo-governance/` file: 80, 215, 397 — all under the 500-word FAIL
  and the 400-word warn.
- `prettier --check` (repo-pinned 3.8.1) passes on all six files.
- No drift under `.opencode/`, `.amazonq/`, or `.cursor/` — `.opencode/skills` mirrors only 16 Nx/CI
  plugin skills and no mirror file states this preference, so no `generate:bindings` commit is owed.

## Not in scope

`claude-in-chrome` is installed in the local harness but is named in **neither** repo's governance.
It falls into the unnamed tier 3. Flagged, not fixed here.

## Companion

A second PR implements the identical change via the `repo-rules-maker` agent, for comparison. Neither
is merged yet.
