### PR TITLE
feat(rhino-cli-fsharp): port env/env-init.feature to F# (Wave B PR4)

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -5,7 +5,7 @@ b5f5e511ac5697c2d2949d898633f079abbce9c7211205aad6f7521f17746df2  apps/rhino-cli
 22b1d0652e8937a20c83841966e4f8b1c451d671d34dd27fb5fa13f11d340a4d  apps/rhino-cli/src-fsharp/.gitignore
 96bd05860d32d93030016db7fa582a1fbb772328d6875cf03fff8957f47b1e90  apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
 11fe7ec2e5e08b432e2d1cedae59e1a555e17e22a1f11494bd83b80c36964b5c  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Convention.fs
-d506ea3be2291c5684fb6015c994d7ad1ce5fb2e7da1a1f71865ceb40efcb5bf  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
+790b5ee886537d88c7f6427b5783ad69b188feeea9061eab634f7ba7ababf1c7  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
 2f8085bcb8089f174e9548e609530471c9318c31b1bcab4a867e33880cec9e57  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Parity.fs
 f68a2a01380e02ce7fa8f5774a0800e9f1281c39d3c90b3c03947c1448799f2d  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/RepoConfig.fs
 fc1346c5ed931f006be550583e92d5603bdffceb270783f4b334bb5ff4d7aa3a  apps/rhino-cli/src-fsharp/RhinoCli.Cli/RhinoCli.Cli.fsproj
@@ -20,12 +20,14 @@ bb55f3c8d4d3daffa7e334ecdacff8bfd9462b12a7098e239943d84a3edf915f  apps/rhino-cli
 631376afb9e4d7c5192d38f51b533c18b64cca83c18ed5c50982ba9acce51d74  apps/rhino-cli/src-fsharp/RhinoCli.Program/RhinoCli.Program.fsproj
 153a226f5ef1d6916aa6e6425b278a606a48659fcba9623c9d01e5cf3b2589a5  apps/rhino-cli/src-fsharp/RhinoCli.Program/src/Program.fs
 822f6ec8446562a4de9a3b1a2481af50fac01bbedc32e1963142709e5f48ec13  apps/rhino-cli/src-fsharp/fsharplint.json
-10f53a32bd254a7fc70e0d9385eb21811cff2fdc71cd3527e91cba82118059c3  apps/rhino-cli/src-fsharp/project.json
+55eb9bcafa2ef859abb0d08e54a7829d5da95300134c266576fe964ac3bd8538  apps/rhino-cli/src-fsharp/project.json
 f7dacc8dd923488c70eebabe298843022ec5a3ba94b8b7568634a779f24b8da4  apps/rhino-cli/src-fsharp/tests/integration/RhinoCli.IntegrationTests.fsproj
-8c1b279e48958e281de2cd2c4a4b2de938fc19bf2d47355d45322df500fb5d38  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+0ff99833b05c16349bf95ab98b72bb1cf420564cfbb89e161a1d43126dfa2d68  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
 85ba308ad0a88485db55b305120d99b9a4ec328d2379536110f73e51f4797fe2  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionSteps.fs
 a909884a9d8816e2b476cc8c00be03ac4085b849cbe83c4b18e0213ac9cad1d7  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionUnitTests.fs
 a0603a9ec897d538381417f8a330b1fa4b75f75f74003fda2a2b9b9512db5a1a  apps/rhino-cli/src-fsharp/tests/unit/Steps/DispatchUnitTests.fs
+ad360c992e3e47ccf8f47693a8f3c42581085a24efa1303204da2ff9963ede58  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvInitSteps.fs
+87c4e6d86da1a67ba92b0fc4a89b3e160ee1aecff6a860e5179959620fab686f  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvInitUnitTests.fs
 8a3ddb5f25240cc12e3045c4af266bebbebc75c113f1969c42c9df18f6554968  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvSteps.fs
 8ec32c7e97c3e4277dffbeadbcd6d278f52c9661874b52e9e8465221fc4e7534  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvUnitTests.fs
 66215f95f2afe48729422ebccadf068687c87bc5538fee88dfa7364da2f08028  apps/rhino-cli/src-fsharp/tests/unit/Steps/FormattersUnitTests.fs

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
@@ -3,11 +3,15 @@
 /// `apps/rhino-cli/src/application/env/backup.rs`,
 /// `apps/rhino-cli/src/commands/env_backup.rs`].
 ///
