### PR TITLE
docs(governance): rank Playwright MCP first for browser verification (repo-rules-maker)

### DIFF
--- a/.claude/skills/web-testing-design-fidelity/reference/browser-driving.md
+++ b/.claude/skills/web-testing-design-fidelity/reference/browser-driving.md
@@ -3,12 +3,12 @@
 ## How to Drive the Browser
 
 Before browser-facing verification, discover the real-browser integrations installed on the machine
-and confirm which are healthy and callable in the current harness. Prefer Playwright MCP; if it is
-unavailable, use Chrome DevTools MCP; if neither is available, use an equivalent installed
-browser-driving tool. Record the selected tool, any fallback, browser/version when available, and
-capability gaps in the verification evidence. Static source, fetched HTML, WebFetch, and curl
-inspection are useful baselines, but do not count as live-browser verification when a working browser
-integration exists.
+and confirm which are healthy and callable in the current harness. Prefer Playwright MCP first, then
+Chrome DevTools MCP; if neither is available, use an equivalent installed browser-driving
+integration. Record the selected tool, any fallback, browser/version when available, and capability
+gaps in the verification evidence. Static source, fetched HTML, WebFetch, and curl inspection are
+useful baselines, but do not count as live-browser verification when a working browser integration
+exists.
 
 1. **Baseline** — `WebFetch` the target(s) for rendered HTML/CSS and link discovery; identify the
    routes and the locale-prefix structure.

--- a/.claude/skills/web-testing-exploratory-methodology/reference/browser-driving.md
+++ b/.claude/skills/web-testing-exploratory-methodology/reference/browser-driving.md
@@ -1,12 +1,12 @@
 # How to Drive the Browser
 
 Before browser-facing verification, discover the real-browser integrations installed on the machine
-and confirm which are healthy and callable in the current harness. Prefer Playwright MCP; if it is
-unavailable, use Chrome DevTools MCP; if neither is available, use an equivalent installed
-browser-driving tool. Record the selected tool, any fallback, browser/version when available, and
-capability gaps in the verification evidence. Static source, fetched HTML, WebFetch, and curl
-inspection are useful baselines, but do not count as live-browser verification when a working browser
-integration exists.
+and confirm which are healthy and callable in the current harness. Prefer Playwright MCP first, then
+Chrome DevTools MCP; if neither is available, use an equivalent installed browser-driving
+integration. Record the selected tool, any fallback, browser/version when available, and capability
+gaps in the verification evidence. Static source, fetched HTML, WebFetch, and curl inspection are
+useful baselines, but do not count as live-browser verification when a working browser integration
+exists.
 
 1. **Baseline (always available)** — `WebFetch` the target(s) for rendered HTML, meta, and link
    discovery; `Bash curl -sS -D - -o /dev/null` for headers/redirects/TLS/status; `curl` each

--- a/.claude/skills/web-testing-usability-heuristics/reference/browser-driving.md
+++ b/.claude/skills/web-testing-usability-heuristics/reference/browser-driving.md
@@ -1,12 +1,12 @@
 # How to Drive the Browser
 
 Before browser-facing verification, discover the real-browser integrations installed on the machine
-and confirm which are healthy and callable in the current harness. Prefer Playwright MCP; if it is
-unavailable, use Chrome DevTools MCP; if neither is available, use an equivalent installed
-browser-driving tool. Record the selected tool, any fallback, browser/version when available, and
-capability gaps in the verification evidence. Static source, fetched HTML, WebFetch, and curl
-inspection are useful baselines, but do not count as live-browser verification when a working browser
-integration exists.
+and confirm which are healthy and callable in the current harness. Prefer Playwright MCP first, then
+Chrome DevTools MCP; if neither is available, use an equivalent installed browser-driving
+integration. Record the selected tool, any fallback, browser/version when available, and capability
+gaps in the verification evidence. Static source, fetched HTML, WebFetch, and curl inspection are
+useful baselines, but do not count as live-browser verification when a working browser integration
+exists.
 
 1. **Baseline** — `WebFetch` the target(s) for rendered text, headings, nav labels, and link
    discovery; `Bash curl -sS -D - -o /dev/null` to read the redirect/locale-prefix/trailing-slash

