### PR TITLE
feat(rhino-cli-fsharp): port env/env-restore.feature to F# (Wave B PR5)

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -5,7 +5,7 @@ b5f5e511ac5697c2d2949d898633f079abbce9c7211205aad6f7521f17746df2  apps/rhino-cli
 22b1d0652e8937a20c83841966e4f8b1c451d671d34dd27fb5fa13f11d340a4d  apps/rhino-cli/src-fsharp/.gitignore
 96bd05860d32d93030016db7fa582a1fbb772328d6875cf03fff8957f47b1e90  apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
 11fe7ec2e5e08b432e2d1cedae59e1a555e17e22a1f11494bd83b80c36964b5c  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Convention.fs
-790b5ee886537d88c7f6427b5783ad69b188feeea9061eab634f7ba7ababf1c7  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
+133a9ea6006e7d14397f8b6e6cc6c480a8f7ace60ee1d789dcf09d4265648c94  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
 2f8085bcb8089f174e9548e609530471c9318c31b1bcab4a867e33880cec9e57  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Parity.fs
 f68a2a01380e02ce7fa8f5774a0800e9f1281c39d3c90b3c03947c1448799f2d  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/RepoConfig.fs
 fc1346c5ed931f006be550583e92d5603bdffceb270783f4b334bb5ff4d7aa3a  apps/rhino-cli/src-fsharp/RhinoCli.Cli/RhinoCli.Cli.fsproj
@@ -20,14 +20,16 @@ bb55f3c8d4d3daffa7e334ecdacff8bfd9462b12a7098e239943d84a3edf915f  apps/rhino-cli
 631376afb9e4d7c5192d38f51b533c18b64cca83c18ed5c50982ba9acce51d74  apps/rhino-cli/src-fsharp/RhinoCli.Program/RhinoCli.Program.fsproj
 153a226f5ef1d6916aa6e6425b278a606a48659fcba9623c9d01e5cf3b2589a5  apps/rhino-cli/src-fsharp/RhinoCli.Program/src/Program.fs
 822f6ec8446562a4de9a3b1a2481af50fac01bbedc32e1963142709e5f48ec13  apps/rhino-cli/src-fsharp/fsharplint.json
-55eb9bcafa2ef859abb0d08e54a7829d5da95300134c266576fe964ac3bd8538  apps/rhino-cli/src-fsharp/project.json
+3743a82bec45d1d0f11b782c817eb1e8233d3068dbf525ce39b7e0ff654070d7  apps/rhino-cli/src-fsharp/project.json
 f7dacc8dd923488c70eebabe298843022ec5a3ba94b8b7568634a779f24b8da4  apps/rhino-cli/src-fsharp/tests/integration/RhinoCli.IntegrationTests.fsproj
-0ff99833b05c16349bf95ab98b72bb1cf420564cfbb89e161a1d43126dfa2d68  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+f47d343cb2582d7a81bca8d94989cae778b7ce6eb91199dd4467f3d19ac423be  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
 85ba308ad0a88485db55b305120d99b9a4ec328d2379536110f73e51f4797fe2  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionSteps.fs
 a909884a9d8816e2b476cc8c00be03ac4085b849cbe83c4b18e0213ac9cad1d7  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionUnitTests.fs
 a0603a9ec897d538381417f8a330b1fa4b75f75f74003fda2a2b9b9512db5a1a  apps/rhino-cli/src-fsharp/tests/unit/Steps/DispatchUnitTests.fs
 ad360c992e3e47ccf8f47693a8f3c42581085a24efa1303204da2ff9963ede58  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvInitSteps.fs
 87c4e6d86da1a67ba92b0fc4a89b3e160ee1aecff6a860e5179959620fab686f  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvInitUnitTests.fs
+7fd4b16aeef96322627d58ae7d3848af45c496881c43680d916d294b6216cb06  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvRestoreSteps.fs
+b49f1f9d865ea485480137d33fbf7a02570ad99b941f7bf6d15bbfa8c96185fe  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvRestoreUnitTests.fs
 8a3ddb5f25240cc12e3045c4af266bebbebc75c113f1969c42c9df18f6554968  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvSteps.fs
 8ec32c7e97c3e4277dffbeadbcd6d278f52c9661874b52e9e8465221fc4e7534  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvUnitTests.fs
 66215f95f2afe48729422ebccadf068687c87bc5538fee88dfa7364da2f08028  apps/rhino-cli/src-fsharp/tests/unit/Steps/FormattersUnitTests.fs

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
@@ -3,15 +3,18 @@
 /// `apps/rhino-cli/src/application/env/backup.rs`,
 /// `apps/rhino-cli/src/commands/env_backup.rs`].
 ///
-/// Scope: this module ports `backup` and `env init`, plus the helpers each
-/// (and their respective feature files' scenarios) needs. `restore` and
-/// `env validate-app-drift` are separate later waves in this same namespace;
+/// Scope: this module ports `backup`, `env init`, and `restore`, plus the
+/// helpers each (and their respective feature files' scenarios) needs. `env
+/// validate-app-drift` is a separate later wave in this same namespace;
 /// `discoverConfig`, `findExisting`, and `detectWorktree` are written here
