### PR TITLE
feat(rhino-cli-fsharp): port env validate app-drift surface (Wave B PR6)

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -5,7 +5,7 @@ b5f5e511ac5697c2d2949d898633f079abbce9c7211205aad6f7521f17746df2  apps/rhino-cli
 22b1d0652e8937a20c83841966e4f8b1c451d671d34dd27fb5fa13f11d340a4d  apps/rhino-cli/src-fsharp/.gitignore
 96bd05860d32d93030016db7fa582a1fbb772328d6875cf03fff8957f47b1e90  apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
 11fe7ec2e5e08b432e2d1cedae59e1a555e17e22a1f11494bd83b80c36964b5c  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Convention.fs
-133a9ea6006e7d14397f8b6e6cc6c480a8f7ace60ee1d789dcf09d4265648c94  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
+a32e7fdb29677bd0fb459436b7b380acbf32ee3bfc6165dc9204a89a0059152b  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
 2f8085bcb8089f174e9548e609530471c9318c31b1bcab4a867e33880cec9e57  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Parity.fs
 f68a2a01380e02ce7fa8f5774a0800e9f1281c39d3c90b3c03947c1448799f2d  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/RepoConfig.fs
 fc1346c5ed931f006be550583e92d5603bdffceb270783f4b334bb5ff4d7aa3a  apps/rhino-cli/src-fsharp/RhinoCli.Cli/RhinoCli.Cli.fsproj
@@ -20,9 +20,9 @@ bb55f3c8d4d3daffa7e334ecdacff8bfd9462b12a7098e239943d84a3edf915f  apps/rhino-cli
 631376afb9e4d7c5192d38f51b533c18b64cca83c18ed5c50982ba9acce51d74  apps/rhino-cli/src-fsharp/RhinoCli.Program/RhinoCli.Program.fsproj
 153a226f5ef1d6916aa6e6425b278a606a48659fcba9623c9d01e5cf3b2589a5  apps/rhino-cli/src-fsharp/RhinoCli.Program/src/Program.fs
 822f6ec8446562a4de9a3b1a2481af50fac01bbedc32e1963142709e5f48ec13  apps/rhino-cli/src-fsharp/fsharplint.json
-3743a82bec45d1d0f11b782c817eb1e8233d3068dbf525ce39b7e0ff654070d7  apps/rhino-cli/src-fsharp/project.json
+989eaa4b18f543004c5b64ba5d330a152c474594a0f934dfd60834a51d8e9a84  apps/rhino-cli/src-fsharp/project.json
 f7dacc8dd923488c70eebabe298843022ec5a3ba94b8b7568634a779f24b8da4  apps/rhino-cli/src-fsharp/tests/integration/RhinoCli.IntegrationTests.fsproj
-f47d343cb2582d7a81bca8d94989cae778b7ce6eb91199dd4467f3d19ac423be  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+e6be0d5f6b1aaca2c852a29c65289c3e1aeafc08b69232c8b30fe9a05fd93088  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
 85ba308ad0a88485db55b305120d99b9a4ec328d2379536110f73e51f4797fe2  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionSteps.fs
 a909884a9d8816e2b476cc8c00be03ac4085b849cbe83c4b18e0213ac9cad1d7  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionUnitTests.fs
 a0603a9ec897d538381417f8a330b1fa4b75f75f74003fda2a2b9b9512db5a1a  apps/rhino-cli/src-fsharp/tests/unit/Steps/DispatchUnitTests.fs
@@ -32,6 +32,8 @@ ad360c992e3e47ccf8f47693a8f3c42581085a24efa1303204da2ff9963ede58  apps/rhino-cli
 b49f1f9d865ea485480137d33fbf7a02570ad99b941f7bf6d15bbfa8c96185fe  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvRestoreUnitTests.fs
 8a3ddb5f25240cc12e3045c4af266bebbebc75c113f1969c42c9df18f6554968  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvSteps.fs
 8ec32c7e97c3e4277dffbeadbcd6d278f52c9661874b52e9e8465221fc4e7534  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvUnitTests.fs
+d43395cc8b45ab5197772682e18ba229bba6194507ca40c77053bf3ccd0929a9  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvValidateSteps.fs
+469970513250f3b199e0efee57fe2279c6e5609ef58e198a64f4b53a29e54c23  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvValidateUnitTests.fs
 66215f95f2afe48729422ebccadf068687c87bc5538fee88dfa7364da2f08028  apps/rhino-cli/src-fsharp/tests/unit/Steps/FormattersUnitTests.fs
 cb605599e8c90b2d6d2bdd7e7c0e54a26410f39fa2d3372285be311301d9fab2  apps/rhino-cli/src-fsharp/tests/unit/Steps/GitRootUnitTests.fs
 b8a8fbf79e78dee93f32944d3bbae2daccf33876ce5988ae31b1259c2f5ce201  apps/rhino-cli/src-fsharp/tests/unit/Steps/ParityUnitTests.fs

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
@@ -35,13 +35,21 @@
 /// `force`, `confirm`, or any prompt at all — it always overwrites silently
 /// — so `restore` also takes an explicit `confirm: unit -> bool` callback
 /// with the same invoke-at-most-once-when-a-real-conflict-exists contract.
+/// This PR additionally ports the `App`-surface-kind slice of `env validate`
+/// (code↔`.env.example` drift detection) for
+/// `env-validate-app-drift.feature`'s 3 scenarios; the `terraform`/`ansible`
+/// surface validators are out of scope, reserved for a later PR7.
 module RhinoCli.Application.Env
 
 open System
+open System.Collections.Generic
 open System.IO
 open System.Text.Encodings.Web
 open System.Text.Json
 open System.Text.Json.Serialization
+open System.Text.RegularExpressions
+open YamlDotNet.Serialization
+open YamlDotNet.Serialization.NamingConventions
 
 /// Maximum file size (in bytes) that will be backed up (1 MiB) [Repo-grounded
 /// — `backup.rs::DEFAULT_MAX_SIZE`].
@@ -987,3 +995,511 @@ let restore (opts: EnvOptions) (confirm: unit -> bool) : Result<EnvOperationResu
                           WorktreeName = opts.WorktreeName
                           Cancelled = false
                           DryRun = false }
