### PR TITLE
docs(plans): record merged handoff predecessors

### DIFF
--- a/plans/in-progress/optimize-pr-process/README.md
+++ b/plans/in-progress/optimize-pr-process/README.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-**In Progress (`PLAN-STATE-READER` is aligning the final reader surfaces; after it merges, PR #290's
-terminal handoff may release `PRIV-ADMISSION`, whose sole successor is `PRIV-A1`, followed by
-`PUB-A2`).**
+**In Progress (PR #291 merged the reader-state alignment; PR #290's terminal handoff still requires
+two fresh strict zero-finding results before it may release `PRIV-ADMISSION`, whose sole successor is
+`PRIV-A1`, followed by `PUB-A2`).**
 [Repo-grounded] Plan assembly merged through EXECUTION-CLOSURE in PR
 [#268](https://github.com/wahidyankf/ose-public/pull/268). Before ACTIVATE or its bounded equivalence audit,
 PRs [#269](https://github.com/wahidyankf/ose-public/pull/269),
@@ -28,9 +28,9 @@ public idea briefs at `5e45ae3e1969359a233ac8be2d7b176492d0531b`,
 Those historical receipts supersede the former future idea-delivery forecast. Public PR #289 merged at
 `539cda50e6aa48079d347ae6131b81901120cd84`, admitting the exact A-wave paths and completing direct
 PUB-A1 size-policy edits. PR #290 merged at `1c916103e75e48c939439d381e8f3ddb9ea3dd54`, correcting
-the executable runbook. This reader-state PR is the required next predecessor; GitHub remains the
-durable review and receipt record. Private rule/code work remains frozen until this PR merges and the
-PR #290 terminal-handoff comment records the fresh strict gate results and its exact URL.
+the executable runbook; PR #291 merged at `92fb921ac9ea5b875f0a83c7a525d82c8af17e1b`, supplying the
+required reader-state receipt. GitHub remains the durable review and receipt record. Private rule/code
+work remains frozen until the PR #290 terminal-handoff comment records two fresh strict gate results.
 
 ## Outcome
 
@@ -95,8 +95,8 @@ WAVES-ENTRY-PRIVATE-IDEAS → WAVES-ENTRY-ADAPTERS → WAVES-A → WAVES-RULES �
 EXECUTION-CLOSURE → reconciliation/bounded equivalence audit → ACTIVATE → remaining PUB-IDEAS subdeliveries
 → terminal public proof → PRIV-BASE → conditional PRIV-REPAIR → PRIV-IDEAS`; see
 [delivery.md](./delivery.md#historical-sequential-plan-assembly-receipt). The executable order after
-this reader-state PR and #290's terminal receipt is `PRIV-ADMISSION` → `PRIV-A1` → `PUB-A2`; later
-waves remain frozen.
+the #291 reader-state receipt and #290's terminal comment is `PRIV-ADMISSION` → `PRIV-A1` → `PUB-A2`;
+later waves remain frozen.
 
 ## Plan Documents
 

--- a/plans/in-progress/optimize-pr-process/delivery.md
+++ b/plans/in-progress/optimize-pr-process/delivery.md
@@ -45,10 +45,10 @@
 
 ### PR #290 Post-Merge Terminal Handoff — Pending
 
-- [ ] `[PLAN-QUALITY-290:P5.HANDOFF][AI]` After PR #290 merges, fetch `origin/main` and prove it
-      equals the merge SHA; then merge/read back one unstacked `PLAN-STATE-READER` PR aligning `README.md`
-      and `idea-disposition-map.md` to this runbook. Record its URL/SHA, rerun the strict plan-quality gate
-      to two consecutive zero-finding confirmations, then post/read back one AI-marked terminal-handoff
+- [ ] `[PLAN-QUALITY-290:P5.HANDOFF][AI]` Fetch `origin/main` and prove it contains PR #290 merge
+      `1c916103e75e48c939439d381e8f3ddb9ea3dd54` and reader-state PR #291 merge
+      `92fb921ac9ea5b875f0a83c7a525d82c8af17e1b`; read back #291's receipt. Rerun the strict gate to two
+      consecutive zero-finding confirmations, then post/read back one AI-marked terminal-handoff
       comment on PR #290. It must name #289's provenance pin `539cda50e6aa48079d347ae6131b81901120cd84`,
       #63's baseline pin `25bb1d81f53156d001f2ab25cca07d23ab8ce062`, the reader PR receipt, and no
       public-to-private authority before it. It must state `PRIV-ADMISSION`, `PRIV-A1`, then `PUB-A2`;
@@ -95,9 +95,9 @@ PUB-IDEAS-5, PR #282 authorized PUB-IDEAS-6's exact four repairs, and PR #283 re
 plan state. Private PR #63 landed the former two-path patch cleanly; PRs #285, #286, and #288 then
 retired the remaining public idea briefs. Public PR #289 admitted the exact A-wave source/mirror paths
 and completed direct PUB-A1 size-policy edits. Its pin is provenance only; the private obligation remains
-frozen until PR #290, then its `PLAN-STATE-READER`, merge and the terminal-handoff receipt are read back.
-All other private A-wave, rules, bindings, workflow, code, and implementation work remains frozen until
-its declared predecessor authorizes it.
+frozen until #291's reader receipt and PR #290's fresh two-zero terminal-handoff receipt are read back.
+All other private A-wave, rules, bindings, workflow, code, and implementation work remains frozen until its
+declared predecessor authorizes it.
 
 ## Worktree
 
@@ -667,7 +667,7 @@ retains both the lineage ID and its correction count.
 - [ ] `[ENTRY-ADAPTERS:A1.14][AI]` Close a pair only with a terminal `satisfied`, `reasoned-deviation`, or `N/A` state, exact public/private pins, and evidence links.
 - [ ] `[ENTRY-ADAPTERS:A1.15][AI]` Seal the terminal pair in its native record; a later defect opens a linked repair pair without reopening the sealed pair, but the same root cause retains its lineage ID and cannot reset the shared correction budget across either `correction-kind`.
 - [ ] `[ENTRY-ADAPTERS:A1.16][AI]` Use only disclosure-safe public summaries and links; retain private task evidence solely in the private PR artifact.
-- [ ] `[ENTRY-ADAPTERS:A1.17][AI]` Record the historical exception for the legacy per-repo/three-grill and iterative formal-gate composite: one control plan, one bounded equivalence audit, and no separate post-plan grill. PR #290's two zero-finding plan-quality validations remain draft evidence until it merges and the required PR-native handoff is read back; only then may `PRIV-ADMISSION` start.
+- [ ] `[ENTRY-ADAPTERS:A1.17][AI]` Record the historical exception for the legacy per-repo/three-grill and iterative formal-gate composite: one control plan, one bounded equivalence audit, and no separate post-plan grill. PR #290 and reader PR #291 are merged; only two fresh strict results plus the required PR-native handoff may start `PRIV-ADMISSION`.
 - [ ] `[ENTRY-ADAPTERS:A1.18][AI]` Instantiate the sole `PLAN-AMENDMENT` route with exact superseded section/pin, frozen units, single-purpose scope, and resumption pin.
 - [ ] `[ENTRY-ADAPTERS:A1.G][AI]` Pass pair-state, freeze, replacement, cycle-budget, disclosure, terminal-seal, and amendment gate.
 - [ ] `[ENTRY-ADAPTERS:A1.P][AI]` Record pair URL, prepared/pending/terminal state, pins, correction count, private-thread URL, and named successor.

--- a/plans/in-progress/optimize-pr-process/idea-disposition-map.md
+++ b/plans/in-progress/optimize-pr-process/idea-disposition-map.md
@@ -28,8 +28,9 @@ No public idea brief remains. PR #285 retired the cross-worktree set at
 `5e45ae3e1969359a233ac8be2d7b176492d0531b`; PR #286 retired the cross-repository set at
 `d440f7385aa32eadeaf224bb10a633837a31055a`; and PR #288 retired the final set at
 `70dbe4187dd720d8fe344960d227c44cf3d549f5`. Their absent source paths and old forecast are
-immutable historical evidence only. PR #290 requires this reader-state delivery before its terminal
-handoff can release `PRIV-ADMISSION`; its successors are `PRIV-A1`, then `PUB-A2`.
+immutable historical evidence only. PR #291 supplied the reader-state receipt; PR #290 still requires
+two fresh strict zero-finding results in its terminal handoff before `PRIV-ADMISSION`, then `PRIV-A1`
+and `PUB-A2`, can start.
 
 ## Historical Public Dispositions
 

--- a/plans/in-progress/optimize-pr-process/tech-docs.md
+++ b/plans/in-progress/optimize-pr-process/tech-docs.md
@@ -365,9 +365,10 @@ does not authorize a new path, and cannot weaken an existing merge gate.
 The historical ACTIVATE audit in `delivery.md` gave every pinned numbered rule, bullet, sub-bullet,
 and conditional check its own evidence or uncovered disposition. Only a catalog-defined conditional
 could use reasoned `N/A`, with its applicability condition and proof; a nonconditional row was never
-`N/A`. Only uncovered rows read the five plan documents. It does not start a second double-zero loop:
-PR #290's two zero-finding results are draft evidence until that PR merges and its native terminal-handoff
-comment is posted and read back; only then can `PRIV-ADMISSION` begin.
+`N/A`. Only uncovered rows read the five plan documents. PR #290 merged at
+`1c916103e75e48c939439d381e8f3ddb9ea3dd54` and its reader receipt, PR #291, at
+`92fb921ac9ea5b875f0a83c7a525d82c8af17e1b`; two fresh strict results plus the native #290 handoff
+comment remain required before `PRIV-ADMISSION` can begin.
 
 It records every blocker first: zero authorizes ACTIVATE; exactly one proven unique blocker may use the
 sole separately gated `PLAN-AMENDMENT`; multiple or uncertain blockers freeze for human judgment. After


### PR DESCRIPTION
## Outcome

Records the already-merged #290 and #291 receipts in every live plan surface, leaving two fresh strict zero-finding results recorded in, and read back from, the AI-marked #290 terminal-handoff comment as the remaining release condition.

## Scope and non-goals

- Four plan Markdown documents only; no rule, code, generated binding, or private-repository change.
- It does not release or execute PRIV-ADMISSION.

## Verification and safety

- Current classification: `P=0`, `N=44` (23 additions + 21 deletions), 4 hand-authored Markdown files.
- Scoped Markdown lint and Prettier passed; the public pre-push surface passed. Roll back by reverting this PR.

Generated by AI