### PR TITLE
docs(plan): split oversized core delivery

### DIFF
--- a/plans/in-progress/optimize-pr-process/README.md
+++ b/plans/in-progress/optimize-pr-process/README.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-**In Progress (EXECUTION-FORECAST active); implementation dormant until ACTIVATE.**
-[Repo-grounded] DESIGN PR [#252](https://github.com/wahidyankf/ose-public/pull/252) merged as
-`3ac2468f534be2faaf0b5a784b04b6411313f49e`. The 25 remaining EXECUTION findings need three named
-human-sized authoring slices. This forecast records those boundaries before substantive checklist
-work begins; no formal plan-quality gate runs until ACTIVATE.
+**In Progress (CORE-SPLIT-FORECAST active); implementation dormant until ACTIVATE.**
+[Repo-grounded] FORECAST PR [#253](https://github.com/wahidyankf/ose-public/pull/253) merged as
+`a46725dba24c4880e7854b0b5504b26dd3bdbb33`. The audited CORE draft reached 405 changed lines, above
+the 400-line ceiling, so this authoring-only correction names CORE-ENTRY and CORE-REVIEW before
+either PR opens. No formal plan-quality gate runs until complete assembly.
 
 ## Outcome
 
@@ -44,8 +44,8 @@ idea retirement, knowledge capture, and plan closure. Out of scope: a new review
 parser, merge queue, universal runtime flag, or unrelated CI cleanup.
 
 Plan assembly must finish before idea or implementation delivery. The exact unstacked order begins
-`FOUNDATION → REQUIREMENTS → DESIGN → EXECUTION-FORECAST → CORE → WAVES → CLOSURE → ACTIVATE →
-PUB-IDEAS → PRIV-IDEAS`; see
+`FOUNDATION → REQUIREMENTS → DESIGN → EXECUTION-FORECAST → CORE-SPLIT-FORECAST → CORE-ENTRY →
+CORE-REVIEW → EXECUTION-WAVES → EXECUTION-CLOSURE → ACTIVATE → PUB-IDEAS → PRIV-IDEAS`; see
 [delivery.md](./delivery.md#sequential-plan-assembly). Later public/private waves consume exact
 merged-green pins and record discharge or deliberate deviation.
 

--- a/plans/in-progress/optimize-pr-process/delivery.md
+++ b/plans/in-progress/optimize-pr-process/delivery.md
@@ -7,22 +7,24 @@
 | [Repo-grounded] Merged [PR #250](https://github.com/wahidyankf/ose-public/pull/250) | FOUNDATION at `62608547df0d2063d369537e0753f22699456f44`   |
 | [Repo-grounded] Merged [PR #251](https://github.com/wahidyankf/ose-public/pull/251) | REQUIREMENTS at `8884ec79437a05af3e8404e63239e079a379d84f` |
 | [Repo-grounded] Merged [PR #252](https://github.com/wahidyankf/ose-public/pull/252) | DESIGN at `3ac2468f534be2faaf0b5a784b04b6411313f49e`       |
-| [Repo-grounded] EXECUTION-FORECAST                                                  | Active: name human-sized checklist-authoring boundaries    |
+| [Repo-grounded] Merged [PR #253](https://github.com/wahidyankf/ose-public/pull/253) | FORECAST at `a46725dba24c4880e7854b0b5504b26dd3bdbb33`     |
+| [Repo-grounded] CORE-SPLIT-FORECAST                                                 | Active: split the over-ceiling audited CORE draft          |
 | [Unverified] Complete assembled plan                                                | Fresh formal gate and grill still precede activation       |
 
 ## Dormant Boundary
 
-Plan assembly is deliberately **dormant and non-executable**. EXECUTION-FORECAST may change only
-this plan's `README.md`, `delivery.md`, and `learnings.md`. CORE, WAVES, and CLOSURE remain dormant;
-so do all idea, index, routing-reference, rule, agent, binding, workflow, code, test, implementation,
-and active-plan-index surfaces. The formal plan-quality gate does not run before complete assembly.
+Plan assembly is deliberately **dormant and non-executable**. CORE-SPLIT-FORECAST may change only
+this plan's `README.md`, `delivery.md`, and `learnings.md`. Both CORE slices, EXECUTION-WAVES, and
+EXECUTION-CLOSURE remain dormant; so do all idea, index, routing-reference, rule, agent, binding,
+workflow, code, test, implementation, and active-plan-index surfaces. The formal gate waits for
+complete assembly.
 
 ## Sequential Plan Assembly
 
 ```text
-FOUNDATION (#250) → REQUIREMENTS (#251) → DESIGN (#252) → EXECUTION-FORECAST →
-EXECUTION-CORE → EXECUTION-WAVES → EXECUTION-CLOSURE → ACTIVATE/formal-gate/grill →
-PUB-IDEAS → PRIV-IDEAS → implementation waves
+FOUNDATION (#250) → REQUIREMENTS (#251) → DESIGN (#252) → FORECAST (#253) →
+CORE-SPLIT-FORECAST → CORE-ENTRY → CORE-REVIEW → EXECUTION-WAVES → EXECUTION-CLOSURE →
+ACTIVATE/formal-gate/grill → PUB-IDEAS → PRIV-IDEAS → implementation waves
 ```
 
 Each arrow is a separate, unstacked PR from then-current `origin/main`, using the same owned public
@@ -32,35 +34,35 @@ sub-slices in the prior PR before opening the first split. Gate findings use bou
 `ACTIVATE-REPAIR-*` PRs. Final ACTIVATE contains only the clean formal gate, post-write grill, and
 executable-status change. Merge green and resync before the next PR.
 
-| Slice             | Contract and audit IDs restored before activation                                                                                     | Target changed lines |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------: |
-| EXECUTION-CORE    | Legend, worktrees, mode, boundaries, entry/unit/review/merge transactions; F-005–F-012, F-014–F-017, F-025, F-026, F-028–F-032, F-034 |              260–330 |
-| EXECUTION-WAVES   | Numbered PUB/PRIV idea, A1–A3, B, and optional C units with stability and TDD gates; F-035                                            |              280–340 |
-| EXECUTION-CLOSURE | Reconciliation/dogfood, knowledge, private terminal proof, public archival, cleanup; F-013, F-018, F-036–F-037                        |              220–300 |
-| ACTIVATE          | Clean formal plan-quality gate, post-write grill, and explicit executable-status change                                               |          at most 400 |
+| Slice             | Contract and audit IDs restored before activation                                                                                       | Target changed lines |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------: |
+| CORE-ENTRY        | Complete Phase 0–5 gate/pause-safe spine and state model, plus Phase 0–3 mechanics; F-005–F-011, F-014–F-016, F-025, F-026, F-028–F-030 |              230–300 |
+| CORE-REVIEW       | Review route, CI, correction firewall, merge and amendment; F-012, F-017, F-031, F-032, F-034                                           |              150–230 |
+| EXECUTION-WAVES   | Numbered PUB/PRIV idea, A1–A3, B, and optional C units with stability and TDD gates; F-035                                              |              280–340 |
+| EXECUTION-CLOSURE | Reconciliation/dogfood, knowledge, private terminal proof, public archival, cleanup; F-013, F-018, F-036–F-037                          |              220–300 |
+| ACTIVATE          | Clean formal plan-quality gate, post-write grill, and explicit executable-status change                                                 |          at most 400 |
 
-CORE groups its 20 findings so a reader can check the allocation without decoding one long row:
+The two CORE slices keep the original 20-finding ownership complete:
 
-- Phases, boundaries, worktrees, executor tags, delivery mode, and review routing: F-005–F-012.
-- Failure handling, commits, local verification, and CI: F-014–F-017.
-- Current-state, entry, staging, push, PR-body, review, and merge transactions: F-025, F-026, and
-  F-028–F-032.
-- Plan-amendment escape hatch: F-034.
+- CORE-ENTRY owns the complete lifecycle spine and separate authoring, pushed-head, review, CI,
+  merge, landed-proof, resync, and sibling states, plus detailed Phase 0–3 mechanics.
+- CORE-REVIEW owns routing, review/fixer cycles, current-head CI, cross-repo correction limits,
+  merge/landed proof, and `PLAN-AMENDMENT`.
 
 The other slice names mean:
 
-- WAVES authors the later checklists for paired public/private units: A1 plan-making rules, A2 review
+- EXECUTION-WAVES authors the later checklists for paired public/private units: A1 plan-making rules, A2 review
   routing, A3 PR and reply rules, B legacy-conflict cleanup, and optional C tooling only if evidence
   proves it necessary. Any future code change uses test-driven development: write the failing test
   before the behavior change.
-- CLOSURE authors the later checklist for reconciling the plan with what landed, dogfooding the
+- EXECUTION-CLOSURE authors the later checklist for reconciling the plan with what landed, dogfooding the
   process—using it on its own PRs—capturing knowledge, closing private work, archiving the public
   plan, and safely removing worktrees.
 - ACTIVATE runs the formal plan-quality gate and a structured post-write user review (the “grill”)
   before changing the assembled plan from dormant to executable.
 
-CORE, WAVES, and CLOSURE only author these checklists; none of their described delivery or closure
-actions executes before ACTIVATE.
+Both CORE slices, EXECUTION-WAVES, and EXECUTION-CLOSURE only author checklists; none executes
+before ACTIVATE.
 
 The targets reserve repair headroom below the 400-line ceiling. Each slice is a separate unstacked
 PR from then-current `origin/main`, merges green, records its exact pin, and resyncs this same public
@@ -79,10 +81,11 @@ The fresh findings are confirmed and remain owned, not waived or deferred foreve
 gives every ID a plain-language defect, affected artifact, and REQUIREMENTS, DESIGN, or EXECUTION
 owner even after the gitignored source report is cleared.
 
-FOUNDATION, REQUIREMENTS, and DESIGN fixed their assigned defects. The 25 EXECUTION findings remain
-open and are allocated above; no forecast claim closes them. ACTIVATE may open only after CORE,
-WAVES, and CLOSURE merge and every mapped finding is fixed readably. A fresh formal gate must then
-pass semantic exit, followed by the required grill. Historic audit evidence cannot substitute.
+FOUNDATION, REQUIREMENTS, DESIGN, and FORECAST are merged. The 25 EXECUTION findings remain open and
+are allocated above; this split closes none. ACTIVATE may open only after both CORE slices,
+EXECUTION-WAVES, and EXECUTION-CLOSURE merge and every mapped finding is fixed readably. A fresh
+formal gate must then pass semantic exit, followed by the required grill. Historic audit evidence
+cannot substitute.
 
 ## Dormant Unit-Edit Contract
 
@@ -116,8 +119,9 @@ After activation, PUB-IDEAS merges before PRIV-IDEAS. Later implementation remai
 closure`; C stays a no-change decision unless necessity passes. Public pins and native sibling
 obligations keep the repositories semantically “in sync”; private-only deviations stay private.
 
-The EXECUTION slice must turn this order into a 1:1 runnable checklist and preserve every existing
-merge step and its authority. No assembly PR may weaken merge gates or begin implementation.
+CORE-ENTRY, CORE-REVIEW, EXECUTION-WAVES, and EXECUTION-CLOSURE must turn this order into a 1:1
+runnable checklist and preserve every merge step and its authority. No assembly PR may begin
+implementation.
 
 ## Preserved Merge Authority (Dormant)
 

--- a/plans/in-progress/optimize-pr-process/learnings.md
+++ b/plans/in-progress/optimize-pr-process/learnings.md
@@ -40,7 +40,11 @@
   EXECUTION must use the authoritative cadence and retain this as a process defect, even though no
   rate-limit or CI failure occurred.
 - [Judgment call] Twenty-five execution findings cannot stay bootcamp-readable in one repair-sized
-  PR. A forecast plus CORE, WAVES, and CLOSURE slices keeps mechanics, instantiated units, and final
-  evidence independently reviewable while preserving one worktree and sequential dependencies.
+  PR. A forecast plus CORE, EXECUTION-WAVES, and EXECUTION-CLOSURE slices keeps mechanics,
+  instantiated units, and final evidence independently reviewable while preserving one worktree and
+  sequential dependencies.
+- [Repo-grounded] The audited CORE draft reached 405 changed lines after essential review repairs,
+  crossing the ratified 400-line ceiling. Split forecasting must use the repaired shape, not only
+  the first authoring estimate; CORE-ENTRY and CORE-REVIEW preserve cohesion and repair headroom.
 
 Add final dogfood results, exceptions, measurements, and retained follow-ups before archival.


### PR DESCRIPTION
## Outcome

Split the oversized CORE plan-authoring slice into two smaller PRs before either one opens.

The audited CORE draft reached 405 changed lines after necessary review repairs, crossing this
plan's 400-line ceiling. CORE-ENTRY will own the complete lifecycle/state spine and detailed entry
mechanics; CORE-REVIEW will add review, CI, cross-repository correction, merge, and amendment
mechanics.

## Scope

- Update the exact plan-assembly order and slice budgets.
- Preserve one worktree and sequential, unstacked PRs.
- Keep all 20 CORE findings allocated exactly once.
- Record the sizing lesson for later dogfood analysis.

Not included: executable task checklists, formal plan-quality-gate execution, idea retirement, rule
propagation, agents, bindings, code, tests, or private-worktree use. Those remain dormant.

## Reading order

1. `delivery.md` — revised sequence, budgets, and finding ownership.
2. `README.md` — current authoring-only status.
3. `learnings.md` — why the original forecast was corrected.

## Verification

- Independent documentation and governance audits: PASS after one repair round.
- Markdown formatting and lint: pass.
- Harness sync validation: 95/95 pass.
- Repository pre-push gate: exit 0. Its existing README-index audit reported 419 repository-wide
  findings as a non-blocking warning; this three-file plan-only diff introduced none.
- Diff: 3 hand-authored files, 47 additions, 39 deletions (86 changed lines).

## Risk and rollback

Risk is low: this changes dormant plan text only. Trunk behavior is unchanged. If the split is
wrong, revert this PR before CORE-ENTRY opens; no downstream branch is allowed to stack on it.

Generated by AI