+
+// ---- validate ----
+
+/// Surface kind selecting which drift validator runs for one `env-contract:`
+/// surface entry, deserialized case-insensitively from the lowercase `kind:`
+/// value in `repo-config.yml` [Repo-grounded —
+/// `apps/rhino-cli/src/application/env/validate.rs::SurfaceKind`].
+///
+/// Only `App` is dispatched to a real validator by `validateAll` below —
+/// `Terraform`/`Ansible` surface validation is a separate, later PR7
+/// (`env-contract/iac-env-validation.feature`). Both variants are ported
+/// here anyway so this type stays complete for that later port to extend
+/// without a breaking rename, and so a surface's `kind:` YAML value
+/// round-trips correctly regardless of which kind it declares. No surface in
+/// this repo's live `env-contract:` section currently declares either.
+type SurfaceKind =
+    | App
+    | Terraform
+    | Ansible
+
+/// A single env-validate surface entry from the `env-contract:` section
+/// [Repo-grounded — `validate.rs::SurfaceConfig`].
+type SurfaceConfig =
+    {
+        Root: string
+        Kind: SurfaceKind
+        /// Source language for the app validator: `"rust"`, `"typescript"`, or
+        /// `"fsharp"`. Unused for `Terraform`/`Ansible` surfaces. Defaults to
+        /// `""` when the YAML key is absent.
+        Lang: string
+        /// Keys intentionally exempt from drift detection (framework-injected,
+        /// forward-declared-ahead-of-use, test-only, etc.).
+        Allowlist: string list
+    }
+
+/// Top-level `env-contract:` structure [Repo-grounded —
+/// `validate.rs::Contract`].
+type Contract = { Surfaces: SurfaceConfig list }
+
+/// Drift direction for a [`Finding`] [Repo-grounded —
+/// `validate.rs::DriftKind`]. Only `DeclaredButUnread`/`ReadButUndeclared`
+/// are produced by this PR's `App`-surface validator below; the remaining
+/// three variants exist so the type is complete for PR7's terraform/ansible
+/// validators to extend without a breaking rename.
+type DriftKind =
+    /// App: key present in `.env.example` but not consumed by any code in
+    /// the surface.
+    | DeclaredButUnread
+    /// App: key consumed by code but absent from `.env.example`.
+    | ReadButUndeclared
+    /// Terraform: key in `terraform.tfvars.example` with no matching
+    /// `variable` block.
+    | ExampleNotDeclared
+    /// Terraform: required variable (no `default`) missing from
+    /// `terraform.tfvars.example`.
+    | RequiredMissingFromExample
+    /// Ansible: env lookup in a playbook not declared in `.env.example`.
+    | ConsumedNotDeclared
+
+/// Human-readable labels for [`DriftKind`], matching the Rust CLI's own
+/// wording [Repo-grounded — `validate.rs::DriftKind::label`].
+module DriftKind =
+    let label (drift: DriftKind) : string =
+        match drift with
+        | DeclaredButUnread -> "declared-but-unread"
+        | ReadButUndeclared -> "read-but-undeclared"
+        | ExampleNotDeclared -> "example-not-declared"
+        | RequiredMissingFromExample -> "required-missing-from-example"
+        | ConsumedNotDeclared -> "consumed-not-declared"
+
+/// A single drift finding produced by the validator [Repo-grounded —
+/// `validate.rs::Finding`]. `Root` is a repo-relative path string (e.g.
+/// `"apps/organiclever-be"`) — Rust uses `PathBuf`, but nothing downstream
+/// here needs path-specific operations on it, so a plain string suffices.
+type Finding =
+    { Root: string
+      Drift: DriftKind
+      Key: string }
+
+/// Formats one drift finding, matching the Rust CLI's own `DRIFT root label
+/// key` output line shape [Repo-grounded — `commands/env_validate.rs`].
+let formatFinding (finding: Finding) : string =
+    sprintf "DRIFT  %s  %s  %s" finding.Root (DriftKind.label finding.Drift) finding.Key
+
+/// Raw YAML-shaped intermediate records for the `env-contract:` section. See
+/// `RepoConfig.fs`'s `OwnershipEntryDto`/etc. module doc comment for why
+/// these are deliberately NOT `private`: a `private` F# type's
+/// compiler-generated constructor is non-public even with
+/// `[<CLIMutable>]`, and YamlDotNet's default reflection-based object
+/// factory only ever calls the public-constructor `Activator.CreateInstance`
+/// overload.
+[<CLIMutable>]
+type SurfaceConfigDto =
+    { Root: string
+      Kind: string
+      Lang: string
+      Allowlist: ResizeArray<string> }
+
+[<CLIMutable>]
+type ContractDto =
+    { Surfaces: ResizeArray<SurfaceConfigDto> }
+
+[<CLIMutable>]
+type EnvContractWrapperDto = { EnvContract: ContractDto }
+
+/// Matches `repo-config.yml`'s kebab-case keys (`env-contract`) against the
+/// DTOs' PascalCase properties without per-property `[<YamlMember>]`
+/// attributes, following the exact convention established by
+/// `RepoConfig.fs`'s own `deserializer`.
+let private validateDeserializer: IDeserializer =
+    DeserializerBuilder().WithNamingConvention(HyphenatedNamingConvention.Instance).IgnoreUnmatchedProperties().Build()
+
+let private toStringList (items: ResizeArray<string>) : string list =
+    match items with
+    | null -> []
+    | items -> List.ofSeq items
+
+let private toDtoList (items: ResizeArray<'a>) : 'a list =
+    match items with
+    | null -> []
+    | items -> List.ofSeq items
+
+/// Folds a list of `Result`s into a single `Result` of a list, short-
+/// circuiting on the first `Error` — mirrors `RepoConfig.fs`'s own
+/// `sequenceResults`, duplicated here rather than shared since it is small
+/// enough that a cross-module dependency would cost more than it saves.
+let rec private sequenceSurfaceResults (results: Result<'a, string> list) : Result<'a list, string> =
+    match results with
+    | [] -> Ok []
+    | Error e :: _ -> Error e
+    | Ok x :: rest ->
+        match sequenceSurfaceResults rest with
+        | Ok xs -> Ok(x :: xs)
+        | Error e -> Error e
+
+let private parseSurfaceKind (raw: string) : Result<SurfaceKind, string> =
+    match raw with
+    | null -> Error "kind: required key is missing"
+    | value ->
+        match value.ToLowerInvariant() with
+        | "app" -> Ok App
+        | "terraform" -> Ok Terraform
+        | "ansible" -> Ok Ansible
+        | other -> Error(sprintf "kind: invalid value \"%s\" (expected \"app\", \"terraform\", or \"ansible\")" other)
+
+let private normalizeLang (raw: string) : string =
+    match raw with
+    | null -> ""
+    | value -> value
+
+let private toSurfaceConfig (dto: SurfaceConfigDto) : Result<SurfaceConfig, string> =
+    parseSurfaceKind dto.Kind
+    |> Result.map (fun kind ->
+        { Root = dto.Root
+          Kind = kind
+          Lang = normalizeLang dto.Lang
+          Allowlist = toStringList dto.Allowlist })
+
+/// Parses `data` (the contents of `repo-config.yml`) into a [`Contract`],
+/// mirroring `RepoConfig.fs`'s `parseRepoConfig`'s try/with → `Error
+/// ex.Message` pattern.
+let private parseContract (data: string) (path: string) : Result<Contract, string> =
+    try
+        let wrapper = validateDeserializer.Deserialize<EnvContractWrapperDto>(data)
+
+        match box wrapper.EnvContract with
+        | null -> Error(sprintf "env-contract: section missing from repo-config.yml at %s" path)
+        | _ ->
+            wrapper.EnvContract.Surfaces
+            |> toDtoList
+            |> List.map toSurfaceConfig
+            |> sequenceSurfaceResults
+            |> Result.map (fun surfaces -> { Surfaces = surfaces })
+    with ex ->
+        Error ex.Message
+
+/// Loads and parses the `env-contract:` section from `repo-config.yml` at
+/// `repoRoot` [Repo-grounded — `validate.rs::load_contract`].
+///
+/// Follows `RepoConfig.fs`'s `load`/`parseRepoConfig` DTO-then-map
+/// convention: a wrapper DTO carries a single `env-contract` field
+/// (mirroring Rust's inline `Wrapper { #[serde(rename = "env-contract")]
+/// env_contract: Option<Contract> }`) so an absent section (`null` at
+/// runtime, despite the DTO's non-nullable-looking declared type — see
+/// `RepoConfig.fs`'s `toSpecsConfig`/`toDoctorConfig` for the same pattern)
+/// is distinguishable from a real parse failure.
+///
+/// # Errors
+///
+/// Returns an error when `repo-config.yml` cannot be read, is not valid
+/// YAML, or the `env-contract:` section is absent.
+let loadContract (repoRoot: string) : Result<Contract, string> =
+    let path = Path.Combine(repoRoot, "repo-config.yml")
+
+    try
+        let data = File.ReadAllText path
+        parseContract data path
+    with ex ->
+        Error(sprintf "cannot read repo-config.yml at %s: %s" path ex.Message)
+
+/// Returns `true` when `s` is a valid env var name: non-empty, and every
+/// character is an ASCII uppercase letter, ASCII digit, or underscore
+/// [Repo-grounded — `validate.rs::is_env_var_name`].
+let isEnvVarName (s: string) : bool =
+    not (String.IsNullOrEmpty s)
+    && s
+       |> Seq.forall (fun c -> (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c = '_')
+
+/// Parses declared keys from a `.env.example` file [Repo-grounded —
+/// `validate.rs::parse_declared_keys`].
+///
+/// A line is "declared" when, after trimming and stripping at most one
+/// leading `#` (then trimming again), the result is non-empty, contains
+/// `=`, and the substring before the first `=` (trimmed) passes
+/// [`isEnvVarName`]. Blank lines and pure-comment lines (no `=`) are
+/// ignored — both active (`KEY=value`) and commented-out (`# KEY=value`)
+/// declarations count as declared.
+///
+/// # Errors
+///
+/// Returns an error when the file cannot be read.
+let parseDeclaredKeys (envExample: string) : Result<string list, string> =
+    try
+        File.ReadAllLines envExample
+        |> Array.choose (fun rawLine ->
+            let trimmed = rawLine.Trim()
+
+            let effective =
+                if trimmed.StartsWith("#", StringComparison.Ordinal) then
+                    trimmed.Substring(1).Trim()
+                else
+                    trimmed
+
+            if effective = "" then
+                None
+            else
+                match effective.IndexOf('=') with
+                | -1 -> None
+                | eqPos ->
+                    let key = effective.Substring(0, eqPos).Trim()
+                    if isEnvVarName key then Some key else None)
+        |> Array.toList
+        |> Ok
+    with ex ->
+        Error(sprintf "cannot read %s: %s" envExample ex.Message)
+
+/// Recursively lists every file under `dir`, returning `[]` when `dir` does
+/// not exist (a surface with no `src` directory simply reads zero keys,
+/// matching Rust `WalkDir`'s own tolerant behaviour on a missing root).
+let rec private allFilesUnder (dir: string) : string list =
+    if not (Directory.Exists dir) then
+        []
+    else
+        let files = Directory.EnumerateFiles dir |> List.ofSeq
+        let subDirs = Directory.EnumerateDirectories dir |> List.ofSeq
+        files @ (subDirs |> List.collect allFilesUnder)
+
+let private rustEnvVarRegex =
+    Regex(@"(?:std::)?env::var\s*\(\s*""([A-Z][A-Z0-9_]*)""\s*\)", RegexOptions.Compiled)
+
+let private rustConfigStructRegex =
+    Regex(@"^\s*pub\s+struct\s+Config\b", RegexOptions.Compiled)
+
+let private rustPubFieldRegex =
+    Regex(@"^\s+pub\s+([a-z][a-z0-9_]*)\s*:", RegexOptions.Compiled)
+
+/// Scans Rust source under `root/src` for environment variable keys consumed
+/// by the code [Repo-grounded — `validate.rs::scan_rust_reads`].
+///
+/// Detects direct `(std::)?env::var("KEY")` reads plus `pub struct Config {
+/// ... }` block field names (brace-depth tracked), uppercased, as implied
+/// config keys.
+///
+/// # Errors
+///
+/// Returns an error when a source file cannot be read.
+let scanRustReads (root: string) : Result<string list, string> =
+    let srcDir = Path.Combine(root, "src")
+
+    try
+        let keys = HashSet<string>()
+
+        let rustFiles =
+            allFilesUnder srcDir
+            |> List.filter (fun p -> p.EndsWith(".rs", StringComparison.Ordinal))
+
+        for path in rustFiles do
+            let content = File.ReadAllText path
+
+            for m in rustEnvVarRegex.Matches content do
+                keys.Add(m.Groups[1].Value) |> ignore
+
+            let mutable inConfigStruct = false
+            let mutable braceDepth = 0
+
+            for line in content.Split('\n') do
+                if not inConfigStruct && rustConfigStructRegex.IsMatch line then
+                    inConfigStruct <- true
+                    braceDepth <- 0
+
+                if inConfigStruct then
+                    for ch in line do
+                        match ch with
+                        | '{' -> braceDepth <- braceDepth + 1
+                        | '}' ->
+                            braceDepth <- braceDepth - 1
+
+                            if braceDepth <= 0 then
+                                inConfigStruct <- false
+                        | _ -> ()
+
+                    if inConfigStruct && braceDepth > 0 then
+                        let fieldMatch = rustPubFieldRegex.Match line
+
+                        if fieldMatch.Success then
+                            keys.Add(fieldMatch.Groups[1].Value.ToUpperInvariant()) |> ignore
+
+        Ok(keys |> List.ofSeq)
+    with ex ->
+        Error(sprintf "cannot read source under %s: %s" srcDir ex.Message)
+
+let private tsEnvPropRegex =
+    Regex(@"\benv\.([A-Z][A-Z0-9_]+)\b", RegexOptions.Compiled)
+
+let private tsSchemaKeyRegex =
+    Regex(@"^\s+([A-Z][A-Z0-9_]+)\s*:", RegexOptions.Compiled)
+
+/// Scans TypeScript source under `root/src` for environment variable keys
+/// consumed by the code [Repo-grounded — `validate.rs::scan_ts_reads`].
+///
+/// Detects `env.KEY` property accesses in any `.ts`/`.tsx` file (skipping
+/// `.test.`/`.spec.` files — those set `process.env` for mocking, not for
+/// production reads), plus `createEnv` schema keys (`UPPER_CASE_KEY:` lines)
+/// but only inside a file literally named `env.ts`.
+///
+/// # Errors
+///
+/// Returns an error when a source file cannot be read.
+let scanTsReads (root: string) : Result<string list, string> =
+    let srcDir = Path.Combine(root, "src")
+
+    try
+        let keys = HashSet<string>()
+
+        let candidateFiles =
+            allFilesUnder srcDir
+            |> List.filter (fun p ->
+                let name = Path.GetFileName p
+
+                (name.EndsWith(".ts", StringComparison.Ordinal)
+                 || name.EndsWith(".tsx", StringComparison.Ordinal))
+                && not (name.Contains(".test.") || name.Contains(".spec.")))
+
+        for path in candidateFiles do
+            let name = Path.GetFileName path
+            let content = File.ReadAllText path
+
+            for m in tsEnvPropRegex.Matches content do
+                keys.Add(m.Groups[1].Value) |> ignore
+
+            if name = "env.ts" then
+                for line in content.Split('\n') do
+                    let m = tsSchemaKeyRegex.Match line
+
+                    if m.Success then
+                        keys.Add(m.Groups[1].Value) |> ignore
+
+        Ok(keys |> List.ofSeq)
+    with ex ->
+        Error(sprintf "cannot read source under %s: %s" srcDir ex.Message)
+
+/// Runtime-owned signals that are never application environment contract
+/// keys [Repo-grounded —
+/// `validate.rs::FRAMEWORK_OWNED_ENVIRONMENT_KEYS`].
+let frameworkOwnedEnvironmentKeys: string list = [ "DOTNET_RUNNING_IN_CONTAINER" ]
+
+let private fsharpEnvVarRegex =
+    Regex(@"(?:System\.)?Environment\.GetEnvironmentVariable\s*\(\s*""([A-Z][A-Z0-9_]*)""\s*\)", RegexOptions.Compiled)
+
+let private fsharpReaderWrapperRegex =
+    Regex(@"\breadEnvironment\s+""([A-Z][A-Z0-9_]*)""", RegexOptions.Compiled)
+
+/// Scans F# source under `root/src` for environment variable keys consumed
+/// by the code [Repo-grounded — `validate.rs::scan_fsharp_reads`].
+///
+/// Detects `(System.)?Environment.GetEnvironmentVariable("VAR_NAME")` calls
+/// plus the pure F# environment-reader wrapper pattern `readEnvironment
+/// "VAR_NAME"`. Both exclude [`frameworkOwnedEnvironmentKeys`] — supplied by
+/// the .NET runtime, not application configuration.
+///
+/// # Errors
+///
+/// Returns an error when a source file cannot be read.
+let scanFsharpReads (root: string) : Result<string list, string> =
+    let srcDir = Path.Combine(root, "src")
+
+    try
+        let keys = HashSet<string>()
+
+        let addUnlessFrameworkOwned (key: string) =
+            if not (List.contains key frameworkOwnedEnvironmentKeys) then
+                keys.Add key |> ignore
+
+        let fsharpFiles =
+            allFilesUnder srcDir
+            |> List.filter (fun p -> p.EndsWith(".fs", StringComparison.Ordinal))
+
+        for path in fsharpFiles do
+            let content = File.ReadAllText path
+
+            for m in fsharpEnvVarRegex.Matches content do
+                addUnlessFrameworkOwned m.Groups[1].Value
+
+            for m in fsharpReaderWrapperRegex.Matches content do
+                addUnlessFrameworkOwned m.Groups[1].Value
+
+        Ok(keys |> List.ofSeq)
+    with ex ->
+        Error(sprintf "cannot read source under %s: %s" srcDir ex.Message)
+
+/// Validates a single `App`-kind surface against its `.env.example`
+/// [Repo-grounded — `validate.rs::validate_app_surface`].
+///
+/// Returns zero or more drift findings, sorted by key.
+///
+/// # Errors
+///
+/// Returns an error when source files cannot be read or `surface.Lang`
+/// names an unsupported language.
+let validateAppSurface (repoRoot: string) (surface: SurfaceConfig) : Result<Finding list, string> =
+    let root = Path.Combine(repoRoot, surface.Root)
+    let envExample = Path.Combine(root, ".env.example")
+
+    match parseDeclaredKeys envExample with
+    | Error e -> Error e
+    | Ok declaredKeys ->
+        let readResult =
+            match surface.Lang with
+            | "rust" -> scanRustReads root
+            | "typescript" -> scanTsReads root
+            | "fsharp" -> scanFsharpReads root
+            | other -> Error(sprintf "unsupported lang: %s" other)
+
+        match readResult with
+        | Error e -> Error e
+        | Ok readKeys ->
+            let declared = Set.ofList declaredKeys
+            let read = Set.ofList readKeys
+            let allowlist = Set.ofList surface.Allowlist
+
+            let declaredButUnread =
+                declared
+                |> Set.filter (fun key -> not (Set.contains key read) && not (Set.contains key allowlist))
+                |> Set.toList
+                |> List.map (fun key ->
+                    { Root = surface.Root
+                      Drift = DeclaredButUnread
+                      Key = key })
+
+            let readButUndeclared =
+                read
+                |> Set.filter (fun key -> not (Set.contains key declared) && not (Set.contains key allowlist))
+                |> Set.toList
+                |> List.map (fun key ->
+                    { Root = surface.Root
+                      Drift = ReadButUndeclared
+                      Key = key })
+
+            declaredButUnread @ readButUndeclared
+            |> List.sortWith (fun a b -> String.CompareOrdinal(a.Key, b.Key))
+            |> Ok
+
+/// Validates every surface declared in `contract` [Repo-grounded —
+/// `validate.rs::validate_all`].
+///
+/// Only `App` surfaces are dispatched to a real validator: `Terraform`/
+/// `Ansible` surface validation is PR7 scope
+/// (`env-contract/iac-env-validation.feature`, porting the terraform/ansible
+/// validators at `validate.rs` lines ~430-1259). No surface in this repo's
+/// live `env-contract:` section currently declares either kind, so this
+/// raises a clear error rather than silently no-op-ing — surfacing a real
+/// gap immediately if that ever changes before PR7 lands, rather than
+/// masking it as a clean pass.
+///
+/// # Errors
+///
+/// Returns an error when any `App` surface fails validation, or a
+/// `Terraform`/`Ansible` surface is encountered before PR7 implements it.
+let validateAll (repoRoot: string) (contract: Contract) : Result<Finding list, string> =
+    let rec go (surfaces: SurfaceConfig list) (acc: Finding list) : Result<Finding list, string> =
+        match surfaces with
+        | [] -> Ok acc
+        | surface :: rest ->
+            match surface.Kind with
+            | App ->
+                match validateAppSurface repoRoot surface with
+                | Error e -> Error e
+                | Ok findings -> go rest (acc @ findings)
+            | Terraform
+            | Ansible ->
+                Error(
+                    sprintf
+                        "%s surface at \"%s\": terraform/ansible env-validate surfaces are PR7 scope, not yet implemented"
+                        (surface.Kind.ToString())
+                        surface.Root
+                )
+
+    go contract.Surfaces []

--- a/apps/rhino-cli/src-fsharp/project.json
+++ b/apps/rhino-cli/src-fsharp/project.json
@@ -112,7 +112,7 @@
     "specs:behavior:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-backup.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-init.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-restore.feature apps/rhino-cli/src-fsharp"
+        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-backup.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-init.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-restore.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-validate-app-drift.feature apps/rhino-cli/src-fsharp"
       },
       "cache": true,
       "inputs": ["{workspaceRoot}/specs/apps/rhino/behavior/rhino-cli/gherkin/**/*.feature", "{projectRoot}/**/*.fs"]

--- a/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+++ b/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
@@ -25,6 +25,8 @@
     <Compile Include="Steps/EnvInitUnitTests.fs" />
     <Compile Include="Steps/EnvRestoreSteps.fs" />
     <Compile Include="Steps/EnvRestoreUnitTests.fs" />
+    <Compile Include="Steps/EnvValidateSteps.fs" />
+    <Compile Include="Steps/EnvValidateUnitTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvValidateSteps.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvValidateSteps.fs
@@ -1,0 +1,228 @@
+/// TickSpec step definitions binding `env-validate-app-drift.feature`'s 3
+/// scenarios to `RhinoCli.Application.Env`'s `validateAppSurface` port
+/// [Repo-grounded —
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-validate-app-drift.feature`,
+/// `apps/rhino-cli/src/application/env/validate.rs`].
+///
+/// Follows `EnvRestoreSteps.fs`'s per-scenario slicing convention: each
+/// xunit `[<Fact>]` below runs exactly one scenario, extracted from the
+/// real, frozen feature file rather than a duplicated/rewritten copy of its
+/// wording. There is no CLI wiring in this PR (deferred to the Wave B
+/// integration PR) — "the command exits with a failure code"/"exits
+/// successfully" and "the output names the key as X" are asserted directly
+/// against `validateAppSurface`'s returned `Finding list`: a non-empty list
+/// carrying the expected `Drift`/`Key` stands in for "failure code" plus
+/// "names the key as X"; an empty list stands in for "exits successfully".
+module RhinoCli.Tests.Unit.Steps.EnvValidateSteps
+
+open System
+open System.IO
+open TickSpec
+open Xunit
+open RhinoCli.Application.Env
+
+/// Instance step-definition container — see `ConventionSteps.fs`'s module
+/// doc comment for why TickSpec's one-instance-per-scenario lifecycle makes
+/// instance-level mutable fields the idiomatic state-threading mechanism
+/// here.
+type EnvValidateSteps() =
+    let mutable repoRoot: string option = None
+    let mutable surface: SurfaceConfig option = None
+    let mutable findingsResult: Result<Finding list, string> option = None
+    let mutable ownedDirs: string list = []
+
+    let newTempDir () : string =
+        let dir =
+            Path.Combine(Path.GetTempPath(), "rhino-cli-env-validate-" + Guid.NewGuid().ToString("N"))
+
+        Directory.CreateDirectory(dir) |> ignore
+        ownedDirs <- dir :: ownedDirs
+        dir
+
+    let writeFile (root: string) (relativePath: string) (content: string) =
+        let full = Path.Combine(root, relativePath)
+        Directory.CreateDirectory(Path.GetDirectoryName(full)) |> ignore
+        File.WriteAllText(full, content)
+
+    let ensureRoot () : string =
+        match repoRoot with
+        | Some dir -> dir
+        | None ->
+            let dir = newTempDir ()
+            repoRoot <- Some dir
+            dir
+
+    let findings () : Finding list =
+        match findingsResult with
+        | Some(Ok findings) -> findings
+        | Some(Error message) -> failwith (sprintf "expected env validate to return findings, got error: %s" message)
+        | None -> failwith "no command has been run by a When step"
+
+    // ---- Given ----
+
+    [<Given>]
+    member _.``an app surface whose .env.example declares a key the source code never reads``() =
+        let root = ensureRoot ()
+        writeFile root "surface/.env.example" "UNREAD_KEY=some-value\n"
+        writeFile root "surface/src/main.rs" "fn main() {}\n"
+
+        surface <-
+            Some
+                { Root = "surface"
+                  Kind = App
+                  Lang = "rust"
+                  Allowlist = [] }
+
+    [<Given>]
+    member _.``an app surface whose source code reads a key absent from .env.example``() =
+        let root = ensureRoot ()
+        writeFile root "surface/.env.example" ""
+        writeFile root "surface/src/main.rs" "let x = env::var(\"UNDECLARED_KEY\").unwrap();\n"
+
+        surface <-
+            Some
+                { Root = "surface"
+                  Kind = App
+                  Lang = "rust"
+                  Allowlist = [] }
+
+    // TickSpec 2.0.5's line lexer treats a literal `#` anywhere in a step
+    // line as a comment marker (not just at line-start, unlike the Gherkin
+    // spec) — confirmed empirically: it truncates this scenario's frozen
+    // `Given an F# app surface ...` line to `an F` before step resolution,
+    // so no bound pattern can ever see the text after the `#` at runtime. F#
+    // step names double as regexes in TickSpec (see `speccoverage`'s own
+    // `add_fsharp_step_pattern`, which anchors this text as `^…$` when
+    // checking spec coverage against the real, untruncated Gherkin line), so
+    // `.*` here stands in for everything TickSpec itself never gets to see:
+    // it satisfies TickSpec's truncated `an F` match at runtime AND the
+    // coverage tool's anchored match against the full untruncated sentence.
+    [<Given>]
+    member _.``an F.*``() =
+        let root = ensureRoot ()
+        writeFile root "surface/.env.example" "WRAPPED_KEY=some-value\n"
+
+        writeFile
+            root
+            "surface/src/Config.fs"
+            "let wrapped = readEnvironment \"WRAPPED_KEY\"\nlet inContainer = System.Environment.GetEnvironmentVariable(\"DOTNET_RUNNING_IN_CONTAINER\")\n"
+
+        surface <-
+            Some
+                { Root = "surface"
+                  Kind = App
+                  Lang = "fsharp"
+                  Allowlist = [] }
+
+    // ---- When ----
+
+    [<When>]
+    member _.``the developer runs env validate``() =
+        let root = ensureRoot ()
+
+        let activeSurface =
+            match surface with
+            | Some s -> s
+            | None -> failwith "no surface has been prepared by a Given step"
+
+        findingsResult <- Some(validateAppSurface root activeSurface)
+
+    // ---- Then ----
+
+    [<Then>]
+    member _.``the command exits with a failure code``() = Assert.NotEmpty(findings ())
+
+    [<Then>]
+    member _.``the command exits successfully``() = Assert.Empty(findings ())
+
+    [<Then>]
+    member _.``the output names the key as declared-but-unread``() =
+        Assert.Contains(findings (), fun (f: Finding) -> f.Drift = DeclaredButUnread && f.Key = "UNREAD_KEY")
+
+    [<Then>]
+    member _.``the output names the key as read-but-undeclared``() =
+        Assert.Contains(findings (), fun (f: Finding) -> f.Drift = ReadButUndeclared && f.Key = "UNDECLARED_KEY")
+
+    [<AfterScenario>]
+    member _.Cleanup() =
+        for dir in ownedDirs do
+            if Directory.Exists dir then
+                Directory.Delete(dir, true)
+
+/// Reads one named `Scenario:` block out of the real, frozen
+/// `env-validate-app-drift.feature` file (leaving the file itself untouched)
+/// and runs it through TickSpec bound only against `EnvValidateSteps` — see
+/// `EnvSteps.fs`'s `FeatureRunner` for why this is per-scenario rather than
+/// per-file.
+module private FeatureRunner =
+
+    let private featurePath: string =
+        Path.GetFullPath(
+            Path.Combine(
+                __SOURCE_DIRECTORY__,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "specs",
+                "apps",
+                "rhino",
+                "behavior",
+                "rhino-cli",
+                "gherkin",
+                "env",
+                "env-validate-app-drift.feature"
+            )
+        )
+
+    let private extractScenario (featureLines: string[]) (scenarioTitle: string) : string[] =
+        let featureLine =
+            featureLines
+            |> Array.find (fun l -> l.TrimStart().StartsWith("Feature:", StringComparison.Ordinal))
+
+        let scenarioHeader = sprintf "Scenario: %s" scenarioTitle
+
+        let startIdx = featureLines |> Array.findIndex (fun l -> l.Trim() = scenarioHeader)
+
+        let endIdx =
+            featureLines
+            |> Array.skip (startIdx + 1)
+            |> Array.tryFindIndex (fun l ->
+                let trimmed = l.Trim()
+
+                trimmed.StartsWith("Scenario:", StringComparison.Ordinal)
+                || trimmed.StartsWith("Scenario Outline:", StringComparison.Ordinal)
+                // env-validate-app-drift.feature tags only the feature itself
+                // (`@env-validate-app-drift`), with no per-scenario tags — a
+                // `@`-prefixed line still ends the slice, matching
+                // `EnvRestoreSteps.fs`'s tag-aware convention, even though no
+                // scenario here actually carries one.
+                || trimmed.StartsWith("@", StringComparison.Ordinal))
+            |> Option.map (fun relativeIdx -> startIdx + 1 + relativeIdx)
+            |> Option.defaultValue featureLines.Length
+
+        Array.append [| featureLine; "" |] featureLines.[startIdx .. endIdx - 1]
+
+    /// Runs the single scenario named `scenarioTitle` from
+    /// `env-validate-app-drift.feature`, bound against `EnvValidateSteps`.
+    let run (scenarioTitle: string) : unit =
+        let allLines = File.ReadAllLines featurePath
+        let snippet = extractScenario allLines scenarioTitle
+        let definitions = StepDefinitions([| typeof<EnvValidateSteps> |])
+        let feature = definitions.GenerateFeature(featurePath, snippet)
+        let scenario = Seq.exactlyOne feature.Scenarios
+        scenario.Action.Invoke()
+
+[<Fact>]
+let ``A key declared in .env.example but never read by the app fails validation`` () =
+    FeatureRunner.run "A key declared in .env.example but never read by the app fails validation"
+
+[<Fact>]
+let ``A key read by the app but never declared in .env.example fails validation`` () =
+    FeatureRunner.run "A key read by the app but never declared in .env.example fails validation"
+
+[<Fact>]
+let ``F# environment wrapper reads remain detectable after convergence`` () =
+    FeatureRunner.run "F# environment wrapper reads remain detectable after convergence"

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvValidateUnitTests.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvValidateUnitTests.fs
@@ -1,0 +1,365 @@
+/// Plain xunit tests for `RhinoCli.Application.Env`'s `env validate`
+/// (`App`-surface-kind) port — behaviour with no dedicated Gherkin scenario,
+/// or exercised only indirectly there (mirrors the rationale
+/// `EnvRestoreUnitTests.fs`'s module doc comment states for its own split
+/// from `EnvRestoreSteps.fs`). Ported from
+/// `apps/rhino-cli/src/application/env/validate.rs`'s `#[cfg(test)] mod
+/// tests`, `App`-surface slice only — the `terraform`/`ansible` validator
+/// tests in the Rust reference are PR7 scope.
+module RhinoCli.Tests.Unit.Steps.EnvValidateUnitTests
+
+open System
+open System.IO
+open Xunit
+open RhinoCli.Application.Env
+
+let private newTempDir () : string =
+    let dir =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-env-validate-unit-" + Guid.NewGuid().ToString("N"))
+
+    Directory.CreateDirectory(dir) |> ignore
+    dir
+
+let private writeFile (root: string) (relativePath: string) (content: string) =
+    let full = Path.Combine(root, relativePath)
+    Directory.CreateDirectory(Path.GetDirectoryName(full)) |> ignore
+    File.WriteAllText(full, content)
+
+// ---- isEnvVarName ----
+
+[<Fact>]
+let ``isEnvVarName rejects an empty string`` () = Assert.False(isEnvVarName "")
+
+[<Fact>]
+let ``isEnvVarName accepts uppercase letters, digits, and underscores`` () = Assert.True(isEnvVarName "FOO_BAR_2")
+
+[<Fact>]
+let ``isEnvVarName rejects a name containing a lowercase letter`` () = Assert.False(isEnvVarName "FOO_bar")
+
+[<Fact>]
+let ``isEnvVarName rejects a name containing a hyphen`` () = Assert.False(isEnvVarName "FOO-BAR")
+
+[<Fact>]
+let ``isEnvVarName rejects a name containing whitespace`` () = Assert.False(isEnvVarName "FOO BAR")
+
+// ---- parseDeclaredKeys ----
+
+[<Fact>]
+let ``parseDeclaredKeys collects an active KEY=value declaration`` () =
+    let dir = newTempDir ()
+    let path = Path.Combine(dir, ".env.example")
+    File.WriteAllText(path, "FOO_KEY=some-value\n")
+
+    match parseDeclaredKeys path with
+    | Ok keys -> Assert.Equal<string list>([ "FOO_KEY" ], keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``parseDeclaredKeys collects a commented-out KEY=value declaration`` () =
+    let dir = newTempDir ()
+    let path = Path.Combine(dir, ".env.example")
+    File.WriteAllText(path, "# COMMENTED_KEY=\n")
+
+    match parseDeclaredKeys path with
+    | Ok keys -> Assert.Equal<string list>([ "COMMENTED_KEY" ], keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``parseDeclaredKeys ignores a pure-annotation comment with no equals sign`` () =
+    let dir = newTempDir ()
+    let path = Path.Combine(dir, ".env.example")
+    File.WriteAllText(path, "# this is just an annotation, not a declaration\n")
+
+    match parseDeclaredKeys path with
+    | Ok keys -> Assert.Empty(keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``parseDeclaredKeys ignores blank lines`` () =
+    let dir = newTempDir ()
+    let path = Path.Combine(dir, ".env.example")
+    File.WriteAllText(path, "\n   \nFOO=bar\n")
+
+    match parseDeclaredKeys path with
+    | Ok keys -> Assert.Equal<string list>([ "FOO" ], keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``parseDeclaredKeys ignores a lowercase key which fails isEnvVarName`` () =
+    let dir = newTempDir ()
+    let path = Path.Combine(dir, ".env.example")
+    File.WriteAllText(path, "not_a_valid_key=value\n")
+
+    match parseDeclaredKeys path with
+    | Ok keys -> Assert.Empty(keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``parseDeclaredKeys fails with a descriptive message when the file does not exist`` () =
+    let dir = newTempDir ()
+    let path = Path.Combine(dir, "nope", ".env.example")
+
+    match parseDeclaredKeys path with
+    | Error message -> Assert.Contains(path, message)
+    | Ok _ -> Assert.Fail("expected an error for a missing file")
+
+// ---- scanRustReads ----
+
+[<Fact>]
+let ``scanRustReads detects a direct env::var read`` () =
+    let root = newTempDir ()
+    writeFile root "src/main.rs" "let x = env::var(\"MY_RUST_KEY\").unwrap();\n"
+
+    match scanRustReads root with
+    | Ok keys -> Assert.Contains("MY_RUST_KEY", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanRustReads detects a std::env::var read`` () =
+    let root = newTempDir ()
+    writeFile root "src/main.rs" "let x = std::env::var(\"OTHER_KEY\").unwrap();\n"
+
+    match scanRustReads root with
+    | Ok keys -> Assert.Contains("OTHER_KEY", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanRustReads extracts pub struct Config field names uppercased`` () =
+    let root = newTempDir ()
+
+    writeFile root "src/config.rs" "pub struct Config {\n    pub database_url: String,\n    pub port: u16,\n}\n"
+
+    match scanRustReads root with
+    | Ok keys ->
+        Assert.Contains("DATABASE_URL", keys)
+        Assert.Contains("PORT", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanRustReads does not extract fields from a struct other than Config`` () =
+    let root = newTempDir ()
+    writeFile root "src/other.rs" "pub struct Other {\n    pub unrelated_field: String,\n}\n"
+
+    match scanRustReads root with
+    | Ok keys -> Assert.DoesNotContain("UNRELATED_FIELD", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanRustReads returns an empty list when the src directory does not exist`` () =
+    let root = newTempDir ()
+
+    match scanRustReads root with
+    | Ok keys -> Assert.Empty(keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+// ---- scanTsReads ----
+
+[<Fact>]
+let ``scanTsReads detects an env property access`` () =
+    let root = newTempDir ()
+    writeFile root "src/server.ts" "const url = env.DATABASE_URL;\n"
+
+    match scanTsReads root with
+    | Ok keys -> Assert.Contains("DATABASE_URL", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanTsReads detects a createEnv schema key only inside env.ts`` () =
+    let root = newTempDir ()
+
+    writeFile root "src/env.ts" "export const env = createEnv({\n  server: {\n    SCHEMA_KEY: z.string(),\n  },\n});\n"
+
+    match scanTsReads root with
+    | Ok keys -> Assert.Contains("SCHEMA_KEY", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanTsReads ignores a schema-shaped key in a file not literally named env.ts`` () =
+    let root = newTempDir ()
+    writeFile root "src/schema.ts" "  NOT_ENV_TS_KEY: z.string(),\n"
+
+    match scanTsReads root with
+    | Ok keys -> Assert.DoesNotContain("NOT_ENV_TS_KEY", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanTsReads skips a .test. file`` () =
+    let root = newTempDir ()
+    writeFile root "src/server.test.ts" "const url = env.SHOULD_BE_SKIPPED;\n"
+
+    match scanTsReads root with
+    | Ok keys -> Assert.DoesNotContain("SHOULD_BE_SKIPPED", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanTsReads skips a .spec. file`` () =
+    let root = newTempDir ()
+    writeFile root "src/server.spec.ts" "const url = env.ALSO_SKIPPED;\n"
+
+    match scanTsReads root with
+    | Ok keys -> Assert.DoesNotContain("ALSO_SKIPPED", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+// ---- scanFsharpReads ----
+
+[<Fact>]
+let ``scanFsharpReads detects a direct Environment.GetEnvironmentVariable read`` () =
+    let root = newTempDir ()
+    writeFile root "src/Config.fs" "let x = Environment.GetEnvironmentVariable(\"MY_FSHARP_KEY\")\n"
+
+    match scanFsharpReads root with
+    | Ok keys -> Assert.Contains("MY_FSHARP_KEY", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanFsharpReads detects a fully-qualified System.Environment.GetEnvironmentVariable read`` () =
+    let root = newTempDir ()
+    writeFile root "src/Config.fs" "let x = System.Environment.GetEnvironmentVariable(\"QUALIFIED_KEY\")\n"
+
+    match scanFsharpReads root with
+    | Ok keys -> Assert.Contains("QUALIFIED_KEY", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanFsharpReads detects the pure environment-reader wrapper pattern`` () =
+    let root = newTempDir ()
+    writeFile root "src/Config.fs" "let port = readEnvironment \"WRAPPED_KEY\"\n"
+
+    match scanFsharpReads root with
+    | Ok keys -> Assert.Contains("WRAPPED_KEY", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanFsharpReads excludes the framework-owned DOTNET_RUNNING_IN_CONTAINER key from a direct read`` () =
+    let root = newTempDir ()
+
+    writeFile
+        root
+        "src/Config.fs"
+        "let inContainer = Environment.GetEnvironmentVariable(\"DOTNET_RUNNING_IN_CONTAINER\")\n"
+
+    match scanFsharpReads root with
+    | Ok keys -> Assert.DoesNotContain("DOTNET_RUNNING_IN_CONTAINER", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanFsharpReads excludes the framework-owned DOTNET_RUNNING_IN_CONTAINER key from the wrapper pattern`` () =
+    let root = newTempDir ()
+    writeFile root "src/Config.fs" "let inContainer = readEnvironment \"DOTNET_RUNNING_IN_CONTAINER\"\n"
+
+    match scanFsharpReads root with
+    | Ok keys -> Assert.DoesNotContain("DOTNET_RUNNING_IN_CONTAINER", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+// ---- validateAppSurface ----
+
+let private defaultSurface (root: string) (lang: string) (allowlist: string list) : SurfaceConfig =
+    { Root = root
+      Kind = App
+      Lang = lang
+      Allowlist = allowlist }
+
+[<Fact>]
+let ``validateAppSurface omits an allowlisted declared-but-unread key`` () =
+    let repoRoot = newTempDir ()
+    writeFile repoRoot "surface/.env.example" "ALLOWED_KEY=1\n"
+    writeFile repoRoot "surface/src/main.rs" "fn main() {}\n"
+
+    let surface = defaultSurface "surface" "rust" [ "ALLOWED_KEY" ]
+
+    match validateAppSurface repoRoot surface with
+    | Ok findings -> Assert.Empty(findings)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``validateAppSurface omits an allowlisted read-but-undeclared key`` () =
+    let repoRoot = newTempDir ()
+    writeFile repoRoot "surface/.env.example" ""
+    writeFile repoRoot "surface/src/main.rs" "let x = env::var(\"ALLOWED_READ_KEY\").unwrap();\n"
+
+    let surface = defaultSurface "surface" "rust" [ "ALLOWED_READ_KEY" ]
+
+    match validateAppSurface repoRoot surface with
+    | Ok findings -> Assert.Empty(findings)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``validateAppSurface sorts findings by key`` () =
+    let repoRoot = newTempDir ()
+    writeFile repoRoot "surface/.env.example" "ZEBRA_KEY=1\nALPHA_KEY=1\n"
+    writeFile repoRoot "surface/src/main.rs" "fn main() {}\n"
+
+    let surface = defaultSurface "surface" "rust" []
+
+    match validateAppSurface repoRoot surface with
+    | Ok findings -> Assert.Equal<string list>([ "ALPHA_KEY"; "ZEBRA_KEY" ], findings |> List.map (fun f -> f.Key))
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``validateAppSurface fails with a descriptive message for an unsupported lang`` () =
+    let repoRoot = newTempDir ()
+    writeFile repoRoot "surface/.env.example" ""
+
+    let surface = defaultSurface "surface" "cobol" []
+
+    match validateAppSurface repoRoot surface with
+    | Error message -> Assert.Contains("cobol", message)
+    | Ok _ -> Assert.Fail("expected an error for an unsupported lang")
+
+// ---- loadContract ----
+
+[<Fact>]
+let ``loadContract fails with a descriptive message when env-contract is absent`` () =
+    let repoRoot = newTempDir ()
+    File.WriteAllText(Path.Combine(repoRoot, "repo-config.yml"), "harness: []\n")
+
+    match loadContract repoRoot with
+    | Error message -> Assert.Contains("env-contract", message)
+    | Ok _ -> Assert.Fail("expected an error when env-contract is absent")
+
+[<Fact>]
+let ``loadContract fails with a descriptive message when repo-config.yml does not exist`` () =
+    let repoRoot = newTempDir ()
+
+    match loadContract repoRoot with
+    | Error message -> Assert.Contains("repo-config.yml", message)
+    | Ok _ -> Assert.Fail("expected an error when repo-config.yml is missing")
+
+[<Fact>]
+let ``loadContract parses a declared app surface`` () =
+    let repoRoot = newTempDir ()
+
+    File.WriteAllText(
+        Path.Combine(repoRoot, "repo-config.yml"),
+        "env-contract:\n  surfaces:\n    - root: apps/example\n      kind: app\n      lang: rust\n      allowlist:\n        - SOME_KEY\n"
+    )
+
+    match loadContract repoRoot with
+    | Ok contract ->
+        let surface = Assert.Single(contract.Surfaces)
+        Assert.Equal("apps/example", surface.Root)
+        Assert.Equal(App, surface.Kind)
+        Assert.Equal("rust", surface.Lang)
+        Assert.Equal<string list>([ "SOME_KEY" ], surface.Allowlist)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+// ---- DriftKind.label ----
+
+[<Fact>]
+let ``DriftKind label covers all five variants`` () =
+    Assert.Equal("declared-but-unread", DriftKind.label DeclaredButUnread)
+    Assert.Equal("read-but-undeclared", DriftKind.label ReadButUndeclared)
+    Assert.Equal("example-not-declared", DriftKind.label ExampleNotDeclared)
+    Assert.Equal("required-missing-from-example", DriftKind.label RequiredMissingFromExample)
+    Assert.Equal("consumed-not-declared", DriftKind.label ConsumedNotDeclared)
+
+// ---- formatFinding ----
+
+[<Fact>]
+let ``formatFinding renders the DRIFT root label key line shape`` () =
+    let finding =
+        { Root = "apps/example"
+          Drift = DeclaredButUnread
+          Key = "SOME_KEY" }
+
+    Assert.Equal("DRIFT  apps/example  declared-but-unread  SOME_KEY", formatFinding finding)

--- a/repo-config.yml
+++ b/repo-config.yml
@@ -169,7 +169,7 @@ coverage:
     # option that does not regress the still-canonical Rust side.
     - name: rhino-cli-fsharp
       levels: [unit, integration]
-      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention/**,repo-config/**,repo-config-validate/**,env/env-backup.feature,env/env-init.feature,env/env-restore.feature}"
+      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention/**,repo-config/**,repo-config-validate/**,env/env-backup.feature,env/env-init.feature,env/env-restore.feature,env/env-validate-app-drift.feature}"
 
     # ose domain
     - name: ose-be


### PR DESCRIPTION
## Summary
- Ports the `App`-surface-kind slice of `env validate` (`SurfaceKind`, `Contract`, `Finding`, `DriftKind`, `loadContract`, `parseDeclaredKeys`, `scanRustReads`, `scanTsReads`, `scanFsharpReads`, `validateAppSurface`, `validateAll`) to F#, satisfying all 3 scenarios in `env-validate-app-drift.feature`.
- Terraform/Ansible surface validation is out of scope here — deferred to Wave B PR7 (`env-contract/iac-env-validation.feature`).
- Fixes a real cross-tool conflict: TickSpec 2.0.5's line lexer truncates a step's Given text at the first literal `#` (confirmed empirically — the frozen scenario's `Given an F# app surface ...` line reduces to `Given an F` before step resolution), while the Rust behavior-coverage gate's own F# step scanner needs the full untruncated sentence. A regex step name (`` `an F.*` ``) satisfies both: TickSpec's truncated runtime match and the coverage tool's anchored full-sentence match.

## Cost/benefit
New F# code ported line-for-line from `apps/rhino-cli/src/application/env/validate.rs`'s `App`-surface path; no new runtime dependencies (reuses the `RepoConfig.fs`-established YamlDotNet convention). Cost is the added `Env.fs` surface area (+516 lines) and two new test files, offset by closing 3 more Gherkin scenarios toward full Wave B F# coverage.

## Test plan
- [x] `nx run rhino-cli-fsharp:typecheck` — 0 errors
- [x] `nx run rhino-cli-fsharp:lint` (fantomas, fsharplint, G-Research analyzers) — 0 warnings
- [x] `nx run rhino-cli-fsharp:test:unit` — 277/277 passed
- [x] `nx run rhino-cli-fsharp:test:coverage` — 91.64% line coverage (≥90% threshold)
- [x] `nx run rhino-cli-fsharp:specs:behavior:coverage` — all covered after widening `--shared-steps`/`repo-config.yml` glob
- [x] `nx run rhino-cli-fsharp:specs:structure-validation` — 0 findings
- [x] `nx run-many -t test:quick -p rhino-cli,rhino-cli-fsharp` — both projects pass
- [x] Parity manifest regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)