-/// Scope: this module ports `backup` and the helpers it (and this feature
-/// file's scenarios) need. `restore`, `env init`, and `env validate-app-drift`
-/// are separate later waves in this same namespace; `discoverConfig`,
-/// `findExisting`, and `detectWorktree` are written here because `backup`
-/// needs them, and are expected to be reused unchanged once `restore` lands.
+/// Scope: this module ports `backup` and `env init`, plus the helpers each
+/// (and their respective feature files' scenarios) needs. `restore` and
+/// `env validate-app-drift` are separate later waves in this same namespace;
+/// `discoverConfig`, `findExisting`, and `detectWorktree` are written here
+/// because `backup` needs them, and are expected to be reused unchanged once
+/// `restore` lands. `env init`'s own scan (`collectEnvExamples`) does not
+/// share `backup`'s `discover`/`walkDir` machinery — it is deliberately
+/// simpler: two fixed root directories, no skip-dirs list, and no file-size
+/// ceiling.
 ///
 /// Design decision — confirmation is real here, not a silent no-op: grepping
 /// the Rust reference shows `Options.force` is threaded from the CLI args
@@ -751,3 +755,112 @@ let formatMarkdown (r: EnvOperationResult) : string =
                 sb.Append(sprintf "- %s\n" e) |> ignore
 
         sb.ToString()
