### PR TITLE
docs(review): bound review recovery cycles

### DIFF
--- a/.agents/skills/plan-applying-fixes/reference/pr-review-cycle-and-merge-tag-fixes.md
+++ b/.agents/skills/plan-applying-fixes/reference/pr-review-cycle-and-merge-tag-fixes.md
@@ -2,15 +2,14 @@
 
 ## How to Fix a `*-to-pr` Plan Missing the PR-Review Maker→Fixer Cycle
 
-Insert the cycle steps (strictly sequential scout→fan-out→synthesis→fixer, **ceiling N = 7** — never
-extended, each cycle CI-green-gated) immediately before the PR-merge step, sourced
+Insert the cycle steps (strictly sequential scout→fan-out→synthesis→fixer; target 1–3, focused
+recovery only in 4–5, stop before 6; each cycle CI-green-gated) immediately before the PR-merge step, sourced
 verbatim in structure from the
 [PR Review Quality Gate workflow](../../../../repo-governance/workflows/pr/pr-review-quality-gate.md):
 one `- [ ] [AI] Invoke pr-review-scout-maker on $PR` / `- [ ] [AI] Invoke pr-review-synthesis-maker on $PR` /
 `- [ ] [AI] Invoke pr-review-fixer on $PR` triple per cycle, the loop-exit condition (**clean
-exit** — stop at two consecutive clean cycles under previously-unused probe classes, neither
-leaving a [code-related](../../../../repo-governance/workflows/pr/pr-review-quality-gate/what-code-related-means.md) MEDIUM/HIGH/CRITICAL finding; N is a ceiling, not a floor, so scaffolding all seven pairs is wrong and running fewer is
-correct when the loop exits clean),
+exit** — stop when the current head is green with no blocking thread; a blocking finding after
+cycle 5 requires human direction, so scaffolding every cycle is wrong),
 and — where the plan folder is tracked in this repo — an archival-in-PR step (`git mv` to
 `plans/done/` + README updates) committed inside the same PR, before the final merge step — whatever
 tag it already carries. Never retag it while scaffolding.

--- a/.agents/skills/plan-verifying-execution/reference/delivery-mode-phase0-and-boundaries.md
+++ b/.agents/skills/plan-verifying-execution/reference/delivery-mode-phase0-and-boundaries.md
@@ -25,10 +25,9 @@
 - `*-to-pr` mode: PR's CI gates not green: **CRITICAL**
 - `*-to-pr` mode: no review-loop evidence at all: **CRITICAL**
 - `*-to-pr` mode: loop exited with a [code-related](../../../../repo-governance/workflows/pr/pr-review-quality-gate/what-code-related-means.md) MEDIUM/HIGH/CRITICAL finding outstanding, or hit
-  the seven-cycle ceiling with one open (`blocked`): **CRITICAL**
-- `*-to-pr` mode: loop ran past the seven-cycle ceiling, last cycle clean: **HIGH**
-- `*-to-pr` mode: a low cycle count ending in two clean cycles: **not a finding** (the ceiling is
-  not a floor — a clean exit ends the loop)
+  the five-cycle cap with one open: **CRITICAL**
+- `*-to-pr` mode: loop started cycle 6: **HIGH**
+- `*-to-pr` mode: a low cycle count with a green current head and no blocking thread: **not a finding**
 - `*-to-pr` mode: unresolved thread with no reply and no `[HUMAN]` escalation note: **HIGH**
 - `*-to-pr` mode: archival-in-PR missing or deferred post-merge (where applicable): **HIGH**
 - Filing a finding solely because a `*-to-pr` PR remains unmerged: **not a finding** (false positive

--- a/.agents/skills/plan-verifying-execution/reference/delivery-mode-pr-review-cycle.md
+++ b/.agents/skills/plan-verifying-execution/reference/delivery-mode-pr-review-cycle.md
@@ -20,16 +20,14 @@ PR to be merged.
    - **PR's CI gates are green** on the current head SHA. Not green: **CRITICAL** — plan is not done,
      regardless of other criteria.
    - **Review loop ran and exited clean** — evidence of the PR-Review Maker→Fixer Cycle (strictly
-     sequential scout→fan-out→synthesis→fixer cycles under a **configurable ceiling, seven by default**) actually
-     executing. **Verify the outcome, not the cycle count.** The ceiling is not a floor: the loop
-     stops at [its clean exit](../../../../repo-governance/workflows/pr/pr-review-quality-gate/probe-variation-and-exit.md) — two consecutive cycles under unused probe
-     classes, each leaving zero [code-related](../../../../repo-governance/workflows/pr/pr-review-quality-gate/what-code-related-means.md) MEDIUM/HIGH/CRITICAL findings — so a low cycle
-     count is **correct and never a finding**. File:
+     sequential scout→fan-out→synthesis→fixer cycles, targeting 1–3 with focused recovery only in
+     4–5) actually executing. **Verify the outcome, not the count.** A green current head with no
+     blocking thread may merge; a low cycle count is correct. File:
      - No review-loop evidence at all: **CRITICAL**.
      - The last completed cycle left a code-related MEDIUM/HIGH/CRITICAL finding outstanding, or the
        loop reached its configured ceiling with one still open (status `blocked`): **CRITICAL** —
        a `blocked` route never merges, per merge preconditions (a) and (b).
