### PR TITLE
feat(rhino-cli-fsharp): port env/env-backup.feature to F# (Wave B PR3)

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -20,7 +20,7 @@ bb55f3c8d4d3daffa7e334ecdacff8bfd9462b12a7098e239943d84a3edf915f  apps/rhino-cli
 631376afb9e4d7c5192d38f51b533c18b64cca83c18ed5c50982ba9acce51d74  apps/rhino-cli/src-fsharp/RhinoCli.Program/RhinoCli.Program.fsproj
 153a226f5ef1d6916aa6e6425b278a606a48659fcba9623c9d01e5cf3b2589a5  apps/rhino-cli/src-fsharp/RhinoCli.Program/src/Program.fs
 822f6ec8446562a4de9a3b1a2481af50fac01bbedc32e1963142709e5f48ec13  apps/rhino-cli/src-fsharp/fsharplint.json
-e2f0e58b912fc9a9ae2fa0f6031b62fe9a7ab8749fc19cb9900bae3e03f6ffec  apps/rhino-cli/src-fsharp/project.json
+10f53a32bd254a7fc70e0d9385eb21811cff2fdc71cd3527e91cba82118059c3  apps/rhino-cli/src-fsharp/project.json
 f7dacc8dd923488c70eebabe298843022ec5a3ba94b8b7568634a779f24b8da4  apps/rhino-cli/src-fsharp/tests/integration/RhinoCli.IntegrationTests.fsproj
 8c1b279e48958e281de2cd2c4a4b2de938fc19bf2d47355d45322df500fb5d38  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
 85ba308ad0a88485db55b305120d99b9a4ec328d2379536110f73e51f4797fe2  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionSteps.fs

--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -3,8 +3,9 @@
 51f04bc4a3f84b9b73386a760312757e62af4fa5ed4a6d357b6d9b0a266cf48e  apps/rhino-cli/LICENSE
 b5f5e511ac5697c2d2949d898633f079abbce9c7211205aad6f7521f17746df2  apps/rhino-cli/project.json
 22b1d0652e8937a20c83841966e4f8b1c451d671d34dd27fb5fa13f11d340a4d  apps/rhino-cli/src-fsharp/.gitignore
-4e30e3e91484c5e869c6db80759c566d9b0fd12a777a8ddc49b784046a4a77ca  apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
+96bd05860d32d93030016db7fa582a1fbb772328d6875cf03fff8957f47b1e90  apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
 11fe7ec2e5e08b432e2d1cedae59e1a555e17e22a1f11494bd83b80c36964b5c  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Convention.fs
+920de36c1a52aff1c0118af5b9374c89608428779c0b0b87ed62391861c869cc  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
 2f8085bcb8089f174e9548e609530471c9318c31b1bcab4a867e33880cec9e57  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Parity.fs
 f68a2a01380e02ce7fa8f5774a0800e9f1281c39d3c90b3c03947c1448799f2d  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/RepoConfig.fs
 fc1346c5ed931f006be550583e92d5603bdffceb270783f4b334bb5ff4d7aa3a  apps/rhino-cli/src-fsharp/RhinoCli.Cli/RhinoCli.Cli.fsproj
@@ -21,10 +22,12 @@ bb55f3c8d4d3daffa7e334ecdacff8bfd9462b12a7098e239943d84a3edf915f  apps/rhino-cli
 822f6ec8446562a4de9a3b1a2481af50fac01bbedc32e1963142709e5f48ec13  apps/rhino-cli/src-fsharp/fsharplint.json
 e2f0e58b912fc9a9ae2fa0f6031b62fe9a7ab8749fc19cb9900bae3e03f6ffec  apps/rhino-cli/src-fsharp/project.json
 f7dacc8dd923488c70eebabe298843022ec5a3ba94b8b7568634a779f24b8da4  apps/rhino-cli/src-fsharp/tests/integration/RhinoCli.IntegrationTests.fsproj
-39550258cd7bc7a1b12d791d6f1e64d4cecbe88d0fb023f9886e10db87811da7  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+8c1b279e48958e281de2cd2c4a4b2de938fc19bf2d47355d45322df500fb5d38  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
 85ba308ad0a88485db55b305120d99b9a4ec328d2379536110f73e51f4797fe2  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionSteps.fs
 a909884a9d8816e2b476cc8c00be03ac4085b849cbe83c4b18e0213ac9cad1d7  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionUnitTests.fs
 a0603a9ec897d538381417f8a330b1fa4b75f75f74003fda2a2b9b9512db5a1a  apps/rhino-cli/src-fsharp/tests/unit/Steps/DispatchUnitTests.fs
+8a3ddb5f25240cc12e3045c4af266bebbebc75c113f1969c42c9df18f6554968  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvSteps.fs
+8ec32c7e97c3e4277dffbeadbcd6d278f52c9661874b52e9e8465221fc4e7534  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvUnitTests.fs
 66215f95f2afe48729422ebccadf068687c87bc5538fee88dfa7364da2f08028  apps/rhino-cli/src-fsharp/tests/unit/Steps/FormattersUnitTests.fs
 cb605599e8c90b2d6d2bdd7e7c0e54a26410f39fa2d3372285be311301d9fab2  apps/rhino-cli/src-fsharp/tests/unit/Steps/GitRootUnitTests.fs
 b8a8fbf79e78dee93f32944d3bbae2daccf33876ce5988ae31b1259c2f5ce201  apps/rhino-cli/src-fsharp/tests/unit/Steps/ParityUnitTests.fs

--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -5,7 +5,7 @@ b5f5e511ac5697c2d2949d898633f079abbce9c7211205aad6f7521f17746df2  apps/rhino-cli
 22b1d0652e8937a20c83841966e4f8b1c451d671d34dd27fb5fa13f11d340a4d  apps/rhino-cli/src-fsharp/.gitignore
 96bd05860d32d93030016db7fa582a1fbb772328d6875cf03fff8957f47b1e90  apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
 11fe7ec2e5e08b432e2d1cedae59e1a555e17e22a1f11494bd83b80c36964b5c  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Convention.fs
-920de36c1a52aff1c0118af5b9374c89608428779c0b0b87ed62391861c869cc  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
+d506ea3be2291c5684fb6015c994d7ad1ce5fb2e7da1a1f71865ceb40efcb5bf  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
 2f8085bcb8089f174e9548e609530471c9318c31b1bcab4a867e33880cec9e57  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Parity.fs
 f68a2a01380e02ce7fa8f5774a0800e9f1281c39d3c90b3c03947c1448799f2d  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/RepoConfig.fs
 fc1346c5ed931f006be550583e92d5603bdffceb270783f4b334bb5ff4d7aa3a  apps/rhino-cli/src-fsharp/RhinoCli.Cli/RhinoCli.Cli.fsproj

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="src/Convention.fs" />
     <Compile Include="src/Parity.fs" />
     <Compile Include="src/RepoConfig.fs" />
