### PR TITLE
feat(rhino-cli-fsharp): port repo-config-validate.feature to F# (Wave B PR2)

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -6,7 +6,7 @@ b5f5e511ac5697c2d2949d898633f079abbce9c7211205aad6f7521f17746df2  apps/rhino-cli
 4e30e3e91484c5e869c6db80759c566d9b0fd12a777a8ddc49b784046a4a77ca  apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
 11fe7ec2e5e08b432e2d1cedae59e1a555e17e22a1f11494bd83b80c36964b5c  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Convention.fs
 2f8085bcb8089f174e9548e609530471c9318c31b1bcab4a867e33880cec9e57  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Parity.fs
-ce07710a9596e4c7319e21303fd484e2162a23635cdeac58b18a9e534282aa1b  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/RepoConfig.fs
+f68a2a01380e02ce7fa8f5774a0800e9f1281c39d3c90b3c03947c1448799f2d  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/RepoConfig.fs
 fc1346c5ed931f006be550583e92d5603bdffceb270783f4b334bb5ff4d7aa3a  apps/rhino-cli/src-fsharp/RhinoCli.Cli/RhinoCli.Cli.fsproj
 c3032e5f206e9eb7aded9d420e3baa0d2751e331fd3bd95947d0b5de23761b2e  apps/rhino-cli/src-fsharp/RhinoCli.Cli/src/Dispatch.fs
 beb756fa4e0e02786adeedc97ef39c7d1855a99d260b4741e83652736144245f  apps/rhino-cli/src-fsharp/RhinoCli.Cli/src/Formatters.fs
@@ -19,9 +19,9 @@ bb55f3c8d4d3daffa7e334ecdacff8bfd9462b12a7098e239943d84a3edf915f  apps/rhino-cli
 631376afb9e4d7c5192d38f51b533c18b64cca83c18ed5c50982ba9acce51d74  apps/rhino-cli/src-fsharp/RhinoCli.Program/RhinoCli.Program.fsproj
 153a226f5ef1d6916aa6e6425b278a606a48659fcba9623c9d01e5cf3b2589a5  apps/rhino-cli/src-fsharp/RhinoCli.Program/src/Program.fs
 822f6ec8446562a4de9a3b1a2481af50fac01bbedc32e1963142709e5f48ec13  apps/rhino-cli/src-fsharp/fsharplint.json
-677575ce39f2c407d1e13cb6f52db9a362f08dd933ee2b0be0d4fbfa2e1a5f52  apps/rhino-cli/src-fsharp/project.json
+e2f0e58b912fc9a9ae2fa0f6031b62fe9a7ab8749fc19cb9900bae3e03f6ffec  apps/rhino-cli/src-fsharp/project.json
 f7dacc8dd923488c70eebabe298843022ec5a3ba94b8b7568634a779f24b8da4  apps/rhino-cli/src-fsharp/tests/integration/RhinoCli.IntegrationTests.fsproj
-4777ec354c93637b9a179f0a6105d9b3ad77afae92cd586747d3b4672cf22838  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+39550258cd7bc7a1b12d791d6f1e64d4cecbe88d0fb023f9886e10db87811da7  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
 85ba308ad0a88485db55b305120d99b9a4ec328d2379536110f73e51f4797fe2  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionSteps.fs
 a909884a9d8816e2b476cc8c00be03ac4085b849cbe83c4b18e0213ac9cad1d7  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionUnitTests.fs
 a0603a9ec897d538381417f8a330b1fa4b75f75f74003fda2a2b9b9512db5a1a  apps/rhino-cli/src-fsharp/tests/unit/Steps/DispatchUnitTests.fs
@@ -30,6 +30,8 @@ cb605599e8c90b2d6d2bdd7e7c0e54a26410f39fa2d3372285be311301d9fab2  apps/rhino-cli
 b8a8fbf79e78dee93f32944d3bbae2daccf33876ce5988ae31b1259c2f5ce201  apps/rhino-cli/src-fsharp/tests/unit/Steps/ParityUnitTests.fs
 76ee39dfa9f270aeffdbee896cf4f521f8685dea723f8ec41acb24d3f80abf47  apps/rhino-cli/src-fsharp/tests/unit/Steps/RepoConfigSteps.fs
 7d6558430a23078b4306c31a0198fb7ff0a5775f03e0100ee7a62cec7f4aa932  apps/rhino-cli/src-fsharp/tests/unit/Steps/RepoConfigUnitTests.fs
+e99afc8498e7d937658f115e43394ca206c9d4a9bf53235cf303ef1031600c3b  apps/rhino-cli/src-fsharp/tests/unit/Steps/RepoConfigValidateSteps.fs
+00e5f934b41bbbc0d384afbd3eede0979b6a29fa08dc5f98f07e497569ab6758  apps/rhino-cli/src-fsharp/tests/unit/Steps/RepoConfigValidateUnitTests.fs
 998712745702e44ab27c25f5baecef0f90e4fe9e02aa016032a0f68b15137b3b  apps/rhino-cli/src/application/agents/agent_validator.rs
 371c1e14d1532a1eea1214d98818c3e3da39a82b24dbb46e24cd09426e6ecc18  apps/rhino-cli/src/application/agents/bindings.rs
 0adf2fb9fb4ef5390caa25b75943505ac96aebabd0c46d966f60f66a9037f7c2  apps/rhino-cli/src/application/agents/catalog.rs

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/RepoConfig.fs
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/RepoConfig.fs
@@ -1,18 +1,25 @@
-/// Port of the slice of the Rust `repo_config` namespace needed by the nine
+/// Port of the slice of the Rust `repo_config` namespace needed by the
 /// scenarios in
 /// `specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config/data-driven.feature`
+/// and
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate/repo-config-validate.feature`
 /// [Repo-grounded — `apps/rhino-cli/src/application/repo_config/mod.rs`,
 /// `apps/rhino-cli/src/commands/repo_config_validate.rs`].
 ///
 /// Scope note: the Rust `RepoConfig` schema is a ~40-field struct covering
-/// gate wiring, ownership classes, env contracts, word budgets, and the full
-/// Doctor tool roster. This port models only `harness[].{name,tier,agent-dir,
-/// mirrors,forbid-dir}`, `gates[].{id,args}`, `specs.{ddd-areas,domain-areas}`,
-/// and `doctor.dotnet-global-json` — the fields these nine scenarios read —
-/// and deserializes with `IgnoreUnmatchedProperties` rather than Rust's
-/// `deny_unknown_fields`, so every other real `repo-config.yml` key is
-/// silently accepted rather than schema-validated. None of the nine scenarios
-/// exercises unknown-key rejection.
+/// gate wiring, env contracts, word budgets, and the full Doctor tool
+/// roster. This port models only `harness[].{name,tier,agent-dir,mirrors,
+/// forbid-dir,skills-dir,skills-mirrors,vendored,ownership}`,
+/// `gates[].{id,args}`, `specs.{ddd-areas,domain-areas}`, and
+/// `doctor.dotnet-global-json` — the fields these two feature files'
+/// scenarios read — and deserializes the rest of the document with
+/// `IgnoreUnmatchedProperties` rather than Rust's `deny_unknown_fields`, so
+/// every other real `repo-config.yml` key is silently accepted rather than
+/// schema-validated. `harness[]` and `harness[].ownership[]` are the
+/// exception: `checkNoUnknownHarnessKeys` below independently walks the raw
+/// YAML structure to reject an unknown key in either, since the
+/// repo-config-validate scenarios exercise exactly that. Widening this
+/// strictness to the rest of the schema is future work for later waves.
 module RhinoCli.Application.RepoConfig
 
 open System
@@ -28,15 +35,39 @@ type Tier =
     | Source
     | Generated
 
+/// The three ownership classes a binding path may declare in a harness
+/// entry's `ownership:` list — named `Class*` rather than reusing `Tier`'s
+/// `Source`/`Generated` case names, which would otherwise collide under a
+/// single `open RhinoCli.Application.RepoConfig`
+/// [Repo-grounded — `repo_config/mod.rs::OwnershipClass`].
+type OwnershipClass =
+    | ClassSource
+    | ClassGenerated
+    | ClassVendored
+
+/// One entry in a harness entry's `ownership:` list, declaring which of the
+/// three classes above a single binding path belongs to, and — for a
+/// `vendored` path — why it is exempt from regeneration
+/// [Repo-grounded — `repo_config/mod.rs::OwnershipEntry`].
+type OwnershipEntry =
+    { Path: string
+      Class: OwnershipClass
+      Reason: string option }
+
 /// One harness entry in the `harness:` section of `repo-config.yml`, trimmed
-/// to the fields the codex-entry and three-harness-registry scenarios read
+/// to the fields the codex-entry, three-harness-registry, and
+/// repo-config-validate scenarios read
 /// [Repo-grounded — `repo_config/mod.rs::HarnessEntry`].
 type HarnessEntry =
     { Name: string
       Tier: Tier
       AgentDir: string option
       Mirrors: string option
-      ForbidDir: string option }
+      ForbidDir: string option
+      SkillsDir: string option
+      SkillsMirrors: string option
+      Vendored: string list
+      Ownership: OwnershipEntry list }
 
 /// One entry in the `gates:` section, trimmed to the `id` and `args` fields
 /// the website-exclusion scenario reads