+
+// ---- env init ----
+
+/// Directories under a repo root that `env init` scans for `.env.example`
+/// files [Repo-grounded — `env_init.rs::SCAN_ROOTS`]. Deliberately not
+/// `backup`'s `discover`/`walkDir`: this scan is two fixed roots, with no
+/// skip-dirs list and no file-size ceiling — see the module doc comment.
+let envInitScanRoots: string list = [ "infra/dev"; "apps" ]
+
+/// The tier `env init` bootstraps: local development, never committed
+/// [Repo-grounded — `env_init.rs::ENV_TIER_DEFAULT`].
+[<Literal>]
+let EnvInitTargetTier: string = ".env.local"
+
+/// Recursively finds every `.env.example` file under `dir`.
+let rec private walkForExamples (dir: string) : string list =
+    let here =
+        Directory.EnumerateFiles dir
+        |> Seq.filter (fun f -> Path.GetFileName f = ".env.example")
+        |> List.ofSeq
+
+    let nested =
+        Directory.EnumerateDirectories dir |> Seq.collect walkForExamples |> List.ofSeq
+
+    here @ nested
+
+/// Collects every `.env.example` file found under `envInitScanRoots` inside
+/// `repoRoot` [Repo-grounded — `env_init.rs::collect_examples`].
+let collectEnvExamples (repoRoot: string) : string list =
+    envInitScanRoots
+    |> List.collect (fun root ->
+        let scanDir = Path.Combine(repoRoot, root)
+
+        if Directory.Exists scanDir then
+            walkForExamples scanDir
+        else
+            [])
+
+/// Computes the `.env.local` path that sits alongside `examplePath`, in the
+/// same directory [Repo-grounded — `env_init.rs::target_env_path`]. Unlike
+/// the Rust original this returns a plain `string` rather than an `Option`:
+/// every `examplePath` this module passes in comes from `collectEnvExamples`
+/// walking real files on disk, so it always has a parent directory.
+let targetEnvPath (examplePath: string) : string =
+    Path.Combine(Path.GetDirectoryName examplePath, EnvInitTargetTier)
+
+/// One discovered `.env.example` file's copy outcome [Repo-grounded —
+/// `env_init.rs::run`'s per-file `println!` branches].
+type EnvInitFileOutcome =
+    | EnvInitCreated of relPath: string * exampleFileName: string
+    | EnvInitSkipped of relPath: string
+
+/// Outcome of an `env init` operation [Repo-grounded — `env_init.rs::run`].
+type EnvInitResult =
+    { Files: EnvInitFileOutcome list
+      Created: int
+      Skipped: int }
+
+/// Copies every `.env.example` file found under `repoRoot` to its sibling
+/// `.env.local`, skipping files that already exist unless `force` is `true`
+/// [Repo-grounded — `env_init.rs::run`]. Unlike `backup`, this has no
+/// `Result` wrapper: `env_init.rs::run`'s only failure mode is git-root
+/// discovery, which this port's callers (mirroring `backup`'s `EnvOptions`)
+/// handle by passing `repoRoot` in directly rather than looking it up here.
+let runEnvInit (repoRoot: string) (force: bool) : EnvInitResult =
+    let outcomes =
+        collectEnvExamples repoRoot
+        |> List.map (fun examplePath ->
+            let envPath = targetEnvPath examplePath
+            let rel = Path.GetRelativePath(repoRoot, envPath).Replace('\\', '/')
+
+            if not force && (File.Exists envPath || Directory.Exists envPath) then
+                EnvInitSkipped rel
+            else
+                File.Copy(examplePath, envPath, true)
+                EnvInitCreated(rel, Path.GetFileName examplePath))
+
+    let created =
+        outcomes
+        |> List.filter (function
+            | EnvInitCreated _ -> true
+            | EnvInitSkipped _ -> false)
+        |> List.length
+
+    let skipped = List.length outcomes - created
+
+    { Files = outcomes
+      Created = created
+      Skipped = skipped }
+
+/// Formats an [`EnvInitResult`] as human-readable text [Repo-grounded —
+/// `env_init.rs::run`'s `println!` calls]. `env init` has no JSON/Markdown
+/// Gherkin scenario, so unlike `backup`'s `formatText`/`formatJson`/
+/// `formatMarkdown` trio this is the only formatter it needs.
+let formatEnvInitText (r: EnvInitResult) : string =
+    let sb = Text.StringBuilder()
+
+    for f in r.Files do
+        match f with
+        | EnvInitCreated(rel, exampleFileName) ->
+            sb.Append(sprintf "Created: %s (from %s)\n" rel exampleFileName) |> ignore
+        | EnvInitSkipped rel ->
+            sb.Append(sprintf "Skipped: %s (already exists, use --force to overwrite)\n" rel)
+            |> ignore
+
+    sb.Append(sprintf "\nSummary: %d created, %d skipped\n" r.Created r.Skipped)
+    |> ignore
+
+    sb.ToString()

--- a/apps/rhino-cli/src-fsharp/project.json
+++ b/apps/rhino-cli/src-fsharp/project.json
@@ -112,7 +112,7 @@
     "specs:behavior:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-backup.feature apps/rhino-cli/src-fsharp"
+        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-backup.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-init.feature apps/rhino-cli/src-fsharp"
       },
       "cache": true,
       "inputs": ["{workspaceRoot}/specs/apps/rhino/behavior/rhino-cli/gherkin/**/*.feature", "{projectRoot}/**/*.fs"]

--- a/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+++ b/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
@@ -21,6 +21,8 @@
     <Compile Include="Steps/RepoConfigValidateUnitTests.fs" />
     <Compile Include="Steps/EnvSteps.fs" />
     <Compile Include="Steps/EnvUnitTests.fs" />