+    <Compile Include="src/Env.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
@@ -1,0 +1,753 @@
+/// Port of the slice of the Rust `env` namespace needed by
+/// `env-backup.feature`'s 21 scenarios [Repo-grounded —
+/// `apps/rhino-cli/src/application/env/backup.rs`,
+/// `apps/rhino-cli/src/commands/env_backup.rs`].
+///
+/// Scope: this module ports `backup` and the helpers it (and this feature
+/// file's scenarios) need. `restore`, `env init`, and `env validate-app-drift`
+/// are separate later waves in this same namespace; `discoverConfig`,
+/// `findExisting`, and `detectWorktree` are written here because `backup`
+/// needs them, and are expected to be reused unchanged once `restore` lands.
+///
+/// Design decision — confirmation is real here, not a silent no-op: grepping
+/// the Rust reference shows `Options.force` is threaded from the CLI args
+/// into `Options` but never read inside `backup()`'s body, and `find_existing`
+/// is only ever called from its own unit test — the Rust binary always
+/// silently overwrites an existing backup file, regardless of `--force`. The
+/// four `@env-backup-confirm` scenarios describe behaviour the current Rust
+/// binary does not actually have, so `backup` below closes that gap rather
+/// than reproducing it: it takes an explicit `confirm: unit -> bool`
+/// callback and invokes it only when a real conflict exists in the
+/// destination and `Force` is `false`. Whether to invoke the callback at all
+/// is itself a pure function of `Options` and `findExisting`'s result — the
+/// callback is the one deliberately impure seam — so tests can assert both
+/// the decision made and that the callback fires exactly when (and only
+/// when) a real decision is needed, without touching `Console.In`.
+module RhinoCli.Application.Env
+
+open System
+open System.IO
+open System.Text.Encodings.Web
+open System.Text.Json
+open System.Text.Json.Serialization
+
+/// Maximum file size (in bytes) that will be backed up (1 MiB) [Repo-grounded
+/// — `backup.rs::DEFAULT_MAX_SIZE`].
+[<Literal>]
+let DefaultMaxSize: int64 = 1024L * 1024L
+
+/// Default name of the backup directory placed outside the repository
+/// [Repo-grounded — `backup.rs::DEFAULT_BACKUP_DIR`]. This is ose-public's
+/// own canonical value; ose-private's Rust constant differs and its F# port
+/// must mirror whatever that repository's own constant currently is, not
+/// this literal.
+[<Literal>]
+let DefaultBackupDir: string = "ose-public-env-backup"
+
+/// Directory names the walker skips outright [Repo-grounded —
+/// `backup.rs::default_skip_dirs`].
+let defaultSkipDirs: string list =
+    [ ".git"
+      "node_modules"
+      "bower_components"
+      ".nx"
+      ".next"
+      ".turbo"
+      ".cache"
+      ".parcel-cache"
+      ".nyc_output"
+      "dist"
+      "build"
+      "coverage"
+      "__pycache__"
+      ".venv"
+      "venv"
+      "target"
+      ".gradle"
+      "vendor"
+      "_build"
+      "deps"
+      ".elixir_ls"
+      ".mix"
+      ".dart_tool"
+      ".cargo"
+      "zig-cache"
+      ".stack-work"
+      "elm-stuff"
+      "_deps"
+      ".terraform"
+      ".pulumi"
+      "generated-contracts" ]
+
+/// One well-known config file that `--include-config` may also back up
+/// [Repo-grounded — `backup.rs::ConfigPattern`].
+type ConfigPattern =
+    { RelPath: string
+      Description: string
+      Category: string }
+
+/// Default `--include-config` patterns [Repo-grounded —
+/// `backup.rs::default_config_patterns`].
+let defaultConfigPatterns: ConfigPattern list =
+    [ { RelPath = ".claude/settings.local.json"
+        Description = "Claude Code local settings"
+        Category = "ai-tools" }
+      { RelPath = ".claude/settings.local.json.bkup"
+        Description = "Claude Code settings backup"
+        Category = "ai-tools" }
+      { RelPath = ".cursor/mcp.json"
+        Description = "Cursor MCP configuration"
+        Category = "ai-tools" }
+      { RelPath = ".windsurfrules"
+        Description = "Windsurf project rules"
+        Category = "ai-tools" }
+      { RelPath = ".clinerules"
+        Description = "Cline project rules"
+        Category = "ai-tools" }
+      { RelPath = ".aider.conf.yml"
+        Description = "Aider configuration"
+        Category = "ai-tools" }
+      { RelPath = ".aiderignore"
+        Description = "Aider ignore patterns"
+        Category = "ai-tools" }
+      { RelPath = ".continue/config.json"
+        Description = "Continue configuration"
+        Category = "ai-tools" }
+      { RelPath = ".gemini/settings.json"
+        Description = "Gemini CLI settings"
+        Category = "ai-tools" }
+      { RelPath = ".amazonq/mcp.json"
+        Description = "Amazon Q MCP configuration"
+        Category = "ai-tools" }
+      { RelPath = ".roomodes"
+        Description = "Roo Code custom modes"
+        Category = "ai-tools" }
+      { RelPath = "docker-compose.override.yml"
+        Description = "Docker Compose local overrides"
+        Category = "docker" }
+      { RelPath = "mise.local.toml"
+        Description = "mise local overrides"
+        Category = "version-mgrs" }
+      { RelPath = ".envrc"
+        Description = "direnv environment setup"
+        Category = "environment" } ]
+
+/// One file discovered during a scan, and its copy outcome [Repo-grounded —
+/// `backup.rs::FileEntry`]. `Reason`/`Source` use `""` (rather than `option`)
+/// as their unset sentinel, mirroring the Rust struct's `String` fields and
+/// its `f.source.is_empty()`/`f.reason` emptiness checks in the reporters.
+type EnvFileEntry =
+    { RelPath: string
+      AbsPath: string
+      Size: int64
+      Skipped: bool
+      Reason: string
+      Source: string }
+
+/// Options for a [`backup`] operation [Repo-grounded — `backup.rs::Options`].
+/// `Force` is threaded here (unlike the never-read Rust field it mirrors —
+/// see the module doc comment) because `backup` below genuinely reads it.
+type EnvOptions =
+    { RepoRoot: string
+      BackupDir: string
+      SkipDirs: string list
+      MaxSize: int64
+      WorktreeAware: bool
+      WorktreeName: string
+      Force: bool
+      IncludeConfig: bool
+      DryRun: bool }
+
+/// Outcome of a [`backup`] operation [Repo-grounded — `backup.rs::Result`].
+/// Named `EnvOperationResult` rather than `Result` to avoid colliding with
+/// `FSharp.Core.Result`.
+type EnvOperationResult =
+    { Direction: string
+      Dir: string
+      Files: EnvFileEntry list
+      Copied: int
+      Skipped: int
+      Errors: string list
+      WorktreeName: string
+      Cancelled: bool
+      DryRun: bool }
+
+/// Expands a leading `~` in `path` to the value of the `HOME` environment
+/// variable; returns `path` unchanged when it does not start with `~`
+/// [Repo-grounded — `backup.rs::expand_tilde`].
+///
+/// # Errors
+///
+/// Returns an error when `path` starts with `~` but `HOME` is not set.
+let expandTilde (path: string) : Result<string, string> =
+    if not (path.StartsWith("~", StringComparison.Ordinal)) then
+        Ok path
+    else
+        match Environment.GetEnvironmentVariable("HOME") with
+        | null -> Error "HOME not set"
+        | home ->
+            let tail = path.Substring(1)
+
+            if tail.StartsWith("/", StringComparison.Ordinal) then
+                Ok(Path.Combine(home, tail.Substring(1)))
+            elif tail = "" then
+                Ok home
+            else
+                Ok(Path.Combine(home, tail))
+
+/// Splits `path` into its non-empty components, tolerating either separator.
+let private pathComponents (path: string) : string list =
+    path.Split('/', '\\')
+    |> Array.filter (fun segment -> segment <> "")
+    |> List.ofArray
+
+/// `true` when `backupDir` is `repoRoot` or a subdirectory of it, compared
+/// component-wise on the raw (non-canonicalized) strings — mirroring Rust's
+/// `Path::strip_prefix` [Repo-grounded — `backup.rs::is_inside_repo`].
+let isInsideRepo (backupDir: string) (repoRoot: string) : bool =
+    let backupParts = pathComponents backupDir
+    let rootParts = pathComponents repoRoot
+
+    rootParts.Length <= backupParts.Length
+    && (backupParts |> List.take rootParts.Length) = rootParts
+
+/// Canonicalizes `path`, falling back to the nearest existing ancestor when
+/// `path` itself (or its trailing components) does not yet exist on disk
+/// [Repo-grounded — `backup.rs::canonicalize_best_effort`].
+///
+/// A user-supplied `--dir` for `env backup` is frequently a directory that
+/// has not been created yet, so a plain "canonicalize or fall back to the
+/// raw path" approach would silently compare a non-canonical `backup_dir`
+/// against a canonical `repo_root` in [`isInsideRepo`], defeating the safety
+/// guard that check exists for (the same physical-vs-logical-path reasoning
+/// `GitRoot.fs`'s module doc comment describes for macOS's `/private/var`).
+/// This walks up to the nearest existing ancestor, resolves that ancestor's
+/// full path, and rejoins the missing trailing components.
+///
+/// Scope note: unlike Rust's `fs::canonicalize`, this uses `Path.GetFullPath`
+/// (lexical normalization), since the .NET base class library has no public
+/// equivalent that also resolves symlinks — the same disclosed limitation as
+/// `RepoConfig.fs::confinedRepoPath`. The two-step existing-ancestor fallback
+/// control flow is otherwise identical.
+///
+/// # Errors
+///
+/// Returns an error when no ancestor of `path` exists, which should not
+/// happen for any path derived from an absolute filesystem location.
+let canonicalizeBestEffort (path: string) : Result<string, string> =
+    if Directory.Exists path || File.Exists path then
+        Ok(Path.GetFullPath path)
+    else
+        let rec walk (cursor: string) (tail: string list) : Result<string, string> =
+            match Path.GetDirectoryName cursor with
+            | null
+            | "" -> Error(sprintf "no existing ancestor found while canonicalizing %s" path)
+            | parent ->
+                let name = Path.GetFileName cursor
+                let tail = if name = "" then tail else name :: tail
+
+                if Directory.Exists parent || File.Exists parent then
+                    let canonicalParent = Path.GetFullPath parent
+
+                    Ok(
+                        tail
+                        |> List.fold (fun acc segment -> Path.Combine(acc, segment)) canonicalParent
+                    )
+                else
+                    walk parent tail
+
+        walk path []
+
+/// `true` for files that belong in a secret backup [Repo-grounded —
+/// `backup.rs::is_secret_file`]: `.env`/`.env.*`, `secrets.json`, anything
+/// under `.secrets/`, or a `.pem`/`.key`/`.crt`/`.pfx` file.
+let isSecretFile (rel: string) (baseName: string) : bool =
+    if
+        baseName.StartsWith(".env", StringComparison.Ordinal)
+        || baseName = "secrets.json"
+        || rel.StartsWith(".secrets/", StringComparison.Ordinal)
+    then
+        true
+    else
+        let rawExt = Path.GetExtension baseName
+
+        let ext =
+            if rawExt.StartsWith(".", StringComparison.Ordinal) then
+                rawExt.Substring(1)
+            else
+                rawExt
+
+        match ext with
+        | "pem"
+        | "key"
+        | "crt"
+        | "pfx" -> true
+        | _ -> false
+
+/// `true` when a symlink is present at `path` [Repo-grounded —
+/// `backup.rs::discover`'s `meta.file_type().is_symlink()` check].
+let private isSymlink (path: string) : bool =
+    match FileInfo(path).LinkTarget with
+    | null -> false
+    | _ -> true
+
+/// Recursively walks `dir`, returning every secret-shaped file under it.
+/// Hidden directories are skipped entirely except `.secrets/`, which is
+/// descended; directories named in `skipDirs` are likewise skipped
+/// [Repo-grounded — `backup.rs::discover`].
+let rec private walkDir (repoRoot: string) (skipDirs: Set<string>) (maxSize: int64) (dir: string) : EnvFileEntry list =
+    let fileEntries =
+        Directory.EnumerateFiles dir
+        |> Seq.choose (fun filePath ->
+            let baseName = Path.GetFileName filePath
+            let rel = Path.GetRelativePath(repoRoot, filePath).Replace('\\', '/')
+
+            if not (isSecretFile rel baseName) then
+                None
+            elif isSymlink filePath then
+                Some
+                    { RelPath = rel
+                      AbsPath = filePath
+                      Size = 0L
+                      Skipped = true
+                      Reason = "symlink"
+                      Source = "" }
+            else
+                let size = FileInfo(filePath).Length
+
+                if size > maxSize then
+                    Some
+                        { RelPath = rel
+                          AbsPath = filePath
+                          Size = size
+                          Skipped = true
+                          Reason = "exceeds 1 MB"
+                          Source = "" }
+                else
+                    Some
+                        { RelPath = rel
+                          AbsPath = filePath
+                          Size = size
+                          Skipped = false
+                          Reason = ""
+                          Source = "" })
+        |> List.ofSeq
+
+    let dirEntries =
+        Directory.EnumerateDirectories dir
+        |> Seq.collect (fun subDir ->
+            let baseName = Path.GetFileName subDir
+
+            if baseName.StartsWith(".", StringComparison.Ordinal) then
+                let relDir = Path.GetRelativePath(repoRoot, subDir).Replace('\\', '/')
+
+                if relDir = ".secrets" then
+                    walkDir repoRoot skipDirs maxSize subDir
+                else
+                    []
+            elif Set.contains baseName skipDirs then
+                []
+            else
+                walkDir repoRoot skipDirs maxSize subDir)
+        |> List.ofSeq
+
+    fileEntries @ dirEntries
+
+/// Walks `opts.RepoRoot` and returns every `.env*`/secret-shaped file found,
+/// sorted by relative path [Repo-grounded — `backup.rs::discover`].
+let discover (opts: EnvOptions) : EnvFileEntry list =
+    let maxSize = if opts.MaxSize <= 0L then DefaultMaxSize else opts.MaxSize
+
+    let skipDirs =
+        if List.isEmpty opts.SkipDirs then
+            Set.ofList defaultSkipDirs
+        else
+            Set.ofList opts.SkipDirs
+
+    walkDir opts.RepoRoot skipDirs maxSize opts.RepoRoot
+    |> List.sortWith (fun a b -> String.CompareOrdinal(a.RelPath, b.RelPath))
+
+/// Checks each `ConfigPattern` relative to `repoRoot` and returns entries for
+/// any that exist on disk, sorted by relative path [Repo-grounded —
+/// `backup.rs::discover_config`].
+let discoverConfig (repoRoot: string) (patterns: ConfigPattern list) (maxSize: int64) : EnvFileEntry list =
+    let effectiveMax = if maxSize <= 0L then DefaultMaxSize else maxSize
+
+    patterns
+    |> List.choose (fun pattern ->
+        let abs = Path.Combine(repoRoot, pattern.RelPath)
+
+        if Directory.Exists abs || not (File.Exists abs) then
+            None
+        elif isSymlink abs then
+            Some
+                { RelPath = pattern.RelPath
+                  AbsPath = abs
+                  Size = 0L
+                  Skipped = true
+                  Reason = "symlink"
+                  Source = "config" }
+        else
+            let size = FileInfo(abs).Length
+
+            if size > effectiveMax then
+                Some
+                    { RelPath = pattern.RelPath
+                      AbsPath = abs
+                      Size = size
+                      Skipped = true
+                      Reason = sprintf "file too large (%d bytes > %d)" size effectiveMax
+                      Source = "config" }
+            else
+                Some
+                    { RelPath = pattern.RelPath
+                      AbsPath = abs
+                      Size = size
+                      Skipped = false
+                      Reason = ""
+                      Source = "config" })
+    |> List.sortWith (fun a b -> String.CompareOrdinal(a.RelPath, b.RelPath))
+
+/// Returns the relative paths of the non-skipped `entries` that already
+/// exist under `destRoot` [Repo-grounded — `backup.rs::find_existing`].
+let findExisting (entries: EnvFileEntry list) (destRoot: string) : string list =
+    entries
+    |> List.filter (fun e -> not e.Skipped)
+    |> List.choose (fun e ->
+        let dst = Path.Combine(destRoot, e.RelPath)
+
+        if File.Exists dst || Directory.Exists dst then
+            Some e.RelPath
+        else
+            None)
+
+/// Whether a repository root is a linked Git worktree [Repo-grounded —
+/// `backup.rs::WorktreeInfo`].
+type WorktreeInfo =
+    { IsWorktree: bool
+      WorktreeName: string }
+
+/// Detects whether `repoRoot` is a linked Git worktree by inspecting its
+/// `.git` entry: a regular checkout has `.git` as a directory, a linked
+/// worktree has `.git` as a file starting with `"gitdir:"` [Repo-grounded —
+/// `backup.rs::detect_worktree`].
+///
+/// # Errors
+///
+/// Returns an error when `.git` does not exist at `repoRoot`, or when it
+/// exists as a file that does not start with `"gitdir:"`.
+let detectWorktree (repoRoot: string) : Result<WorktreeInfo, string> =
+    let gitPath = Path.Combine(repoRoot, ".git")
+    let name = Path.GetFileName(repoRoot.TrimEnd('/', '\\'))
+
+    if Directory.Exists gitPath then
+        Ok
+            { IsWorktree = false
+              WorktreeName = name }
+    elif File.Exists gitPath then
+        let line = (File.ReadAllText gitPath).Trim()
+
+        if line.StartsWith("gitdir:", StringComparison.Ordinal) then
+            Ok
+                { IsWorktree = true
+                  WorktreeName = name }
+        else
+            Error(sprintf ".git file does not start with 'gitdir:' (got: %s)" line)
+    else
+        Error(sprintf "no .git found at %s" repoRoot)
+
+/// Running total kept while copying `backup`'s discovered entries.
+type private CopyAcc =
+    { Copied: int
+      Skipped: int
+      Errors: string list }
+
+/// Copies one entry into `destRoot`, folding its outcome into `acc`
+/// [Repo-grounded — `backup.rs::backup`'s per-entry copy loop].
+let private copyOne (destRoot: string) (acc: CopyAcc) (e: EnvFileEntry) : CopyAcc =
+    if e.Skipped then
+        { acc with Skipped = acc.Skipped + 1 }
+    else
+        let dst = Path.Combine(destRoot, e.RelPath)
+
+        try
+            match Path.GetDirectoryName dst with
+            | null
+            | "" -> ()
+            | parent -> Directory.CreateDirectory parent |> ignore
+
+            File.Copy(e.AbsPath, dst, true)
+            { acc with Copied = acc.Copied + 1 }
+        with ex ->
+            { acc with
+                Skipped = acc.Skipped + 1
+                Errors = acc.Errors @ [ sprintf "copy %s: %s" e.RelPath ex.Message ] }
+
+/// Copies `.env*` files (and optionally config files) from
+/// `opts.RepoRoot` to `opts.BackupDir` [Repo-grounded — `backup.rs::backup`].
+///
+/// `confirm` is invoked at most once, and only when the destination already
+/// contains at least one of the non-skipped discovered files and
+/// `opts.Force` is `false` — see the module doc comment for why this is a
+/// real decision here rather than the dead `force` field it is ported from.
+///
+/// # Errors
+///
+/// Returns an error when `opts.BackupDir` (after tilde expansion) is inside
+/// `opts.RepoRoot`.
+let backup (opts: EnvOptions) (confirm: unit -> bool) : Result<EnvOperationResult, string> =
+    match expandTilde opts.BackupDir with
+    | Error message -> Error message
+    | Ok expandedBackupDir ->
+        if isInsideRepo expandedBackupDir opts.RepoRoot then
+            Error(
+                sprintf
+                    "backup dir %s is inside repo root %s; choose a directory outside the repo"
+                    expandedBackupDir
+                    opts.RepoRoot
+            )
+        else
+            let maxSize = if opts.MaxSize <= 0L then DefaultMaxSize else opts.MaxSize
+
+            let discoverOpts =
+                { opts with
+                    BackupDir = expandedBackupDir
+                    MaxSize = maxSize }
+
+            let envEntries = discover discoverOpts
+
+            let entries =
+                if opts.IncludeConfig then
+                    let tagged =
+                        envEntries
+                        |> List.map (fun e -> if e.Source = "" then { e with Source = "env" } else e)
+
+                    let configEntries = discoverConfig opts.RepoRoot defaultConfigPatterns maxSize
+
+                    tagged @ configEntries
+                    |> List.sortWith (fun a b -> String.CompareOrdinal(a.RelPath, b.RelPath))
+                else
+                    envEntries
+
+            let destRoot =
+                if opts.WorktreeAware && opts.WorktreeName <> "" then
+                    Path.Combine(expandedBackupDir, opts.WorktreeName)
+                else
+                    expandedBackupDir
+
+            if opts.DryRun then
+                Ok
+                    { Direction = "backup"
+                      Dir = expandedBackupDir
+                      Files = entries
+                      Copied = 0
+                      Skipped = 0
+                      Errors = []
+                      WorktreeName = opts.WorktreeName
+                      Cancelled = false
+                      DryRun = true }
+            else
+                let existing = findExisting entries destRoot
+                let proceed = opts.Force || List.isEmpty existing || confirm ()
+
+                if not proceed then
+                    Ok
+                        { Direction = "backup"
+                          Dir = expandedBackupDir
+                          Files = entries
+                          Copied = 0
+                          Skipped = 0
+                          Errors = []
+                          WorktreeName = opts.WorktreeName
+                          Cancelled = true
+                          DryRun = false }
+                else
+                    Directory.CreateDirectory destRoot |> ignore
+
+                    let finalAcc =
+                        entries |> List.fold (copyOne destRoot) { Copied = 0; Skipped = 0; Errors = [] }
+
+                    Ok
+                        { Direction = "backup"
+                          Dir = expandedBackupDir
+                          Files = entries
+                          Copied = finalAcc.Copied
+                          Skipped = finalAcc.Skipped
+                          Errors = finalAcc.Errors
+                          WorktreeName = opts.WorktreeName
+                          Cancelled = false
+                          DryRun = false }
+
+// ---- Reporters ----
+
+/// Capitalises the first character of `s`, leaving the rest unchanged
+/// [Repo-grounded — `backup.rs::capitalize`].
+let capitalize (s: string) : string =
+    if s = "" then
+        ""
+    else
+        string (Char.ToUpperInvariant s.[0]) + s.Substring(1)
+
+/// Formats an [`EnvOperationResult`] as human-readable text [Repo-grounded —
+/// `backup.rs::format_text`]. When `quiet` is `true`, per-file lines are
+/// suppressed; when `verbose` is `true`, skipped files are also listed.
+let formatText (r: EnvOperationResult) (verbose: bool) (quiet: bool) : string =
+    if r.Cancelled then
+        let label = if r.Direction = "" then "operation" else r.Direction
+        sprintf "%s cancelled.\n" (capitalize label)
+    else
+        let sb = Text.StringBuilder()
+
+        if not quiet then
+            let action = if r.DryRun then "WOULD" else r.Direction.ToUpperInvariant()
+
+            for f in r.Files do
+                if f.Skipped then
+                    if verbose then
+                        sb.Append(sprintf "  SKIPPED  %s  (%s)\n" f.RelPath f.Reason) |> ignore
+                else
+                    let tag = if f.Source = "config" then " [config]" else ""
+                    sb.Append(sprintf "  %s  %s%s\n" action f.RelPath tag) |> ignore
+
+            for e in r.Errors do
+                sb.Append(sprintf "  WARNING  %s\n" e) |> ignore
+
+        let label = if r.Direction = "" then "processed" else r.Direction
+
+        if r.DryRun then
+            let wouldCount = r.Files |> List.filter (fun f -> not f.Skipped) |> List.length
+
+            sb.Append(sprintf "Dry-run %s: %d file(s) would be %sd, %d skipped" label wouldCount label r.Skipped)
+            |> ignore
+        else
+            sb.Append(sprintf "%s complete: %d file(s) %sd, %d skipped" (capitalize label) r.Copied label r.Skipped)
+            |> ignore
+
+        let configCount =
+            r.Files
+            |> List.filter (fun f -> f.Source = "config" && not f.Skipped)
+            |> List.length
+
+        if configCount > 0 then
+            sb.Append(sprintf " (%d config)" configCount) |> ignore
+
+        if r.WorktreeName <> "" then
+            sb.Append(sprintf "  [worktree: %s]" r.WorktreeName) |> ignore
+
+        sb.Append('\n') |> ignore
+        sb.ToString()
+
+/// JSON shape of one file entry [Repo-grounded — `backup.rs::JsonEntry`].
+/// Scope note: unlike Rust's `#[serde(skip_serializing_if = ...)]`, every
+/// field is always emitted here (no omission of zero/empty values) — this
+/// port's `formatJson` only needs to satisfy "the JSON includes ..."
+/// (env-backup.feature), not byte-identical CLI JSON output; that
+/// byte-identical requirement belongs to the later CLI-wiring wave.
+///
+/// Not `private`: `System.Text.Json`'s default reflection-based resolver
+/// silently reflects into zero members of a non-visible (`private`) type —
+/// it neither throws nor logs, it just serializes `{}` — the same pitfall
+/// `RepoConfig.fs`'s module doc comment warns about for a `private` YamlDotNet
+/// DTO, reproduced here for `System.Text.Json` instead. This type is still
+/// excluded from this module's public surface indirectly: nothing outside
+/// `formatJson` ever constructs or returns one.
+type JsonFileEntry =
+    { relPath: string
+      size: int64
+      skipped: bool
+      reason: string
+      source: string }
+
+/// JSON shape of the top-level envelope [Repo-grounded —
+/// `backup.rs::JsonOut`]. See `JsonFileEntry`'s scope note for why this is
+/// not `private`.
+type JsonEnvelope =
+    { direction: string
+      dir: string
+      files: JsonFileEntry list
+      copied: int
+      skipped: int
+      errors: string list
+      worktreeName: string
+      cancelled: bool }
+
+let private jsonOptions: JsonSerializerOptions =
+    let opts = JsonSerializerOptions()
+    opts.WriteIndented <- true
+    opts.Encoder <- JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    opts
+
+/// Serialises an [`EnvOperationResult`] to a pretty-printed JSON string
+/// [Repo-grounded — `backup.rs::format_json`].
+let formatJson (r: EnvOperationResult) : string =
+    let toJsonEntry (f: EnvFileEntry) : JsonFileEntry =
+        { relPath = f.RelPath
+          size = f.Size
+          skipped = f.Skipped
+          reason = f.Reason
+          source = f.Source }
+
+    let env: JsonEnvelope =
+        { direction = r.Direction
+          dir = r.Dir
+          files = r.Files |> List.map toJsonEntry
+          copied = r.Copied
+          skipped = r.Skipped
+          errors = r.Errors
+          worktreeName = r.WorktreeName
+          cancelled = r.Cancelled }
+
+    JsonSerializer.Serialize(env, jsonOptions)
+
+/// Formats an [`EnvOperationResult`] as a Markdown report [Repo-grounded —
+/// `backup.rs::format_markdown`].
+let formatMarkdown (r: EnvOperationResult) : string =
+    let sb = Text.StringBuilder()
+    let action = capitalize r.Direction
+    sb.Append(sprintf "## %s Report\n\n" action) |> ignore
+    sb.Append(sprintf "**Directory**: `%s`\n\n" r.Dir) |> ignore
+
+    sb.Append(sprintf "**Copied**: %d | **Skipped**: %d\n\n" r.Copied r.Skipped)
+    |> ignore
+
+    if r.WorktreeName <> "" then
+        sb.Append(sprintf "**Worktree**: `%s`\n\n" r.WorktreeName) |> ignore
+
+    if r.Cancelled then
+        let label = if r.Direction = "" then "operation" else r.Direction
+        sb.Append(sprintf "_%s cancelled._\n" (capitalize label)) |> ignore
+        sb.ToString()
+    elif List.isEmpty r.Files then
+        sb.Append("_No .env files found._\n") |> ignore
+        sb.ToString()
+    else
+        let hasConfig = r.Files |> List.exists (fun f -> f.Source = "config")
+
+        if hasConfig then
+            sb.Append("| File | Size (bytes) | Source | Status | Reason |\n") |> ignore
+            sb.Append("|------|-------------|--------|--------|--------|\n") |> ignore
+        else
+            sb.Append("| File | Size (bytes) | Status | Reason |\n") |> ignore
+            sb.Append("|------|-------------|--------|--------|\n") |> ignore
+
+        for f in r.Files do
+            let status = if f.Skipped then "skipped" else "copied"
+            let reason = if f.Skipped then f.Reason else ""
+            let display = f.RelPath.Replace('\\', '/')
+
+            if hasConfig then
+                let source = if f.Source = "" then "env" else f.Source
+
+                sb.Append(sprintf "| `%s` | %d | %s | %s | %s |\n" display f.Size source status reason)
+                |> ignore
+            else
+                sb.Append(sprintf "| `%s` | %d | %s | %s |\n" display f.Size status reason)
+                |> ignore
+
+        if not (List.isEmpty r.Errors) then
+            sb.Append("\n### Warnings\n") |> ignore
+
+            for e in r.Errors do
+                sb.Append(sprintf "- %s\n" e) |> ignore
+
+        sb.ToString()

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
@@ -586,7 +586,7 @@ let capitalize (s: string) : string =
     if s = "" then
         ""
     else