--- a/repo-governance/development/quality/manual-behavioral-verification/ui-verification.md
+++ b/repo-governance/development/quality/manual-behavioral-verification/ui-verification.md
@@ -17,12 +17,12 @@ when_to_use: "Use when preparing to manually verify a UI change."
 # UI Verification
 
 Before browser-facing verification, discover the real-browser integrations installed on the machine
-and confirm which are healthy and callable in the current harness. Prefer Playwright MCP; if it is
-unavailable, use Chrome DevTools MCP; if neither is available, use an equivalent installed
-browser-driving tool. Record the selected tool, any fallback, browser/version when available, and
-capability gaps in the verification evidence. Static source, fetched HTML, WebFetch, and curl
-inspection are useful baselines, but do not count as live-browser verification when a working browser
-integration exists.
+and confirm which are healthy and callable in the current harness. Prefer Playwright MCP first, then
+Chrome DevTools MCP; if neither is available, use an equivalent installed browser-driving
+integration. Record the selected tool, any fallback, browser/version when available, and capability
+gaps in the verification evidence. Static source, fetched HTML, WebFetch, and curl inspection are
+useful baselines, but do not count as live-browser verification when a working browser integration
+exists.
 
 ## Required Tools
 

--- a/repo-governance/workflows/web/web-ux-test-fixing-planning/phase-0-pre-flight.md
+++ b/repo-governance/workflows/web/web-ux-test-fixing-planning/phase-0-pre-flight.md
@@ -13,8 +13,8 @@ when_to_use: "Use when checking exactly what pre-flight verifies and compiles be
   the user to start it — the testers cannot run against a dead target.
 - **Browser-tool preflight** — before browser-facing verification, discover the real-browser
   integrations installed on the machine and confirm which are healthy and callable in the current
-  harness. Prefer Playwright MCP; if it is unavailable, use Chrome DevTools MCP; if neither is
-  available, use an equivalent installed browser-driving tool. Record the selected tool, any fallback,
+  harness. Prefer Playwright MCP first, then Chrome DevTools MCP; if neither is available, use an
+  equivalent installed browser-driving integration. Record the selected tool, any fallback,
   browser/version when available, and capability gaps in the verification evidence. Static source,
   fetched HTML, WebFetch, and curl inspection are useful baselines, but do not count as live-browser
   verification when a working browser integration exists.


### PR DESCRIPTION
## What

Same target as the hand-authored PR: reorder the browser-tool preference so **Playwright MCP is
first**, Chrome DevTools MCP second, equivalent installed integration third, and the tier-4 floor
(static source / WebFetch / curl are not live-browser verification) unchanged.

This is the **`repo-rules-maker`-authored** half of a deliberate with/without comparison. The agent
was given the target ranking and the repo's constraints but **not** the file list — its discovery was
independent.

## What the agent found that the hand pass did not

It flagged that the old sentence ranked a browser **engine**, not an integration:

> Prefer Chrome/Chromium through Chrome DevTools MCP or Playwright MCP

That framing only holds while the Chrome-native integration leads. Playwright drives Chromium,
Firefox, and WebKit, so once it is first the preference has to be stated over *integrations*. It also
caught a noun that switched mid-rule — the paragraph says "integrations" before the ranking and
"tool" inside it — and made tier 3 consistent.

## Verification

- Zero residual Chrome-first phrasings under `repo-governance/` or `.claude/`.
- Word budget on touched `repo-governance/` files: all under the 500-word FAIL and the 400-word warn.
- `prettier --check` passes.
- No drift under `.opencode/`, `.amazonq/`, or `.cursor/`; no `generate:bindings` commit owed.

## Relationship to the companion PR

Both PRs edit the same files. This one is rebased on top of the hand-authored change, so its diff is
the delta between the two wordings — the stronger phrasing wins where they differ.
