### PR TITLE
fix(rhino-cli): ignore an unresolvable GATE_CHANGED_BASE instead of failing every gate

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -109,7 +109,7 @@ abc10d0efefbfab5dba718cc5d0010d86adfc33fa8ec1191d35841c3625d6918  apps/rhino-cli
 c30bbe0aeabc93d5d50d17749453deb4dcd72314010b4fe98381548e59b3eb6f  apps/rhino-cli/src/commands/gate/emit.rs
 bd80157f5cb43f030d0101e0be9e76d060b23a623a576745bc7179057d3a4590  apps/rhino-cli/src/commands/gate/list.rs
 d500838c85c402bd260502f1a28d489db2ea4e74bc5769f4adf42bb4fc2035b9  apps/rhino-cli/src/commands/gate/mod.rs
-4dde30147e688ef9d7546151427695fd24db40bf1c5196577030af0588d45ed1  apps/rhino-cli/src/commands/gate/run.rs
+bc4b0d1d3df339c739991b299b1638ef82faf8d8e268d3ee5f80955fe4c549c2  apps/rhino-cli/src/commands/gate/run.rs
 70cd5e4416236420d1aef57e703af1f8f5c00a69a3e3fd1fbb3a5534c24fd3e8  apps/rhino-cli/src/commands/gate/validate.rs
 e9c874d47d04b17c2b50a8d3c95dc3a4b287b3ab6cb8861a0d3d7ddd7b0e57e5  apps/rhino-cli/src/commands/git/lockfile.rs
 e15eb24ffe611254491ab849e7acce1ab51996e2a38f04f9bf2f7c5fe447a0a7  apps/rhino-cli/src/commands/git/mod.rs

--- a/apps/rhino-cli/src/commands/gate/run.rs
+++ b/apps/rhino-cli/src/commands/gate/run.rs
@@ -681,6 +681,7 @@ fn changed_paths(repo_root: &Path, surface: &GateSurface) -> Result<Vec<String>,
         && let Some(base) = std::env::var(GATE_CHANGED_BASE_ENV)
             .ok()
             .filter(|base| !base.trim().is_empty())
+            .filter(|base| commit_resolves(repo_root, base.trim()))
     {
         return changed_paths_from_base(repo_root, base.trim(), GATE_CHANGED_BASE_ENV);
     }
@@ -688,6 +689,28 @@ fn changed_paths(repo_root: &Path, surface: &GateSurface) -> Result<Vec<String>,
         return merge_base_paths(repo_root);
     }
     Ok(Vec::new())
+}
+
+/// Returns whether `rev` names a commit reachable in `repo_root`.
+///
+/// `GATE_CHANGED_BASE` carries `github.event.before`, which is not always a commit this checkout
+/// holds: it is all-zeroes on branch creation, absent after a force-push, and absent from any
+/// unrelated repository -- including the disposable fixtures the unit tests build, which inherit
+/// the ambient CI environment because they call `run_at_root` in-process. Treating an unresolvable
+/// base as "no explicit base" lets the caller fall through to the merge base, which computes the
+/// same answer the gate would have used without the variable at all. Failing hard instead would
+/// break every gate on a force-push for no gain.
+fn commit_resolves(repo_root: &Path, rev: &str) -> bool {
+    Command::new("git")
+        .args([
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("{rev}^{{commit}}"),
+        ])
+        .current_dir(repo_root)
+        .output()
+        .is_ok_and(|output| output.status.success())
 }
 
 /// Returns paths changed from the branch merge base to `HEAD`.