-        string (Char.ToUpperInvariant s.[0]) + s.Substring(1)
+        (Char.ToUpperInvariant s.[0]).ToString() + s.Substring(1)
 
 /// Formats an [`EnvOperationResult`] as human-readable text [Repo-grounded —
 /// `backup.rs::format_text`]. When `quiet` is `true`, per-file lines are

--- a/apps/rhino-cli/src-fsharp/project.json
+++ b/apps/rhino-cli/src-fsharp/project.json
@@ -112,7 +112,7 @@
     "specs:behavior:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate apps/rhino-cli/src-fsharp"
+        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-backup.feature apps/rhino-cli/src-fsharp"
       },
       "cache": true,
       "inputs": ["{workspaceRoot}/specs/apps/rhino/behavior/rhino-cli/gherkin/**/*.feature", "{projectRoot}/**/*.fs"]

--- a/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+++ b/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
@@ -19,6 +19,8 @@
     <Compile Include="Steps/RepoConfigUnitTests.fs" />
     <Compile Include="Steps/RepoConfigValidateSteps.fs" />
     <Compile Include="Steps/RepoConfigValidateUnitTests.fs" />
+    <Compile Include="Steps/EnvSteps.fs" />
+    <Compile Include="Steps/EnvUnitTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvSteps.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvSteps.fs
@@ -1,0 +1,621 @@
+/// TickSpec step definitions binding `env-backup.feature`'s 21 scenarios to
+/// `RhinoCli.Application.Env` [Repo-grounded —
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-backup.feature`,
+/// `apps/rhino-cli/src/application/env/backup.rs`,
+/// `apps/rhino-cli/src/commands/env_backup.rs`].
+///
+/// Follows `RepoConfigSteps.fs`'s per-scenario slicing convention: each xunit
+/// `[<Fact>]` below runs exactly one scenario, extracted from the real,
+/// frozen feature file rather than a duplicated/rewritten copy of its
+/// wording.
+///
+/// Every scenario builds its own throwaway temp-directory fixtures for both
+/// the repository root and the backup destination — this feature file never
+/// reads this repository's own real files, unlike some `repo-config`/
+/// `repo-config-validate` scenarios.
+module RhinoCli.Tests.Unit.Steps.EnvSteps
+
+open System
+open System.IO
+open System.Text.Json
+open TickSpec
+open Xunit
+open RhinoCli.Application.Env
+
+/// Instance step-definition container — see `ConventionSteps.fs`'s module
+/// doc comment for why TickSpec's one-instance-per-scenario lifecycle makes
+/// instance-level mutable fields the idiomatic state-threading mechanism
+/// here.
+type EnvSteps() =
+    let mutable repoRoot: string option = None
+    let mutable backupDir: string option = None
+    let mutable expectedEnvRelPaths: string list = []
+    let mutable worktreeAware = false
+    let mutable worktreeName: string option = None
+    let mutable forceFlag = false
+    let mutable includeConfigFlag = false
+    let mutable dryRunFlag = false
+    let mutable confirmChoice: bool option = None
+    let mutable confirmCallCount = 0
+    let mutable opResult: Result<EnvOperationResult, string> option = None
+    let mutable ownedDirs: string list = []
+
+    let newTempDir (prefix: string) : string =
+        let dir =
+            Path.Combine(Path.GetTempPath(), "rhino-cli-env-" + prefix + "-" + Guid.NewGuid().ToString("N"))
+
+        Directory.CreateDirectory(dir) |> ignore
+        ownedDirs <- dir :: ownedDirs
+        dir
+
+    let writeFile (root: string) (relativePath: string) (content: string) =
+        let full = Path.Combine(root, relativePath)
+        Directory.CreateDirectory(Path.GetDirectoryName(full)) |> ignore
+        File.WriteAllText(full, content)
+
+    let root () : string =
+        match repoRoot with
+        | Some dir -> dir
+        | None -> failwith "no repository root has been prepared by a Given step"
+
+    /// Reuses the repository root when a prior `Given` already created one
+    /// (the secrets-pattern and dry-run scenarios chain three `Given`/`And`
+    /// steps against the same repository), otherwise creates a fresh one.
+    let ensureRoot () : string =
+        match repoRoot with
+        | Some dir -> dir
+        | None ->
+            let dir = newTempDir "repo"
+            repoRoot <- Some dir
+            dir
+
+    let ensureBackupDir () : string =
+        match backupDir with
+        | Some dir -> dir
+        | None ->
+            let dir = newTempDir "backup"
+            backupDir <- Some dir
+            dir
+
+    let outcome () : EnvOperationResult =
+        match opResult with
+        | Some(Ok r) -> r
+        | Some(Error message) -> failwith (sprintf "expected a successful backup, got error: %s" message)
+        | None -> failwith "no command has been run by a When step"
+
+    let confirm () : bool =
+        confirmCallCount <- confirmCallCount + 1
+
+        match confirmChoice with
+        | Some v -> v
+        | None -> failwith "confirm callback invoked but no confirm/decline choice was set by a When step"
+
+    let runBackup () =
+        let repo = root ()
+        let dest = ensureBackupDir ()
+
+        let opts: EnvOptions =
+            { RepoRoot = repo
+              BackupDir = dest
+              SkipDirs = defaultSkipDirs
+              MaxSize = DefaultMaxSize
+              WorktreeAware = worktreeAware
+              WorktreeName = worktreeName |> Option.defaultValue ""
+              Force = forceFlag
+              IncludeConfig = includeConfigFlag
+              DryRun = dryRunFlag }
+
+        opResult <- Some(backup opts confirm)
+
+    // ---- Given ----
+
+    [<Given>]
+    member _.``a git repository containing .env files at the root and in app subdirectories``() =
+        let dir = ensureRoot ()
+        writeFile dir ".env" "root=1"
+        writeFile dir "apps/web/.env" "web=1"
+        writeFile dir "apps/api/.env" "api=1"
+        expectedEnvRelPaths <- [ ".env"; "apps/web/.env"; "apps/api/.env" ]
+
+    [<Given>]
+    member _.``a git repository containing a .env file at the root``() =
+        let dir = ensureRoot ()
+        writeFile dir ".env" "k=v"
+
+    [<Given>]
+    member _.``the backup directory already contains a backed-up .env file``() =
+        let dest = ensureBackupDir ()
+        writeFile dest ".env" "old-backup"
+
+    [<Given>]
+    member _.``the backup directory is empty``() = ensureBackupDir () |> ignore
+
+    [<Given>]
+    member _.``a git repository containing a symlinked .env file, a .env file larger than 1 MB, and a regular .env file``
+        ()
+        =
+        let dir = ensureRoot ()
+        let targetFile = Path.Combine(dir, "target.txt")
+        File.WriteAllText(targetFile, "target contents")
+        File.CreateSymbolicLink(Path.Combine(dir, ".env.symlink"), targetFile) |> ignore
+        File.WriteAllBytes(Path.Combine(dir, ".env.large"), Array.zeroCreate<byte> (int DefaultMaxSize + 1))
+        writeFile dir ".env" "regular=1"
+
+    [<Given>]
+    member _.``a git repository containing no .env files``() =
+        let dir = ensureRoot ()
+        writeFile dir "README.md" "nothing secret here"
+
+    [<Given>]
+    member _.``a git repository containing .env files inside node_modules, dist, build, .next, __pycache__, target, vendor, coverage, and generated-contracts directories``
+        ()
+        =
+        let dir = ensureRoot ()
+
+        for name in
+            [ "node_modules"
+              "dist"
+              "build"
+              ".next"
+              "__pycache__"
+              "target"
+              "vendor"
+              "coverage"
+              "generated-contracts" ] do
+            writeFile dir (sprintf "%s/.env" name) "should-not-be-found"
+
+    [<Given>]
+    member _.``a git repository where apps/web/node_modules contains a .env file and apps/web contains a .env.local file``
+        ()
+        =
+        let dir = ensureRoot ()
+        writeFile dir "apps/web/node_modules/.env" "should-not-be-found"
+        writeFile dir "apps/web/.env.local" "web-local=1"
+
+    [<Given>]
+    member _.``a git worktree containing a .env file at its root``() =
+        let dir = ensureRoot ()
+        File.WriteAllText(Path.Combine(dir, ".git"), "gitdir: /elsewhere/.git")
+        writeFile dir ".env" "k=v"
+
+    [<Given>]
+    member _.``a git worktree named "(.*)" containing a .env file at its root``(name: string) =
+        let parent = newTempDir "worktree-parent"
+        let dir = Path.Combine(parent, name)
+        Directory.CreateDirectory(dir) |> ignore
+        repoRoot <- Some dir
+        File.WriteAllText(Path.Combine(dir, ".git"), "gitdir: /elsewhere/.git")
+        writeFile dir ".env" "k=v"
+
+    [<Given>]
+    member _.``the main git repository named "(.*)" containing a .env file at its root``(name: string) =
+        let parent = newTempDir "repo-parent"
+        let dir = Path.Combine(parent, name)
+        Directory.CreateDirectory(dir) |> ignore
+        repoRoot <- Some dir
+        Directory.CreateDirectory(Path.Combine(dir, ".git")) |> ignore
+        writeFile dir ".env" "k=v"
+
+    [<Given>]
+    member _.``a git repository containing a .env file and a .claude/settings.local.json file``() =
+        let dir = ensureRoot ()
+        writeFile dir ".env" "k=v"
+        writeFile dir ".claude/settings.local.json" "{}"
+
+    [<Given>]
+    member _.``a git repository containing a .env file but no known config files``() =
+        let dir = ensureRoot ()
+        writeFile dir ".env" "k=v"
+
+    [<Given>]
+    member _.``a git repository containing a secrets.json file at the root``() =
+        let dir = ensureRoot ()
+        writeFile dir "secrets.json" "{\"key\":\"val\"}"
+
+    [<Given>]
+    member _.``a git repository containing a cert.pem file at the root``() =
+        let dir = ensureRoot ()
+        writeFile dir "cert.pem" "-----BEGIN CERTIFICATE-----"
+
+    [<Given>]
+    member _.``a git repository containing a .secrets/notes.md file``() =
+        let dir = ensureRoot ()
+        writeFile dir ".secrets/notes.md" "secret notes"
+
+    [<Given>]
+    member _.``a git repository containing a .env file and a secrets.json file``() =
+        let dir = ensureRoot ()
+        writeFile dir ".env" "k=v"
+        writeFile dir "secrets.json" "{\"key\":\"val\"}"
+        writeFile dir ".git/config" "[core]\n"
+
+    // ---- When ----
+
+    [<When>]
+    member _.``the developer runs rhino-cli env backup``() = runBackup ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env backup with --dir pointing to a directory outside the repository``() =
+        ensureBackupDir () |> ignore
+        runBackup ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env backup with --dir pointing to a path inside the git root``() =
+        backupDir <- Some(Path.Combine(root (), "inside-backup"))
+        runBackup ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env backup with --output json``() = runBackup ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env backup with --worktree-aware``() =
+        worktreeAware <- true
+
+        match detectWorktree (root ()) with
+        | Ok info -> worktreeName <- Some info.WorktreeName
+        | Error message -> failwith message
+
+        runBackup ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env backup and confirms the overwrite``() =
+        confirmChoice <- Some true
+        runBackup ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env backup and declines the overwrite``() =
+        confirmChoice <- Some false
+        runBackup ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env backup with --force``() =
+        forceFlag <- true
+        runBackup ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env backup with --include-config and --force``() =
+        forceFlag <- true
+        includeConfigFlag <- true
+        runBackup ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env backup with --dry-run``() =
+        dryRunFlag <- true
+        runBackup ()
+
+    // ---- Then ----
+
+    [<Then>]
+    member _.``the command exits successfully``() =
+        match opResult with
+        | Some(Ok _) -> ()
+        | Some(Error message) -> Assert.Fail(sprintf "expected success, got error: %s" message)
+        | None -> Assert.Fail("no command has been run by a When step")
+
+    [<Then>]
+    member _.``the command exits with a failure code``() =
+        match opResult with
+        | Some(Error _) -> ()
+        | Some(Ok _) -> Assert.Fail("expected a failure code, got success")
+        | None -> Assert.Fail("no command has been run by a When step")
+
+    [<Then>]
+    member _.``each .env file is copied to the backup directory preserving its relative path``() =
+        let dest = ensureBackupDir ()
+
+        for relPath in expectedEnvRelPaths do
+            Assert.True(File.Exists(Path.Combine(dest, relPath)), sprintf "expected %s to be backed up" relPath)
+
+    [<Then>]
+    member _.``the output lists each backed-up file``() =
+        let text = formatText (outcome ()) false false
+
+        for relPath in expectedEnvRelPaths do
+            Assert.Contains(relPath, text)
+
+    [<Then>]
+    member _.``the .env file is copied to the specified directory preserving its relative path``() =
+        let dest = ensureBackupDir ()
+        Assert.True(File.Exists(Path.Combine(dest, ".env")))
+        Assert.Equal("k=v", File.ReadAllText(Path.Combine(dest, ".env")))
+
+    [<Then>]
+    member _.``the output warns that the backup directory must be outside the repository``() =
+        match opResult with
+        | Some(Error message) -> Assert.Contains("outside the repo", message)
+        | other -> Assert.Fail(sprintf "expected an error, got %A" other)
+
+    [<Then>]
+    member _.``the symlinked .env file is skipped with a warning``() =
+        let entry = (outcome ()).Files |> List.find (fun f -> f.RelPath = ".env.symlink")
+        Assert.True(entry.Skipped)
+        Assert.Equal("symlink", entry.Reason)
+
+    [<Then>]
+    member _.``the oversized .env file is skipped with a warning``() =
+        let entry = (outcome ()).Files |> List.find (fun f -> f.RelPath = ".env.large")
+        Assert.True(entry.Skipped)
+        Assert.Contains("exceeds", entry.Reason)
+
+    [<Then>]
+    member _.``the regular .env file is copied to the backup directory``() =
+        Assert.True(File.Exists(Path.Combine(ensureBackupDir (), ".env")))
+
+    [<Then>]
+    member _.``the output reports that zero files were backed up``() =
+        let r = outcome ()
+        Assert.Equal(0, r.Copied)
+        Assert.Contains("0 file(s)", formatText r false false)
+
+    [<Then>]
+    member _.``the output is valid JSON``() =
+        use _doc = JsonDocument.Parse(formatJson (outcome ()))
+        ()
+
+    [<Then>]
+    member _.``the JSON includes the direction, backup directory, list of files, copied count, and skipped count``() =
+        use doc = JsonDocument.Parse(formatJson (outcome ()))
+        let rootElement = doc.RootElement
+        Assert.True(rootElement.TryGetProperty("direction") |> fst)
+        Assert.True(rootElement.TryGetProperty("dir") |> fst)
+        Assert.True(rootElement.TryGetProperty("files") |> fst)
+        Assert.True(rootElement.TryGetProperty("copied") |> fst)
+        Assert.True(rootElement.TryGetProperty("skipped") |> fst)
+
+    [<Then>]
+    member _.``none of the .env files inside auto-generated directories are backed up``() =
+        let r = outcome ()
+        Assert.Empty(r.Files)
+        Assert.Equal(0, r.Copied)
+
+    [<Then>]
+    member _.``only apps/web/.env.local is copied to the backup directory``() =
+        Assert.True(File.Exists(Path.Combine(ensureBackupDir (), "apps", "web", ".env.local")))
+
+    [<Then>]
+    member _.``the .env file inside apps/web/node_modules is not backed up``() =
+        Assert.False(File.Exists(Path.Combine(ensureBackupDir (), "apps", "web", "node_modules", ".env")))
+
+    [<Then>]
+    member _.``the .env file is copied to the backup directory with a flat structure``() =
+        Assert.True(File.Exists(Path.Combine(ensureBackupDir (), ".env")))
+
+    [<Then>]
+    member _.``the .env file is copied under a feature-branch subdirectory inside the backup directory``() =
+        Assert.True(File.Exists(Path.Combine(ensureBackupDir (), "feature-branch", ".env")))
+
+    [<Then>]
+    member _.``the .env file is copied under an open-sharia-enterprise subdirectory inside the backup directory``() =
+        Assert.True(File.Exists(Path.Combine(ensureBackupDir (), "open-sharia-enterprise", ".env")))
+
+    [<Then>]
+    member _.``the .env file is overwritten in the backup directory``() =
+        Assert.Equal(1, confirmCallCount)
+        Assert.Equal("k=v", File.ReadAllText(Path.Combine(ensureBackupDir (), ".env")))
+
+    [<Then>]
+    member _.``the output reports that backup was cancelled``() =
+        Assert.Contains("cancelled", formatText (outcome ()) false false)
+
+    [<Then>]
+    member _.``the existing backup file is unchanged``() =
+        Assert.Equal(1, confirmCallCount)
+        Assert.Equal("old-backup", File.ReadAllText(Path.Combine(ensureBackupDir (), ".env")))
+
+    [<Then>]
+    member _.``the .env file is overwritten in the backup directory without prompting``() =
+        Assert.Equal(0, confirmCallCount)
+        Assert.Equal("k=v", File.ReadAllText(Path.Combine(ensureBackupDir (), ".env")))
+
+    [<Then>]
+    member _.``no confirmation prompt is shown``() = Assert.Equal(0, confirmCallCount)
+
+    [<Then>]
+    member _.``the .env file is copied to the backup directory``() =
+        Assert.True(File.Exists(Path.Combine(ensureBackupDir (), ".env")))
+
+    [<Then>]
+    member _.``the .claude/settings.local.json is copied to the backup directory preserving its relative path``() =
+        Assert.True(File.Exists(Path.Combine(ensureBackupDir (), ".claude", "settings.local.json")))
+
+    [<Then>]
+    member _.``the .claude/settings.local.json is not copied to the backup directory``() =
+        Assert.False(File.Exists(Path.Combine(ensureBackupDir (), ".claude", "settings.local.json")))
+
+    [<Then>]
+    member _.``only the .env file is copied to the backup directory``() =
+        let r = outcome ()
+        Assert.Equal(1, r.Copied)
+
+        let copiedPaths =
+            r.Files |> List.filter (fun f -> not f.Skipped) |> List.map (fun f -> f.RelPath)
+
+        Assert.Equal<string list>([ ".env" ], copiedPaths)
+
+    [<Then>]
+    member _.``secrets.json is copied to the backup directory``() =
+        Assert.True(File.Exists(Path.Combine(ensureBackupDir (), "secrets.json")))
+
+    [<Then>]
+    member _.``cert.pem is copied to the backup directory``() =
+        Assert.True(File.Exists(Path.Combine(ensureBackupDir (), "cert.pem")))
+
+    [<Then>]
+    member _.``.secrets/notes.md is copied to the backup directory preserving its relative path``() =
+        Assert.True(File.Exists(Path.Combine(ensureBackupDir (), ".secrets", "notes.md")))
+
+    [<Then>]
+    member _.``no files from the .git directory are backed up``() =
+        let r = outcome ()
+        Assert.False(Directory.Exists(Path.Combine(ensureBackupDir (), ".git")))
+
+        Assert.DoesNotContain(r.Files, fun (f: EnvFileEntry) -> f.RelPath.StartsWith(".git/", StringComparison.Ordinal))
+
+    [<Then>]
+    member _.``no files are written to the backup directory``() =
+        let dest = ensureBackupDir ()
+        Assert.Empty(Directory.EnumerateFileSystemEntries dest)
+
+    [<Then>]
+    member _.``the output lists the files that would be backed up``() =
+        let text = formatText (outcome ()) false false
+        Assert.Contains("secrets.json", text)
+        Assert.Contains("cert.pem", text)
+        Assert.Contains(".secrets/notes.md", text)
+        Assert.Contains("WOULD", text)
+
+    [<AfterScenario>]
+    member _.Cleanup() =
+        for dir in ownedDirs do
+            if Directory.Exists dir then
+                Directory.Delete(dir, true)
+
+/// Reads one named `Scenario:` block out of the real, frozen
+/// `env-backup.feature` file (leaving the file itself untouched) and runs it
+/// through TickSpec bound only against `EnvSteps` — see `RepoConfigSteps.fs`'s
+/// `FeatureRunner` for why this is per-scenario rather than per-file.
+module private FeatureRunner =
+
+    let private featurePath: string =
+        Path.GetFullPath(
+            Path.Combine(
+                __SOURCE_DIRECTORY__,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "specs",
+                "apps",
+                "rhino",
+                "behavior",
+                "rhino-cli",
+                "gherkin",
+                "env",
+                "env-backup.feature"
+            )
+        )
+
+    let private extractScenario (featureLines: string[]) (scenarioTitle: string) : string[] =
+        let featureLine =
+            featureLines
+            |> Array.find (fun l -> l.TrimStart().StartsWith("Feature:", StringComparison.Ordinal))
+
+        let scenarioHeader = sprintf "Scenario: %s" scenarioTitle
+
+        let startIdx = featureLines |> Array.findIndex (fun l -> l.Trim() = scenarioHeader)
+
+        let endIdx =
+            featureLines
+            |> Array.skip (startIdx + 1)
+            |> Array.tryFindIndex (fun l ->
+                let trimmed = l.Trim()
+
+                trimmed.StartsWith("Scenario:", StringComparison.Ordinal)
+                || trimmed.StartsWith("Scenario Outline:", StringComparison.Ordinal)
+                // env-backup.feature tags every scenario with a leading
+                // `@tag` line (unlike repo-config-validate.feature/
+                // convention-audit.feature, which this slicing pattern was
+                // first written against) — the next scenario's tag line must
+                // also end the slice, or it gets pulled in as a dangling
+                // trailing line with no scenario body to attach to.
+                || trimmed.StartsWith("@", StringComparison.Ordinal))
+            |> Option.map (fun relativeIdx -> startIdx + 1 + relativeIdx)
+            |> Option.defaultValue featureLines.Length
+
+        Array.append [| featureLine; "" |] featureLines.[startIdx .. endIdx - 1]
+
+    /// Runs the single scenario named `scenarioTitle` from
+    /// `env-backup.feature`, bound against `EnvSteps`.
+    let run (scenarioTitle: string) : unit =
+        let allLines = File.ReadAllLines featurePath
+        let snippet = extractScenario allLines scenarioTitle
+        let definitions = StepDefinitions([| typeof<EnvSteps> |])
+        let feature = definitions.GenerateFeature(featurePath, snippet)
+        let scenario = Seq.exactlyOne feature.Scenarios
+        scenario.Action.Invoke()
+
+[<Fact>]
+let ``Backup discovers and copies all .env files`` () =
+    FeatureRunner.run "Backup discovers and copies all .env files"
+
+[<Fact>]
+let ``Backup with custom directory`` () =
+    FeatureRunner.run "Backup with custom directory"
+
+[<Fact>]
+let ``Backup rejects a directory inside the repository`` () =
+    FeatureRunner.run "Backup rejects a directory inside the repository"
+
+[<Fact>]
+let ``Symlinks and oversized files are skipped`` () =
+    FeatureRunner.run "Symlinks and oversized files are skipped"
+
+[<Fact>]
+let ``Backup with zero .env files`` () =
+    FeatureRunner.run "Backup with zero .env files"
+
+[<Fact>]
+let ``JSON output for backup`` () =
+    FeatureRunner.run "JSON output for backup"
+
+[<Fact>]
+let ``Env files inside auto-generated directories are not discovered`` () =
+    FeatureRunner.run "Env files inside auto-generated directories are not discovered"
+
+[<Fact>]
+let ``Env files inside nested auto-generated directories are not discovered`` () =
+    FeatureRunner.run "Env files inside nested auto-generated directories are not discovered"
+
+[<Fact>]
+let ``Backup works in a git worktree`` () =
+    FeatureRunner.run "Backup works in a git worktree"
+
+[<Fact>]
+let ``Worktree-aware backup namespaces by worktree name`` () =
+    FeatureRunner.run "Worktree-aware backup namespaces by worktree name"
+
+[<Fact>]
+let ``Main repo with worktree-aware uses repository directory name`` () =
+    FeatureRunner.run "Main repo with worktree-aware uses repository directory name"
+
+[<Fact>]
+let ``Backup prompts when destination files already exist`` () =
+    FeatureRunner.run "Backup prompts when destination files already exist"
+
+[<Fact>]
+let ``Backup aborts when user declines overwrite`` () =
+    FeatureRunner.run "Backup aborts when user declines overwrite"
+
+[<Fact>]
+let ``Backup with --force skips confirmation`` () =
+    FeatureRunner.run "Backup with --force skips confirmation"
+
+[<Fact>]
+let ``Backup proceeds without prompt when no conflicts exist`` () =
+    FeatureRunner.run "Backup proceeds without prompt when no conflicts exist"
+
+[<Fact>]
+let ``Backup includes config files with --include-config`` () =
+    FeatureRunner.run "Backup includes config files with --include-config"
+
+[<Fact>]
+let ``Backup without --include-config ignores config files`` () =
+    FeatureRunner.run "Backup without --include-config ignores config files"
+
+[<Fact>]
+let ``Backup with --include-config and no config files found`` () =
+    FeatureRunner.run "Backup with --include-config and no config files found"
+
+[<Fact>]
+let ``Backup discovers common secret file patterns`` () =
+    FeatureRunner.run "Backup discovers common secret file patterns"
+
+[<Fact>]
+let ``The .git directory itself is never backed up`` () =
+    FeatureRunner.run "The .git directory itself is never backed up"
+
+[<Fact>]
+let ``Dry-run backup previews without writing files`` () =
+    FeatureRunner.run "Dry-run backup previews without writing files"

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvUnitTests.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvUnitTests.fs
@@ -1,0 +1,583 @@
+/// Plain xunit tests for `RhinoCli.Application.Env`'s pure helpers and the
+/// `backup` confirm-callback design — behaviour with no dedicated Gherkin
+/// scenario, or exercised only indirectly there (mirrors the rationale
+/// `RepoConfigValidateUnitTests.fs`'s module doc comment states for its own
+/// split from `RepoConfigValidateSteps.fs`). Ported from
+/// `apps/rhino-cli/src/application/env/backup.rs`'s `#[cfg(test)] mod tests`.
+module RhinoCli.Tests.Unit.Steps.EnvUnitTests
+
+open System
+open System.IO
+open System.Text.Json
+open Xunit
+open RhinoCli.Application.Env
+
+let private newTempDir () : string =
+    let dir =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-env-unit-" + Guid.NewGuid().ToString("N"))
+
+    Directory.CreateDirectory(dir) |> ignore
+    dir
+
+let private defaultOptions (repoRoot: string) (backupDir: string) : EnvOptions =
+    { RepoRoot = repoRoot
+      BackupDir = backupDir
+      SkipDirs = defaultSkipDirs
+      MaxSize = DefaultMaxSize
+      WorktreeAware = false
+      WorktreeName = ""
+      Force = false
+      IncludeConfig = false
+      DryRun = false }
+
+let private neverConfirm () : bool =
+    failwith "confirm callback must not be invoked"
+
+// ---- expandTilde ----
+
+[<Fact>]
+let ``expandTilde replaces a leading tilde with HOME`` () =
+    match expandTilde "~/foo" with
+    | Ok r -> Assert.EndsWith("/foo", r)
+    | Error message -> Assert.Fail(message)
+
+[<Fact>]
+let ``expandTilde leaves an absolute path unchanged`` () =
+    Assert.Equal(Ok "/abs/path", expandTilde "/abs/path")
+
+// ---- isInsideRepo ----
+
+[<Fact>]
+let ``isInsideRepo is true for a child directory`` () =
+    Assert.True(isInsideRepo "/repo/sub/backup" "/repo")
+
+[<Fact>]
+let ``isInsideRepo is false for a sibling directory`` () =
+    Assert.False(isInsideRepo "/other" "/repo")
+
+// ---- canonicalizeBestEffort ----
+
+[<Fact>]
+let ``canonicalizeBestEffort resolves an existing path directly`` () =
+    let dir = newTempDir ()
+
+    try
+        match canonicalizeBestEffort dir with
+        | Ok resolved -> Assert.Equal(Path.GetFullPath dir, resolved)
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``canonicalizeBestEffort walks up to the nearest existing ancestor and rejoins the tail`` () =
+    let dir = newTempDir ()
+
+    try
+        let candidate = Path.Combine(dir, "does-not-exist-yet", "nested")
+
+        match canonicalizeBestEffort candidate with
+        | Ok resolved -> Assert.Equal(Path.GetFullPath candidate, resolved)
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(dir, true)
+
+// ---- isSecretFile ----
+
+[<Fact>]
+let ``isSecretFile matches cert and key extensions`` () =
+    Assert.True(isSecretFile "cert.pem" "cert.pem")
+    Assert.True(isSecretFile "sub/dir/id.key" "id.key")
+    Assert.True(isSecretFile "server.crt" "server.crt")
+    Assert.True(isSecretFile "bundle.pfx" "bundle.pfx")
+    Assert.False(isSecretFile "README.md" "README.md")
+
+[<Fact>]
+let ``isSecretFile matches dotenv files, secrets.json, and the .secrets directory`` () =
+    Assert.True(isSecretFile ".env" ".env")
+    Assert.True(isSecretFile ".env.local" ".env.local")
+    Assert.True(isSecretFile "secrets.json" "secrets.json")
+    Assert.True(isSecretFile ".secrets/notes.md" "notes.md")
+
+// ---- discover ----
+
+[<Fact>]
+let ``discover finds .env files`` () =
+    let dir = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(dir, ".env"), "x=1")
+        File.WriteAllText(Path.Combine(dir, ".env.local"), "y=2")
+        File.WriteAllText(Path.Combine(dir, "README.md"), "x")
+        let opts = defaultOptions dir dir
+        let entries = discover opts
+        Assert.Equal(2, List.length entries)
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``discover finds a pem file`` () =
+    let dir = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(dir, "cert.pem"), "x")
+        let entries = discover (defaultOptions dir dir)
+        Assert.Equal<string list>([ "cert.pem" ], entries |> List.map (fun e -> e.RelPath))
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``discover skips oversized files`` () =
+    let dir = newTempDir ()
+
+    try
+        File.WriteAllBytes(Path.Combine(dir, ".env"), Array.zeroCreate<byte> 100)
+
+        let opts =
+            { defaultOptions dir dir with
+                MaxSize = 10L }
+
+        let entries = discover opts
+        Assert.Single(entries) |> ignore
+        Assert.True(entries.[0].Skipped)
+        Assert.Contains("exceeds", entries.[0].Reason)
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``discover skips configured skip-dirs`` () =
+    let dir = newTempDir ()
+
+    try
+        Directory.CreateDirectory(Path.Combine(dir, "node_modules")) |> ignore
+        File.WriteAllText(Path.Combine(dir, "node_modules", ".env"), "x")
+        File.WriteAllText(Path.Combine(dir, ".env"), "y")
+        let entries = discover (defaultOptions dir dir)
+        Assert.Equal<string list>([ ".env" ], entries |> List.map (fun e -> e.RelPath))
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``discover finds a file inside the .secrets directory`` () =
+    let dir = newTempDir ()
+
+    try
+        Directory.CreateDirectory(Path.Combine(dir, ".secrets")) |> ignore
+        File.WriteAllText(Path.Combine(dir, ".secrets", "notes.md"), "secret")
+        let entries = discover (defaultOptions dir dir)
+        Assert.Contains(".secrets/notes.md", entries |> List.map (fun e -> e.RelPath))
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``discover still skips the .git directory`` () =
+    let dir = newTempDir ()
+
+    try
+        Directory.CreateDirectory(Path.Combine(dir, ".git")) |> ignore
+        File.WriteAllText(Path.Combine(dir, ".git", "config"), "gitconfig")
+        File.WriteAllText(Path.Combine(dir, ".env"), "k=v")
+        let entries = discover (defaultOptions dir dir)
+        Assert.DoesNotContain(entries, fun (e: EnvFileEntry) -> e.RelPath.StartsWith(".git/", StringComparison.Ordinal))
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``discover finds secrets.json`` () =
+    let dir = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(dir, "secrets.json"), "{\"key\":\"val\"}")
+        let entries = discover (defaultOptions dir dir)
+        Assert.Contains("secrets.json", entries |> List.map (fun e -> e.RelPath))
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``discover marks a symlinked secret file as skipped`` () =
+    let dir = newTempDir ()
+
+    try
+        let target = Path.Combine(dir, "target.txt")
+        File.WriteAllText(target, "x")
+        let link = Path.Combine(dir, ".env.link")
+        File.CreateSymbolicLink(link, target) |> ignore
+        let entries = discover (defaultOptions dir dir)
+        let entry = entries |> List.find (fun e -> e.RelPath = ".env.link")
+        Assert.True(entry.Skipped)
+        Assert.Equal("symlink", entry.Reason)
+    finally
+        Directory.Delete(dir, true)
+
+// ---- discoverConfig ----
+
+[<Fact>]
+let ``discoverConfig picks up an existing pattern`` () =
+    let dir = newTempDir ()
+
+    try
+        Directory.CreateDirectory(Path.Combine(dir, ".claude")) |> ignore
+        File.WriteAllText(Path.Combine(dir, ".claude", "settings.local.json"), "{}")
+        let entries = discoverConfig dir defaultConfigPatterns DefaultMaxSize
+        Assert.NotEmpty(entries)
+        Assert.Equal("config", entries.[0].Source)
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``discoverConfig returns nothing when no pattern exists`` () =
+    let dir = newTempDir ()
+
+    try
+        Assert.Empty(discoverConfig dir defaultConfigPatterns DefaultMaxSize)
+    finally
+        Directory.Delete(dir, true)
+
+// ---- findExisting ----
+
+[<Fact>]
+let ``findExisting returns the intersection of entries and destination files`` () =
+    let dir = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(dir, "a.txt"), "x")
+
+        let entries =
+            [ { RelPath = "a.txt"
+                AbsPath = ""
+                Size = 0L
+                Skipped = false
+                Reason = ""
+                Source = "" }
+              { RelPath = "b.txt"
+                AbsPath = ""
+                Size = 0L
+                Skipped = false
+                Reason = ""
+                Source = "" } ]
+
+        Assert.Equal<string list>([ "a.txt" ], findExisting entries dir)
+    finally
+        Directory.Delete(dir, true)
+
+// ---- detectWorktree ----
+
+[<Fact>]
+let ``detectWorktree reports a normal repository`` () =
+    let dir = newTempDir ()
+
+    try
+        Directory.CreateDirectory(Path.Combine(dir, ".git")) |> ignore
+
+        match detectWorktree dir with
+        | Ok info ->
+            Assert.False(info.IsWorktree)
+            Assert.NotEqual<string>("", info.WorktreeName)
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``detectWorktree reports a linked worktree`` () =
+    let dir = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(dir, ".git"), "gitdir: /elsewhere/.git")
+
+        match detectWorktree dir with
+        | Ok info -> Assert.True(info.IsWorktree)
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``detectWorktree fails when no .git is present`` () =
+    let dir = newTempDir ()
+
+    try
+        match detectWorktree dir with
+        | Error _ -> ()
+        | Ok _ -> Assert.Fail("expected an error when no .git is present")
+    finally
+        Directory.Delete(dir, true)
+
+// ---- backup ----
+
+[<Fact>]
+let ``backup rejects a backup dir inside the repo`` () =
+    let dir = newTempDir ()
+
+    try
+        let opts = defaultOptions dir (Path.Combine(dir, "subdir"))
+
+        match backup opts neverConfirm with
+        | Error _ -> ()
+        | Ok _ -> Assert.Fail("expected an error for a backup dir inside the repo")
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``backup copies files`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(repo, ".env"), "k=v")
+
+        let opts =
+            { defaultOptions repo dest with
+                Force = true }
+
+        match backup opts neverConfirm with
+        | Ok r ->
+            Assert.Equal(1, r.Copied)
+            Assert.True(File.Exists(Path.Combine(dest, ".env")))
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+[<Fact>]
+let ``backup dry-run writes nothing`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(repo, ".env"), "k=v")
+
+        let opts =
+            { defaultOptions repo dest with
+                Force = true
+                DryRun = true }
+
+        match backup opts neverConfirm with
+        | Ok r ->
+            Assert.Equal(0, r.Copied)
+            Assert.False(File.Exists(Path.Combine(dest, ".env")))
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+[<Fact>]
+let ``backup with Force never invokes confirm and overwrites unconditionally`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(repo, ".env"), "new")
+        File.WriteAllText(Path.Combine(dest, ".env"), "old")
+
+        let opts =
+            { defaultOptions repo dest with
+                Force = true }
+
+        match backup opts neverConfirm with
+        | Ok r ->
+            Assert.Equal(1, r.Copied)
+            Assert.Equal("new", File.ReadAllText(Path.Combine(dest, ".env")))
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+[<Fact>]
+let ``backup with no conflicts never invokes confirm`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(repo, ".env"), "k=v")
+        let opts = defaultOptions repo dest
+
+        match backup opts neverConfirm with
+        | Ok r -> Assert.Equal(1, r.Copied)
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+[<Fact>]
+let ``backup invokes confirm exactly once on a real conflict and proceeds when it returns true`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(repo, ".env"), "new")
+        File.WriteAllText(Path.Combine(dest, ".env"), "old")
+        let opts = defaultOptions repo dest
+        let mutable callCount = 0
+
+        let confirm () =
+            callCount <- callCount + 1
+            true
+
+        match backup opts confirm with
+        | Ok r ->
+            Assert.Equal(1, callCount)
+            Assert.False(r.Cancelled)
+            Assert.Equal("new", File.ReadAllText(Path.Combine(dest, ".env")))
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+[<Fact>]
+let ``backup cancels and leaves the destination unchanged when confirm returns false`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(repo, ".env"), "new")
+        File.WriteAllText(Path.Combine(dest, ".env"), "old")
+        let opts = defaultOptions repo dest
+        let mutable callCount = 0
+
+        let confirm () =
+            callCount <- callCount + 1
+            false
+
+        match backup opts confirm with
+        | Ok r ->
+            Assert.Equal(1, callCount)
+            Assert.True(r.Cancelled)
+            Assert.Equal("old", File.ReadAllText(Path.Combine(dest, ".env")))
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+[<Fact>]
+let ``backup tags entries as env when include-config is set`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(repo, ".env"), "k=v")
+        Directory.CreateDirectory(Path.Combine(repo, ".claude")) |> ignore
+        File.WriteAllText(Path.Combine(repo, ".claude", "settings.local.json"), "{}")
+
+        let opts =
+            { defaultOptions repo dest with
+                Force = true
+                IncludeConfig = true }
+
+        match backup opts neverConfirm with
+        | Ok r ->
+            Assert.Equal(2, r.Copied)
+            let envEntry = r.Files |> List.find (fun f -> f.RelPath = ".env")
+            Assert.Equal("env", envEntry.Source)
+
+            let configEntry =
+                r.Files |> List.find (fun f -> f.RelPath = ".claude/settings.local.json")
+
+            Assert.Equal("config", configEntry.Source)
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+[<Fact>]
+let ``backup namespaces the destination by worktree name when worktree-aware`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(repo, ".env"), "k=v")
+
+        let opts =
+            { defaultOptions repo dest with
+                Force = true
+                WorktreeAware = true
+                WorktreeName = "feature-branch" }
+
+        match backup opts neverConfirm with
+        | Ok _ -> Assert.True(File.Exists(Path.Combine(dest, "feature-branch", ".env")))
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+// ---- capitalize ----
+
+[<Fact>]
+let ``capitalize upcases the first character only`` () =
+    Assert.Equal("Backup", capitalize "backup")
+    Assert.Equal("", capitalize "")
+
+// ---- formatText / formatJson / formatMarkdown ----
+
+let private sampleResult () : EnvOperationResult =
+    { Direction = "backup"
+      Dir = "/tmp/bk"
+      Files =
+        [ { RelPath = ".env"
+            AbsPath = ""
+            Size = 10L
+            Skipped = false
+            Reason = ""
+            Source = "" }
+          { RelPath = ".env.large"
+            AbsPath = ""
+            Size = 999_999_999L
+            Skipped = true
+            Reason = "exceeds 1 MB"
+            Source = "" }
+          { RelPath = ".envrc"
+            AbsPath = ""
+            Size = 50L
+            Skipped = false
+            Reason = ""
+            Source = "config" } ]
+      Copied = 2
+      Skipped = 1
+      Errors = []
+      WorktreeName = ""
+      Cancelled = false
+      DryRun = false }
+
+[<Fact>]
+let ``formatText reports the summary and config count`` () =
+    let s = formatText (sampleResult ()) false false
+    Assert.Contains("Backup complete", s)
+    Assert.Contains("(1 config)", s)
+
+[<Fact>]
+let ``formatText quiet mode suppresses per-file lines`` () =
+    let s = formatText (sampleResult ()) false true
+    Assert.Contains("Backup complete", s)
+    Assert.DoesNotContain("BACKUP  .env", s)
+
+[<Fact>]
+let ``formatText verbose mode lists skipped files`` () =
+    let s = formatText (sampleResult ()) true false
+    Assert.Contains("SKIPPED  .env.large", s)
+
+[<Fact>]
+let ``formatText reports cancellation`` () =
+    let r =
+        { sampleResult () with
+            Cancelled = true }
+
+    Assert.Contains("cancelled", formatText r false false)
+
+[<Fact>]
+let ``formatJson round-trips through JsonDocument`` () =
+    let s = formatJson (sampleResult ())
+    use doc = JsonDocument.Parse(s)
+    Assert.Equal("backup", doc.RootElement.GetProperty("direction").GetString())
+    Assert.Equal(2, doc.RootElement.GetProperty("copied").GetInt32())
+
+[<Fact>]
+let ``formatMarkdown renders the report header and table`` () =
+    let s = formatMarkdown (sampleResult ())
+    Assert.Contains("## Backup Report", s)
+    Assert.Contains("**Copied**: 2", s)
+    Assert.Contains("| File |", s)
+
+[<Fact>]
+let ``formatMarkdown reports cancellation`` () =
+    let r =
+        { sampleResult () with
+            Cancelled = true }
+
+    Assert.Contains("cancelled", formatMarkdown r)