-/// because `backup` needs them, and are expected to be reused unchanged once
-/// `restore` lands. `env init`'s own scan (`collectEnvExamples`) does not
-/// share `backup`'s `discover`/`walkDir` machinery — it is deliberately
-/// simpler: two fixed root directories, no skip-dirs list, and no file-size
-/// ceiling.
+/// because `backup` needs them, and are reused unchanged by `restore`. `env
+/// init`'s own scan (`collectEnvExamples`) does not share `backup`'s
+/// `discover`/`walkDir` machinery — it is deliberately simpler: two fixed
+/// root directories, no skip-dirs list, and no file-size ceiling. `restore`
+/// does share `discover`, but scans narrower than `backup`'s own scan: only
+/// `.git` is skipped (not the full `defaultSkipDirs` list), matching
+/// `backup.rs::restore`'s own
+/// `Options { skip_dirs: vec![".git".to_string()], ..Default::default() }`.
 ///
 /// Design decision — confirmation is real here, not a silent no-op: grepping
 /// the Rust reference shows `Options.force` is threaded from the CLI args
@@ -26,7 +29,12 @@
 /// is itself a pure function of `Options` and `findExisting`'s result — the
 /// callback is the one deliberately impure seam — so tests can assert both
 /// the decision made and that the callback fires exactly when (and only
-/// when) a real decision is needed, without touching `Console.In`.
+/// when) a real decision is needed, without touching `Console.In`. `restore`
+/// (below) closes the identical gap for its own `@env-restore-confirm`
+/// scenarios: grepping `backup.rs::restore` shows zero references to
+/// `force`, `confirm`, or any prompt at all — it always overwrites silently
+/// — so `restore` also takes an explicit `confirm: unit -> bool` callback
+/// with the same invoke-at-most-once-when-a-real-conflict-exists contract.
 module RhinoCli.Application.Env
 
 open System
@@ -864,3 +872,118 @@ let formatEnvInitText (r: EnvInitResult) : string =
     |> ignore
 
     sb.ToString()
+
+// ---- restore ----
+
+/// Copies `.env*` files (and optionally config files) from a backup
+/// directory back into the repository [Repo-grounded — `backup.rs::restore`].
+///
+/// Scans the source directory with [`discover`], but narrower than
+/// `backup`'s own scan — see the module doc comment for why only `.git` is
+/// skipped here rather than the full `defaultSkipDirs` list.
+///
+/// `confirm` is invoked at most once, and only when the destination already
+/// contains at least one of the restore candidates and `opts.Force` is
+/// `false` — see the module doc comment for why this is a real decision here
+/// rather than the confirm/force gap `backup.rs::restore` never has at all.
+/// Dry-run never invokes `confirm`: there is nothing to write, so the
+/// per-entry copy loop is skipped outright rather than reaching a real
+/// decision point.
+///
+/// # Errors
+///
+/// Returns an error when the source directory (`opts.BackupDir`, joined with
+/// `opts.WorktreeName` when `opts.WorktreeAware` is set) does not exist.
+let restore (opts: EnvOptions) (confirm: unit -> bool) : Result<EnvOperationResult, string> =
+    match expandTilde opts.BackupDir with
+    | Error message -> Error message
+    | Ok expandedBackupDir ->
+        let srcRoot =
+            if opts.WorktreeAware && opts.WorktreeName <> "" then
+                Path.Combine(expandedBackupDir, opts.WorktreeName)
+            else
+                expandedBackupDir
+
+        if not (Directory.Exists srcRoot) then
+            Error(sprintf "backup dir does not exist: %s" srcRoot)
+        else
+            let maxSize = if opts.MaxSize <= 0L then DefaultMaxSize else opts.MaxSize
+
+            let discoverOpts: EnvOptions =
+                { RepoRoot = srcRoot
+                  BackupDir = ""
+                  SkipDirs = [ ".git" ]
+                  MaxSize = maxSize
+                  WorktreeAware = false
+                  WorktreeName = ""
+                  Force = false
+                  IncludeConfig = false
+                  DryRun = false }
+
+            let discovered = discover discoverOpts
+
+            let entries =
+                if opts.IncludeConfig then
+                    let tagged =
+                        discovered
+                        |> List.map (fun e -> if e.Source = "" then { e with Source = "env" } else e)
+
+                    let configEntries = discoverConfig srcRoot defaultConfigPatterns maxSize
+
+                    tagged @ configEntries
+                    |> List.sortWith (fun a b -> String.CompareOrdinal(a.RelPath, b.RelPath))
+                else
+                    discovered
+
+            // Mirrors `backup.rs::restore`'s per-entry `if e.source != "config"
+            // && !is_secret_file(...) { continue; }` check: entries from
+            // `discover` are already secret-shaped (it pre-filters), so this
+            // matters only for `discoverConfig` entries, which bypass
+            // `isSecretFile` entirely.
+            let restoreCandidates =
+                entries
+                |> List.filter (fun e ->
+                    let baseName = Path.GetFileName e.RelPath
+                    e.Source = "config" || isSecretFile e.RelPath baseName)
+
+            if opts.DryRun then
+                Ok
+                    { Direction = "restore"
+                      Dir = expandedBackupDir
+                      Files = restoreCandidates
+                      Copied = 0
+                      Skipped = restoreCandidates |> List.filter (fun e -> e.Skipped) |> List.length
+                      Errors = []
+                      WorktreeName = opts.WorktreeName
+                      Cancelled = false
+                      DryRun = true }
+            else
+                let existing = findExisting restoreCandidates opts.RepoRoot
+                let proceed = opts.Force || List.isEmpty existing || confirm ()
+
+                if not proceed then
+                    Ok
+                        { Direction = "restore"
+                          Dir = expandedBackupDir
+                          Files = restoreCandidates
+                          Copied = 0
+                          Skipped = 0
+                          Errors = []
+                          WorktreeName = opts.WorktreeName
+                          Cancelled = true
+                          DryRun = false }
+                else
+                    let finalAcc =
+                        restoreCandidates
+                        |> List.fold (copyOne opts.RepoRoot) { Copied = 0; Skipped = 0; Errors = [] }
+
+                    Ok
+                        { Direction = "restore"
+                          Dir = expandedBackupDir
+                          Files = restoreCandidates
+                          Copied = finalAcc.Copied
+                          Skipped = finalAcc.Skipped
+                          Errors = finalAcc.Errors
+                          WorktreeName = opts.WorktreeName
+                          Cancelled = false
+                          DryRun = false }