@@ -87,12 +118,22 @@ let empty: RepoConfig =
 /// still excluded from this module's public surface indirectly: nothing
 /// outside `parseRepoConfig` ever constructs or returns one.
 [<CLIMutable>]
+type OwnershipEntryDto =
+    { Path: string
+      Class: string
+      Reason: string | null }
+
+[<CLIMutable>]
 type HarnessEntryDto =
     { Name: string
       Tier: string
       AgentDir: string | null
       Mirrors: string | null
-      ForbidDir: string | null }
+      ForbidDir: string | null
+      SkillsDir: string | null
+      SkillsMirrors: string | null
+      Vendored: ResizeArray<string>
+      Ownership: ResizeArray<OwnershipEntryDto> }
 
 [<CLIMutable>]
 type GateEntryDto =
@@ -147,14 +188,55 @@ let private parseTier (index: int) (raw: string) : Result<Tier, string> =
     | other ->
         Error(sprintf "harness[%d].tier: invalid value \"%s\" (expected \"source\" or \"generated\")" index other)
 
+/// Parses one `ownership[].class` value
+/// [Repo-grounded — `repo_config/mod.rs::OwnershipClass`'s `Deserialize`
+/// impl].
+let private parseOwnershipClass
+    (harnessIndex: int)
+    (ownershipIndex: int)
+    (raw: string)
+    : Result<OwnershipClass, string> =
+    match raw with
+    | null -> Error(sprintf "harness[%d].ownership[%d].class: required key is missing" harnessIndex ownershipIndex)
+    | "source" -> Ok ClassSource
+    | "generated" -> Ok ClassGenerated
+    | "vendored" -> Ok ClassVendored
+    | other ->
+        Error(
+            sprintf
+                "harness[%d].ownership[%d].class: invalid value \"%s\" (expected \"source\", \"generated\", or \"vendored\")"
+                harnessIndex
+                ownershipIndex
+                other
+        )
+
+let private toOwnershipEntry
+    (harnessIndex: int)
+    (ownershipIndex: int)
+    (dto: OwnershipEntryDto)
+    : Result<OwnershipEntry, string> =
+    parseOwnershipClass harnessIndex ownershipIndex dto.Class
+    |> Result.map (fun cls ->
+        { Path = dto.Path
+          Class = cls
+          Reason = Option.ofObj dto.Reason })
+
 let private toHarnessEntry (index: int) (dto: HarnessEntryDto) : Result<HarnessEntry, string> =
     parseTier index dto.Tier
-    |> Result.map (fun tier ->
-        { Name = dto.Name
-          Tier = tier
-          AgentDir = Option.ofObj dto.AgentDir
-          Mirrors = Option.ofObj dto.Mirrors
-          ForbidDir = Option.ofObj dto.ForbidDir })
+    |> Result.bind (fun tier ->
+        toOptionList dto.Ownership
+        |> List.mapi (toOwnershipEntry index)
+        |> sequenceResults
+        |> Result.map (fun ownership ->
+            { Name = dto.Name
+              Tier = tier
+              AgentDir = Option.ofObj dto.AgentDir
+              Mirrors = Option.ofObj dto.Mirrors
+              ForbidDir = Option.ofObj dto.ForbidDir
+              SkillsDir = Option.ofObj dto.SkillsDir
+              SkillsMirrors = Option.ofObj dto.SkillsMirrors
+              Vendored = toOptionList dto.Vendored
+              Ownership = ownership }))
 
 let private toGateEntry (dto: GateEntryDto) : GateEntry =
     let args =
@@ -176,25 +258,140 @@ let private toDoctorConfig (dto: DoctorConfigDto) : DoctorConfig =
     | null -> { DotnetGlobalJson = None }
     | _ -> { DotnetGlobalJson = Option.ofObj dto.DotnetGlobalJson }
 
+/// `harness[]` entries' allowed key set, matching `HarnessEntryDto`'s fields
+/// in the kebab-case spelling `repo-config.yml` uses for them.
+let private allowedHarnessKeys: Set<string> =
+    Set.ofList
+        [ "name"
+          "tier"
+          "agent-dir"
+          "skills-dir"
+          "rules-dir"
+          "agent-name"
+          "mirrors"
+          "skills-mirrors"
+          "vendored"
+          "config"
+          "forbid-dir"
+          "shadow"
+          "instruction"
+          "catalog"
+          "ownership" ]
+
+/// `harness[].ownership[]` entries' allowed key set, matching
+/// `OwnershipEntryDto`'s fields.
+let private allowedOwnershipKeys: Set<string> =
+    Set.ofList [ "path"; "class"; "reason" ]
+
+let private asRawMap (value: obj) : IDictionary<obj, obj> option =
+    match value with
+    | :? IDictionary<obj, obj> as dict -> Some dict
+    | _ -> None
+
+let private asRawList (value: obj) : obj list option =
+    match value with
+    | :? IDictionary<obj, obj> -> None
+    | :? System.Collections.IEnumerable as items when not (value :? string) ->
+        Some(items |> Seq.cast<obj> |> List.ofSeq)
+    | _ -> None
+
+let private tryGetRawValue (dict: IDictionary<obj, obj>) (key: string) : obj option =
+    dict
+    |> Seq.tryFind (fun kv ->
+        match kv.Key with
+        | :? string as candidate -> String.Equals(candidate, key, StringComparison.Ordinal)
+        | _ -> false)
+    |> Option.map (fun kv -> kv.Value)
+
+let private unknownKeyFindings (allowed: Set<string>) (dict: IDictionary<obj, obj>) (label: string) : string list =
+    dict
+    |> Seq.choose (fun kv ->
+        match kv.Key with
+        | :? string as key when not (Set.contains key allowed) ->
+            Some(
+                sprintf
+                    "%s: unknown key \"%s\" (expected one of %s)"
+                    label
+                    key
+                    (String.concat ", " (Set.toList allowed))
+            )
+        | _ -> None)
+    |> List.ofSeq
+
+/// Independently walks `data`'s raw YAML structure (rather than the lenient
+/// `RepoConfigDto`) to reject an unknown key inside a `harness[]` entry or a
+/// `harness[].ownership[]` sub-entry, reproducing Rust's
+/// `#[serde(deny_unknown_fields)]` on `HarnessEntry`/`OwnershipEntry` for
+/// exactly these two substructures.
+///
+/// Scope note: this does NOT reproduce `deny_unknown_fields` for the rest of
+/// the ~40-field `RepoConfig` schema (`gates[]`, `specs`, `doctor`, and
+/// everything this port does not model at all) — see the module doc comment.
+/// Widening this check to more of the schema is future work for later
+/// waves, as this port grows to cover more of `repo-config.yml`.
+let private checkNoUnknownHarnessKeys (data: string) : Result<unit, string> =
+    try
+        let root = deserializer.Deserialize<obj>(data)
+
+        match asRawMap root with
+        | None -> Ok()
+        | Some rootMap ->
+            match tryGetRawValue rootMap "harness" |> Option.bind asRawList with
+            | None -> Ok()
+            | Some harnessItems ->
+                let findings =
+                    harnessItems
+                    |> List.mapi (fun i item ->
+                        match asRawMap item with
+                        | None -> []
+                        | Some entryMap ->
+                            let ownershipFindings =
+                                match tryGetRawValue entryMap "ownership" |> Option.bind asRawList with
+                                | None -> []
+                                | Some ownershipItems ->
+                                    ownershipItems
+                                    |> List.mapi (fun j oitem ->
+                                        match asRawMap oitem with
+                                        | None -> []
+                                        | Some ownedMap ->
+                                            unknownKeyFindings
+                                                allowedOwnershipKeys
+                                                ownedMap
+                                                (sprintf "harness[%d].ownership[%d]" i j))
+                                    |> List.collect id
+
+                            unknownKeyFindings allowedHarnessKeys entryMap (sprintf "harness[%d]" i)
+                            @ ownershipFindings)
+                    |> List.collect id
+
+                match findings with
+                | [] -> Ok()
+                | _ -> Error(String.concat "; " findings)
+    with ex ->
+        Error ex.Message
+
 /// Parses `data` (the contents of `repo-config.yml`) into a [`RepoConfig`]
 /// [Repo-grounded — `repo_config/mod.rs::parse_repo_config`].
 let private parseRepoConfig (data: string) : Result<RepoConfig, string> =