--- a/repo-config.yml
+++ b/repo-config.yml
@@ -151,22 +151,25 @@ coverage:
       specs: "specs/apps/rhino/behavior/rhino-cli/**"
     # rhino-cli-fsharp (rewrite-rhino-cli-to-fsharp): registry hygiene from
     # Phase 2 onward per this registry's own "every project is listed"
-    # comment above. The glob covers exactly the Gherkin directories whose
-    # F# step definitions have landed — a property of implementation, not of
+    # comment above. The glob covers exactly the Gherkin files whose F#
+    # step definitions have landed — a property of implementation, not of
     # FSHARP_NAMESPACES — so it widens with *each wave's implementation
     # work*, not with the wave's later integration/flip PR: a namespace's
     # step definitions exist (and must be provably covered) before that
-    # wave's namespace ever serves real traffic. Directory-level (not
-    # file-level) scope matches ose-private, since `RhinoCli.Application.
-    # Convention` binds all three of the `convention` namespace's feature
-    # files together (emoji, license, and the aggregate audit share one
-    # module) — splitting the scope per-file would not reflect how the
-    # implementation is actually structured. Wave A widened it from nothing
-    # (Phase 2) to the full `convention/` directory. Wave B widens it PR by
-    # PR, one sibling directory at a time, in the same brace-list glob.
+    # wave's namespace ever serves real traffic. Directory-level scope
+    # matches ose-private when a whole directory lands in one PR (Wave A's
+    # `convention/`, since `RhinoCli.Application.Convention` binds all
+    # three of its feature files together). When a directory's feature
+    # files are split across several PRs — Wave B's `env/`, ported one
+    # file per PR — the glob is file-scoped instead: widening to the whole
+    # directory before every sibling file is implemented would require
+    # `@wip`-tagging the not-yet-ported scenarios, which also exempts them
+    # from `rhino-cli`'s own one-to-one coverage check even though the
+    # Rust implementation already covers them — so file-scoping is the only
+    # option that does not regress the still-canonical Rust side.
     - name: rhino-cli-fsharp
       levels: [unit, integration]
