### PR TITLE
docs(plan): add waves a checklist

### DIFF
--- a/plans/in-progress/optimize-pr-process/README.md
+++ b/plans/in-progress/optimize-pr-process/README.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**In Progress (WAVES-ENTRY-ADAPTERS active, authoring only); dormant until ACTIVATE.**
+**In Progress (WAVES-A active, authoring only); dormant until ACTIVATE.**
 [Repo-grounded] WAVES-ENTRY-PUBLIC PR
 [#261](https://github.com/wahidyankf/ose-public/pull/261) merged as
 `9f1669e14bfed1e900b2ed81bb042d1b5c13ffd8`. PR #264 completed the private entry checklist at

--- a/plans/in-progress/optimize-pr-process/delivery.md
+++ b/plans/in-progress/optimize-pr-process/delivery.md
@@ -741,7 +741,19 @@ adding the immutable merge SHA and private entry command. It never copies privat
 - [ ] `[PUB-A1:P1.05][AI]` Run strict current-isolation rule propagation and retain its manifest.
 - [ ] `[PUB-A1:P1.06][AI]` Edit only plan-making sources admitted by the ledger.
 - [ ] `[PUB-A1:P1.07][AI]` Generate bindings once and reconcile every generated path.
-- [ ] `[PUB-A1:P1.08][AI]` Validate sync, local gates, staging ledger, committed diff, draft body, review, current-head CI, merge fingerprint, and resync as separate Phase 2–5 evidence states.
+- [ ] `[PUB-A1:P1.08][AI]` Run `npm run validate:sync` and retain its result.
+- [ ] `[PUB-A1:P2.01][AI]` Run each applicable local quality gate and retain its result.
+- [ ] `[PUB-A1:P2.02][AI]` Reconcile working paths to the admitted ledger before staging.
+- [ ] `[PUB-A1:P2.03][AI]` Stage only admitted paths and prove cached-ledger equality.
+- [ ] `[PUB-A1:P2.04][AI]` Read the complete cached diff and commit one cohesive change.
+- [ ] `[PUB-A1:P3.01][AI]` Rerun the pre-push surface on the committed head.
+- [ ] `[PUB-A1:P3.02][AI]` Push the declared branch and read back the remote head.
+- [ ] `[PUB-A1:P3.03][AI]` Open a human-readable draft PR and read back its body and statistics.
+- [ ] `[PUB-A1:P4.01][AI]` Post the exact-head review route and run bounded review cycles.
+- [ ] `[PUB-A1:P4.02][AI]` Reply to each finding in its original thread and resolve only true terminal evidence.
+- [ ] `[PUB-A1:P4.03][AI]` Poll current-head CI, prove readiness, and read back ready state.
+- [ ] `[PUB-A1:P5.01][AI]` Compute the reviewed raw-patch fingerprint and squash-merge.
+- [ ] `[PUB-A1:P5.02][AI]` Compare landed fingerprint, resync to merge SHA, and prepare the sibling obligation.
 - [ ] `[PUB-A1:P1.G][AI]` Pass propagated-rule, binding, current-head, sibling-obligation, and landed-proof gate.
 - [ ] `[PUB-A1:P1.P][AI]` Record public merge pin and prepared PRIV-A1 obligation.
 
@@ -753,6 +765,14 @@ adding the immutable merge SHA and private entry command. It never copies privat
 - [ ] `[PRIV-A1:P1.04][AI]` Adapt only admitted private sources; retain private evidence in the private PR.
 - [ ] `[PRIV-A1:P1.05][AI]` Run propagation, bindings, local gates, review, CI, merge proof, and overlay resync as separate evidence states.
 - [ ] `[PRIV-A1:P1.06][AI]` Use ENTRY-ADAPTERS for any portable or plan defect; do not open a second obligation.
+- [ ] `[PRIV-A1:P2.01][AI]` Reconcile the private source/generated ledger and overlay exclusion before staging.
+- [ ] `[PRIV-A1:P2.02][AI]` Run local gates and prove the overlay is absent from cached change paths.
+- [ ] `[PRIV-A1:P2.03][AI]` Commit the private adaptation and recheck the working-overlay fingerprint.
+- [ ] `[PRIV-A1:P3.01][AI]` Push the declared branch and open a private-safe AI-marked draft PR.
+- [ ] `[PRIV-A1:P3.02][AI]` Read back remote head, private-safe body, and safe statistics.
+- [ ] `[PRIV-A1:P4.01][AI]` Post a private-safe exact-head route and run bounded review cycles.
+- [ ] `[PRIV-A1:P4.02][AI]` Preserve same-thread replies, current-head CI, and the existing cycle count.
+- [ ] `[PRIV-A1:P5.01][AI]` Compare reviewed and landed fingerprints and resync without stashing the overlay.
 - [ ] `[PRIV-A1:P1.G][AI]` Pass semantic-correspondence, overlay, current-head, and terminal-obligation gate.
 - [ ] `[PRIV-A1:P1.P][AI]` Record private merge pin and prepared PUB-A2 obligation.
 
@@ -763,6 +783,13 @@ adding the immutable merge SHA and private entry command. It never copies privat
 - [ ] `[PUB-A2:P1.03][AI]` Propagate only the selected-risk, applicability, changed-probe, and human-readable route rules.
 - [ ] `[PUB-A2:P1.04][AI]` Generate and validate bindings without hand-editing generated mirrors.
 - [ ] `[PUB-A2:P1.05][AI]` Prove route, specialist selection, synthesis, fix reply, CI, merge, and resync separately.
+- [ ] `[PUB-A2:P2.01][AI]` Run local quality gates and exact-ledger staging checks.
+- [ ] `[PUB-A2:P2.02][AI]` Inspect the cached and committed full diffs before push.
+- [ ] `[PUB-A2:P3.01][AI]` Push the declared branch, open a human-readable draft PR, and read it back.
+- [ ] `[PUB-A2:P4.01][AI]` Post the exact-head route, use changed probes, and stop before Cycle 6.
+- [ ] `[PUB-A2:P4.02][AI]` Reply to every finding with one four-way disposition and current-head evidence.
+- [ ] `[PUB-A2:P4.03][AI]` Poll current-head CI and prove readiness before merge.
+- [ ] `[PUB-A2:P5.01][AI]` Compare reviewed/landed fingerprints, resync, and prepare PRIV-A2.
 - [ ] `[PUB-A2:P1.G][AI]` Pass routing, binding, five-cycle, scope-freeze, and landed-proof gate.
 - [ ] `[PUB-A2:P1.P][AI]` Record public merge pin and prepared PRIV-A2 obligation.
 
@@ -773,6 +800,12 @@ adding the immutable merge SHA and private entry command. It never copies privat
 - [ ] `[PRIV-A2:P1.03][AI]` Keep public summaries disclosure-safe and private evidence in the private PR.
 - [ ] `[PRIV-A2:P1.04][AI]` Run propagation, bindings, review, current-head CI, merge proof, and overlay resync separately.
 - [ ] `[PRIV-A2:P1.05][AI]` Freeze and hand portable/plan defects to ENTRY-ADAPTERS; retain the private cycle count.
+- [ ] `[PRIV-A2:P2.01][AI]` Reconcile the private ledger, generated paths, and overlay exclusion before staging.
+- [ ] `[PRIV-A2:P2.02][AI]` Run private local gates, cached checks, and committed overlay fingerprint proof.
+- [ ] `[PRIV-A2:P3.01][AI]` Push only the declared branch and read back its private-safe draft PR.
+- [ ] `[PRIV-A2:P4.01][AI]` Run the private-safe route, same-thread replies, changed probes, and current-head CI.
+- [ ] `[PRIV-A2:P4.02][AI]` Stop before Cycle 6 or a second public reversal, preserving the frozen record.
+- [ ] `[PRIV-A2:P5.01][AI]` Compare reviewed/landed fingerprints and resync without disturbing overlay state.
 - [ ] `[PRIV-A2:P1.G][AI]` Pass semantic-correspondence, scope, cycle, overlay, and obligation gate.
 - [ ] `[PRIV-A2:P1.P][AI]` Record private merge pin and prepare PUB-A3 only after terminal state.
 

--- a/plans/in-progress/optimize-pr-process/delivery.md
+++ b/plans/in-progress/optimize-pr-process/delivery.md
@@ -17,10 +17,10 @@
 | [Repo-grounded] Merged [PR #260](https://github.com/wahidyankf/ose-public/pull/260) | BASE split at `5c61907d9d24718267dae8a2307e3578df1d18c9`     |
 | [Repo-grounded] Merged [PR #261](https://github.com/wahidyankf/ose-public/pull/261) | PUBLIC at `9f1669e14bfed1e900b2ed81bb042d1b5c13ffd8`         |
 | [Repo-grounded] Merged [PR #262](https://github.com/wahidyankf/ose-public/pull/262) | PRIVATE split at `3d9c0d843f877cfa498fe73ff4b321cef677dfb3`  |
-| [Repo-grounded] WAVES-ENTRY-ADAPTERS                                                | #264 merged; author correction/amendment adapters            |
+| [Repo-grounded] WAVES-A                                                             | #265 merged; author A1/A2 public/private checklists          |
 | [Unverified] Complete assembled plan                                                | Fresh formal gate still precedes explicit activation         |
 
-> **AUTHORING-ONLY UNTIL ACTIVATE:** WAVES-ENTRY-ADAPTERS changes plan docs only; it runs no
+> **AUTHORING-ONLY UNTIL ACTIVATE:** WAVES-A changes plan docs only; it runs no
 > gate, private-worktree action, idea retirement, or implementation.
 
 ## Executor Legend and Plain-Language Terms
@@ -55,7 +55,7 @@ After ACTIVATE: `[AI]` acts, `[HUMAN]` decides, and `[AI+HUMAN]` means agent pre
 
 ## Dormant Boundary
 
-Plan assembly is deliberately **dormant and non-executable**. WAVES-ENTRY-ADAPTERS may change
+Plan assembly is deliberately **dormant and non-executable**. WAVES-A may change
 only this plan's `README.md`, `delivery.md`, and `learnings.md`. Both private checklist slices,
 ENTRY-ADAPTERS, WAVES-A, WAVES-RULES, EXECUTION-CLOSURE, ideas, indexes, rules, agents, bindings,
 workflows, code, tests, implementation, private worktree state, and active-plan indexes remain
@@ -257,7 +257,7 @@ The fresh findings are confirmed and remain owned, not waived or deferred foreve
 gives every ID a plain-language defect, affected artifact, and REQUIREMENTS, DESIGN, or EXECUTION
 owner even after the gitignored source report is cleared.
 
-FOUNDATION through WAVES-ENTRY-PRIVATE-IDEAS are merged; WAVES-ENTRY-ADAPTERS is active. ACTIVATE
+FOUNDATION through WAVES-ENTRY-ADAPTERS are merged; WAVES-A is active. ACTIVATE
 may open only after PUBLIC, both PRIVATE slices, ADAPTERS, WAVES-A, WAVES-RULES, and EXECUTION-CLOSURE
 instantiate every delivery unit as granular, attributable checkboxes and every finding is fixed. A
 fresh formal gate must then pass; historic evidence cannot substitute.
@@ -729,6 +729,52 @@ adding the immutable merge SHA and private entry command. It never copies privat
 - [ ] `[ENTRY-ADAPTERS:A1.18][AI]` Instantiate the sole `PLAN-AMENDMENT` route with exact superseded section/pin, frozen units, single-purpose scope, and resumption pin.
 - [ ] `[ENTRY-ADAPTERS:A1.G][AI]` Pass pair-state, freeze, replacement, cycle-budget, disclosure, terminal-seal, and amendment gate.
 - [ ] `[ENTRY-ADAPTERS:A1.P][AI]` Record pair URL, prepared/pending/terminal state, pins, correction count, private-thread URL, and named successor.
+
+## Dormant A-Wave Checklist
+
+### PUB-A1 — Plan-Making Rules
+
+- [ ] `[PUB-A1:P1.01][AI]` Read the terminal PRIV-IDEAS obligation and exact predecessor pin.
+- [ ] `[PUB-A1:P1.02][AI]` Fetch public `origin/main` and prove the predecessor is an ancestor.
+- [ ] `[PUB-A1:P1.03][AI]` Create only the declared branch from current public main.
+- [ ] `[PUB-A1:P1.04][AI]` Publish the exact source/generated path ledger and size forecast.
+- [ ] `[PUB-A1:P1.05][AI]` Run strict current-isolation rule propagation and retain its manifest.
+- [ ] `[PUB-A1:P1.06][AI]` Edit only plan-making sources admitted by the ledger.
+- [ ] `[PUB-A1:P1.07][AI]` Generate bindings once and reconcile every generated path.
+- [ ] `[PUB-A1:P1.08][AI]` Validate sync, local gates, staging ledger, committed diff, draft body, review, current-head CI, merge fingerprint, and resync as separate Phase 2–5 evidence states.
+- [ ] `[PUB-A1:P1.G][AI]` Pass propagated-rule, binding, current-head, sibling-obligation, and landed-proof gate.
+- [ ] `[PUB-A1:P1.P][AI]` Record public merge pin and prepared PRIV-A1 obligation.
+
+### PRIV-A1 — Private Plan-Making Adaptation
+
+- [ ] `[PRIV-A1:P1.01][AI]` Read the PUB-A1 obligation and its immutable public merge pin.
+- [ ] `[PRIV-A1:P1.02][AI]` Preserve the authorized overlay before entering the declared private branch.
+- [ ] `[PRIV-A1:P1.03][AI]` Measure the private destination and classify satisfaction, deviation, N/A, or portable defect.
+- [ ] `[PRIV-A1:P1.04][AI]` Adapt only admitted private sources; retain private evidence in the private PR.
+- [ ] `[PRIV-A1:P1.05][AI]` Run propagation, bindings, local gates, review, CI, merge proof, and overlay resync as separate evidence states.
+- [ ] `[PRIV-A1:P1.06][AI]` Use ENTRY-ADAPTERS for any portable or plan defect; do not open a second obligation.
+- [ ] `[PRIV-A1:P1.G][AI]` Pass semantic-correspondence, overlay, current-head, and terminal-obligation gate.
+- [ ] `[PRIV-A1:P1.P][AI]` Record private merge pin and prepared PUB-A2 obligation.
+
+### PUB-A2 — Public Review-Routing Rules
+
+- [ ] `[PUB-A2:P1.01][AI]` Read the terminal PRIV-A1 pin and fetch current public main.
+- [ ] `[PUB-A2:P1.02][AI]` Publish the exact review-routing source/generated ledger and forecast.
+- [ ] `[PUB-A2:P1.03][AI]` Propagate only the selected-risk, applicability, changed-probe, and human-readable route rules.
+- [ ] `[PUB-A2:P1.04][AI]` Generate and validate bindings without hand-editing generated mirrors.
+- [ ] `[PUB-A2:P1.05][AI]` Prove route, specialist selection, synthesis, fix reply, CI, merge, and resync separately.
+- [ ] `[PUB-A2:P1.G][AI]` Pass routing, binding, five-cycle, scope-freeze, and landed-proof gate.
+- [ ] `[PUB-A2:P1.P][AI]` Record public merge pin and prepared PRIV-A2 obligation.
+
+### PRIV-A2 — Private Review-Routing Adaptation
+
+- [ ] `[PRIV-A2:P1.01][AI]` Read PUB-A2's immutable obligation and preserve the private overlay.
+- [ ] `[PRIV-A2:P1.02][AI]` Measure private routing surfaces and adapt only admitted private sources.
+- [ ] `[PRIV-A2:P1.03][AI]` Keep public summaries disclosure-safe and private evidence in the private PR.
+- [ ] `[PRIV-A2:P1.04][AI]` Run propagation, bindings, review, current-head CI, merge proof, and overlay resync separately.
+- [ ] `[PRIV-A2:P1.05][AI]` Freeze and hand portable/plan defects to ENTRY-ADAPTERS; retain the private cycle count.
+- [ ] `[PRIV-A2:P1.G][AI]` Pass semantic-correspondence, scope, cycle, overlay, and obligation gate.
+- [ ] `[PRIV-A2:P1.P][AI]` Record private merge pin and prepare PUB-A3 only after terminal state.
 
 ## Dormant Lifecycle and Evidence-State Template
 


### PR DESCRIPTION
## Outcome

Add 65 dormant public/private A1 and A2 tasks for plan-making and risk-based PR-review routing.

## Why

Each cross-repository rule wave needs separate evidence for authoring, propagation, bindings, review, CI, merge, resync, and the sibling obligation. This keeps the two repositories semantically "in sync" without exposing private details or adding new tooling.

## Scope

- PUB-A1 / PRIV-A1: plan-making and plan-quality-gate rules.
- PUB-A2 / PRIV-A2: review-route, specialist, and review-protocol rules.
- Cross-repository correction remains solely in ENTRY-ADAPTERS.

Non-goals: execute rules, access private content, activate the plan, or add a bot.

## Verification

- 65 unique A1/A2 task IDs.
- Prettier and Markdown lint pass.
- 89 changed lines across two plan files, within the overall 400-line/20-file cap.

Generated by AI