-    try
-        let dto = deserializer.Deserialize<RepoConfigDto>(data)
+    match checkNoUnknownHarnessKeys data with
+    | Error message -> Error message
+    | Ok() ->
+        try
+            let dto = deserializer.Deserialize<RepoConfigDto>(data)
 
-        match box dto with
-        | null -> Ok empty
-        | _ ->
-            toOptionList dto.Harness
-            |> List.mapi toHarnessEntry
-            |> sequenceResults
-            |> Result.map (fun harness ->
-                { Harness = harness
-                  Gates = toOptionList dto.Gates |> List.map toGateEntry
-                  Specs = toSpecsConfig dto.Specs
-                  Doctor = toDoctorConfig dto.Doctor })
-    with ex ->
-        Error ex.Message
+            match box dto with
+            | null -> Ok empty
+            | _ ->
+                toOptionList dto.Harness
+                |> List.mapi toHarnessEntry
+                |> sequenceResults
+                |> Result.map (fun harness ->
+                    { Harness = harness
+                      Gates = toOptionList dto.Gates |> List.map toGateEntry
+                      Specs = toSpecsConfig dto.Specs
+                      Doctor = toDoctorConfig dto.Doctor })
+        with ex ->
+            Error ex.Message
 
 /// Loads and parses `repo-config.yml` at `repoRoot`
 /// [Repo-grounded — `repo_config/mod.rs::load`].
@@ -320,22 +517,128 @@ let confinedRepoPath (repoRoot: string) (value: string) : Result<string, string>
         with ex ->
             Error ex.Message
 
-/// Collects `repo-config validate`'s semantic findings, trimmed to the one
-/// check the leading-`./`-rejection scenario exercises
-/// [Repo-grounded — `repo_config_validate.rs::semantic_findings`].
+/// Splits a path into its non-empty components, tolerating either separator
+/// so a trailing separator does not manufacture a spurious empty component
+/// [Repo-grounded — `repo_config/mod.rs::paths_equal`/`path_is_under`'s use
+/// of `Path::components()`].
+let private pathComponents (path: string) : string list =
+    path.Split('/', '\\')
+    |> Array.filter (fun segment -> segment <> "")
+    |> List.ofArray
+
+/// Component-wise path equality — tolerates a trailing separator difference
+/// but not a real typo [Repo-grounded — `repo_config/mod.rs::paths_equal`].
+let pathsEqual (a: string) (b: string) : bool = pathComponents a = pathComponents b
+
+/// True when `path` lies under `dir` (component-wise prefix). False when
+/// `dir` is empty [Repo-grounded — `repo_config/mod.rs::path_is_under`].
+let pathIsUnder (path: string) (dir: string) : bool =
+    if String.IsNullOrEmpty dir then
+        false
+    else
+        let dirComponents = pathComponents dir
+        let pathParts = pathComponents path
+
+        dirComponents.Length <= pathParts.Length
+        && (pathParts |> List.take dirComponents.Length) = dirComponents
+
+/// Forward direction: an ownership entry declared `class: vendored` under
+/// this harness entry's `skills-dir`, with no matching `vendored[]` entry.
+/// A no-op when `skills-dir` is unset
+/// [Repo-grounded —
+/// `repo_config/mod.rs::vendored_missing_from_ownership_backed_list`].
+let vendoredMissingFromOwnershipBackedList (index: int) (entry: HarnessEntry) : string list =
+    match entry.SkillsDir with
+    | None -> []
+    | Some skillsDir ->
+        entry.Ownership
+        |> List.filter (fun owned ->
+            owned.Class = ClassVendored
+            && pathIsUnder owned.Path skillsDir
+            && not (entry.Vendored |> List.exists (fun v -> pathsEqual v owned.Path)))
+        |> List.map (fun owned ->
+            sprintf
+                "harness[%d].ownership: \"%s\" is declared class: vendored under skills-dir \"%s\" but has no matching harness[%d].vendored entry (the skills mirror will delete it on the next regeneration)"
+                index
+                owned.Path
+                skillsDir
+                index)
+
+/// Reverse direction: a `vendored[]` entry with no matching `ownership`
+/// entry declared `class: vendored`. Always checked, with no `skills-dir`
+/// gate — `vendored[]` itself only makes sense under `skills-dir`
+/// [Repo-grounded — `repo_config/mod.rs::vendored_without_ownership_entry`].
+let vendoredWithoutOwnershipEntry (index: int) (entry: HarnessEntry) : string list =
+    entry.Vendored
+    |> List.mapi (fun k vendoredPath ->
+        let declared =
+            entry.Ownership
+            |> List.exists (fun owned -> owned.Class = ClassVendored && pathsEqual owned.Path vendoredPath)
+
+        if declared then
+            None
+        else
+            Some(
+                sprintf
+                    "harness[%d].vendored[%d]: \"%s\" has no matching harness[%d].ownership entry with class: vendored (a vendored[] entry that fails to match its real directory — most commonly a typo — leaves that real directory unprotected and the skills mirror will delete it on the next regeneration)"
+                    index
+                    k
+                    vendoredPath
+                    index
+            ))
+    |> List.choose id
+
+/// Per-harness-entry semantic findings: every `class: vendored` ownership
+/// declaration must carry a non-empty `reason`, plus both cross-checks above
+/// [Repo-grounded —
+/// `repo_config_validate.rs::harness_entry_semantic_findings`].
+let harnessEntrySemanticFindings (index: int) (entry: HarnessEntry) : string list =
+    let reasonFindings =
+        entry.Ownership
+        |> List.mapi (fun j owned ->
+            let blank =
+                owned.Reason
+                |> Option.map (fun r -> r.Trim())
+                |> Option.forall (fun r -> r = "")
+
+            if owned.Class = ClassVendored && blank then
+                Some(
+                    sprintf
+                        "harness[%d].ownership[%d].reason: required non-empty value for path \"%s\" (a vendored path must record why it cannot be regenerated)"
+                        index
+                        j
+                        owned.Path
+                )
+            else
+                None)
+        |> List.choose id
+
+    reasonFindings
+    @ vendoredMissingFromOwnershipBackedList index entry
+    @ vendoredWithoutOwnershipEntry index entry
+
+/// Collects `repo-config validate`'s semantic findings
+/// [Repo-grounded — `repo_config_validate.rs::semantic_findings`,
+/// `harness_entry_semantic_findings`].
 ///
 /// Scope note: the Rust validator additionally requires non-empty `harness`/
 /// `coverage.projects`, validates every harness path field, and checks gate
-/// wiring/carve-out/duplicate-id rules — none of which this feature file's
-/// nine scenarios exercise, and none of which this trimmed `RepoConfig` type
-/// (see module doc comment) carries enough data to check.
+/// wiring/carve-out/duplicate-id rules — none of which either feature file's
+/// scenarios exercise, and none of which this trimmed `RepoConfig` type (see
+/// module doc comment) carries enough data to check.
 let semanticFindings (config: RepoConfig) : string list =
-    match config.Doctor.DotnetGlobalJson with
-    | None -> []
-    | Some path ->
-        match validateRepoRelativePath path with
-        | Ok() -> []
-        | Error message -> [ sprintf "doctor.dotnet-global-json: invalid value \"%s\" (%s)" path message ]
+    let doctorFindings =
+        match config.Doctor.DotnetGlobalJson with
+        | None -> []
+        | Some path ->
+            match validateRepoRelativePath path with
+            | Ok() -> []
+            | Error message -> [ sprintf "doctor.dotnet-global-json: invalid value \"%s\" (%s)" path message ]
+
+    let harnessFindings =
+        config.Harness |> List.mapi harnessEntrySemanticFindings |> List.collect id
+
+    doctorFindings @ harnessFindings
 
 /// Runs `repo-config validate` from a known `repoRoot`, returning whether it
 /// passed alongside the human-readable text a CLI invocation would print

--- a/apps/rhino-cli/src-fsharp/project.json
+++ b/apps/rhino-cli/src-fsharp/project.json
@@ -112,7 +112,7 @@
     "specs:behavior:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config apps/rhino-cli/src-fsharp"
+        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate apps/rhino-cli/src-fsharp"
       },
       "cache": true,
       "inputs": ["{workspaceRoot}/specs/apps/rhino/behavior/rhino-cli/gherkin/**/*.feature", "{projectRoot}/**/*.fs"]

--- a/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+++ b/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
@@ -17,6 +17,8 @@
     <Compile Include="Steps/ParityUnitTests.fs" />
     <Compile Include="Steps/RepoConfigSteps.fs" />
     <Compile Include="Steps/RepoConfigUnitTests.fs" />