-      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention,repo-config,repo-config-validate}/**"
+      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention/**,repo-config/**,repo-config-validate/**,env/env-backup.feature}"
 
     # ose domain
     - name: ose-be


### PR DESCRIPTION
## Summary
- Ports `RhinoCli.Application.Env.backup` (discovery, worktree-aware namespacing, confirm-callback overwrite handling, text/json/markdown formatting) — the F# port of the Rust `env backup` command.
- Closes a spec/implementation gap in the Rust reference: `Options.force`/`find_existing` are dead code there, so the F# port implements real confirm/decline behavior via an explicit `confirm: unit -> bool` callback instead of reproducing the silent always-overwrite.
- Scopes `specs:behavior:coverage` and `repo-config.yml`'s coverage registry to exactly `env/env-backup.feature` (not the whole `env/` directory, which still has 3 unimplemented sibling files) — file-scoping avoids `@wip`-tagging Gherkin scenarios that Rust's own one-to-one coverage check already covers.

## Test plan
- [x] `dotnet build` — 0 warnings
- [x] `dotnet test` — 196/196 passing
- [x] `fantomas --check` — clean
- [x] G-Research F# analyzers — clean (all 5 fsproj)
- [x] `fsharplint` — clean
- [x] `specs:behavior:coverage` — 6 specs, 46 scenarios, 203 steps, all covered
- [x] `rhino-cli:test:specs` (Rust one-to-one coverage) — unaffected, 72 specs still all covered
- [x] `nx run-many -t test:quick -p rhino-cli,rhino-cli-fsharp` green