+    <Compile Include="Steps/EnvInitSteps.fs" />
+    <Compile Include="Steps/EnvInitUnitTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvInitSteps.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvInitSteps.fs
@@ -1,0 +1,218 @@
+/// TickSpec step definitions binding `env-init.feature`'s 4 scenarios to
+/// `RhinoCli.Application.Env`'s `env init` port [Repo-grounded —
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-init.feature`,
+/// `apps/rhino-cli/src/commands/env_init.rs`].
+///
+/// Follows `EnvSteps.fs`'s per-scenario slicing convention: each xunit
+/// `[<Fact>]` below runs exactly one scenario, extracted from the real,
+/// frozen feature file rather than a duplicated/rewritten copy of its
+/// wording. Kept as its own file (rather than added to `EnvSteps.fs`) since
+/// `env-init.feature` is its own PR-sized slice of the `env` namespace, same
+/// as `env-backup.feature` was.
+module RhinoCli.Tests.Unit.Steps.EnvInitSteps
+
+open System
+open System.IO
+open TickSpec
+open Xunit
+open RhinoCli.Application.Env
+
+/// Instance step-definition container — see `ConventionSteps.fs`'s module
+/// doc comment for why TickSpec's one-instance-per-scenario lifecycle makes
+/// instance-level mutable fields the idiomatic state-threading mechanism
+/// here.
+type EnvInitSteps() =
+    let mutable repoRoot: string option = None
+    let mutable forceFlag = false
+    let mutable result: EnvInitResult option = None
+    let mutable ownedDirs: string list = []
+
+    let newTempDir (prefix: string) : string =
+        let dir =
+            Path.Combine(Path.GetTempPath(), "rhino-cli-env-init-" + prefix + "-" + Guid.NewGuid().ToString("N"))
+
+        Directory.CreateDirectory(dir) |> ignore
+        ownedDirs <- dir :: ownedDirs
+        dir
+
+    let writeFile (root: string) (relativePath: string) (content: string) =
+        let full = Path.Combine(root, relativePath)
+        Directory.CreateDirectory(Path.GetDirectoryName(full)) |> ignore
+        File.WriteAllText(full, content)
+
+    let ensureRoot () : string =
+        match repoRoot with
+        | Some dir -> dir
+        | None ->
+            let dir = newTempDir "repo"
+            repoRoot <- Some dir
+            dir
+
+    let root () : string =
+        match repoRoot with
+        | Some dir -> dir
+        | None -> failwith "no repository root has been prepared by a Given step"
+
+    let outcome () : EnvInitResult =
+        match result with
+        | Some r -> r
+        | None -> failwith "no command has been run by a When step"
+
+    let runEnvInitStep () =
+        result <- Some(runEnvInit (root ()) forceFlag)
+
+    // ---- Given ----
+
+    [<Given>]
+    member _.``.env.example files exist in infra/dev but no .env.local files``() =
+        let dir = ensureRoot ()
+        writeFile dir "infra/dev/organiclever/.env.example" "organiclever=1"
+        writeFile dir "infra/dev/ose-be/.env.example" "ose-be=1"
+
+    [<Given>]
+    member _.``.env.example files exist in infra/dev and some .env.local files already exist``() =
+        let dir = ensureRoot ()
+        writeFile dir "infra/dev/organiclever/.env.example" "organiclever=1"
+        writeFile dir "infra/dev/ose-be/.env.example" "ose-be=1"
+        writeFile dir "infra/dev/ose-be/.env.local" "pre-existing=1"
+
+    [<Given>]
+    member _.``no .env.example files exist in infra/dev``() =
+        let dir = ensureRoot ()
+        writeFile dir "infra/dev/.gitkeep" ""
+
+    // ---- When ----
+
+    [<When>]
+    member _.``the developer runs env init``() = runEnvInitStep ()
+
+    [<When>]
+    member _.``the developer runs env init with the force flag``() =
+        forceFlag <- true
+        runEnvInitStep ()
+
+    // ---- Then ----
+
+    [<Then>]
+    member _.``the command exits successfully``() = outcome () |> ignore
+
+    [<Then>]
+    member _.``.env.local files are created from each .env.example``() =
+        Assert.True(File.Exists(Path.Combine(root (), "infra/dev/organiclever/.env.local")))
+        Assert.True(File.Exists(Path.Combine(root (), "infra/dev/ose-be/.env.local")))
+
+    [<Then>]
+    member _.``no bare .env file is created``() =
+        Assert.False(File.Exists(Path.Combine(root (), "infra/dev/organiclever/.env")))
+        Assert.False(File.Exists(Path.Combine(root (), "infra/dev/ose-be/.env")))
+
+    [<Then>]
+    member _.``the output lists each created file``() =
+        let text = formatEnvInitText (outcome ())
+        Assert.Contains("Created:", text)
+
+    [<Then>]
+    member _.``existing .env.local files are not overwritten``() =
+        Assert.Equal("pre-existing=1", File.ReadAllText(Path.Combine(root (), "infra/dev/ose-be/.env.local")))
+
+    [<Then>]
+    member _.``the output shows skipped files``() =
+        let text = formatEnvInitText (outcome ())
+        Assert.Contains("Skipped:", text)
+
+    [<Then>]
+    member _.``all .env.local files are created or overwritten``() =
+        Assert.True(File.Exists(Path.Combine(root (), "infra/dev/organiclever/.env.local")))
+        Assert.Equal("ose-be=1", File.ReadAllText(Path.Combine(root (), "infra/dev/ose-be/.env.local")))
+
+    [<Then>]
+    member _.``the output reports zero files created``() =
+        let r = outcome ()
+        Assert.Equal(0, r.Created)
+        Assert.Contains("Summary: 0 created", formatEnvInitText r)
+
+    [<AfterScenario>]
+    member _.Cleanup() =
+        for dir in ownedDirs do
+            if Directory.Exists dir then
+                Directory.Delete(dir, true)
+
+/// Reads one named `Scenario:` block out of the real, frozen `env-init.feature`
+/// file (leaving the file itself untouched) and runs it through TickSpec
+/// bound only against `EnvInitSteps` — see `EnvSteps.fs`'s `FeatureRunner`
+/// for why this is per-scenario rather than per-file.
+module private FeatureRunner =
+
+    let private featurePath: string =
+        Path.GetFullPath(
+            Path.Combine(
+                __SOURCE_DIRECTORY__,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "specs",
+                "apps",
+                "rhino",
+                "behavior",
+                "rhino-cli",
+                "gherkin",
+                "env",
+                "env-init.feature"
+            )
+        )
+
+    let private extractScenario (featureLines: string[]) (scenarioTitle: string) : string[] =
+        let featureLine =
+            featureLines
+            |> Array.find (fun l -> l.TrimStart().StartsWith("Feature:", StringComparison.Ordinal))
+
+        let scenarioHeader = sprintf "Scenario: %s" scenarioTitle
+
+        let startIdx = featureLines |> Array.findIndex (fun l -> l.Trim() = scenarioHeader)
+
+        let endIdx =
+            featureLines
+            |> Array.skip (startIdx + 1)
+            |> Array.tryFindIndex (fun l ->
+                let trimmed = l.Trim()
+
+                trimmed.StartsWith("Scenario:", StringComparison.Ordinal)
+                || trimmed.StartsWith("Scenario Outline:", StringComparison.Ordinal)
+                // env-init.feature tags every scenario with a leading `@tag`
+                // line, same as env-backup.feature — the next scenario's tag
+                // line must also end the slice, or it gets pulled in as a
+                // dangling trailing line with no scenario body to attach to.
+                || trimmed.StartsWith("@", StringComparison.Ordinal))
+            |> Option.map (fun relativeIdx -> startIdx + 1 + relativeIdx)
+            |> Option.defaultValue featureLines.Length
+
+        Array.append [| featureLine; "" |] featureLines.[startIdx .. endIdx - 1]
+
+    /// Runs the single scenario named `scenarioTitle` from `env-init.feature`,
+    /// bound against `EnvInitSteps`.
+    let run (scenarioTitle: string) : unit =
+        let allLines = File.ReadAllLines featurePath
+        let snippet = extractScenario allLines scenarioTitle
+        let definitions = StepDefinitions([| typeof<EnvInitSteps> |])
+        let feature = definitions.GenerateFeature(featurePath, snippet)
+        let scenario = Seq.exactlyOne feature.Scenarios
+        scenario.Action.Invoke()
+
+[<Fact>]
+let ``Bootstrap env files from examples`` () =
+    FeatureRunner.run "Bootstrap env files from examples"
+
+[<Fact>]
+let ``Skip existing env files`` () =
+    FeatureRunner.run "Skip existing env files"
+
+[<Fact>]
+let ``Force overwrite existing env files`` () =
+    FeatureRunner.run "Force overwrite existing env files"
+
+[<Fact>]
+let ``No env.example files found`` () =
+    FeatureRunner.run "No env.example files found"

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvInitUnitTests.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvInitUnitTests.fs
@@ -1,0 +1,150 @@
+/// Plain xunit tests for `RhinoCli.Application.Env`'s `env init` pure
+/// helpers — behaviour with no dedicated Gherkin scenario, or exercised only
+/// indirectly there (mirrors the rationale `EnvUnitTests.fs`'s module doc
+/// comment states for its own split from `EnvSteps.fs`). Ported from
+/// `apps/rhino-cli/src/commands/env_init.rs`'s `#[cfg(test)] mod tests`.
+module RhinoCli.Tests.Unit.Steps.EnvInitUnitTests
+
+open System
+open System.IO
+open Xunit
+open RhinoCli.Application.Env
+
+let private newTempDir () : string =
+    let dir =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-env-init-unit-" + Guid.NewGuid().ToString("N"))
+
+    Directory.CreateDirectory(dir) |> ignore
+    dir
+
+let private writeFile (root: string) (relativePath: string) (content: string) =
+    let full = Path.Combine(root, relativePath)
+    Directory.CreateDirectory(Path.GetDirectoryName(full)) |> ignore
+    File.WriteAllText(full, content)
+
+// ---- targetEnvPath ----
+
+[<Fact>]
+let ``targetEnvPath uses the .env.local suffix`` () =
+    let example = Path.Combine("apps", "ose-be", ".env.example")
+    let target = targetEnvPath example
+    Assert.Equal(Path.Combine("apps", "ose-be", ".env.local"), target)
+
+[<Fact>]
+let ``targetEnvPath never produces a bare .env file`` () =
+    let example = Path.Combine("apps", "ose-be", ".env.example")
+    let target = targetEnvPath example
+    Assert.NotEqual<string>(".env", Path.GetFileName target)
+
+// ---- collectEnvExamples ----
+
+[<Fact>]
+let ``collectEnvExamples finds .env.example files under infra/dev and apps`` () =
+    let dir = newTempDir ()
+
+    try
+        writeFile dir "infra/dev/organiclever/.env.example" "organiclever=1"
+        writeFile dir "apps/ose-be/.env.example" "ose-be=1"
+
+        let found =
+            collectEnvExamples dir
+            |> List.map (fun p -> Path.GetRelativePath(dir, p).Replace('\\', '/'))
+
+        Assert.Contains("apps/ose-be/.env.example", found)
+        Assert.Contains("infra/dev/organiclever/.env.example", found)
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``collectEnvExamples returns nothing when neither scan root exists`` () =
+    let dir = newTempDir ()
+
+    try
+        Assert.Empty(collectEnvExamples dir)
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``collectEnvExamples ignores an .env.example file outside the scan roots`` () =
+    let dir = newTempDir ()
+
+    try
+        writeFile dir "libs/shared/.env.example" "should-not-be-found"
+        Assert.Empty(collectEnvExamples dir)
+    finally
+        Directory.Delete(dir, true)
+
+// ---- runEnvInit ----
+
+[<Fact>]
+let ``runEnvInit creates .env.local files from .env.example templates`` () =
+    let dir = newTempDir ()
+
+    try
+        writeFile dir "infra/dev/organiclever/.env.example" "k=v"
+        let r = runEnvInit dir false
+        Assert.Equal(1, r.Created)
+        Assert.Equal(0, r.Skipped)
+        Assert.Equal("k=v", File.ReadAllText(Path.Combine(dir, "infra/dev/organiclever/.env.local")))
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``runEnvInit skips an existing .env.local file without force`` () =
+    let dir = newTempDir ()
+
+    try
+        writeFile dir "infra/dev/organiclever/.env.example" "new"
+        writeFile dir "infra/dev/organiclever/.env.local" "old"
+        let r = runEnvInit dir false
+        Assert.Equal(0, r.Created)
+        Assert.Equal(1, r.Skipped)
+        Assert.Equal("old", File.ReadAllText(Path.Combine(dir, "infra/dev/organiclever/.env.local")))
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``runEnvInit overwrites an existing .env.local file with force`` () =
+    let dir = newTempDir ()
+
+    try
+        writeFile dir "infra/dev/organiclever/.env.example" "new"
+        writeFile dir "infra/dev/organiclever/.env.local" "old"
+        let r = runEnvInit dir true
+        Assert.Equal(1, r.Created)
+        Assert.Equal(0, r.Skipped)
+        Assert.Equal("new", File.ReadAllText(Path.Combine(dir, "infra/dev/organiclever/.env.local")))
+    finally
+        Directory.Delete(dir, true)
+
+[<Fact>]
+let ``runEnvInit reports zero files created when no .env.example files exist`` () =
+    let dir = newTempDir ()
+
+    try
+        let r = runEnvInit dir false
+        Assert.Equal(0, r.Created)
+        Assert.Empty(r.Files)
+    finally
+        Directory.Delete(dir, true)
+
+// ---- formatEnvInitText ----
+
+[<Fact>]
+let ``formatEnvInitText lists created and skipped files, then a summary line`` () =
+    let r =
+        { Files =
+            [ EnvInitCreated("infra/dev/organiclever/.env.local", ".env.example")
+              EnvInitSkipped "infra/dev/ose-be/.env.local" ]
+          Created = 1
+          Skipped = 1 }
+
+    let text = formatEnvInitText r
+    Assert.Contains("Created: infra/dev/organiclever/.env.local (from .env.example)", text)
+    Assert.Contains("Skipped: infra/dev/ose-be/.env.local (already exists, use --force to overwrite)", text)
+    Assert.Contains("Summary: 1 created, 1 skipped", text)
+
+[<Fact>]
+let ``formatEnvInitText reports zero created and zero skipped when nothing was found`` () =
+    let r = { Files = []; Created = 0; Skipped = 0 }
+    Assert.Contains("Summary: 0 created, 0 skipped", formatEnvInitText r)