@@ -1498,6 +1521,50 @@ fn affected_file_type_scope_excludes_deleted_paths_from_merge_base_diff() {
         !argv.contains("deleted.rs"),
         "a deleted file must never be passed to a gate command — it cannot be linted, \
          formatted, or checked because it no longer exists: {argv:?}"
+    );
+}
+
+/// Regression: `GATE_CHANGED_BASE` is a workflow-level environment variable, so it is visible to
+/// every process in the job -- including `cargo test`, whose in-process fixtures build throwaway
+/// repositories that have never heard of the outer repository's commits. Before `commit_resolves`
+/// guarded the lookup, `changed_paths` took the explicit-base branch, `git diff <foreign-sha> HEAD`
+/// failed inside the fixture, and
+/// `affected_file_type_scope_excludes_deleted_paths_from_merge_base_diff` panicked in CI while
+/// passing on every developer machine. The same shape is real in production: `github.event.before`
+/// is all-zeroes on branch creation and unreachable after a force-push.
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+#[test]
+fn an_unresolvable_changed_base_is_ignored_rather_than_failing_the_gate() {
+    let repo = tempfile::TempDir::new().unwrap();
+    let git = |args: &[&str]| {
+        let status = fixture_git_command(repo.path())
+            .args(args)
+            .env("GIT_AUTHOR_NAME", "Rhino CLI Test")
+            .env("GIT_AUTHOR_EMAIL", "rhino-cli-test@example.invalid")
+            .env("GIT_COMMITTER_NAME", "Rhino CLI Test")
+            .env("GIT_COMMITTER_EMAIL", "rhino-cli-test@example.invalid")
+            .status()
+            .unwrap();
+        assert!(status.success(), "git {args:?} failed");
+    };
+    git(&["init", "--quiet", "--initial-branch=main", "."]);
+    std::fs::write(repo.path().join("kept.rs"), "fn kept() {}\n").unwrap();
+    git(&["add", "."]);
+    git(&["commit", "--quiet", "-m", "base"]);
+
+    assert!(
+        commit_resolves(repo.path(), "HEAD"),
+        "a commit this repository holds must resolve"
+    );
+    assert!(
+        !commit_resolves(repo.path(), "0000000000000000000000000000000000000000"),
+        "the all-zeroes sha GitHub sends on branch creation must not resolve"
+    );
+    assert!(
+        !commit_resolves(repo.path(), "8632122e4bcd0000000000000000000000000000"),
+        "a sha from an unrelated repository must not resolve, so the caller falls back to the \
+         merge base instead of failing every gate"
     );
 }
 


### PR DESCRIPTION
Parity propagation from `ose-private`, where the defect surfaced. `apps/rhino-cli/src/commands/gate/run.rs` is byte-identical across both repos, so this lands the identical change and refreshes `parity-manifest.sha256`.

## The defect

`pr-quality-gate.yml` sets `GATE_CHANGED_BASE` at **workflow** level, so every process in the job inherits it — including `cargo test`. `commands::gate::run::affected_file_type_scope_excludes_deleted_paths_from_merge_base_diff` builds a disposable fixture repo and calls `run_at_root` **in-process**, so `changed_paths` took the explicit-base branch and ran `git diff <sha> HEAD` against a commit the fixture has never heard of.

It passes on every developer machine and fails in CI whenever the Nx cache misses and the Rust suite actually runs — which is why it stayed hidden.

## The fix

`changed_paths` takes the explicit-base branch only when the named base **resolves to a commit in this repository**; otherwise it falls through to the merge base, which computes the same answer the gate would have used without the variable. That is also the correct production behaviour: `github.event.before` is all-zeroes on branch creation and unreachable after a force-push, and failing every gate then is worse than falling back.

## Verification

Verified in both directions, not assumed:

- guard removed + `GATE_CHANGED_BASE=<foreign-sha>` exported → the original test **fails**
- guard restored + same env → `cargo test --lib` reports **1448 passed**, `cargo clippy --all-targets -- -D warnings` clean

Regression test `an_unresolvable_changed_base_is_ignored_rather_than_failing_the_gate` added, covering `HEAD`, the all-zeroes sha, and a foreign sha.

## Cost/benefit

One guard function plus its test, carried for byte-identity with `ose-private`. The benefit is that the CI gate stops depending on whether the Nx cache happens to be warm, and a force-pushed branch no longer fails every affected-file-type gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)