### PR TITLE
docs(plans): forecast PR process execution slices

### DIFF
--- a/plans/in-progress/optimize-pr-process/README.md
+++ b/plans/in-progress/optimize-pr-process/README.md
@@ -2,10 +2,11 @@
 
 ## Status
 
-**In Progress (DESIGN active); implementation dormant and non-executable until ACTIVATE.**
-[Repo-grounded] REQUIREMENTS PR [#251](https://github.com/wahidyankf/ose-public/pull/251) merged as
-`8884ec79437a05af3e8404e63239e079a379d84f`. This slice adds file-impact, propagation, cross-repo,
-and rollback design. EXECUTION remains dormant; no formal plan-quality gate runs until ACTIVATE.
+**In Progress (EXECUTION-FORECAST active); implementation dormant until ACTIVATE.**
+[Repo-grounded] DESIGN PR [#252](https://github.com/wahidyankf/ose-public/pull/252) merged as
+`3ac2468f534be2faaf0b5a784b04b6411313f49e`. The 25 remaining EXECUTION findings need three named
+human-sized authoring slices. This forecast records those boundaries before substantive checklist
+work begins; no formal plan-quality gate runs until ACTIVATE.
 
 ## Outcome
 
@@ -43,7 +44,8 @@ idea retirement, knowledge capture, and plan closure. Out of scope: a new review
 parser, merge queue, universal runtime flag, or unrelated CI cleanup.
 
 Plan assembly must finish before idea or implementation delivery. The exact unstacked order begins
-`FOUNDATION → REQUIREMENTS → DESIGN → EXECUTION → ACTIVATE → PUB-IDEAS → PRIV-IDEAS`; see
+`FOUNDATION → REQUIREMENTS → DESIGN → EXECUTION-FORECAST → CORE → WAVES → CLOSURE → ACTIVATE →
+PUB-IDEAS → PRIV-IDEAS`; see
 [delivery.md](./delivery.md#sequential-plan-assembly). Later public/private waves consume exact
 merged-green pins and record discharge or deliberate deviation.
 

--- a/plans/in-progress/optimize-pr-process/delivery.md
+++ b/plans/in-progress/optimize-pr-process/delivery.md
@@ -2,29 +2,27 @@
 
 ## Current State
 
-| Evidence                                                                            | State                                                       |
-| ----------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| [Repo-grounded] Merged [PR #250](https://github.com/wahidyankf/ose-public/pull/250) | FOUNDATION at `62608547df0d2063d369537e0753f22699456f44`    |
-| [Repo-grounded] Merged [PR #251](https://github.com/wahidyankf/ose-public/pull/251) | REQUIREMENTS at `8884ec79437a05af3e8404e63239e079a379d84f`  |
-| [Repo-grounded] DESIGN                                                              | Active: file impact, propagation, transaction, and rollback |
-| [Repo-grounded] EXECUTION                                                           | Dormant; no implementation or formal gate in this slice     |
-| [Unverified] Complete assembled plan                                                | Must pass a fresh formal gate and grill before activation   |
+| Evidence                                                                            | State                                                      |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| [Repo-grounded] Merged [PR #250](https://github.com/wahidyankf/ose-public/pull/250) | FOUNDATION at `62608547df0d2063d369537e0753f22699456f44`   |
+| [Repo-grounded] Merged [PR #251](https://github.com/wahidyankf/ose-public/pull/251) | REQUIREMENTS at `8884ec79437a05af3e8404e63239e079a379d84f` |
+| [Repo-grounded] Merged [PR #252](https://github.com/wahidyankf/ose-public/pull/252) | DESIGN at `3ac2468f534be2faaf0b5a784b04b6411313f49e`       |
+| [Repo-grounded] EXECUTION-FORECAST                                                  | Active: name human-sized checklist-authoring boundaries    |
+| [Unverified] Complete assembled plan                                                | Fresh formal gate and grill still precede activation       |
 
 ## Dormant Boundary
 
-Plan assembly is deliberately **dormant and non-executable**. DESIGN may repair only this plan's
-`README.md`, `delivery.md`, `learnings.md`, and `tech-docs.md`; REQUIREMENTS already added the
-planning-only [idea disposition map](./idea-disposition-map.md). All idea-brief, idea-index, and
-idea-routing-reference edits, moves, deletions, and retirements wait for PUB-IDEAS or PRIV-IDEAS
-after ACTIVATE. No rule, agent, binding, workflow, code, test, implementation, active-plan index, or
-formal plan gate may change or run in DESIGN.
+Plan assembly is deliberately **dormant and non-executable**. EXECUTION-FORECAST may change only
+this plan's `README.md`, `delivery.md`, and `learnings.md`. CORE, WAVES, and CLOSURE remain dormant;
+so do all idea, index, routing-reference, rule, agent, binding, workflow, code, test, implementation,
+and active-plan-index surfaces. The formal plan-quality gate does not run before complete assembly.
 
 ## Sequential Plan Assembly
 
 ```text
-FOUNDATION (#250) → REQUIREMENTS/idea-disposition-map → DESIGN/file-impact/cross-repo diagrams →
-EXECUTION/worktree/mode/boundaries/phases/commands/gates/knowledge/archival →
-ACTIVATE/formal-gate/grill → PUB-IDEAS → PRIV-IDEAS → implementation waves
+FOUNDATION (#250) → REQUIREMENTS (#251) → DESIGN (#252) → EXECUTION-FORECAST →
+EXECUTION-CORE → EXECUTION-WAVES → EXECUTION-CLOSURE → ACTIVATE/formal-gate/grill →
+PUB-IDEAS → PRIV-IDEAS → implementation waves
 ```
 
 Each arrow is a separate, unstacked PR from then-current `origin/main`, using the same owned public
@@ -34,12 +32,17 @@ sub-slices in the prior PR before opening the first split. Gate findings use bou
 `ACTIVATE-REPAIR-*` PRs. Final ACTIVATE contains only the clean formal gate, post-write grill, and
 executable-status change. Merge green and resync before the next PR.
 
-| Slice        | Contract restored before activation                                                                 |
-| ------------ | --------------------------------------------------------------------------------------------------- |
-| REQUIREMENTS | Business/product structure plus the planning-only public/private idea-disposition map               |
-| DESIGN       | File-impact tree, public/private obligation design, propagation/correction and rollback diagrams    |
-| EXECUTION    | Worktree/mode/boundaries, phases, commands, gates, review transaction, knowledge, archival, cleanup |
-| ACTIVATE     | Clean formal plan-quality gate, post-write grill, and explicit executable-status change             |
+| Slice             | Contract and audit IDs restored before activation                                                                | Target changed lines |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------- | -------------------: |
+| EXECUTION-CORE    | Legend, worktrees, mode, boundaries, entry/unit/review/merge transactions; F-005–F-012, F-014–F-017, F-025–F-034 |              260–330 |
+| EXECUTION-WAVES   | Numbered PUB/PRIV idea, A1–A3, B, and optional C units with stability and TDD gates; F-035                       |              280–340 |
+| EXECUTION-CLOSURE | Reconciliation/dogfood, knowledge, private terminal proof, public archival, cleanup; F-013, F-018, F-036–F-037   |              220–300 |
+| ACTIVATE          | Clean formal plan-quality gate, post-write grill, and explicit executable-status change                          |          at most 400 |
+
+The targets reserve repair headroom below the 400-line ceiling. Each slice is a separate unstacked
+PR from then-current `origin/main`, merges green, records its exact pin, and resyncs this same public
+worktree before the next slice. If a slice forecast crosses 400 lines or 20 files, split that slice
+again in its immediately preceding PR; never rely on a later explanation of an already-large diff.
 
 The exact 20-source classification, owner, retained requirement, and later retirement unit live in
 the [idea disposition map](./idea-disposition-map.md). Its public source pin is
@@ -53,12 +56,10 @@ The fresh findings are confirmed and remain owned, not waived or deferred foreve
 gives every ID a plain-language defect, affected artifact, and REQUIREMENTS, DESIGN, or EXECUTION
 owner even after the gitignored source report is cleared.
 
-FOUNDATION and REQUIREMENTS fixed their assigned defects. DESIGN owns F-004, F-019, F-020, and
-F-027; its [technical design](./tech-docs.md) now supplies the bounded tree/ledger, propagation and
-parity contract, cross-repo transaction, and reverse-order rollback DAG. EXECUTION findings remain
-dormant and open. ACTIVATE may open only after every mapped finding is fixed readably. A fresh
-formal gate must then pass its full semantic exit, followed by the required grill. Historic audit
-evidence cannot substitute.
+FOUNDATION, REQUIREMENTS, and DESIGN fixed their assigned defects. The 25 EXECUTION findings remain
+open and are allocated above; no forecast claim closes them. ACTIVATE may open only after CORE,
+WAVES, and CLOSURE merge and every mapped finding is fixed readably. A fresh formal gate must then
+pass semantic exit, followed by the required grill. Historic audit evidence cannot substitute.
 
 ## Dormant Unit-Edit Contract
 

--- a/plans/in-progress/optimize-pr-process/delivery.md
+++ b/plans/in-progress/optimize-pr-process/delivery.md
@@ -39,6 +39,14 @@ executable-status change. Merge green and resync before the next PR.
 | EXECUTION-CLOSURE | Reconciliation/dogfood, knowledge, private terminal proof, public archival, cleanup; F-013, F-018, F-036–F-037                        |              220–300 |
 | ACTIVATE          | Clean formal plan-quality gate, post-write grill, and explicit executable-status change                                               |          at most 400 |
 
+CORE groups its 20 findings so a reader can check the allocation without decoding one long row:
+
+- Phases, boundaries, worktrees, executor tags, delivery mode, and review routing: F-005–F-012.
+- Failure handling, commits, local verification, and CI: F-014–F-017.
+- Current-state, entry, staging, push, PR-body, review, and merge transactions: F-025, F-026, and
+  F-028–F-032.
+- Plan-amendment escape hatch: F-034.
+
 The targets reserve repair headroom below the 400-line ceiling. Each slice is a separate unstacked
 PR from then-current `origin/main`, merges green, records its exact pin, and resyncs this same public
 worktree before the next slice. If a slice forecast crosses 400 lines or 20 files, split that slice

--- a/plans/in-progress/optimize-pr-process/delivery.md
+++ b/plans/in-progress/optimize-pr-process/delivery.md
@@ -47,6 +47,16 @@ CORE groups its 20 findings so a reader can check the allocation without decodin
   F-028–F-032.
 - Plan-amendment escape hatch: F-034.
 
+The other slice names mean:
+
+- WAVES delivers paired public/private units: A1 plan-making rules, A2 review routing, A3 PR and
+  reply rules, B legacy-conflict cleanup, and optional C tooling only if evidence proves it necessary.
+  Any code change uses test-driven development: write the failing test before the behavior change.
+- CLOSURE reconciles the plan with what landed and dogfoods the process—uses it on its own PRs—then
+  captures knowledge, closes private work, archives the public plan, and safely removes worktrees.
+- ACTIVATE runs the formal plan-quality gate and a structured post-write user review (the “grill”)
+  before changing the assembled plan from dormant to executable.
+
 The targets reserve repair headroom below the 400-line ceiling. Each slice is a separate unstacked
 PR from then-current `origin/main`, merges green, records its exact pin, and resyncs this same public
 worktree before the next slice. If a slice forecast crosses 400 lines or 20 files, split that slice

--- a/plans/in-progress/optimize-pr-process/delivery.md
+++ b/plans/in-progress/optimize-pr-process/delivery.md
@@ -32,12 +32,12 @@ sub-slices in the prior PR before opening the first split. Gate findings use bou
 `ACTIVATE-REPAIR-*` PRs. Final ACTIVATE contains only the clean formal gate, post-write grill, and
 executable-status change. Merge green and resync before the next PR.
 
-| Slice             | Contract and audit IDs restored before activation                                                                | Target changed lines |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------- | -------------------: |
-| EXECUTION-CORE    | Legend, worktrees, mode, boundaries, entry/unit/review/merge transactions; F-005–F-012, F-014–F-017, F-025–F-034 |              260–330 |
-| EXECUTION-WAVES   | Numbered PUB/PRIV idea, A1–A3, B, and optional C units with stability and TDD gates; F-035                       |              280–340 |
-| EXECUTION-CLOSURE | Reconciliation/dogfood, knowledge, private terminal proof, public archival, cleanup; F-013, F-018, F-036–F-037   |              220–300 |
-| ACTIVATE          | Clean formal plan-quality gate, post-write grill, and explicit executable-status change                          |          at most 400 |
+| Slice             | Contract and audit IDs restored before activation                                                                                     | Target changed lines |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------: |
+| EXECUTION-CORE    | Legend, worktrees, mode, boundaries, entry/unit/review/merge transactions; F-005–F-012, F-014–F-017, F-025, F-026, F-028–F-032, F-034 |              260–330 |
+| EXECUTION-WAVES   | Numbered PUB/PRIV idea, A1–A3, B, and optional C units with stability and TDD gates; F-035                                            |              280–340 |
+| EXECUTION-CLOSURE | Reconciliation/dogfood, knowledge, private terminal proof, public archival, cleanup; F-013, F-018, F-036–F-037                        |              220–300 |
+| ACTIVATE          | Clean formal plan-quality gate, post-write grill, and explicit executable-status change                                               |          at most 400 |
 
 The targets reserve repair headroom below the 400-line ceiling. Each slice is a separate unstacked
 PR from then-current `origin/main`, merges green, records its exact pin, and resyncs this same public

--- a/plans/in-progress/optimize-pr-process/delivery.md
+++ b/plans/in-progress/optimize-pr-process/delivery.md
@@ -49,13 +49,18 @@ CORE groups its 20 findings so a reader can check the allocation without decodin
 
 The other slice names mean:
 
-- WAVES delivers paired public/private units: A1 plan-making rules, A2 review routing, A3 PR and
-  reply rules, B legacy-conflict cleanup, and optional C tooling only if evidence proves it necessary.
-  Any code change uses test-driven development: write the failing test before the behavior change.
-- CLOSURE reconciles the plan with what landed and dogfoods the process—uses it on its own PRs—then
-  captures knowledge, closes private work, archives the public plan, and safely removes worktrees.
+- WAVES authors the later checklists for paired public/private units: A1 plan-making rules, A2 review
+  routing, A3 PR and reply rules, B legacy-conflict cleanup, and optional C tooling only if evidence
+  proves it necessary. Any future code change uses test-driven development: write the failing test
+  before the behavior change.
+- CLOSURE authors the later checklist for reconciling the plan with what landed, dogfooding the
+  process—using it on its own PRs—capturing knowledge, closing private work, archiving the public
+  plan, and safely removing worktrees.
 - ACTIVATE runs the formal plan-quality gate and a structured post-write user review (the “grill”)
   before changing the assembled plan from dormant to executable.
+
+CORE, WAVES, and CLOSURE only author these checklists; none of their described delivery or closure
+actions executes before ACTIVATE.
 
 The targets reserve repair headroom below the 400-line ceiling. Each slice is a separate unstacked
 PR from then-current `origin/main`, merges green, records its exact pin, and resyncs this same public

--- a/plans/in-progress/optimize-pr-process/learnings.md
+++ b/plans/in-progress/optimize-pr-process/learnings.md
@@ -32,9 +32,10 @@
   prohibitions. Repairs should preserve the authoritative ownership class instead of widening a path
   rule for convenience; a different probe is useful because a coherent fix batch can still introduce
   a new boundary error.
-- [Repo-grounded] DESIGN converged in target Cycle 3 with 12 findings and no recovery cycle. Its
-  reviewed and squash-merged patches had the same stable patch ID, so landed-diff verification did
-  not rely on branch ancestry.
+- [Repo-grounded] DESIGN converged in target Cycle 3 with 12 findings and no recovery cycle. A patch
+  ID is a fingerprint of changed content. Because a squash merge creates a new commit without the
+  reviewed branch's ancestry, matching patch IDs proved the reviewed and landed changes were
+  equivalent.
 - [Repo-grounded] DESIGN CI was polled more frequently than the repository's two-minute minimum.
   EXECUTION must use the authoritative cadence and retain this as a process defect, even though no
   rate-limit or CI failure occurred.

--- a/plans/in-progress/optimize-pr-process/learnings.md
+++ b/plans/in-progress/optimize-pr-process/learnings.md
@@ -32,5 +32,14 @@
   prohibitions. Repairs should preserve the authoritative ownership class instead of widening a path
   rule for convenience; a different probe is useful because a coherent fix batch can still introduce
   a new boundary error.
+- [Repo-grounded] DESIGN converged in target Cycle 3 with 12 findings and no recovery cycle. Its
+  reviewed and squash-merged patches had the same stable patch ID, so landed-diff verification did
+  not rely on branch ancestry.
+- [Repo-grounded] DESIGN CI was polled more frequently than the repository's two-minute minimum.
+  EXECUTION must use the authoritative cadence and retain this as a process defect, even though no
+  rate-limit or CI failure occurred.
+- [Judgment call] Twenty-five execution findings cannot stay bootcamp-readable in one repair-sized
+  PR. A forecast plus CORE, WAVES, and CLOSURE slices keeps mechanics, instantiated units, and final
+  evidence independently reviewable while preserving one worktree and sequential dependencies.
 
 Add final dogfood results, exceptions, measurements, and retained follow-ups before archival.


### PR DESCRIPTION
## Outcome

Record how the remaining EXECUTION checklist will be split before writing its substantive content.

## Why this split exists

The audit leaves 25 EXECUTION findings. Writing them as one estimated 760–970-line change would make the PR harder for a human to understand and exceed this plan's 400-line review boundary. The forecast defines three cohesive, sequential PRs with repair headroom.

## What changed

- name the `EXECUTION-CORE`, `EXECUTION-WAVES`, and `EXECUTION-CLOSURE` slices;
- assign every remaining audit finding to one slice;
- state target changed-line budgets and the unstacked merge order;
- keep the plan dormant while those slices are assembled; and
- retain DESIGN dogfood evidence, including review convergence and the corrected CI-polling cadence.

## Not in this PR

This PR does not write the execution checklist, change repository rules or agents, touch private-repository ideas, run the formal plan quality gate, or activate the plan.

## Reading guide

1. Start with `delivery.md` for the split, boundaries, and finding allocation.
2. Read `README.md` for current status and assembly order.
3. Read `learnings.md` for the evidence behind the split.

## Review focus

- Is the 25-finding allocation exact and exhaustive?
- Are the three slices cohesive and small enough for a human review?
- Does the dormant boundary prevent substantive execution work from leaking into this PR?

## Verification

- Markdown formatting and lint passed.
- Git diff checks passed.
- Commit and push hooks passed.
- The repository-wide README index reported its unchanged 419 pre-existing advisory findings.

This is a documentation-only dormant planning change. It can be reverted as one unit, and `EXECUTION-CORE` cannot begin until this PR merges.

Generated by AI
