### PR TITLE
docs(plan): correct public A3 admission

### DIFF
--- a/plans/in-progress/optimize-pr-process/delivery.md
+++ b/plans/in-progress/optimize-pr-process/delivery.md
@@ -339,7 +339,7 @@ future PR. PR #289 remains provenance only: private PR #64 at
 A1 at `71c8a0f1f318bf856141f1067a31f15f307b7f3b`. `PUB-A2`, `PUB-A3`, and `PUB-B` remain
 independently bounded PRs; each future private counterpart has a separate admission PR before source work.
 
-The A2 list has 10 hand-authored candidates, A3 has 8, and B has 12; their generated mirrors are
+The A2 list has 10 hand-authored candidates, A3 has 11, and B has 12; their generated mirrors are
 counted separately when binding generation identifies them. Each unit first uses one PR for as much
 of its natural, independently stable seam as fits. Only if its measured complete ledger would cross
 20 hand-authored files, 400 handwritten program/script lines, 900 handwritten lines when both

--- a/plans/in-progress/optimize-pr-process/tech-docs.md
+++ b/plans/in-progress/optimize-pr-process/tech-docs.md
@@ -209,11 +209,15 @@ that hunk division prevents overlapping edits.
 - `.claude/skills/pr-review-fixer-resolution/reference/four-way-triage.md`
 - `.claude/skills/pr-review-fixer-resolution/reference/reply-resolve-discipline.md`
 - `.claude/skills/pr-review-fixer-resolution/reference/identity-and-quality-gates.md`
+- `.claude/skills/plan-creating-project-plans/SKILL.md`
+- `.claude/skills/plan-creating-project-plans/reference/mandatory-grilling.md`
+- `.claude/skills/plan-creating-project-plans/reference/plan-lifecycle-and-git-workflow.md`
 
 Its exact generated mirrors are `.agents/skills/pr-review-fixer-resolution/reference/four-way-triage.md`,
 `.agents/skills/pr-review-fixer-resolution/reference/reply-resolve-discipline.md`, and
-`.agents/skills/pr-review-fixer-resolution/reference/identity-and-quality-gates.md`. `PUB-B` owns
-only the cadence hunk in `reply-resolve-discipline.md`.
+`.agents/skills/pr-review-fixer-resolution/reference/identity-and-quality-gates.md`, plus the
+same relative three plan-creating-project-plans paths under `.agents/skills/`. `PUB-B` owns only
+the cadence hunk in `reply-resolve-discipline.md`.
 
 `PUB-B` owns the remaining exact sources and the named cadence/terminal hunks above:
 


### PR DESCRIPTION
## Outcome

Corrects public A3’s exact source ledger before its PR-process rules change.

## Why

A3 already requires removing the obsolete post-write/post-plan grilling requirement. The three canonical planning-skill files that state that requirement were omitted from its ledger. Admitting them first keeps the forthcoming rule PR bounded and reviewable.

## What changed

- adds only the three canonical planning-skill sources and their generated mirrors to A3;
- corrects the A3 hand-authored candidate count from eight to eleven.

## Non-goals

This does not change any planning, review, or runtime rule. It simply authorizes the already-planned source seam.

## Verification

Two Markdown plan files; 7 additions and 3 deletions; within the documentation-only cap. Local pre-push gates passed; the README-index report contains pre-existing unrelated findings.

## Risk

If these are not the right canonical sources, reject this correction and keep A3 frozen. No unlisted path may be added to the source PR.

Generated by AI