--- a/apps/rhino-cli/src-fsharp/project.json
+++ b/apps/rhino-cli/src-fsharp/project.json
@@ -112,7 +112,7 @@
     "specs:behavior:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-backup.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-init.feature apps/rhino-cli/src-fsharp"
+        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-backup.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-init.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-restore.feature apps/rhino-cli/src-fsharp"
       },
       "cache": true,
       "inputs": ["{workspaceRoot}/specs/apps/rhino/behavior/rhino-cli/gherkin/**/*.feature", "{projectRoot}/**/*.fs"]

--- a/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+++ b/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
@@ -23,6 +23,8 @@
     <Compile Include="Steps/EnvUnitTests.fs" />
     <Compile Include="Steps/EnvInitSteps.fs" />
     <Compile Include="Steps/EnvInitUnitTests.fs" />
+    <Compile Include="Steps/EnvRestoreSteps.fs" />
+    <Compile Include="Steps/EnvRestoreUnitTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvRestoreSteps.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvRestoreSteps.fs
@@ -1,0 +1,500 @@
+/// TickSpec step definitions binding `env-restore.feature`'s 16 scenarios to
+/// `RhinoCli.Application.Env`'s `restore` port [Repo-grounded —
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-restore.feature`,
+/// `apps/rhino-cli/src/application/env/backup.rs`,
+/// `apps/rhino-cli/src/commands/env_restore.rs`].
+///
+/// Follows `EnvSteps.fs`'s per-scenario slicing convention: each xunit
+/// `[<Fact>]` below runs exactly one scenario, extracted from the real,
+/// frozen feature file rather than a duplicated/rewritten copy of its
+/// wording. Kept as its own file (rather than added to `EnvSteps.fs`) since
+/// `env-restore.feature` is its own PR-sized slice of the `env` namespace,
+/// same as `env-init.feature` was.
+///
+/// Two scenarios in the feature file spell a literal absolute path
+/// (`/tmp/my-env-backup`, `/nonexistent`) in their Given/When wording. Rather
+/// than actually touching those host paths (non-hermetic, and unsafe under
+/// parallel test runs), the step bodies below satisfy the same natural-
+/// language meaning using this file's own managed temp-directory fixtures —
+/// the literal step text still matches the frozen feature file verbatim.
+module RhinoCli.Tests.Unit.Steps.EnvRestoreSteps
+
+open System
+open System.IO
+open System.Text.Json
+open TickSpec
+open Xunit
+open RhinoCli.Application.Env
+
+/// Instance step-definition container — see `ConventionSteps.fs`'s module
+/// doc comment for why TickSpec's one-instance-per-scenario lifecycle makes
+/// instance-level mutable fields the idiomatic state-threading mechanism
+/// here.
+type EnvRestoreSteps() =
+    let mutable repoRoot: string option = None
+    let mutable backupDir: string option = None
+    let mutable expectedEnvRelPaths: string list = []
+    let mutable worktreeAware = false
+    let mutable worktreeName: string option = None
+    let mutable forceFlag = false
+    let mutable includeConfigFlag = false
+    let mutable dryRunFlag = false
+    let mutable confirmChoice: bool option = None
+    let mutable confirmCallCount = 0
+    let mutable opResult: Result<EnvOperationResult, string> option = None
+    let mutable ownedDirs: string list = []
+
+    let newTempDir (prefix: string) : string =
+        let dir =
+            Path.Combine(Path.GetTempPath(), "rhino-cli-env-restore-" + prefix + "-" + Guid.NewGuid().ToString("N"))
+
+        Directory.CreateDirectory(dir) |> ignore
+        ownedDirs <- dir :: ownedDirs
+        dir
+
+    let writeFile (root: string) (relativePath: string) (content: string) =
+        let full = Path.Combine(root, relativePath)
+        Directory.CreateDirectory(Path.GetDirectoryName(full)) |> ignore
+        File.WriteAllText(full, content)
+
+    let root () : string =
+        match repoRoot with
+        | Some dir -> dir
+        | None -> failwith "no repository root has been prepared by a Given step"
+
+    /// Reuses the repository root when a prior `Given`/`When` already created
+    /// one, otherwise lazily creates a fresh one — unlike `backup`'s
+    /// `EnvSteps.fs`, most `restore` scenarios never mention the destination
+    /// repository explicitly at all, so it is only ever established lazily.
+    let ensureRoot () : string =
+        match repoRoot with
+        | Some dir -> dir
+        | None ->
+            let dir = newTempDir "repo"
+            repoRoot <- Some dir
+            dir
+
+    let ensureBackupDir () : string =
+        match backupDir with
+        | Some dir -> dir
+        | None ->
+            let dir = newTempDir "backup"
+            backupDir <- Some dir
+            dir
+
+    let outcome () : EnvOperationResult =
+        match opResult with
+        | Some(Ok r) -> r
+        | Some(Error message) -> failwith (sprintf "expected a successful restore, got error: %s" message)
+        | None -> failwith "no command has been run by a When step"
+
+    let confirm () : bool =
+        confirmCallCount <- confirmCallCount + 1
+
+        match confirmChoice with
+        | Some v -> v
+        | None -> failwith "confirm callback invoked but no confirm/decline choice was set by a When step"
+
+    let runRestore () =
+        let repo = ensureRoot ()
+        let dest = ensureBackupDir ()
+
+        let opts: EnvOptions =
+            { RepoRoot = repo
+              BackupDir = dest
+              SkipDirs = []
+              MaxSize = DefaultMaxSize
+              WorktreeAware = worktreeAware
+              WorktreeName = worktreeName |> Option.defaultValue ""
+              Force = forceFlag
+              IncludeConfig = includeConfigFlag
+              DryRun = dryRunFlag }
+
+        opResult <- Some(restore opts confirm)
+
+    // ---- Given ----
+
+    [<Given>]
+    member _.``a backup directory containing previously backed-up .env files from the repository``() =
+        let dir = ensureBackupDir ()
+        writeFile dir ".env" "root=1"
+        writeFile dir "apps/web/.env" "web=1"
+        writeFile dir "apps/api/.env" "api=1"
+        expectedEnvRelPaths <- [ ".env"; "apps/web/.env"; "apps/api/.env" ]
+
+    [<Given>]
+    member _.``a backup directory at /tmp/my-env-backup containing a backed-up .env file``() =
+        let dir = ensureBackupDir ()
+        writeFile dir ".env" "k=v"
+
+    [<Given>]
+    member _.``no directory exists at /nonexistent``() =
+        let parent = newTempDir "missing-parent"
+        backupDir <- Some(Path.Combine(parent, "nonexistent"))
+
+    [<Given>]
+    member _.``a backup directory containing a previously backed-up .env file``() =
+        let dir = ensureBackupDir ()
+        writeFile dir ".env" "k=v"
+
+    [<Given>]
+    member _.``a backup directory containing a backed-up .env file and a README.md file``() =
+        let dir = ensureBackupDir ()
+        writeFile dir ".env" "k=v"
+        writeFile dir "README.md" "not a secret"
+
+    [<Given>]
+    member _.``a backup directory containing no .env files``() = ensureBackupDir () |> ignore
+
+    [<Given>]
+    member _.``a backup directory containing a .env file backed up under a feature-branch namespace``() =
+        let dir = ensureBackupDir ()
+        writeFile dir "feature-branch/.env" "k=v"
+
+    [<Given>]
+    member _.``the repository already contains a .env file at the original path``() =
+        let dir = ensureRoot ()
+        writeFile dir ".env" "existing=1"
+
+    [<Given>]
+    member _.``the repository does not contain a .env file at the original path``() = ensureRoot () |> ignore
+
+    [<Given>]
+    member _.``a backup directory containing a .env file and a .claude/settings.local.json file``() =
+        let dir = ensureBackupDir ()
+        writeFile dir ".env" "k=v"
+        writeFile dir ".claude/settings.local.json" "{}"
+
+    [<Given>]
+    member _.``a backup directory containing a secrets.json file``() =
+        let dir = ensureBackupDir ()
+        writeFile dir "secrets.json" "{\"key\":\"val\"}"
+
+    [<Given>]
+    member _.``a backup directory containing a cert.pem file``() =
+        let dir = ensureBackupDir ()
+        writeFile dir "cert.pem" "-----BEGIN CERTIFICATE-----"
+
+    [<Given>]
+    member _.``a backup directory containing a .secrets/notes.md file``() =
+        let dir = ensureBackupDir ()
+        writeFile dir ".secrets/notes.md" "secret notes"
+
+    [<Given>]
+    member _.``a backup directory containing a .env file and a secrets.json file``() =
+        let dir = ensureBackupDir ()
+        writeFile dir ".env" "k=v"
+        writeFile dir "secrets.json" "{\"key\":\"val\"}"
+
+    // ---- When ----
+
+    [<When>]
+    member _.``the developer runs rhino-cli env restore``() = runRestore ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env restore with --dir /tmp/my-env-backup``() = runRestore ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env restore with --dir /nonexistent``() = runRestore ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env restore with --output json``() = runRestore ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env restore with --worktree-aware from a worktree named "(.*)"``
+        (name: string)
+        =
+        worktreeAware <- true
+        worktreeName <- Some name
+        runRestore ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env restore and confirms the overwrite``() =
+        confirmChoice <- Some true
+        runRestore ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env restore and declines the overwrite``() =
+        confirmChoice <- Some false
+        runRestore ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env restore with --force``() =
+        forceFlag <- true
+        runRestore ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env restore with --include-config and --force``() =
+        forceFlag <- true
+        includeConfigFlag <- true
+        runRestore ()
+
+    [<When>]
+    member _.``the developer runs rhino-cli env restore with --dry-run``() =
+        dryRunFlag <- true
+        runRestore ()
+
+    // ---- Then ----
+
+    [<Then>]
+    member _.``the command exits successfully``() =
+        match opResult with
+        | Some(Ok _) -> ()
+        | Some(Error message) -> Assert.Fail(sprintf "expected success, got error: %s" message)
+        | None -> Assert.Fail("no command has been run by a When step")
+
+    [<Then>]
+    member _.``the command exits with a failure code``() =
+        match opResult with
+        | Some(Error _) -> ()
+        | Some(Ok _) -> Assert.Fail("expected a failure code, got success")
+        | None -> Assert.Fail("no command has been run by a When step")
+
+    [<Then>]
+    member _.``each .env file is copied back to its original path in the repository``() =
+        for relPath in expectedEnvRelPaths do
+            Assert.True(File.Exists(Path.Combine(root (), relPath)), sprintf "expected %s to be restored" relPath)
+
+    [<Then>]
+    member _.``the output lists each restored file``() =
+        let text = formatText (outcome ()) false false
+
+        for relPath in expectedEnvRelPaths do
+            Assert.Contains(relPath, text)
+
+    [<Then>]
+    member _.``the .env file is copied back to its original path in the repository``() =
+        Assert.True(File.Exists(Path.Combine(root (), ".env")))
+
+    [<Then>]
+    member _.``the output reports that the directory does not exist``() =
+        match opResult with
+        | Some(Error message) -> Assert.Contains("does not exist", message)
+        | other -> Assert.Fail(sprintf "expected an error, got %A" other)
+
+    [<Then>]
+    member _.``the output is valid JSON``() =
+        use _doc = JsonDocument.Parse(formatJson (outcome ()))
+        ()
+
+    [<Then>]
+    member _.``the JSON includes the direction, backup directory, list of files, copied count, and skipped count``() =
+        use doc = JsonDocument.Parse(formatJson (outcome ()))
+        let rootElement = doc.RootElement
+        Assert.True(rootElement.TryGetProperty("direction") |> fst)
+        Assert.True(rootElement.TryGetProperty("dir") |> fst)
+        Assert.True(rootElement.TryGetProperty("files") |> fst)
+        Assert.True(rootElement.TryGetProperty("copied") |> fst)
+        Assert.True(rootElement.TryGetProperty("skipped") |> fst)
+
+    [<Then>]
+    member _.``README.md is not restored``() =
+        Assert.False(File.Exists(Path.Combine(root (), "README.md")))
+
+    [<Then>]
+    member _.``the output reports that zero files were restored``() =
+        let r = outcome ()
+        Assert.Equal(0, r.Copied)
+        Assert.Contains("0 file(s)", formatText r false false)
+
+    [<Then>]
+    member _.``the .env file is read from the feature-branch namespace inside the backup directory``() =
+        Assert.Contains(outcome().Files, fun (f: EnvFileEntry) -> f.RelPath = ".env")
+
+    [<Then>]
+    member _.``the .env file is copied back to its original path in the worktree``() =
+        Assert.True(File.Exists(Path.Combine(root (), ".env")))
+
+    [<Then>]
+    member _.``the .env file in the repository is overwritten with the backup``() =
+        Assert.Equal(1, confirmCallCount)
+        Assert.Equal("k=v", File.ReadAllText(Path.Combine(root (), ".env")))
+
+    [<Then>]
+    member _.``the output reports that restore was cancelled``() =
+        Assert.Contains("cancelled", formatText (outcome ()) false false)
+
+    [<Then>]
+    member _.``the existing repository file is unchanged``() =
+        Assert.Equal(1, confirmCallCount)
+        Assert.Equal("existing=1", File.ReadAllText(Path.Combine(root (), ".env")))
+
+    [<Then>]
+    member _.``the .env file in the repository is overwritten without prompting``() =
+        Assert.Equal(0, confirmCallCount)
+        Assert.Equal("k=v", File.ReadAllText(Path.Combine(root (), ".env")))
+
+    [<Then>]
+    member _.``no confirmation prompt is shown``() = Assert.Equal(0, confirmCallCount)
+
+    [<Then>]
+    member _.``the .env file is restored to the repository``() =
+        Assert.True(File.Exists(Path.Combine(root (), ".env")))
+        Assert.Equal("k=v", File.ReadAllText(Path.Combine(root (), ".env")))
+
+    [<Then>]
+    member _.``the .claude/settings.local.json is restored to the repository preserving its relative path``() =
+        Assert.True(File.Exists(Path.Combine(root (), ".claude", "settings.local.json")))
+
+    [<Then>]
+    member _.``the .claude/settings.local.json is not restored to the repository``() =
+        Assert.False(File.Exists(Path.Combine(root (), ".claude", "settings.local.json")))
+
+    [<Then>]
+    member _.``secrets.json is copied back to the repository``() =
+        Assert.True(File.Exists(Path.Combine(root (), "secrets.json")))
+
+    [<Then>]
+    member _.``cert.pem is copied back to the repository``() =
+        Assert.True(File.Exists(Path.Combine(root (), "cert.pem")))
+
+    [<Then>]
+    member _.``.secrets/notes.md is copied back to the repository preserving its relative path``() =
+        Assert.True(File.Exists(Path.Combine(root (), ".secrets", "notes.md")))
+
+    [<Then>]
+    member _.``no files are written to the repository``() =
+        Assert.Empty(Directory.EnumerateFileSystemEntries(ensureRoot ()))
+
+    [<Then>]
+    member _.``the output lists the files that would be restored``() =
+        let text = formatText (outcome ()) false false
+        Assert.Contains("secrets.json", text)
+        Assert.Contains("cert.pem", text)
+        Assert.Contains(".secrets/notes.md", text)
+        Assert.Contains("WOULD", text)
+
+    [<AfterScenario>]
+    member _.Cleanup() =
+        for dir in ownedDirs do
+            if Directory.Exists dir then
+                Directory.Delete(dir, true)
+
+/// Reads one named `Scenario:` block out of the real, frozen
+/// `env-restore.feature` file (leaving the file itself untouched) and runs it
+/// through TickSpec bound only against `EnvRestoreSteps` — see `EnvSteps.fs`'s
+/// `FeatureRunner` for why this is per-scenario rather than per-file.
+module private FeatureRunner =
+
+    let private featurePath: string =
+        Path.GetFullPath(
+            Path.Combine(
+                __SOURCE_DIRECTORY__,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "specs",
+                "apps",
+                "rhino",
+                "behavior",
+                "rhino-cli",
+                "gherkin",
+                "env",
+                "env-restore.feature"
+            )
+        )
+
+    let private extractScenario (featureLines: string[]) (scenarioTitle: string) : string[] =
+        let featureLine =
+            featureLines
+            |> Array.find (fun l -> l.TrimStart().StartsWith("Feature:", StringComparison.Ordinal))
+
+        let scenarioHeader = sprintf "Scenario: %s" scenarioTitle
+
+        let startIdx = featureLines |> Array.findIndex (fun l -> l.Trim() = scenarioHeader)
+
+        let endIdx =
+            featureLines
+            |> Array.skip (startIdx + 1)
+            |> Array.tryFindIndex (fun l ->
+                let trimmed = l.Trim()
+
+                trimmed.StartsWith("Scenario:", StringComparison.Ordinal)
+                || trimmed.StartsWith("Scenario Outline:", StringComparison.Ordinal)
+                // env-restore.feature tags every scenario with a leading
+                // `@tag` line, same as env-backup.feature/env-init.feature —
+                // the next scenario's tag line must also end the slice, or it
+                // gets pulled in as a dangling trailing line with no scenario
+                // body to attach to.
+                || trimmed.StartsWith("@", StringComparison.Ordinal))
+            |> Option.map (fun relativeIdx -> startIdx + 1 + relativeIdx)
+            |> Option.defaultValue featureLines.Length
+
+        Array.append [| featureLine; "" |] featureLines.[startIdx .. endIdx - 1]
+
+    /// Runs the single scenario named `scenarioTitle` from
+    /// `env-restore.feature`, bound against `EnvRestoreSteps`.
+    let run (scenarioTitle: string) : unit =
+        let allLines = File.ReadAllLines featurePath
+        let snippet = extractScenario allLines scenarioTitle
+        let definitions = StepDefinitions([| typeof<EnvRestoreSteps> |])
+        let feature = definitions.GenerateFeature(featurePath, snippet)
+        let scenario = Seq.exactlyOne feature.Scenarios
+        scenario.Action.Invoke()
+
+[<Fact>]
+let ``Restore copies files back from backup`` () =
+    FeatureRunner.run "Restore copies files back from backup"
+
+[<Fact>]
+let ``Restore with custom source directory`` () =
+    FeatureRunner.run "Restore with custom source directory"
+
+[<Fact>]
+let ``Restore fails when backup directory does not exist`` () =
+    FeatureRunner.run "Restore fails when backup directory does not exist"
+
+[<Fact>]
+let ``JSON output for restore`` () =
+    FeatureRunner.run "JSON output for restore"
+
+[<Fact>]
+let ``Restore only restores .env files`` () =
+    FeatureRunner.run "Restore only restores .env files"
+
+[<Fact>]
+let ``Restore with zero .env files in backup`` () =
+    FeatureRunner.run "Restore with zero .env files in backup"
+
+[<Fact>]
+let ``Worktree-aware restore reads from correct namespace`` () =
+    FeatureRunner.run "Worktree-aware restore reads from correct namespace"
+
+[<Fact>]
+let ``Restore prompts when destination files already exist`` () =
+    FeatureRunner.run "Restore prompts when destination files already exist"
+
+[<Fact>]
+let ``Restore aborts when user declines overwrite`` () =
+    FeatureRunner.run "Restore aborts when user declines overwrite"
+
+[<Fact>]
+let ``Restore with --force skips confirmation`` () =
+    FeatureRunner.run "Restore with --force skips confirmation"
+
+[<Fact>]
+let ``Restore proceeds without prompt when no conflicts exist`` () =
+    FeatureRunner.run "Restore proceeds without prompt when no conflicts exist"
+
+[<Fact>]
+let ``Restore includes config files with --include-config`` () =
+    FeatureRunner.run "Restore includes config files with --include-config"
+
+[<Fact>]
+let ``Restore without --include-config ignores config files in backup`` () =
+    FeatureRunner.run "Restore without --include-config ignores config files in backup"
+
+[<Fact>]
+let ``Restore recovers common secret file patterns`` () =
+    FeatureRunner.run "Restore recovers common secret file patterns"
+
+[<Fact>]
+let ``Restore recovers a mix of .env and secret files together`` () =
+    FeatureRunner.run "Restore recovers a mix of .env and secret files together"
+
+[<Fact>]
+let ``Dry-run restore previews without writing files`` () =
+    FeatureRunner.run "Dry-run restore previews without writing files"

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvRestoreUnitTests.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvRestoreUnitTests.fs
@@ -1,0 +1,308 @@
+/// Plain xunit tests for `RhinoCli.Application.Env`'s `restore` port —
+/// behaviour with no dedicated Gherkin scenario, or exercised only
+/// indirectly there (mirrors the rationale `EnvUnitTests.fs`'s module doc
+/// comment states for its own split from `EnvSteps.fs`). Ported from
+/// `apps/rhino-cli/src/application/env/backup.rs`'s `#[cfg(test)] mod tests`
+/// for `restore`.
+module RhinoCli.Tests.Unit.Steps.EnvRestoreUnitTests
+
+open System
+open System.IO
+open Xunit
+open RhinoCli.Application.Env
+
+let private newTempDir () : string =
+    let dir =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-env-restore-unit-" + Guid.NewGuid().ToString("N"))
+
+    Directory.CreateDirectory(dir) |> ignore
+    dir
+
+let private defaultOptions (repoRoot: string) (backupDir: string) : EnvOptions =
+    { RepoRoot = repoRoot
+      BackupDir = backupDir
+      SkipDirs = []
+      MaxSize = DefaultMaxSize
+      WorktreeAware = false
+      WorktreeName = ""
+      Force = false
+      IncludeConfig = false
+      DryRun = false }
+
+let private neverConfirm () : bool =
+    failwith "confirm callback must not be invoked"
+
+// ---- error path ----
+
+[<Fact>]
+let ``restore fails with a descriptive message when the source directory does not exist`` () =
+    let repo = newTempDir ()
+
+    try
+        let missing = Path.Combine(repo, "does-not-exist")
+        let opts = defaultOptions repo missing
+
+        match restore opts neverConfirm with
+        | Error message ->
+            Assert.Contains("does not exist", message)
+            Assert.Contains(missing, message)
+        | Ok _ -> Assert.Fail("expected an error for a missing source directory")
+    finally
+        Directory.Delete(repo, true)
+
+// ---- narrower skip-dirs than backup ----
+
+[<Fact>]
+let ``restore scans only .git as a skip-dir, unlike backup's full defaultSkipDirs list`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        Directory.CreateDirectory(Path.Combine(dest, "node_modules")) |> ignore
+        File.WriteAllText(Path.Combine(dest, "node_modules", ".env"), "should-be-found")
+
+        let opts = defaultOptions repo dest
+
+        match restore opts neverConfirm with
+        | Ok r ->
+            Assert.Contains("node_modules/.env", r.Files |> List.map (fun f -> f.RelPath))
+            Assert.True(File.Exists(Path.Combine(repo, "node_modules", ".env")))
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+[<Fact>]
+let ``restore still skips the .git directory itself`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        Directory.CreateDirectory(Path.Combine(dest, ".git")) |> ignore
+        File.WriteAllText(Path.Combine(dest, ".git", "config"), "gitconfig")
+        File.WriteAllText(Path.Combine(dest, ".env"), "k=v")
+
+        let opts = defaultOptions repo dest
+
+        match restore opts neverConfirm with
+        | Ok r ->
+            Assert.DoesNotContain(
+                r.Files,
+                fun (f: EnvFileEntry) -> f.RelPath.StartsWith(".git/", StringComparison.Ordinal)
+            )
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+// ---- worktree-aware source root ----
+
+[<Fact>]
+let ``restore does not join a worktree subdirectory when WorktreeName is empty`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(dest, ".env"), "k=v")
+
+        let opts =
+            { defaultOptions repo dest with
+                WorktreeAware = true
+                WorktreeName = "" }
+
+        match restore opts neverConfirm with
+        | Ok _ -> Assert.True(File.Exists(Path.Combine(repo, ".env")))
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+[<Fact>]
+let ``restore does not join a worktree subdirectory when WorktreeAware is false even if WorktreeName is set`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(dest, ".env"), "k=v")
+
+        let opts =
+            { defaultOptions repo dest with
+                WorktreeAware = false
+                WorktreeName = "feature-branch" }
+
+        match restore opts neverConfirm with
+        | Ok _ -> Assert.True(File.Exists(Path.Combine(repo, ".env")))
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+[<Fact>]
+let ``restore's Dir field reports the backup dir itself, not the worktree-joined source root`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        Directory.CreateDirectory(Path.Combine(dest, "feature-branch")) |> ignore
+        File.WriteAllText(Path.Combine(dest, "feature-branch", ".env"), "k=v")
+
+        let opts =
+            { defaultOptions repo dest with
+                WorktreeAware = true
+                WorktreeName = "feature-branch" }
+
+        match restore opts neverConfirm with
+        | Ok r -> Assert.Equal(dest, r.Dir)
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+// ---- default max size ----
+
+[<Fact>]
+let ``restore applies the default max size when MaxSize is zero or negative`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllBytes(Path.Combine(dest, ".env"), Array.zeroCreate<byte> 1000)
+
+        let opts =
+            { defaultOptions repo dest with
+                MaxSize = 0L }
+
+        match restore opts neverConfirm with
+        | Ok r ->
+            let entry = r.Files |> List.find (fun f -> f.RelPath = ".env")
+            Assert.False(entry.Skipped)
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+// ---- skipped entries during restore ----
+
+[<Fact>]
+let ``restore counts an already-skipped entry without copying it`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllBytes(Path.Combine(dest, ".env"), Array.zeroCreate<byte> (int DefaultMaxSize + 1))
+
+        let opts = defaultOptions repo dest
+
+        match restore opts neverConfirm with
+        | Ok r ->
+            Assert.Equal(0, r.Copied)
+            Assert.Equal(1, r.Skipped)
+            Assert.False(File.Exists(Path.Combine(repo, ".env")))
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+[<Fact>]
+let ``restore's dry-run counts already-skipped entries but performs no copy`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllBytes(Path.Combine(dest, ".env"), Array.zeroCreate<byte> (int DefaultMaxSize + 1))
+        File.WriteAllText(Path.Combine(dest, "secrets.json"), "{}")
+
+        let opts =
+            { defaultOptions repo dest with
+                DryRun = true }
+
+        match restore opts neverConfirm with
+        | Ok r ->
+            Assert.True(r.DryRun)
+            Assert.Equal(0, r.Copied)
+            Assert.Equal(1, r.Skipped)
+            Assert.Equal(2, List.length r.Files)
+            Assert.False(File.Exists(Path.Combine(repo, "secrets.json")))
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+// ---- include-config ordering ----
+
+[<Fact>]
+let ``restore sorts merged env and config entries by relative path`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(dest, ".env"), "k=v")
+        Directory.CreateDirectory(Path.Combine(dest, ".claude")) |> ignore
+        File.WriteAllText(Path.Combine(dest, ".claude", "settings.local.json"), "{}")
+
+        let opts =
+            { defaultOptions repo dest with
+                Force = true
+                IncludeConfig = true }
+
+        match restore opts neverConfirm with
+        | Ok r ->
+            let paths = r.Files |> List.map (fun f -> f.RelPath)
+            let sorted = paths |> List.sortWith (fun a b -> String.CompareOrdinal(a, b))
+            Assert.Equal<string list>(sorted, paths)
+
+            let envEntry = r.Files |> List.find (fun f -> f.RelPath = ".env")
+            Assert.Equal("env", envEntry.Source)
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+// ---- confirm contract ----
+
+[<Fact>]
+let ``restore never invokes confirm during a dry-run even with a real conflict`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(dest, ".env"), "new")
+        File.WriteAllText(Path.Combine(repo, ".env"), "old")
+
+        let opts =
+            { defaultOptions repo dest with
+                DryRun = true }
+
+        match restore opts neverConfirm with
+        | Ok r ->
+            Assert.True(r.DryRun)
+            Assert.Equal("old", File.ReadAllText(Path.Combine(repo, ".env")))
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)
+
+[<Fact>]
+let ``restore invokes confirm exactly once on a real conflict and proceeds when it returns true`` () =
+    let repo = newTempDir ()
+    let dest = newTempDir ()
+
+    try
+        File.WriteAllText(Path.Combine(dest, ".env"), "new")
+        File.WriteAllText(Path.Combine(repo, ".env"), "old")
+        let opts = defaultOptions repo dest
+        let mutable callCount = 0
+
+        let confirm () =
+            callCount <- callCount + 1
+            true
+
+        match restore opts confirm with
+        | Ok r ->
+            Assert.Equal(1, callCount)
+            Assert.False(r.Cancelled)
+            Assert.Equal("new", File.ReadAllText(Path.Combine(repo, ".env")))
+        | Error message -> Assert.Fail(message)
+    finally
+        Directory.Delete(repo, true)
+        Directory.Delete(dest, true)