--- a/repo-config.yml
+++ b/repo-config.yml
@@ -169,7 +169,7 @@ coverage:
     # option that does not regress the still-canonical Rust side.
     - name: rhino-cli-fsharp
       levels: [unit, integration]
-      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention/**,repo-config/**,repo-config-validate/**,env/env-backup.feature}"
+      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention/**,repo-config/**,repo-config-validate/**,env/env-backup.feature,env/env-init.feature}"
 
     # ose domain
     - name: ose-be


### PR DESCRIPTION
## Summary
- Ports `env init` (env_init.rs) to F#: `collectEnvExamples`, `targetEnvPath`, `runEnvInit`, `formatEnvInitText` in `Env.fs`.
- Adds `EnvInitSteps.fs` (TickSpec, 4 scenarios) and `EnvInitUnitTests.fs` (pure-helper xunit tests).
- Widens `specs:behavior:coverage` shared-steps and `repo-config.yml`'s `rhino-cli-fsharp` specs glob to include `env/env-init.feature`, file-scoped per the established Wave B pattern (env/ is split across multiple PRs).
- Application-layer only; CLI dispatch wiring deferred to the Wave B integration PR, per the established wave pattern.

## Test plan
- [x] `dotnet build` — 0 errors/warnings
- [x] `dotnet test` (unit) — 211/211 passing
- [x] `fantomas --check` — clean
- [x] `fsharplint` — 0 warnings
- [x] G-Research analyzers (5 projects) — exit 0
- [x] `nx run rhino-cli-fsharp:specs:behavior:coverage` — 7 specs, 50 scenarios, 223 steps, all covered
- [x] `nx run rhino-cli:test:specs` (Rust one-to-one coverage) — 72 specs, 531 scenarios, 2165 steps, all covered
- [x] `nx run-many -t test:quick -p rhino-cli,rhino-cli-fsharp` — full local pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)