### PR TITLE
docs(plans): align reader state with runbook

### DIFF
--- a/plans/in-progress/optimize-pr-process/README.md
+++ b/plans/in-progress/optimize-pr-process/README.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-**In Progress (PUB-IDEAS-5 is complete; PUB-IDEAS-6 is the sole candidate successor, frozen until
-two consecutive strict zero-finding plan-quality validations are recorded from PR #283's merged
-state).**
+**In Progress (`PLAN-STATE-READER` is aligning the final reader surfaces; after it merges, PR #290's
+terminal handoff may release `PRIV-ADMISSION`, whose sole successor is `PRIV-A1`, followed by
+`PUB-A2`).**
 [Repo-grounded] Plan assembly merged through EXECUTION-CLOSURE in PR
 [#268](https://github.com/wahidyankf/ose-public/pull/268). Before ACTIVATE or its bounded equivalence audit,
 PRs [#269](https://github.com/wahidyankf/ose-public/pull/269),
@@ -12,7 +12,8 @@ PRs [#269](https://github.com/wahidyankf/ose-public/pull/269),
 [#271](https://github.com/wahidyankf/ose-public/pull/271) retired 9 of the 19 mapped public ideas.
 Treat those merges as non-authorizing execution data points: the remaining 10 public ideas, all
 private work, and every rule/code wave stayed frozen until the reconciliation merged and the
-equivalence audit recorded the ACTIVATE pin. The private overlay remains untouched. PR #273 merged the
+equivalence audit recorded the ACTIVATE pin. The former private two-path overlay landed in private
+PR #63 at `25bb1d81f53156d001f2ab25cca07d23ab8ce062`; it is no longer worktree residue. PR #273 merged the
 sole bounded amendment at `22bffb9263b020301d4ad9a6ff938c2277deef87`; PR #274 then merged, its
 AI-marked A0.P receipt was verified, and PUB-BASE completed cleanly. PR #275 supplied PUB-IDEAS-4's
 live-backlink authority, PR #276 completed PUB-IDEAS-4, and PR #277 supplied PUB-IDEAS-5's
@@ -20,11 +21,16 @@ live-backlink authority. The plan-quality remediation merged as PR #280 at
 `7ea591ee54363c4811fb42ccef94cac898b598cc`; PUB-IDEAS-5 then completed in PR #281 at
 `e70ef47b945cbc91d23a641230a87a2b8879f75a`, whose receipt named PUB-IDEAS-6. PR #282 merged at
 `56e5fa6c5168ffe5569d21a4b685a76168dd6f13` and admitted PUB-IDEAS-6's four exact live-backlink
-repairs. PR #283 then merged at `6ecb22d0a4f7216cfb6865c502ca21801ebed70b`, recording the current
-state and finite runbook rule. Tracked plan text defines the successor and admissible paths; GitHub
-remains the durable review and receipt record. PUB-IDEAS-6 remains frozen until two consecutive
-strict revalidation passes are recorded from this merged state; the private
-overlay and every rule/code wave remain frozen until their declared predecessor authorizes them.
+repairs. PR #283 then merged at `6ecb22d0a4f7216cfb6865c502ca21801ebed70b`, recording the prior
+state and finite runbook rule. Public PRs #285, #286, and #288 subsequently retired the remaining
+public idea briefs at `5e45ae3e1969359a233ac8be2d7b176492d0531b`,
+`d440f7385aa32eadeaf224bb10a633837a31055a`, and `70dbe4187dd720d8fe344960d227c44cf3d549f5`.
+Those historical receipts supersede the former future idea-delivery forecast. Public PR #289 merged at
+`539cda50e6aa48079d347ae6131b81901120cd84`, admitting the exact A-wave paths and completing direct
+PUB-A1 size-policy edits. PR #290 merged at `1c916103e75e48c939439d381e8f3ddb9ea3dd54`, correcting
+the executable runbook. This reader-state PR is the required next predecessor; GitHub remains the
+durable review and receipt record. Private rule/code work remains frozen until this PR merges and the
+PR #290 terminal-handoff comment records the fresh strict gate results and its exact URL.
 
 ## Outcome
 
@@ -36,8 +42,11 @@ computer-science background. A merged PR remains an educational team record, not
 
 - Prefer prose, existing GitHub features, and existing workflows. Add mechanical enforcement only
   when evidence shows it is necessary; every line of tooling becomes maintenance burden.
-- [Judgment call] Keep each PR cohesive and readable. Program/script lines (`P`) are at most 400.
-  A PR that mixes program/script and non-program files (`N`) is at most 900 handwritten lines
+- [Judgment call] Keep each PR cohesive and readable. `P` is the count of handwritten changed lines
+  in program or script files (including tests); `N` is the count in handwritten non-program files
+  such as Markdown, plans, specs, and configuration. Generated files are excluded from both counts.
+  Program/script lines (`P`) are at most 400. A PR that mixes program/script and non-program files
+  (`N`) is at most 900 handwritten lines
   (`P + N ≤ 900`, therefore `N ≤ 900 − P`); 1,000 handwritten lines is the absolute ceiling for
   every PR. Thus a 100-program-line mixed PR may contain 800 non-program lines, a 300-program-line
   mixed PR may contain 600, while a documentation-only PR may contain 1,000 non-program lines. The
@@ -78,15 +87,16 @@ cycle gates, planning lifecycle, repo-rule propagation, necessary binding update
 idea retirement, knowledge capture, and plan closure. Out of scope: a new review bot, database,
 parser, merge queue, universal runtime flag, or unrelated CI cleanup.
 
-Plan assembly must finish before idea or implementation delivery. The exact unstacked order begins
+The following plan-assembly order is an immutable historical receipt, not an executable route.
 `FOUNDATION → REQUIREMENTS → DESIGN → EXECUTION-FORECAST → CORE-SPLIT-FORECAST → CORE-ENTRY →
 CORE-REVIEW → WAVES-SPLIT → WAVES-ENTRY-SPLIT → WAVES-ENTRY-BASE-SPLIT →
 WAVES-ENTRY-PUBLIC → WAVES-ENTRY-PRIVATE-SPLIT → WAVES-ENTRY-PRIVATE-BASE-REPAIR →
 WAVES-ENTRY-PRIVATE-IDEAS → WAVES-ENTRY-ADAPTERS → WAVES-A → WAVES-RULES →
 EXECUTION-CLOSURE → reconciliation/bounded equivalence audit → ACTIVATE → remaining PUB-IDEAS subdeliveries
 → terminal public proof → PRIV-BASE → conditional PRIV-REPAIR → PRIV-IDEAS`; see
-[delivery.md](./delivery.md#historical-sequential-plan-assembly-receipt). Later public/private waves consume exact
-merged-green pins and record discharge or deliberate deviation.
+[delivery.md](./delivery.md#historical-sequential-plan-assembly-receipt). The executable order after
+this reader-state PR and #290's terminal receipt is `PRIV-ADMISSION` → `PRIV-A1` → `PUB-A2`; later
+waves remain frozen.
 
 ## Plan Documents
 
@@ -107,16 +117,17 @@ Defining claims use `[Repo-grounded]` for repository/PR evidence, `[Web-cited]` 
 `[Judgment call]` for user-ratified policy, and `[Unverified]` for work activation must still prove.
 Repeated claims cross-reference this section rather than duplicating evidence.
 
-| Claim                             | Source evidence (paraphrased)                                                                                                                                        | Accessed   |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| [Web-cited] Small, focused PRs    | [Google small changes][google-small] says no universal size; [descriptions][google-body] ask what and why                                                            | 2026-08-23 |
-| [Web-cited] Native review history | [GitHub review help][github-help] recommends focused context; [resolution][github-resolve] preserves discussion                                                      | 2026-08-23 |
-| [Web-cited] Teaching and pushback | [Microsoft reviewer guidance][ms-review] asks reviewers to explain why; [author guidance][ms-author] allows a reasoned “won't fix” and keeps questions in the review | 2026-08-23 |
-| [Web-cited] Bounded feedback      | [Stripe Minions][stripe] reports often one, at most two CI runs after local repair—not five review cycles                                                            | 2026-08-23 |
-| [Web-cited] Short-lived branches  | [Trunk Based Development][tbd] describes branches integrated quickly to trunk                                                                                        | 2026-08-23 |
+| Claim                             | Source evidence (short excerpt)                                                                                                                          | Accessed   |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| [Web-cited] Small, focused PRs    | [Google small changes][google-small]: “no hard and fast rules”; [descriptions][google-body]: “What change” and “Why”                                     | 2026-08-24 |
+| [Web-cited] Native review history | [GitHub review help][github-help]: “focused, clear, and easy to follow”; [resolution][github-resolve]: “mark conversations as resolved”                  | 2026-08-24 |
+| [Web-cited] Teaching and pushback | [Microsoft reviewer guidance][ms-review]: “explain why ... preferably with an example”; [author guidance][ms-author]: “won't fix” with “clear reasoning” | 2026-08-24 |
+| [Judgment call] Bounded feedback  | Cycles 1–3 target, Cycles 4–5 recovery, and the hard stop before Cycle 6 are this repository's bounded policy; no Stripe measurement is claimed.         | 2026-08-24 |
+| [Web-cited] Short-lived branches  | [Trunk Based Development][tbd]: “the branch should only last a couple of days.”                                                                          | 2026-08-24 |
 
-The 400-program-line / 1,000-combined-line / 20-file ceiling and hard stop before Cycle 6 are repository judgment calls, not
-universal industry measurements. The inaccessible DOI previously listed here is removed.
+The 400-program-line / 900-mixed-line / 1,000-absolute-line / 20-file ceiling and hard stop before
+Cycle 6 are repository judgment calls, not universal industry measurements. The inaccessible DOI
+and the unverified Stripe cycle claim previously listed here are removed.
 
 [google-small]: https://google.github.io/eng-practices/review/developer/small-cls.html
 [google-body]: https://google.github.io/eng-practices/review/developer/cl-descriptions.html
@@ -124,5 +135,4 @@ universal industry measurements. The inaccessible DOI previously listed here is 
 [github-resolve]: https://docs.github.com/en/pull-requests/concepts/resolving-reviews
 [ms-review]: https://microsoft.github.io/code-with-engineering-playbook/code-reviews/process-guidance/reviewer-guidance/
 [ms-author]: https://microsoft.github.io/code-with-engineering-playbook/code-reviews/process-guidance/author-guidance/
-[stripe]: https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents
 [tbd]: https://trunkbaseddevelopment.com/short-lived-feature-branches/

--- a/plans/in-progress/optimize-pr-process/idea-disposition-map.md
+++ b/plans/in-progress/optimize-pr-process/idea-disposition-map.md
@@ -13,8 +13,9 @@ unchanged.
 - [Repo-grounded] Private source: `ose-private` commit
   `718c20c923707d777a89639f760f98d53740bd70`. The one brief is 135 lines and 1,381 words; its
   tracked inbound index entry is `plans/ideas/README.md:22`.
-- [Repo-grounded] No private retirement has merged. The pinned private source remains authoritative
-  until PRIV-IDEAS records retirement against an activated public plan pin.
+- [Repo-grounded] Private PR [#63](https://github.com/wahidyankf/ose-private/pull/63) merged the
+  two-path `PRIV-IDEAS` retirement at `25bb1d81f53156d001f2ab25cca07d23ab8ce062`. Its terminal
+  comment names `PRE-A1-ADMISSION` as the public historical successor; no private overlay remains.
 
 ## Current Public Retirement State
 
@@ -23,13 +24,12 @@ completed unit. PRs #269–#271 retired nine briefs before ACTIVATE; PUB-IDEAS-4
 in PR #276; and PUB-IDEAS-5 completed two in PR #281. Those 13 retirements and their associated
 backlink repairs are historical evidence only.
 
-Exactly six public briefs remain: PUB-IDEAS-6 owns
-`nx-affected-cross-worktree-contamination.md` and `stale-checkout-ref-advance-drift.md`; PUB-IDEAS-7
-owns `cross-repo-governance-link-parity.md` and `plan-archival-in-pr-multi-repo-gap.md`; and
-PUB-IDEAS-8 owns `propagation-checklist-under-coverage.md` and
-`recurring-defect-family-escalation.md`. PUB-IDEAS-6 is the sole candidate successor and remains
-frozen until the two strict revalidations recorded in `delivery.md` are clean. The plan-state
-correction already merged in PR #283 at `6ecb22d0a4f7216cfb6865c502ca21801ebed70b`.
+No public idea brief remains. PR #285 retired the cross-worktree set at
+`5e45ae3e1969359a233ac8be2d7b176492d0531b`; PR #286 retired the cross-repository set at
+`d440f7385aa32eadeaf224bb10a633837a31055a`; and PR #288 retired the final set at
+`70dbe4187dd720d8fe344960d227c44cf3d549f5`. Their absent source paths and old forecast are
+immutable historical evidence only. PR #290 requires this reader-state delivery before its terminal
+handoff can release `PRIV-ADMISSION`; its successors are `PRIV-A1`, then `PUB-A2`.
 
 ## Historical Public Dispositions
 
@@ -111,15 +111,12 @@ correction already merged in PR #283 at `6ecb22d0a4f7216cfb6865c502ca21801ebed70
    validator,” legacy Cycle 10/12/two-clean rules, three-repo assumptions, the stale five-consumer
    count (the pinned base has six), and the unrelated 168-annotation sweep. Private PR
    [#62 review 5000710561](https://github.com/wahidyankf/ose-private/pull/62#pullrequestreview-5000710561)
-   remains historical discovery evidence, not current authority.
+   remains historical discovery evidence, not current authority. This row was retired in private
+   PR #63 and remains historical planning evidence only.
 
-## Retirement Rule
+## Historical Retirement Rule
 
 The original forecast allocated ten remaining briefs to five named `PUB-IDEAS-4`–`PUB-IDEAS-8`
-subdeliveries. It is now historical: PUB-IDEAS-4 and PUB-IDEAS-5 are immutable completed evidence,
-and only the six paths named in **Current Public Retirement State** may be retired through
-PUB-IDEAS-6–8. Only PUB-IDEAS-8's terminal proof may authorize `PRIV-BASE`; its clean or
-overlay-owned result, or an evidenced failure repaired by `PRIV-REPAIR`, may then authorize
-`PRIV-IDEAS`, which retires the private brief and index entry separately. Every retirement PR
-preserves historical references and cites its exact predecessor; no subdelivery may exceed the
-plan's human-size boundary.
+subdeliveries. It is entirely historical: PRs #285, #286, and #288 retired its remaining public
+briefs, and private PR #63 retired the private brief and index entry. The old DAG, order, and
+checklists remain immutable audit receipts; they authorize no path, branch, PR, merge, or successor.


### PR DESCRIPTION
## Outcome

Aligns the plan readers with merged PRs #285–#290 and makes this reader-state PR an explicit predecessor of the #290 terminal handoff.

## Why

A bootcamp-graduate engineer should reach the same next step from the README, disposition map, and executable delivery runbook. These two surfaces still described retired idea work as live.

## Scope and non-goals

- Two plan Markdown documents only; no rule, code, generated binding, or private-repository change.
- It does not release or execute PRIV-ADMISSION. After merge, #290 still requires its two fresh strict plan-quality confirmations and native terminal-handoff comment.

## Verification and safety

- Current classification: `P=0`, `N=91` (49 additions + 42 deletions), 2 hand-authored Markdown files.
- Scoped Markdown lint and Prettier passed; the public pre-push surface passed. Roll back by reverting this PR.

Generated by AI