--- a/repo-config.yml
+++ b/repo-config.yml
@@ -169,7 +169,7 @@ coverage:
     # option that does not regress the still-canonical Rust side.
     - name: rhino-cli-fsharp
       levels: [unit, integration]
-      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention/**,repo-config/**,repo-config-validate/**,env/env-backup.feature,env/env-init.feature}"
+      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention/**,repo-config/**,repo-config-validate/**,env/env-backup.feature,env/env-init.feature,env/env-restore.feature}"
 
     # ose domain
     - name: ose-be


### PR DESCRIPTION
## Summary
- Ports `restore` (backup.rs::restore, lines 617-692) to F#: reuses `discover`, `discoverConfig`, `isSecretFile`, `findExisting`, and the private `copyOne` fold helper already in `Env.fs` from the `backup`/`env init` ports.
- Scans the backup dir narrower than `backup`'s own scan (only `.git` skipped, not `defaultSkipDirs`), matching `backup.rs::restore`'s own `Options { skip_dirs: vec![".git".to_string()], ..Default::default() }`.
- Closes the same dead-`force`-field gap `backup` already closes: `backup.rs::restore` has zero references to `force`/`confirm`/prompts, so the F# port takes an explicit `confirm: unit -> bool` callback invoked at most once, only on a real destination conflict with `Force = false` — same contract as `backup`. Dry-run never invokes `confirm`.
- Adds `EnvRestoreSteps.fs` (TickSpec, 16 scenarios) and `EnvRestoreUnitTests.fs` (12 pure/edge-case xunit tests).
- Widens `specs:behavior:coverage` shared-steps and `repo-config.yml`'s `rhino-cli-fsharp` specs glob to include `env/env-restore.feature`.
- Application-layer only; CLI dispatch wiring deferred to the Wave B integration PR.

## Test plan
- [x] `dotnet build` — 0 errors/warnings
- [x] `dotnet test` (unit) — 239/239 passing
- [x] `fantomas --check` — clean
- [x] `fsharplint` (Application + UnitTests projects) — 0 warnings
- [x] G-Research analyzers (5 projects) — exit 0
- [x] `nx run rhino-cli-fsharp:specs:behavior:coverage` — 8 specs, 66 scenarios, 305 steps, all covered
- [x] `nx run rhino-cli:test:specs` (Rust one-to-one coverage) — 72 specs, 531 scenarios, 2165 steps, all covered
- [x] `nx run-many -t test:quick -p rhino-cli,rhino-cli-fsharp` — full local pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)