+    <Compile Include="Steps/RepoConfigValidateSteps.fs" />
+    <Compile Include="Steps/RepoConfigValidateUnitTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/RepoConfigValidateSteps.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/RepoConfigValidateSteps.fs
@@ -1,0 +1,544 @@
+/// TickSpec step definitions binding
+/// `repo-config-validate.feature`'s five scenarios to
+/// `RhinoCli.Application.RepoConfig`
+/// [Repo-grounded —
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate/repo-config-validate.feature`,
+/// `apps/rhino-cli/tests/repo_config_validate.rs`].
+///
+/// Follows `RepoConfigSteps.fs`'s per-scenario slicing convention: each xunit
+/// `[<Fact>]` below runs exactly one scenario, extracted from the real,
+/// frozen feature file rather than a duplicated/rewritten copy of its
+/// wording.
+///
+/// Scenarios 2 and 3 ("the canonical repo-config.yml") read THIS
+/// repository's own real `repo-config.yml` via
+/// `RhinoCli.Infrastructure.GitRoot.findRoot` — mirroring the Rust step
+/// definitions, which load the real file for the same reason. The vendored
+/// skill-directory set is derived from the real `.agents/skills`/
+/// `.claude/skills` trees at test-run time rather than hard-coded, because
+/// that plugin payload differs across sibling repositories (ose-public
+/// carries a caveman/cavecrew payload; ose-private carries none) — a
+/// hard-coded expectation here would make this file non-portable across
+/// them, breaking this port's byte-identical-source goal.
+///
+/// Scenarios 4 and 5 build a synthetic, self-contained fixture (mirroring
+/// the Rust suite's `synthetic_config_with_vendored_probe`) for the same
+/// reason: which paths are vendored is repository-local, so a scenario
+/// probing the vendored/ownership cross-check must not depend on either
+/// repo's actual vendored set.
+module RhinoCli.Tests.Unit.Steps.RepoConfigValidateSteps
+
+open System
+open System.IO
+open TickSpec
+open Xunit
+open RhinoCli.Application.RepoConfig
+
+/// Instance step-definition container — see `ConventionSteps.fs`'s module
+/// doc comment for why TickSpec's one-instance-per-scenario lifecycle makes
+/// instance-level mutable fields the idiomatic state-threading mechanism
+/// here.
+type RepoConfigValidateSteps() =
+    let mutable canonicalText: string option = None
+    let mutable loadedConfig: RepoConfig option = None
+    let mutable codexEntry: HarnessEntry option = None
+    let mutable codexEntryText: string option = None
+    let mutable lastValidate: (bool * string) option = None
+    let mutable lastLoad: Result<RepoConfig, string> option = None
+    let mutable baselineText: string option = None
+    let mutable workingText: string option = None
+
+    let probePath = ".agents/skills/probe"
+
+    let newTempDir () =
+        let dir =
+            Path.Combine(Path.GetTempPath(), "rhino-cli-repo-config-validate-" + Guid.NewGuid().ToString("N"))
+
+        Directory.CreateDirectory(dir) |> ignore
+        dir
+
+    /// Writes `content` as `repo-config.yml` inside a fresh, throwaway temp
+    /// directory, runs `f` against that directory, then deletes it — every
+    /// synthetic fixture below is validated through this rather than a
+    /// persistent shared directory, since each call is independent.
+    let withTempConfig (content: string) (f: string -> 'a) : 'a =
+        let dir = newTempDir ()
+
+        try
+            File.WriteAllText(Path.Combine(dir, "repo-config.yml"), content)
+            f dir
+        finally
+            Directory.Delete(dir, true)
+
+    let runLoad (content: string) : Result<RepoConfig, string> =
+        withTempConfig content RhinoCli.Application.RepoConfig.load
+
+    let runValidate (content: string) : bool * string =
+        withTempConfig content RhinoCli.Application.RepoConfig.validateAtRoot
+
+    /// Replaces the first (and, for every call site below, only) occurrence
+    /// of `pattern` in `input` with `replacement` — `String.Replace` would
+    /// silently replace every occurrence, which is the wrong tool whenever a
+    /// test needs to prove exactly one mutation caused a result.
+    let replaceFirst (pattern: string) (replacement: string) (input: string) : string =
+        let idx = input.IndexOf(pattern, StringComparison.Ordinal)
+
+        if idx < 0 then
+            failwith (sprintf "pattern not found: %s" pattern)
+
+        input.Substring(0, idx) + replacement + input.Substring(idx + pattern.Length)
+
+    let readCanonicalConfigText () : string * string =
+        match RhinoCli.Infrastructure.GitRoot.findRoot () with
+        | Error message -> failwith message
+        | Ok repoRoot -> repoRoot, File.ReadAllText(Path.Combine(repoRoot, "repo-config.yml"))
+
+    /// Slices the `- name: codex` harness entry out of raw repo-config.yml
+    /// text: from its own line up to (but excluding) the next line that
+    /// starts at column 0, mirroring the Rust suite's `slice_codex_entry`.
+    let sliceCodexEntry (text: string) : string =
+        let marker = "\n  - name: codex"
+        let idx = text.IndexOf(marker, StringComparison.Ordinal)
+
+        if idx < 0 then
+            failwith "codex harness entry not found in repo-config.yml"
+
+        let rest = text.Substring(idx + 1)
+        let lines = rest.Split('\n')
+
+        let entryLines =
+            lines
+            |> Array.skip 1
+            |> Array.takeWhile (fun l -> l.Length = 0 || Char.IsWhiteSpace(l.[0]))
+
+        String.concat "\n" (Array.append [| lines.[0] |] entryLines)
+
+    /// Every `.agents/skills/<dir>` with no `.claude/skills/<dir>`
+    /// counterpart: plugin payload with no canonical source to regenerate it
+    /// from, derived from the real filesystem rather than hard-coded (see
+    /// module doc comment). Repo-relative, sorted.
+    let vendoredSkillDirs (repoRoot: string) : string list =
+        let mirror = Path.Combine(repoRoot, ".agents", "skills")
+        let source = Path.Combine(repoRoot, ".claude", "skills")
+
+        if not (Directory.Exists mirror) then
+            []
+        else
+            Directory.GetDirectories(mirror)
+            |> Array.map Path.GetFileName
+            |> Array.filter (fun name -> not (Directory.Exists(Path.Combine(source, name))))
+            |> Array.map (fun name -> ".agents/skills/" + name)
+            |> Array.sort
+            |> List.ofArray
+
+    /// A minimal, self-contained registry declaring one generated harness
+    /// entry whose `vendored:` list and `ownership: class: vendored`
+    /// declaration agree on `probePath` — the fixture scenarios 4 and 5
+    /// mutate in one direction each.
+    let syntheticConfigWithVendoredProbe () : string =
+        String.concat
+            "\n"
+            [ "harness:"
+              "  - name: codex"
+              "    tier: generated"
+              "    agent-dir: .codex/agents"
+              "    mirrors: .claude/agents"
+              "    skills-dir: .agents/skills"
+              "    skills-mirrors: .claude/skills"
+              "    vendored:"
+              sprintf "      - %s" probePath
+              "    ownership:"
+              sprintf "      - { path: %s, class: vendored, reason: synthetic probe for the cross-check }" probePath
+              "" ]
+
+    // ---- Given/When/Then: schema-parity gate (scenario 1) ----
+
+    [<Given>]
+    member _.``"rhino-cli repo-config validate" in each repo's pre-commit and pre-push/PR``() =
+        let _, text = readCanonicalConfigText ()
+        canonicalText <- Some text
+
+    [<When>]
+    member _.``repo-config.yml is validated``() =
+        lastValidate <- Some(runValidate (Option.get canonicalText))
+
+    [<Then>]
+    member _.``the command strict-deserializes it against the canonical RepoConfig schema``() =
+        match lastValidate with
+        | Some(ok, output) -> Assert.True(ok, sprintf "canonical repo-config.yml must validate cleanly: %s" output)
+        | None -> Assert.Fail("no validation has run")
+
+    [<Then>]
+    member _.``it passes when only values differ``() =
+        let mutated =
+            replaceFirst
+                "config: .opencode/opencode.json"
+                "config: .opencode/opencode-alt.json"
+                (Option.get canonicalText)
+
+        let ok, output = runValidate mutated
+        Assert.True(ok, sprintf "a value-only change (identical key set) must still pass: %s" output)
+
+    [<Then>]
+    member _.``it fails when a required key is missing or an unknown key is present``() =
+        let withUnknownKey =
+            replaceFirst
+                "  - name: claude-code\n"
+                "  - name: claude-code\n    bogus-unknown-key: true\n"
+                (Option.get canonicalText)
+
+        let okUnknown, outputUnknown = runValidate withUnknownKey
+        Assert.False(okUnknown, sprintf "an unknown key inside a harness entry must be rejected: %s" outputUnknown)
+
+        let withMissingTier =
+            replaceFirst
+                "  - name: claude-code\n    tier: source\n"
+                "  - name: claude-code\n"
+                (Option.get canonicalText)
+
+        let okMissing, outputMissing = runValidate withMissingTier
+        Assert.False(okMissing, sprintf "a missing required key must be rejected: %s" outputMissing)
+
+    [<Then>]
+    member _.``running it independently against the byte-identical schema in both repos is equivalent to an identical key set across both repo-config.yml files``
+        ()
+        =
+        let valueVariant =
+            replaceFirst
+                "config: .opencode/opencode.json"
+                "config: .opencode/opencode-alt.json"
+                (Option.get canonicalText)
+
+        let keyVariant =
+            replaceFirst
+                "  - name: claude-code\n"
+                "  - name: claude-code\n    bogus-unknown-key: true\n"
+                (Option.get canonicalText)
+
+        let okValue, _ = runValidate valueVariant
+        let okKey, _ = runValidate keyVariant
+        Assert.True(okValue, "identical key set (values differ) must validate")
+        Assert.False(okKey, "divergent key set (unknown key) must fail")
+
+    // ---- Given/When/Then: codex skills mirror (scenario 2) ----
+
+    [<Given>]
+    member _.``the canonical repo-config.yml``() =
+        let repoRoot, text = readCanonicalConfigText ()
+        canonicalText <- Some text
+
+        match RhinoCli.Application.RepoConfig.load repoRoot with
+        | Error message -> failwith message
+        | Ok config -> loadedConfig <- Some config
+
+    [<When>]
+    member _.``the codex harness entry is inspected``() =
+        match loadedConfig with
+        | None -> Assert.Fail("no config was loaded by a Given step")
+        | Some config ->
+            codexEntry <- config.Harness |> List.tryFind (fun h -> h.Name = "codex")
+            codexEntryText <- canonicalText |> Option.map sliceCodexEntry
+            Assert.True(codexEntry.IsSome, "codex harness entry must exist in repo-config.yml")
+
+    [<Then>]
+    member _.``it declares ".agents/skills" as a mirror of ".claude/skills"``() =
+        match codexEntry with
+        | None -> Assert.Fail("codex entry was not loaded by a When step")
+        | Some entry ->
+            Assert.Equal<string option>(Some ".agents/skills", entry.SkillsDir)
+            Assert.Equal<string option>(Some ".claude/skills", entry.SkillsMirrors)
+            // A declaration the schema does not know is a silent no-op, so
+            // prove the strict deserializer actually accepts these keys
+            // rather than merely tolerating their absence.
+            let ok, output = runValidate (Option.get canonicalText)
+            Assert.True(ok, sprintf "the canonical config carrying skills-mirrors must strict-deserialize: %s" output)
+
+    [<Then>]
+    member _.``it declares every vendored skill subdirectory``() =
+        let repoRoot, _ = readCanonicalConfigText ()
+        let expected = vendoredSkillDirs repoRoot
+
+        match codexEntry with
+        | None -> Assert.Fail("codex entry was not loaded by a When step")
+        | Some entry ->
+            let declared = entry.Vendored |> List.sort
+            Assert.Equal<string list>(expected, declared)
+
+    [<Then>]
+    member _.``each vendored entry names the plugin it came from``() =
+        match codexEntry, codexEntryText with
+        | None, _
+        | _, None -> Assert.Fail("codex entry was not loaded by a When step")
+        | Some entry, Some entryText ->
+            // A bare path list says WHICH directories are exempt but not WHY,
+            // so a later reader cannot tell a genuine plugin payload from a
+            // mistake someone silenced.
+            for dir in entry.Vendored do
+                let line =
+                    entryText.Split('\n')
+                    |> Array.tryFind (fun l -> l.TrimStart().StartsWith("- " + dir, StringComparison.Ordinal))
+
+                match line with
+                | None -> Assert.Fail(sprintf "vendored entry %s must be on its own line" dir)
+                | Some l ->
+                    let parts = l.Split('#')
+
+                    Assert.True(parts.Length > 1, sprintf "vendored entry %s carries no inline origin comment" dir)
+                    Assert.Contains("plugin", parts.[1].ToLowerInvariant())
+
+    [<Then>]
+    member _.``the schema rejects a typo'd key inside the vendored declaration``() =
+        let baseline =
+            String.concat
+                "\n"
+                [ "harness:"
+                  "  - name: probe"
+                  "    tier: generated"
+                  "    ownership:"
+                  "      - { path: probe/path, class: vendored, reason: synthetic probe }"
+                  "" ]
+
+        match runLoad baseline with
+        | Ok _ -> ()
+        | Error message -> Assert.Fail(sprintf "baseline ownership fixture (no typo) must load cleanly: %s" message)
+
+        let typod = replaceFirst "reason:" "resaon:" baseline
+
+        match runLoad typod with
+        | Error _ -> ()
+        | Ok _ -> Assert.Fail("a typo'd key inside an ownership entry must be rejected")
+
+    // ---- Given/When/Then: exhaustive ownership classes (scenario 3) ----
+
+    [<When>]
+    member _.``the harness ownership declarations are inspected``() =
+        match loadedConfig with
+        | None -> Assert.Fail("no config was loaded by a Given step")
+        | Some config -> Assert.False(List.isEmpty config.Harness, "the harness registry must not be empty")
+
+    [<Then>]
+    member _.``every binding path a harness entry claims carries exactly one of the classes "generated", "vendored", or "source"``
+        ()
+        =
+        match loadedConfig with
+        | None -> Assert.Fail("no config was loaded by a Given step")
+        | Some config ->
+            // Every `OwnershipClass` value is, by construction, exactly one
+            // of the three cases below — an exhaustive match on all
+            // three cases, with none omitted, is what makes a fourth case
+            // a compile error rather than a silently-ignored value.
+            let allOwnership = config.Harness |> List.collect (fun h -> h.Ownership)
+            Assert.False(List.isEmpty allOwnership, "at least one ownership declaration must exist")
+
+            for owned in allOwnership do
+                match owned.Class with
+                | ClassGenerated
+                | ClassVendored
+                | ClassSource -> ()
+
+            // Scope note: this port models only agent-dir/skills-dir/vendored
+            // as "claimed paths" (not config/rules-dir/instruction, which
+            // this port does not parse into structured fields — see the
+            // module doc comment on `RepoConfig.fs`), so the completeness
+            // check below is narrower than the Rust suite's own
+            // `claimed_paths`-based check.
+            let claimedPaths (entry: HarnessEntry) : string list =
+                (entry.AgentDir |> Option.toList)
+                @ (entry.SkillsDir |> Option.toList)
+                @ entry.Vendored
+
+            let unclassified =
+                [ for entry in config.Harness do
+                      for path in claimedPaths entry do
+                          if not (entry.Ownership |> List.exists (fun o -> o.Path = path)) then
+                              yield sprintf "%s: %s" entry.Name path ]
+
+            Assert.True(
+                List.isEmpty unclassified,
+                sprintf "every claimed path must carry a declared ownership class; unclassified: %A" unclassified
+            )
+
+    [<Then>]
+    member _.``a registry entry declaring a fourth class value fails to deserialize``() =
+        let mutated =
+            replaceFirst "class: source" "class: bespoke" (Option.get canonicalText)
+
+        match runLoad mutated with
+        | Error _ -> ()
+        | Ok _ ->
+            Assert.Fail(
+                "a class value outside generated/vendored/source must be a hard deserialization error rather than a silently-ignored value"
+            )
+
+    [<Then>]
+    member _.``a vendored declaration carrying an empty reason fails validation``() =
+        let text = Option.get canonicalText
+
+        let line =
+            text.Split('\n')
+            |> Array.tryFind (fun l -> l.Contains("class: vendored"))
+            |> Option.defaultWith (fun () -> failwith "no vendored ownership declaration found")
+
+        let idx = line.IndexOf("reason:", StringComparison.Ordinal)
+        Assert.True(idx >= 0, "a vendored declaration must carry a reason on the same line")
+        let blankedLine = line.Substring(0, idx) + "reason: \"\" }"
+        let mutated = replaceFirst line blankedLine text
+
+        let ok, output = runValidate mutated
+        Assert.False(ok, sprintf "a vendored declaration with an empty reason must fail: %s" output)
+
+    [<Then>]
+    member _.``the canonical config carrying a non-empty reason on every vendored declaration exits 0``() =
+        let ok, output = runValidate (Option.get canonicalText)
+        Assert.True(ok, sprintf "the canonical config must validate: %s" output)
+
+    // ---- Given/When/Then: ownership-without-vendored cross-check (scenario 4) ----
+
+    [<Given>]
+    member _.``a synthetic registry entry whose skills-dir vendored path is declared in both hand-maintained lists``() =
+        let text = syntheticConfigWithVendoredProbe ()
+        let ok, output = runValidate text
+
+        Assert.True(ok, sprintf "the synthetic baseline fixture must validate cleanly before it is mutated: %s" output)
+
+        baselineText <- Some text
+        workingText <- Some text
+
+    [<When>]
+    member _.``the vendored: entry for that path is removed``() =
+        let removedLine = sprintf "      - %s\n" probePath
+        let text = Option.get workingText
+        Assert.Contains(removedLine, text)
+        workingText <- Some(replaceFirst removedLine "" text)
+
+    [<Then>]
+    member _.``rhino-cli repo-config validate fails naming the ownership path with no matching vendored entry``() =
+        let ok, output = runValidate (Option.get workingText)
+        lastValidate <- Some(ok, output)
+
+        Assert.False(
+            ok,
+            sprintf
+                "an ownership entry declared class: vendored under skills-dir with no matching vendored: entry must fail: %s"
+                output
+        )
+
+        Assert.Contains(probePath, output)
+        Assert.Contains("no matching", output)
+
+    [<Then>]
+    member _.``it exits 0 once the vendored entry is restored, proving the check is falsifiable in both directions``() =
+        let ok, output = runValidate (Option.get baselineText)
+        Assert.True(ok, sprintf "the fixture, with the vendored: entry restored, must validate: %s" output)
+
+    // ---- When/Then: vendored-without-ownership cross-check (scenario 5) ----
+
+    [<When>]
+    member _.``the matching "class: vendored" ownership declaration for that path is changed to another class``() =
+        let text = Option.get workingText
+        Assert.Contains("class: vendored", text)
+        workingText <- Some(replaceFirst "class: vendored" "class: generated" text)
+
+    [<Then>]
+    member _.``rhino-cli repo-config validate fails naming the vendored entry with no matching ownership declaration``
+        ()
+        =
+        let ok, output = runValidate (Option.get workingText)
+        lastValidate <- Some(ok, output)
+
+        Assert.False(
+            ok,
+            sprintf
+                "a vendored: entry with no matching ownership declaration carrying class: vendored must fail: %s"
+                output
+        )
+
+        Assert.Contains(probePath, output)
+        Assert.Contains("no matching", output)
+
+    [<Then>]
+    member _.``it exits 0 once the ownership declaration is restored to "class: vendored", proving the check is falsifiable in both directions``
+        ()
+        =
+        let ok, output = runValidate (Option.get baselineText)
+        Assert.True(ok, sprintf "the fixture, with the ownership declaration restored, must validate: %s" output)
+
+/// Reads one named `Scenario:` block out of the real, frozen
+/// `repo-config-validate.feature` file (leaving the file itself untouched)
+/// and runs it through TickSpec bound only against `RepoConfigValidateSteps`
+/// — see `RepoConfigSteps.fs`'s `FeatureRunner` for why this is per-scenario
+/// rather than per-file.
+module private FeatureRunner =
+
+    let private featurePath: string =
+        Path.GetFullPath(
+            Path.Combine(
+                __SOURCE_DIRECTORY__,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "specs",
+                "apps",
+                "rhino",
+                "behavior",
+                "rhino-cli",
+                "gherkin",
+                "repo-config-validate",
+                "repo-config-validate.feature"
+            )
+        )
+
+    let private extractScenario (featureLines: string[]) (scenarioTitle: string) : string[] =
+        let featureLine =
+            featureLines
+            |> Array.find (fun l -> l.TrimStart().StartsWith("Feature:", StringComparison.Ordinal))
+
+        let scenarioHeader = sprintf "Scenario: %s" scenarioTitle
+
+        let startIdx = featureLines |> Array.findIndex (fun l -> l.Trim() = scenarioHeader)
+
+        let endIdx =
+            featureLines
+            |> Array.skip (startIdx + 1)
+            |> Array.tryFindIndex (fun l ->
+                let trimmed = l.Trim()
+
+                trimmed.StartsWith("Scenario:", StringComparison.Ordinal)
+                || trimmed.StartsWith("Scenario Outline:", StringComparison.Ordinal))
+            |> Option.map (fun relativeIdx -> startIdx + 1 + relativeIdx)
+            |> Option.defaultValue featureLines.Length
+
+        Array.append [| featureLine; "" |] featureLines.[startIdx .. endIdx - 1]
+
+    /// Runs the single scenario named `scenarioTitle` from
+    /// `repo-config-validate.feature`, bound against `RepoConfigValidateSteps`.
+    let run (scenarioTitle: string) : unit =
+        let allLines = File.ReadAllLines featurePath
+        let snippet = extractScenario allLines scenarioTitle
+        let definitions = StepDefinitions([| typeof<RepoConfigValidateSteps> |])
+        let feature = definitions.GenerateFeature(featurePath, snippet)
+        let scenario = Seq.exactlyOne feature.Scenarios
+        scenario.Action.Invoke()
+
+[<Fact>]
+let ``A schema-parity gate enforces the identical key set`` () =
+    FeatureRunner.run "A schema-parity gate enforces the identical key set"
+
+[<Fact>]
+let ``The registry declares the Codex skills mirror and its vendored exclusions`` () =
+    FeatureRunner.run "The registry declares the Codex skills mirror and its vendored exclusions"
+
+[<Fact>]
+let ``There is no fourth ownership class and no undeclared reason`` () =
+    FeatureRunner.run "There is no fourth ownership class and no undeclared reason"
+
+[<Fact>]
+let ``A vendored ownership declaration under skills-dir requires a matching vendored entry`` () =
+    FeatureRunner.run "A vendored ownership declaration under skills-dir requires a matching vendored entry"
+
+[<Fact>]
+let ``A vendored entry under skills-dir requires a matching ownership declaration`` () =
+    FeatureRunner.run "A vendored entry under skills-dir requires a matching ownership declaration"

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/RepoConfigValidateUnitTests.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/RepoConfigValidateUnitTests.fs
@@ -1,0 +1,512 @@
+/// Plain xunit tests exercising `RhinoCli.Application.RepoConfig`'s
+/// ownership/vendored machinery directly (`parseOwnershipClass`,
+/// `pathsEqual`, `pathIsUnder`, the two cross-checks, the unknown-harness-key
+/// structural check, and `validateAtRoot` end to end against hand-built
+/// fixtures) — behaviour with no dedicated Gherkin scenario, or exercised
+/// only indirectly there. Kept separate from `RepoConfigValidateSteps.fs`
+/// (which binds only real, frozen feature-file scenarios) so this file can
+/// grow test cases without inflating the plan's tracked Gherkin scenario
+/// count — mirrors `RepoConfigUnitTests.fs`'s own rationale.
+module RhinoCli.Tests.Unit.Steps.RepoConfigValidateUnitTests
+
+open System
+open System.IO
+open Xunit
+open RhinoCli.Application.RepoConfig
+
+let private newTempDir () =
+    let dir =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-repo-config-validate-unit-" + Guid.NewGuid().ToString("N"))
+
+    Directory.CreateDirectory(dir) |> ignore
+    dir
+
+let private writeFile (root: string) (relativePath: string) (content: string) =
+    let full = Path.Combine(root, relativePath)
+    Directory.CreateDirectory(Path.GetDirectoryName(full)) |> ignore
+    File.WriteAllText(full, content)
+
+/// A minimal `HarnessEntry`, built with an explicit type annotation and
+/// updated via `with` in every test below — `HarnessEntryDto` declares the
+/// same field labels (`Name`, `Tier`, `AgentDir`, ...), so a bare record
+/// literal here would otherwise leave the compiler to pick between the two
+/// candidate record types by label-set + declaration order rather than
+/// intent.
+let private defaultHarnessEntry: HarnessEntry =
+    { Name = "probe"
+      Tier = Generated
+      AgentDir = None
+      Mirrors = None
+      ForbidDir = None
+      SkillsDir = None
+      SkillsMirrors = None
+      Vendored = []
+      Ownership = [] }
+
+/// A minimal `OwnershipEntry`, for the same reason as `defaultHarnessEntry`
+/// above (`OwnershipEntryDto` shares its field labels).
+let private defaultOwnershipEntry: OwnershipEntry =
+    { Path = "somewhere"
+      Class = ClassSource
+      Reason = None }
+
+// ---- pathsEqual ----
+
+[<Fact>]
+let ``pathsEqual treats identical paths as equal`` () =
+    Assert.True(pathsEqual ".agents/skills/probe" ".agents/skills/probe")
+
+[<Fact>]
+let ``pathsEqual tolerates a trailing separator difference`` () =
+    Assert.True(pathsEqual ".agents/skills/probe/" ".agents/skills/probe")
+
+[<Fact>]
+let ``pathsEqual rejects a real typo`` () =
+    Assert.False(pathsEqual ".agents/skills/porbe" ".agents/skills/probe")
+
+// ---- pathIsUnder ----
+
+[<Fact>]
+let ``pathIsUnder is true for a direct child`` () =
+    Assert.True(pathIsUnder ".agents/skills/probe" ".agents/skills")
+
+[<Fact>]
+let ``pathIsUnder is true for the directory itself`` () =
+    Assert.True(pathIsUnder ".agents/skills" ".agents/skills")
+
+[<Fact>]
+let ``pathIsUnder is false for a sibling directory`` () =
+    Assert.False(pathIsUnder ".agents/other/probe" ".agents/skills")
+
+[<Fact>]
+let ``pathIsUnder is false when dir is empty`` () =
+    Assert.False(pathIsUnder ".agents/skills/probe" "")
+
+// ---- vendoredMissingFromOwnershipBackedList ----
+
+[<Fact>]
+let ``vendoredMissingFromOwnershipBackedList is empty when skills-dir is unset`` () =
+    let entry =
+        { defaultHarnessEntry with
+            Ownership =
+                [ { defaultOwnershipEntry with
+                      Path = ".agents/skills/probe"
+                      Class = ClassVendored
+                      Reason = Some "reason" } ] }
+
+    Assert.Empty(vendoredMissingFromOwnershipBackedList 0 entry)
+
+[<Fact>]
+let ``vendoredMissingFromOwnershipBackedList finds an ownership entry with no matching vendored entry`` () =
+    let entry =
+        { defaultHarnessEntry with
+            SkillsDir = Some ".agents/skills"
+            Ownership =
+                [ { defaultOwnershipEntry with
+                      Path = ".agents/skills/probe"
+                      Class = ClassVendored
+                      Reason = Some "reason" } ] }
+
+    let findings = vendoredMissingFromOwnershipBackedList 0 entry
+    Assert.Single(findings) |> ignore
+    Assert.Contains(".agents/skills/probe", List.head findings)
+    Assert.Contains("no matching harness[0].vendored", List.head findings)
+
+[<Fact>]
+let ``vendoredMissingFromOwnershipBackedList is empty when the vendored entry matches`` () =
+    let entry =
+        { defaultHarnessEntry with
+            SkillsDir = Some ".agents/skills"
+            Vendored = [ ".agents/skills/probe" ]
+            Ownership =
+                [ { defaultOwnershipEntry with
+                      Path = ".agents/skills/probe"
+                      Class = ClassVendored
+                      Reason = Some "reason" } ] }
+
+    Assert.Empty(vendoredMissingFromOwnershipBackedList 0 entry)
+
+[<Fact>]
+let ``vendoredMissingFromOwnershipBackedList ignores ownership entries outside skills-dir`` () =
+    let entry =
+        { defaultHarnessEntry with
+            SkillsDir = Some ".agents/skills"
+            Ownership =
+                [ { defaultOwnershipEntry with
+                      Path = ".codex/config.toml"
+                      Class = ClassVendored
+                      Reason = Some "reason" } ] }
+
+    Assert.Empty(vendoredMissingFromOwnershipBackedList 0 entry)
+
+// ---- vendoredWithoutOwnershipEntry ----
+
+[<Fact>]
+let ``vendoredWithoutOwnershipEntry finds a vendored entry with no matching ownership declaration`` () =
+    let entry =
+        { defaultHarnessEntry with
+            SkillsDir = Some ".agents/skills"
+            Vendored = [ ".agents/skills/probe" ] }
+
+    let findings = vendoredWithoutOwnershipEntry 0 entry
+    Assert.Single(findings) |> ignore
+    Assert.Contains(".agents/skills/probe", List.head findings)
+    Assert.Contains("no matching harness[0].ownership", List.head findings)
+
+[<Fact>]
+let ``vendoredWithoutOwnershipEntry is empty when the ownership declaration matches`` () =
+    let entry =
+        { defaultHarnessEntry with
+            SkillsDir = Some ".agents/skills"
+            Vendored = [ ".agents/skills/probe" ]
+            Ownership =
+                [ { defaultOwnershipEntry with
+                      Path = ".agents/skills/probe"
+                      Class = ClassVendored
+                      Reason = Some "reason" } ] }
+
+    Assert.Empty(vendoredWithoutOwnershipEntry 0 entry)
+
+[<Fact>]
+let ``vendoredWithoutOwnershipEntry rejects a matching path declared under the wrong class`` () =
+    let entry =
+        { defaultHarnessEntry with
+            SkillsDir = Some ".agents/skills"
+            Vendored = [ ".agents/skills/probe" ]
+            Ownership =
+                [ { defaultOwnershipEntry with
+                      Path = ".agents/skills/probe"
+                      Class = ClassGenerated
+                      Reason = None } ] }
+
+    Assert.Single(vendoredWithoutOwnershipEntry 0 entry) |> ignore
+
+// ---- harnessEntrySemanticFindings: reason required for vendored ----
+
+[<Fact>]
+let ``harnessEntrySemanticFindings rejects an empty reason on a vendored declaration`` () =
+    let entry =
+        { defaultHarnessEntry with
+            Ownership =
+                [ { defaultOwnershipEntry with
+                      Path = "somewhere"
+                      Class = ClassVendored
+                      Reason = Some "   " } ] }
+
+    let findings = harnessEntrySemanticFindings 0 entry
+    Assert.Single(findings) |> ignore
+    Assert.Contains("required non-empty value", List.head findings)
+
+[<Fact>]
+let ``harnessEntrySemanticFindings rejects a missing reason on a vendored declaration`` () =
+    let entry =
+        { defaultHarnessEntry with
+            Ownership =
+                [ { defaultOwnershipEntry with
+                      Path = "somewhere"
+                      Class = ClassVendored
+                      Reason = None } ] }
+
+    Assert.Single(harnessEntrySemanticFindings 0 entry) |> ignore
+
+[<Fact>]
+let ``harnessEntrySemanticFindings does not require a reason on source or generated declarations`` () =
+    let entry =
+        { defaultHarnessEntry with
+            Ownership =
+                [ { defaultOwnershipEntry with
+                      Path = "a"
+                      Class = ClassSource
+                      Reason = None }
+                  { defaultOwnershipEntry with
+                      Path = "b"
+                      Class = ClassGenerated
+                      Reason = None } ] }
+
+    Assert.Empty(harnessEntrySemanticFindings 0 entry)
+
+// ---- load: ownership parsing ----
+
+[<Fact>]
+let ``load parses a well-formed ownership entry`` () =
+    let root = newTempDir ()
+
+    try
+        writeFile
+            root
+            "repo-config.yml"
+            (String.concat
+                "\n"
+                [ "harness:"
+                  "  - name: probe"
+                  "    tier: generated"
+                  "    skills-dir: .agents/skills"
+                  "    skills-mirrors: .claude/skills"
+                  "    vendored:"
+                  "      - .agents/skills/example"
+                  "    ownership:"
+                  "      - { path: .agents/skills/example, class: vendored, reason: third-party payload }"
+                  "" ])
+
+        match load root with
+        | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+        | Ok config ->
+            let entry = config.Harness |> List.find (fun h -> h.Name = "probe")
+            Assert.Equal<string option>(Some ".agents/skills", entry.SkillsDir)
+            Assert.Equal<string option>(Some ".claude/skills", entry.SkillsMirrors)
+            Assert.Equal<string list>([ ".agents/skills/example" ], entry.Vendored)
+            let owned = Assert.Single(entry.Ownership)
+            Assert.Equal(".agents/skills/example", owned.Path)
+            Assert.Equal(ClassVendored, owned.Class)
+            Assert.Equal<string option>(Some "third-party payload", owned.Reason)
+    finally
+        Directory.Delete(root, true)
+
+[<Fact>]
+let ``load rejects an ownership entry declaring a fourth class value`` () =
+    let root = newTempDir ()
+
+    try
+        writeFile
+            root
+            "repo-config.yml"
+            (String.concat
+                "\n"
+                [ "harness:"
+                  "  - name: probe"
+                  "    tier: generated"
+                  "    ownership:"
+                  "      - { path: somewhere, class: bespoke, reason: nope }"
+                  "" ])
+
+        match load root with
+        | Error message ->
+            Assert.Contains("harness[0].ownership[0].class", message)
+            Assert.Contains("bespoke", message)
+        | Ok _ -> Assert.Fail("expected a fourth class value to be rejected")
+    finally
+        Directory.Delete(root, true)
+
+[<Fact>]
+let ``load rejects an ownership entry with a missing class key`` () =
+    let root = newTempDir ()
+
+    try
+        writeFile
+            root
+            "repo-config.yml"
+            (String.concat
+                "\n"
+                [ "harness:"
+                  "  - name: probe"
+                  "    tier: generated"
+                  "    ownership:"
+                  "      - { path: somewhere }"
+                  "" ])
+
+        match load root with
+        | Error message -> Assert.Contains("required key is missing", message)
+        | Ok _ -> Assert.Fail("expected a missing class key to be rejected")
+    finally
+        Directory.Delete(root, true)
+
+[<Fact>]
+let ``a harness entry with no ownership carries an empty ownership list`` () =
+    let root = newTempDir ()
+
+    try
+        writeFile root "repo-config.yml" "harness:\n  - name: probe\n    tier: source\n"
+
+        match load root with
+        | Ok config ->
+            let entry = config.Harness |> List.find (fun h -> h.Name = "probe")
+            Assert.Empty(entry.Ownership)
+            Assert.Empty(entry.Vendored)
+            Assert.Equal<string option>(None, entry.SkillsDir)
+            Assert.Equal<string option>(None, entry.SkillsMirrors)
+        | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+    finally
+        Directory.Delete(root, true)
+
+// ---- load: unknown-key structural check ----
+
+[<Fact>]
+let ``load rejects an unknown key inside a harness entry`` () =
+    let root = newTempDir ()
+
+    try
+        writeFile root "repo-config.yml" "harness:\n  - name: probe\n    tier: source\n    bogus-key: true\n"
+
+        match load root with
+        | Error message -> Assert.Contains("harness[0]: unknown key \"bogus-key\"", message)
+        | Ok _ -> Assert.Fail("expected an unknown harness key to be rejected")
+    finally
+        Directory.Delete(root, true)
+
+[<Fact>]
+let ``load rejects an unknown key inside an ownership entry`` () =
+    let root = newTempDir ()
+
+    try
+        writeFile
+            root
+            "repo-config.yml"
+            (String.concat
+                "\n"
+                [ "harness:"
+                  "  - name: probe"
+                  "    tier: source"
+                  "    ownership:"
+                  "      - { path: somewhere, class: source, resaon: typo }"
+                  "" ])
+
+        match load root with
+        | Error message -> Assert.Contains("harness[0].ownership[0]: unknown key \"resaon\"", message)
+        | Ok _ -> Assert.Fail("expected an unknown ownership key to be rejected")
+    finally
+        Directory.Delete(root, true)
+
+[<Fact>]
+let ``load accepts every recognised harness and ownership key`` () =
+    let root = newTempDir ()
+
+    try
+        writeFile
+            root
+            "repo-config.yml"
+            (String.concat
+                "\n"
+                [ "harness:"
+                  "  - name: probe"
+                  "    tier: generated"
+                  "    agent-dir: .probe/agents"
+                  "    skills-dir: .probe/skills"
+                  "    rules-dir: .probe/rules"
+                  "    agent-name: probe"
+                  "    mirrors: .claude/agents"
+                  "    skills-mirrors: .claude/skills"
+                  "    vendored: []"
+                  "    config: .probe/config.toml"
+                  "    forbid-dir: .probe/forbidden"
+                  "    shadow: true"
+                  "    instruction:"
+                  "      - AGENTS.md"
+                  "    catalog:"
+                  "      platform: Probe"
+                  "    ownership:"
+                  "      - { path: somewhere, class: source, reason: fine }"
+                  "" ])
+
+        match load root with
+        | Ok _ -> ()
+        | Error message -> Assert.Fail(sprintf "expected every recognised key to be accepted, got Error %s" message)
+    finally
+        Directory.Delete(root, true)
+
+// ---- semanticFindings: harness-entry findings folded in ----
+
+[<Fact>]
+let ``semanticFindings includes harness ownership findings alongside the doctor path finding`` () =
+    let root = newTempDir ()
+
+    try
+        writeFile
+            root
+            "repo-config.yml"
+            (String.concat
+                "\n"
+                [ "doctor:"
+                  "  dotnet-global-json: ./bad-path.json"
+                  "harness:"
+                  "  - name: probe"
+                  "    tier: generated"
+                  "    ownership:"
+                  "      - { path: somewhere, class: vendored, reason: \"\" }"
+                  "" ])
+
+        match load root with
+        | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+        | Ok config ->
+            let findings = semanticFindings config
+            Assert.True(findings.Length >= 2, sprintf "expected at least two findings, got %A" findings)
+            Assert.True(findings |> List.exists (fun f -> f.Contains("dotnet-global-json")))
+            Assert.True(findings |> List.exists (fun f -> f.Contains("required non-empty value")))
+    finally
+        Directory.Delete(root, true)
+
+// ---- validateAtRoot: end to end against the cross-checks ----
+
+[<Fact>]
+let ``validateAtRoot fails when a vendored ownership declaration has no matching vendored entry`` () =
+    let root = newTempDir ()
+
+    try
+        writeFile
+            root
+            "repo-config.yml"
+            (String.concat
+                "\n"
+                [ "harness:"
+                  "  - name: probe"
+                  "    tier: generated"
+                  "    skills-dir: .agents/skills"
+                  "    ownership:"
+                  "      - { path: .agents/skills/probe, class: vendored, reason: fine }"
+                  "" ])
+
+        let ok, output = validateAtRoot root
+        Assert.False(ok, output)
+        Assert.Contains(".agents/skills/probe", output)
+        Assert.Contains("no matching harness[0].vendored", output)
+    finally
+        Directory.Delete(root, true)
+
+[<Fact>]
+let ``validateAtRoot fails when a vendored entry has no matching ownership declaration`` () =
+    let root = newTempDir ()
+
+    try
+        writeFile
+            root
+            "repo-config.yml"
+            (String.concat
+                "\n"
+                [ "harness:"
+                  "  - name: probe"
+                  "    tier: generated"
+                  "    skills-dir: .agents/skills"
+                  "    vendored:"
+                  "      - .agents/skills/probe"
+                  "" ])
+
+        let ok, output = validateAtRoot root
+        Assert.False(ok, output)
+        Assert.Contains(".agents/skills/probe", output)
+        Assert.Contains("no matching harness[0].ownership", output)
+    finally
+        Directory.Delete(root, true)
+
+[<Fact>]
+let ``validateAtRoot passes when vendored and ownership agree`` () =
+    let root = newTempDir ()
+
+    try
+        writeFile
+            root
+            "repo-config.yml"
+            (String.concat
+                "\n"
+                [ "harness:"
+                  "  - name: probe"
+                  "    tier: generated"
+                  "    skills-dir: .agents/skills"
+                  "    vendored:"
+                  "      - .agents/skills/probe"
+                  "    ownership:"
+                  "      - { path: .agents/skills/probe, class: vendored, reason: third-party payload }"
+                  "" ])
+
+        let ok, output = validateAtRoot root
+        Assert.True(ok, output)
+    finally
+        Directory.Delete(root, true)

--- a/repo-config.yml
+++ b/repo-config.yml
@@ -162,11 +162,11 @@ coverage:
     # files together (emoji, license, and the aggregate audit share one
     # module) — splitting the scope per-file would not reflect how the
     # implementation is actually structured. Wave A widened it from nothing
-    # (Phase 2) to the full `convention/` directory. Wave B's first PR adds
-    # `repo-config/` as a sibling entry in the same brace-list glob.
+    # (Phase 2) to the full `convention/` directory. Wave B widens it PR by
+    # PR, one sibling directory at a time, in the same brace-list glob.
     - name: rhino-cli-fsharp
       levels: [unit, integration]
-      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention,repo-config}/**"
+      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention,repo-config,repo-config-validate}/**"
 
     # ose domain
     - name: ose-be


### PR DESCRIPTION
## Summary
- Ports `specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate/repo-config-validate.feature` (5 scenarios) to F#.
- Extends `RhinoCli.Application.RepoConfig` with `OwnershipClass`/`OwnershipEntry` and harness `skills-dir`/`skills-mirrors`/`vendored`/`ownership` fields.
- Ports the vendored↔ownership cross-checks (`vendoredMissingFromOwnershipBackedList`, `vendoredWithoutOwnershipEntry`) and the required-non-empty-reason-for-vendored check.
- Adds a scoped raw-YAML unknown-key check covering `harness[]`/`harness[].ownership[]` only (documented as a scope note — full `deny_unknown_fields` parity across the ~40-field schema is future work for later waves; widening it now would break `load` against the real file's not-yet-modeled fields).
- Widens `specs:behavior:coverage` and `repo-config.yml`'s `rhino-cli-fsharp` coverage.projects glob to include `gherkin/repo-config-validate`.

Part of `plans/in-progress/rewrite-rhino-cli-to-fsharp/` Wave B (Phase 4).

## Test plan
- [x] `dotnet test` — 136/136 passing
- [x] `fantomas --check` clean
- [x] `nx run rhino-cli-fsharp:lint` clean (all 5 F# projects, analyzers clean)
- [x] `nx run rhino-cli-fsharp:test:quick` green (unit + specs:structure-validation + specs:behavior:coverage — 5 specs, 25 scenarios, 100 steps)
- [x] `repo-config validate` — schema OK
- [x] Verified the new unknown-key allowlist covers every key the real `repo-config.yml`'s `harness[]`/`harness[].ownership[]` entries actually use (no false-positive risk against the live file)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>