-     - The loop ran past seven cycles after its clean exit: **HIGH**. When both this and the
+     - The loop started cycle 6: **HIGH**. When both this and the
        bullet above match, the **higher severity governs**: an outstanding finding is CRITICAL
        however many cycles ran, and the ceiling is never extended as a substitute for resolving
        a finding.

--- a/.agents/skills/pr-review-fixer-resolution/reference/reply-resolve-discipline.md
+++ b/.agents/skills/pr-review-fixer-resolution/reference/reply-resolve-discipline.md
@@ -61,7 +61,6 @@ The orchestrating
 feeds each fresh cycle the accumulated `prior` findings and their resolution state; use it to
 detect repetition. A reasoned rejection does not erase a [code-related](../../../../repo-governance/workflows/pr/pr-review-quality-gate/what-code-related-means.md)
 MEDIUM/HIGH/CRITICAL finding: the next eligible cycle independently verifies the evidence. If it
-remains, it stays merge-blocking and the PR reaches `blocked` at the seven-cycle ceiling rather
-than being handed to a human gate or silently suppressed. Capture sanitized learning at cycles
-six and seven; see
+remains, it stays merge-blocking through the five-cycle cap. Capture sanitized learning after
+cycle five and request human direction before cycle six; see
 [Loop-Exit and Block Rules](../../../../repo-governance/workflows/pr/pr-review-quality-gate/loop-exit-and-block-rules.md#loop-exit-and-block-rules).

--- a/.agents/skills/pr-review-synthesis-coordination/reference/machine-readable-audit-record.md
+++ b/.agents/skills/pr-review-synthesis-coordination/reference/machine-readable-audit-record.md
@@ -30,7 +30,7 @@ Emit this immediately after the prose header, populated for every cycle includin
 
 ```html
 <!-- ose-pr-review:v1
-{"cycle":3,"cycles_max":7,"tier":"full","head_sha":"<40-char SHA>",
+{"cycle":3,"cycles_max":5,"tier":"full","head_sha":"<40-char SHA>",
  "diff":{"lines_changed":367,"files_changed":44,"files_hand_authored":30},
  "specialists":["architecture","logic","governance","security","integrity"],
  "raw_findings":{"architecture":2,"logic":2,"governance":3},

--- a/.claude/skills/plan-applying-fixes/reference/pr-review-cycle-and-merge-tag-fixes.md
+++ b/.claude/skills/plan-applying-fixes/reference/pr-review-cycle-and-merge-tag-fixes.md
@@ -2,15 +2,14 @@
 
 ## How to Fix a `*-to-pr` Plan Missing the PR-Review Maker→Fixer Cycle
 
-Insert the cycle steps (strictly sequential scout→fan-out→synthesis→fixer, **ceiling N = 7** — never
-extended, each cycle CI-green-gated) immediately before the PR-merge step, sourced
+Insert the cycle steps (strictly sequential scout→fan-out→synthesis→fixer; target 1–3, focused
+recovery only in 4–5, stop before 6; each cycle CI-green-gated) immediately before the PR-merge step, sourced
 verbatim in structure from the
 [PR Review Quality Gate workflow](../../../../repo-governance/workflows/pr/pr-review-quality-gate.md):
 one `- [ ] [AI] Invoke pr-review-scout-maker on $PR` / `- [ ] [AI] Invoke pr-review-synthesis-maker on $PR` /
 `- [ ] [AI] Invoke pr-review-fixer on $PR` triple per cycle, the loop-exit condition (**clean
-exit** — stop at two consecutive clean cycles under previously-unused probe classes, neither
-leaving a [code-related](../../../../repo-governance/workflows/pr/pr-review-quality-gate/what-code-related-means.md) MEDIUM/HIGH/CRITICAL finding; N is a ceiling, not a floor, so scaffolding all seven pairs is wrong and running fewer is
-correct when the loop exits clean),
+exit** — stop when the current head is green with no blocking thread; a blocking finding after
+cycle 5 requires human direction, so scaffolding every cycle is wrong),
 and — where the plan folder is tracked in this repo — an archival-in-PR step (`git mv` to
 `plans/done/` + README updates) committed inside the same PR, before the final merge step — whatever
 tag it already carries. Never retag it while scaffolding.

--- a/.claude/skills/plan-verifying-execution/reference/delivery-mode-phase0-and-boundaries.md
+++ b/.claude/skills/plan-verifying-execution/reference/delivery-mode-phase0-and-boundaries.md
@@ -25,10 +25,9 @@
 - `*-to-pr` mode: PR's CI gates not green: **CRITICAL**
 - `*-to-pr` mode: no review-loop evidence at all: **CRITICAL**
 - `*-to-pr` mode: loop exited with a [code-related](../../../../repo-governance/workflows/pr/pr-review-quality-gate/what-code-related-means.md) MEDIUM/HIGH/CRITICAL finding outstanding, or hit
-  the seven-cycle ceiling with one open (`blocked`): **CRITICAL**
-- `*-to-pr` mode: loop ran past the seven-cycle ceiling, last cycle clean: **HIGH**
-- `*-to-pr` mode: a low cycle count ending in two clean cycles: **not a finding** (the ceiling is
-  not a floor — a clean exit ends the loop)
+  the five-cycle cap with one open: **CRITICAL**
+- `*-to-pr` mode: loop started cycle 6: **HIGH**
+- `*-to-pr` mode: a low cycle count with a green current head and no blocking thread: **not a finding**
 - `*-to-pr` mode: unresolved thread with no reply and no `[HUMAN]` escalation note: **HIGH**
 - `*-to-pr` mode: archival-in-PR missing or deferred post-merge (where applicable): **HIGH**
 - Filing a finding solely because a `*-to-pr` PR remains unmerged: **not a finding** (false positive

--- a/.claude/skills/plan-verifying-execution/reference/delivery-mode-pr-review-cycle.md
+++ b/.claude/skills/plan-verifying-execution/reference/delivery-mode-pr-review-cycle.md
@@ -20,16 +20,14 @@ PR to be merged.
    - **PR's CI gates are green** on the current head SHA. Not green: **CRITICAL** — plan is not done,
      regardless of other criteria.
    - **Review loop ran and exited clean** — evidence of the PR-Review Maker→Fixer Cycle (strictly
-     sequential scout→fan-out→synthesis→fixer cycles under a **configurable ceiling, seven by default**) actually
-     executing. **Verify the outcome, not the cycle count.** The ceiling is not a floor: the loop
-     stops at [its clean exit](../../../../repo-governance/workflows/pr/pr-review-quality-gate/probe-variation-and-exit.md) — two consecutive cycles under unused probe
-     classes, each leaving zero [code-related](../../../../repo-governance/workflows/pr/pr-review-quality-gate/what-code-related-means.md) MEDIUM/HIGH/CRITICAL findings — so a low cycle
-     count is **correct and never a finding**. File:
+     sequential scout→fan-out→synthesis→fixer cycles, targeting 1–3 with focused recovery only in
+     4–5) actually executing. **Verify the outcome, not the count.** A green current head with no
+     blocking thread may merge; a low cycle count is correct. File:
      - No review-loop evidence at all: **CRITICAL**.
      - The last completed cycle left a code-related MEDIUM/HIGH/CRITICAL finding outstanding, or the
        loop reached its configured ceiling with one still open (status `blocked`): **CRITICAL** —
        a `blocked` route never merges, per merge preconditions (a) and (b).
-     - The loop ran past seven cycles after its clean exit: **HIGH**. When both this and the
+     - The loop started cycle 6: **HIGH**. When both this and the
        bullet above match, the **higher severity governs**: an outstanding finding is CRITICAL
        however many cycles ran, and the ceiling is never extended as a substitute for resolving
        a finding.

--- a/.claude/skills/pr-review-fixer-resolution/reference/reply-resolve-discipline.md
+++ b/.claude/skills/pr-review-fixer-resolution/reference/reply-resolve-discipline.md
@@ -61,7 +61,6 @@ The orchestrating
 feeds each fresh cycle the accumulated `prior` findings and their resolution state; use it to
 detect repetition. A reasoned rejection does not erase a [code-related](../../../../repo-governance/workflows/pr/pr-review-quality-gate/what-code-related-means.md)
 MEDIUM/HIGH/CRITICAL finding: the next eligible cycle independently verifies the evidence. If it
-remains, it stays merge-blocking and the PR reaches `blocked` at the seven-cycle ceiling rather
-than being handed to a human gate or silently suppressed. Capture sanitized learning at cycles
-six and seven; see
+remains, it stays merge-blocking through the five-cycle cap. Capture sanitized learning after
+cycle five and request human direction before cycle six; see
 [Loop-Exit and Block Rules](../../../../repo-governance/workflows/pr/pr-review-quality-gate/loop-exit-and-block-rules.md#loop-exit-and-block-rules).

--- a/.claude/skills/pr-review-synthesis-coordination/reference/machine-readable-audit-record.md
+++ b/.claude/skills/pr-review-synthesis-coordination/reference/machine-readable-audit-record.md
@@ -30,7 +30,7 @@ Emit this immediately after the prose header, populated for every cycle includin
 
 ```html
 <!-- ose-pr-review:v1
-{"cycle":3,"cycles_max":7,"tier":"full","head_sha":"<40-char SHA>",
+{"cycle":3,"cycles_max":5,"tier":"full","head_sha":"<40-char SHA>",
  "diff":{"lines_changed":367,"files_changed":44,"files_hand_authored":30},
  "specialists":["architecture","logic","governance","security","integrity"],
  "raw_findings":{"architecture":2,"logic":2,"governance":3},

--- a/repo-governance/conventions/structure/plans/delivery-mode-merge-authority-and-precedence.md
+++ b/repo-governance/conventions/structure/plans/delivery-mode-merge-authority-and-precedence.md
@@ -18,7 +18,7 @@ Continues [Delivery Mode — main-to-origin-main Content Restriction](./delivery
 
 **[AI] merges by default.** Every PR first uses the canonical behavior classifier, not a separate
 plan-specific review path. Eligible executable work must reach its clean exit
-within the seven-cycle maximum; noneligible static work requires the
+within the five-cycle cap and stops before cycle 6; noneligible static work requires the
 named `pr-quality-gate.yml` workflow. A PR touching `plans/**` is **always eligible** and must
 satisfy both routes unless the user waives it for that PR. A blocked eligible PR never merges. The shared hardened
 preconditions still apply: no code-related CRITICAL/HIGH/MEDIUM finding outstanding, branch current

--- a/repo-governance/development/quality/pr-review-disciplines/quality-gate-enhancements-critical-reproduction-and-seven-cycle-maximum.md
+++ b/repo-governance/development/quality/pr-review-disciplines/quality-gate-enhancements-critical-reproduction-and-seven-cycle-maximum.md
@@ -1,6 +1,6 @@
 ---
 title: "Quality Gates: CRITICAL-Reproduction and Cycle Cap"
-description: "Requiring reproduction for CRITICAL, and the seven-cycle cap."
+description: "Requiring reproduction for CRITICAL, and the bounded five-cycle cap."
 category: explanation
 subcategory: development
 tags:
@@ -13,7 +13,7 @@ created: 2026-07-23
 when_to_use: "Use when a CRITICAL finding lacks reproduction steps."
 ---
 
-# Quality-Gate Enhancements: CRITICAL-Requires-Reproduction and Seven-Cycle Maximum With Early Clean Exit
+# Quality-Gate Enhancements: CRITICAL-Requires-Reproduction and Bounded Cycle Cap
 
 ## CRITICAL-Requires-Reproduction
 
@@ -26,15 +26,13 @@ finding — it is held at a lower severity, or held for further verification und
 [Selective Adversarial Verification](./quality-gate-enhancements-selective-adversarial-verification.md) rule above when the
 diff is also high-risk, until a reproduction is attached.
 
-## Seven-Cycle Maximum With Early Clean Exit
+## Five-Cycle Maximum
 
 For an eligible PR, the [PR Review Quality Gate
 workflow](../../workflows/pr/pr-review-quality-gate.md) runs sequential CI-gated cycles only until
-two consecutive clean cycles under previously-unused probe classes, with seven cycles as the default
-maximum. This is a convergence policy, not a target count: one clean cycle is evidence about one
-question, and cycles beyond the second add cost without improving the merge decision.
+the target is resolution in cycles 1–3. Cycles 4–5 may use a changed focused probe only when the
+remaining defect family is named. This is a convergence policy, not a target count.
 
-If code-related MEDIUM/HIGH/CRITICAL findings remain at cycle six or seven, the execution captures
-sanitized learning and a deduplicated improvement idea. At the ceiling, the PR is blocked rather
-than merged or extended automatically. LOW findings retain full evidence but are non-blocking and
-do not prevent the early clean exit.
+If a blocking finding remains after cycle 5, stop before cycle 6, capture sanitized learning, and
+ask for human direction. The ceiling is never extended automatically. LOW findings retain evidence
+but are non-blocking.

--- a/repo-governance/development/workflow/pr-merge-protocol/the-worktree-to-pr-terminal-step.md
+++ b/repo-governance/development/workflow/pr-merge-protocol/the-worktree-to-pr-terminal-step.md
@@ -26,7 +26,8 @@ is:
    sequential specialist review/fix cycles only for the eligible route; a noneligible route verifies
    the named `pr-quality-gate.yml` workflow instead.
 2. Confirm the **done-definition** is met:
-   - The eligible route stopped at its first clean cycle within the seven-cycle maximum, or the
+   - The eligible route targeted cycles 1–3 and, if needed, completed focused recovery within five
+     cycles without starting cycle 6; or the
      noneligible route has recorded classifier evidence and its `pr-quality-gate.yml` run is green.
    - Every inline review comment has a reply (resolved or explicitly addressed).
    - All quality gates are GREEN -- both local (pre-push hook) and CI.

--- a/repo-governance/workflows/plan/plan-execution/finalization-pr-review-gate.md
+++ b/repo-governance/workflows/plan/plan-execution/finalization-pr-review-gate.md
@@ -11,22 +11,19 @@ archival additionally requires the
 against the plan's PR before any archival step below. This gate does not apply to the direct-push
 modes (`worktree-to-origin-main`, `main-to-origin-main`), which carry no PR and no review cycle.
 
-- Run the workflow's strictly sequential loop, **ceiling N = 7**: each cycle,
+- Run the workflow's strictly sequential loop: target cycles 1–3; cycles 4–5 require a named
+  recovery probe; **stop before cycle 6**. Each cycle,
   `pr-review-scout-maker` classifies and briefs the diff, the tier-selected discipline specialists
   fan out, and `pr-review-synthesis-maker` posts one consolidated set of
   line-anchored findings against the PR's current head commit via the GitHub Reviews API, a
   `pr-review-fixer` triages and resolves every unresolved thread, and CI on the PR must be GREEN
-  before the next cycle starts. **N is a ceiling, not a floor**: the loop stops at two consecutive clean
-  cycles under previously-unused probe classes, neither leaving a code-related
-  MEDIUM/HIGH/CRITICAL finding, and spending a further cycle merely to reach a target count is
-  waste, not thoroughness. See the linked workflow for the
+  before the next cycle starts. The cap is not a floor: stop when the current head is green and has
+  no blocking thread; do not spend an extra clean cycle merely to reach a count. See the linked workflow for
   full Loop Algorithm, posting mechanics, and loop-exit rules.
 - **Done-definition for `*-to-pr` modes**: the workflow's own
   [Route-Specific Done-Definition](../../pr/pr-review-quality-gate/route-specific-done-definition.md)
   is normative and is not restated here — satisfy every item it lists, including archival-in-PR
-  below. A loop that reaches the ceiling with a code-related MEDIUM/HIGH/CRITICAL finding
-  outstanding exits `blocked`, and a `blocked` exit prevents the merge on its own, whatever the
-  other preconditions say.
+  below. A blocking finding after cycle 5 requires human direction and prevents merge.
 - **Archival-in-PR**: for `*-to-pr` modes, the `git mv plans/in-progress/... plans/done/...` move
   (and the accompanying README index updates) is committed **inside the delivering PR itself**, as a
   normal commit on the PR branch pushed before the merge — not as a separate commit landed

--- a/repo-governance/workflows/plan/plan-quality-gate/termination-criteria-and-delivery-mode-relationship.md
+++ b/repo-governance/workflows/plan/plan-quality-gate/termination-criteria-and-delivery-mode-relationship.md
@@ -42,11 +42,10 @@ pushed, all PR gates GREEN, archival committed inside the PR — before the merg
 gates the plan document pre-execution; the PR-review cycle gates the delivered change pre-merge.
 
 **The hardened merge preconditions** that gate that eventual merge — **all five** required: (a) the
-PR's route is complete — an eligible PR stopped at two consecutive clean cycles
-under previously-unused probe classes, neither leaving a code-related MEDIUM/HIGH/CRITICAL
-finding, within the **ceiling of seven** (a ceiling, **not a floor** — a PR
-merges once (b)-(e) also hold, never on additional cycles), while a noneligible PR has recorded
-classifier evidence and a green `pr-quality-gate.yml` run; a `blocked` route never merges;
+PR's route is complete — an eligible PR targets cycles 1–3, uses cycles 4–5 only for focused
+recovery, and stops before cycle 6 with no code-related MEDIUM/HIGH/CRITICAL finding; a blocking
+finding after cycle 5 requires human direction. A noneligible PR has recorded classifier evidence
+and a green `pr-quality-gate.yml` run;
 (b) 0 code-related CRITICAL + 0 HIGH + 0 MEDIUM findings outstanding;
 (c) the branch **up-to-date with the latest `origin/main`**, brought forward **non-destructively**
 if behind (never a shared-history rewrite); (d) all PR quality gates green; (e) the

--- a/repo-governance/workflows/pr/README.md
+++ b/repo-governance/workflows/pr/README.md
@@ -18,7 +18,7 @@ Use these workflows when a pull request needs a structured specialist review bef
 
 ## Available Workflows
 
-- [pr-review-quality-gate](./pr-review-quality-gate.md) — Classify every PR by changed-artifact behavior, then run up to seven sequential specialist-review cycles only for an eligible PR, CI-green gated between cycles. Use for every open PR before merge, to decide whether the specialist review loop applies and drive it to done or blocked.
+- [pr-review-quality-gate](./pr-review-quality-gate.md) — Classify every PR by changed-artifact behavior; eligible PRs target 1–3 cycles, use 4–5 for focused recovery, and stop before 6. Use before merge to decide the route and preserve a readable audit.
 
 ## Related Documentation
 

--- a/repo-governance/workflows/pr/pr-review-quality-gate.md
+++ b/repo-governance/workflows/pr/pr-review-quality-gate.md
@@ -4,7 +4,7 @@ title: "pr-review-quality-gate"
 description: "Classify every PR by changed-artifact behavior, then run sequential specialist-review cycles only for an eligible PR, CI-green gated between cycles."
 when_to_use: "Use for every open PR before merge, to decide whether the specialist review loop applies and drive it to done or blocked."
 goal: "Classify every pull request by changed-artifact behavior, then run strictly sequential specialist-review cycles only when the PR is eligible"
-termination: every PR has a recorded behavior classification; eligible PRs stop at two consecutive clean cycles under unused probe classes, or block at the ceiling; noneligible PRs pass pr-quality-gate and merge without the specialist cycle
+termination: every PR has a recorded behavior classification; eligible PRs target cycles 1–3, use cycles 4–5 only for focused recovery, and stop before cycle 6; noneligible PRs pass pr-quality-gate and merge without the specialist cycle
 inputs:
   - name: pr
     type: string
@@ -12,9 +12,9 @@ inputs:
     required: true
   - name: cycles
     type: number
-    description: "Maximum cycles for an eligible PR; lower it only when the caller asks"
+    description: "Maximum cycles for an eligible PR; the repository cap is five"
     required: false
-    default: 7
+    default: 5
 outputs:
   - name: final-status
     type: enum

--- a/repo-governance/workflows/pr/pr-review-quality-gate/convergence-measurement.md
+++ b/repo-governance/workflows/pr/pr-review-quality-gate/convergence-measurement.md
@@ -1,7 +1,7 @@
 ---
 title: "PR-Review Quality Gate — Convergence Measurement"
-description: "How the loop distinguishes genuine convergence from its own exhaust: the three cause tags carried on every disposition, the two series they produce, and the every-third-cycle checkpoint that reads them."
-when_to_use: "Use at every third cycle, and whenever deciding to continue, change fix strategy, block, or extend a ceiling."
+description: "How the loop distinguishes genuine convergence from its own exhaust: cause tags, the two series, and the cycle-three recovery checkpoint."
+when_to_use: "Use at cycle three and whenever deciding whether focused recovery is justified."
 ---
 
 # Convergence Measurement
@@ -36,18 +36,17 @@ change under review — the confusion these tags exist to remove.
 A cycle whose findings are all `fix-induced` says the change is clean and the fixing is the problem
 — a different remedy from another review pass.
 
-## The Checkpoint, Every Third Cycle
+## The Cycle-Three Checkpoint
 
-**The orchestrator** stops after cycles three, six, nine …, reads both series, and records the verdict in [the cycle's audit record](../../../../.claude/skills/pr-review-synthesis-coordination/reference/machine-readable-audit-record.md):
+**The orchestrator** reads both series after cycle three and records the verdict in [the cycle's audit record](../../../../.claude/skills/pr-review-synthesis-coordination/reference/machine-readable-audit-record.md):
 
 - **Continue** — original defects are falling and the induced rate is not rising.
 - **Change fix strategy** — the induced rate is high. Attack the mechanism, not the surface — most
   often [restatement by value](./restatement-by-value.md).
 - **Block** — original defects persist and are not falling.
 
-Extending a ceiling when the checkpoint shows a falling original-defect series is a per-PR override,
-recorded on the PR and citing both series. It funds attempts and
-[never waives a finding](./notes.md).
+Cycles 4–5 are justified only by `continue` or `change fix strategy`; they use a changed focused
+probe. No verdict extends the five-cycle cap.
 
 ## Vary the Probe
 


### PR DESCRIPTION
## Outcome and Why

Replace the remaining live seven-cycle/two-clean review rules with the agreed human-readable convergence policy: target cycles 1–3, use cycles 4–5 only for focused recovery, and stop before cycle 6. This closes the mismatch between the plan, public A3, and the executing PR process.

## Scope

- Update only the admitted live workflow, merge, planning, verification, and skill guidance.
- Keep cause-tag auditability and same-thread reply discipline.
- Generate five `.agents` mirrors from canonical `.claude` sources.

- **Deliberately not in scope, and why:** Historical PR evidence is preserved, not rewritten. No automation is added: convergence and scope relevance require judgment, and tooling would add maintenance burden.

## Summary

The former “seven cycle,” “two clean cycles,” and “extend a ceiling” routes no longer authorize an infinite or agent-only loop. A blocking issue after cycle 5 requires human direction.

## Reading Guide

- **Start here:** `repo-governance/workflows/pr/pr-review-quality-gate.md`
- **Skip these paths:** `.agents/skills/**` are generated mirrors.
- **Size:** `P=0, N=132, total=132, files=13`; one natural legacy-convergence seam, plus 5 generated mirrors.

## Verification

- `npm run generate:bindings` — passed twice; stable second generation.
- `npm run validate:sync` — passed, 95/95.
- `git diff --check` and full pre-push gate — passed.
- README completeness passed; 419 index findings are pre-existing baseline diagnostics.

## Risk and Rollback

Risk is only an interpretation change in live process prose. Revert this commit to restore the prior guidance; no runtime behavior or enforcement changes exist.

---
Generated by AI
