### PR TITLE
feat(rhino-cli-fsharp): port terraform/ansible env-contract validators (Wave B PR7)

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -5,7 +5,7 @@ b5f5e511ac5697c2d2949d898633f079abbce9c7211205aad6f7521f17746df2  apps/rhino-cli
 22b1d0652e8937a20c83841966e4f8b1c451d671d34dd27fb5fa13f11d340a4d  apps/rhino-cli/src-fsharp/.gitignore
 96bd05860d32d93030016db7fa582a1fbb772328d6875cf03fff8957f47b1e90  apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
 11fe7ec2e5e08b432e2d1cedae59e1a555e17e22a1f11494bd83b80c36964b5c  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Convention.fs
-a32e7fdb29677bd0fb459436b7b380acbf32ee3bfc6165dc9204a89a0059152b  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
+2a4d76050534b10fbe69e14c03359ee95fc9525ce8ed23a12be8bc65036313c5  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
 2f8085bcb8089f174e9548e609530471c9318c31b1bcab4a867e33880cec9e57  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Parity.fs
 f68a2a01380e02ce7fa8f5774a0800e9f1281c39d3c90b3c03947c1448799f2d  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/RepoConfig.fs
 fc1346c5ed931f006be550583e92d5603bdffceb270783f4b334bb5ff4d7aa3a  apps/rhino-cli/src-fsharp/RhinoCli.Cli/RhinoCli.Cli.fsproj
@@ -20,12 +20,14 @@ bb55f3c8d4d3daffa7e334ecdacff8bfd9462b12a7098e239943d84a3edf915f  apps/rhino-cli
 631376afb9e4d7c5192d38f51b533c18b64cca83c18ed5c50982ba9acce51d74  apps/rhino-cli/src-fsharp/RhinoCli.Program/RhinoCli.Program.fsproj
 153a226f5ef1d6916aa6e6425b278a606a48659fcba9623c9d01e5cf3b2589a5  apps/rhino-cli/src-fsharp/RhinoCli.Program/src/Program.fs
 822f6ec8446562a4de9a3b1a2481af50fac01bbedc32e1963142709e5f48ec13  apps/rhino-cli/src-fsharp/fsharplint.json
-989eaa4b18f543004c5b64ba5d330a152c474594a0f934dfd60834a51d8e9a84  apps/rhino-cli/src-fsharp/project.json
+ca5c6d0feeb8f0699a81b84d00464834e19fd63f49a09b6d86ce7df6a439c3f4  apps/rhino-cli/src-fsharp/project.json
 f7dacc8dd923488c70eebabe298843022ec5a3ba94b8b7568634a779f24b8da4  apps/rhino-cli/src-fsharp/tests/integration/RhinoCli.IntegrationTests.fsproj
-e6be0d5f6b1aaca2c852a29c65289c3e1aeafc08b69232c8b30fe9a05fd93088  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+bece93e4307cb986a8bf7d0f75dea52e3ead203519a8520965a91d5b170206bb  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
 85ba308ad0a88485db55b305120d99b9a4ec328d2379536110f73e51f4797fe2  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionSteps.fs
 a909884a9d8816e2b476cc8c00be03ac4085b849cbe83c4b18e0213ac9cad1d7  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionUnitTests.fs
 a0603a9ec897d538381417f8a330b1fa4b75f75f74003fda2a2b9b9512db5a1a  apps/rhino-cli/src-fsharp/tests/unit/Steps/DispatchUnitTests.fs
+8d1559277686544b82b919a21387186f237243a5207ad50a598f98fed9b10248  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvContractIacSteps.fs
+cd1f6eae969b1d5fbc2c751680401ead3e6f916648ec5e20d7d7b21f7d0fc681  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvContractIacUnitTests.fs
 ad360c992e3e47ccf8f47693a8f3c42581085a24efa1303204da2ff9963ede58  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvInitSteps.fs
 87c4e6d86da1a67ba92b0fc4a89b3e160ee1aecff6a860e5179959620fab686f  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvInitUnitTests.fs
 7fd4b16aeef96322627d58ae7d3848af45c496881c43680d916d294b6216cb06  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvRestoreSteps.fs

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
@@ -37,8 +37,10 @@
 /// with the same invoke-at-most-once-when-a-real-conflict-exists contract.
 /// This PR additionally ports the `App`-surface-kind slice of `env validate`
 /// (code↔`.env.example` drift detection) for
-/// `env-validate-app-drift.feature`'s 3 scenarios; the `terraform`/`ansible`
-/// surface validators are out of scope, reserved for a later PR7.
+/// `env-validate-app-drift.feature`'s 3 scenarios. This PR (PR7) further
+/// ports the `Terraform`/`Ansible` env-contract validators
+/// (`env-contract/iac-env-validation.feature`), completing `env validate`'s
+/// three-way `SurfaceKind` dispatch.
 module RhinoCli.Application.Env
 
 open System
@@ -1003,13 +1005,9 @@ let restore (opts: EnvOptions) (confirm: unit -> bool) : Result<EnvOperationResu
 /// value in `repo-config.yml` [Repo-grounded —
 /// `apps/rhino-cli/src/application/env/validate.rs::SurfaceKind`].
 ///
-/// Only `App` is dispatched to a real validator by `validateAll` below —
-/// `Terraform`/`Ansible` surface validation is a separate, later PR7
-/// (`env-contract/iac-env-validation.feature`). Both variants are ported
-/// here anyway so this type stays complete for that later port to extend
-/// without a breaking rename, and so a surface's `kind:` YAML value
-/// round-trips correctly regardless of which kind it declares. No surface in
-/// this repo's live `env-contract:` section currently declares either.
+/// All three variants dispatch to a real validator in `validateAll` below:
+/// `App` to `validateAppSurface`, `Terraform` to `validateTerraform`, and
+/// `Ansible` to `validateAnsible`.
 type SurfaceKind =
     | App
     | Terraform
@@ -1035,10 +1033,10 @@ type SurfaceConfig =
 type Contract = { Surfaces: SurfaceConfig list }
 
 /// Drift direction for a [`Finding`] [Repo-grounded —
-/// `validate.rs::DriftKind`]. Only `DeclaredButUnread`/`ReadButUndeclared`
-/// are produced by this PR's `App`-surface validator below; the remaining
-/// three variants exist so the type is complete for PR7's terraform/ansible
-/// validators to extend without a breaking rename.
+/// `validate.rs::DriftKind`]. `DeclaredButUnread`/`ReadButUndeclared` are
+/// produced by the `App`-surface validator below; `ExampleNotDeclared`/
+/// `RequiredMissingFromExample` are produced by `validateTerraform`, and
+/// `ConsumedNotDeclared` by `validateAnsible`.
 type DriftKind =
     /// App: key present in `.env.example` but not consumed by any code in
     /// the surface.
@@ -1467,22 +1465,313 @@ let validateAppSurface (repoRoot: string) (surface: SurfaceConfig) : Result<Find
             |> List.sortWith (fun a b -> String.CompareOrdinal(a.Key, b.Key))
             |> Ok
 
-/// Validates every surface declared in `contract` [Repo-grounded —
-/// `validate.rs::validate_all`].
-///
-/// Only `App` surfaces are dispatched to a real validator: `Terraform`/
-/// `Ansible` surface validation is PR7 scope
-/// (`env-contract/iac-env-validation.feature`, porting the terraform/ansible
-/// validators at `validate.rs` lines ~430-1259). No surface in this repo's
-/// live `env-contract:` section currently declares either kind, so this
-/// raises a clear error rather than silently no-op-ing — surfacing a real
-/// gap immediately if that ever changes before PR7 lands, rather than
-/// masking it as a clean pass.
+// ---- iac validators ----
+
+/// Aggregated drift for a `Terraform` or `Ansible` surface [Repo-grounded —
+/// `validate.rs::ValidationResult`]. App-surface drift is reported directly
+/// through [`Finding`]/[`DriftKind`] by `validateAppSurface`; this record
+/// backs the IaC validators below and is converted into [`Finding`]s by
+/// [`resultToFindings`] for uniform reporting alongside app-surface findings.
+/// `DeclaredNotRead`/`ReadNotDeclared` exist for record completeness (the
+/// fields an app-surface result would populate in the Rust
+/// `#[derive(Default)]` struct this ports) but are never set by
+/// `validateTerraform`/`validateAnsible` below.
+type ValidationResult =
+    { SurfaceRoot: string
+      DeclaredNotRead: string list
+      ReadNotDeclared: string list
+      ExampleNotDeclared: string list
+      RequiredMissingFromExample: string list
+      ConsumedNotDeclared: string list }
+
+/// `true` when a [`ValidationResult`] carries no drift of any kind
+/// [Repo-grounded — `validate.rs::ValidationResult::is_clean`].
+module ValidationResult =
+    let isClean (result: ValidationResult) : bool =
+        List.isEmpty result.DeclaredNotRead
+        && List.isEmpty result.ReadNotDeclared
+        && List.isEmpty result.ExampleNotDeclared
+        && List.isEmpty result.RequiredMissingFromExample
+        && List.isEmpty result.ConsumedNotDeclared
+
+/// Converts a Terraform/Ansible [`ValidationResult`] into [`Finding`]s rooted
+/// at `surfaceRoot`, sorted by key [Repo-grounded —
+/// `validate.rs::result_to_findings`].
+let resultToFindings (surfaceRoot: string) (result: ValidationResult) : Finding list =
+    let exampleNotDeclared =
+        result.ExampleNotDeclared
+        |> List.map (fun key ->
+            { Root = surfaceRoot
+              Drift = ExampleNotDeclared
+              Key = key })
+
+    let requiredMissingFromExample =
+        result.RequiredMissingFromExample
+        |> List.map (fun key ->
+            { Root = surfaceRoot
+              Drift = RequiredMissingFromExample
+              Key = key })
+
+    let consumedNotDeclared =
+        result.ConsumedNotDeclared
+        |> List.map (fun key ->
+            { Root = surfaceRoot
+              Drift = ConsumedNotDeclared
+              Key = key })
+
+    exampleNotDeclared @ requiredMissingFromExample @ consumedNotDeclared
+    |> List.sortWith (fun a b -> String.CompareOrdinal(a.Key, b.Key))
+
+let private terraformVariableBlockRegex =
+    Regex(@"^\s*variable\s+""([A-Za-z_][A-Za-z0-9_]*)""\s*\{", RegexOptions.Compiled)
+
+let private terraformDefaultAssignmentRegex =
+    Regex(@"^\s*default\s*=", RegexOptions.Compiled)
+
+/// Counts the occurrences of `target` in `line`.
+let private countChar (target: char) (line: string) : int =
+    line |> Seq.filter (fun c -> c = target) |> Seq.length
+
+/// Scans every `*.tf` file recursively under `root` for `variable "KEY" { }`
+/// blocks, returning `(allDeclared, requiredOnly)` — `requiredOnly` is the
+/// subset of `allDeclared` whose block has no `default = ...` line anywhere
+/// inside it [Repo-grounded — `validate.rs::scan_terraform_variables`].
 ///
 /// # Errors
 ///
-/// Returns an error when any `App` surface fails validation, or a
-/// `Terraform`/`Ansible` surface is encountered before PR7 implements it.
+/// Returns an error when a `*.tf` file cannot be read.
+let scanTerraformVariables (root: string) : Result<Set<string> * Set<string>, string> =
+    try
+        let tfFiles =
+            allFilesUnder root
+            |> List.filter (fun p -> p.EndsWith(".tf", StringComparison.Ordinal))
+
+        let mutable allDeclared = Set.empty
+        let mutable required = Set.empty
+
+        for path in tfFiles do
+            let lines = File.ReadAllLines path
+            let mutable i = 0
+
+            while i < lines.Length do
+                let line = lines.[i]
+                let m = terraformVariableBlockRegex.Match line
+
+                if m.Success then
+                    let key = m.Groups.[1].Value
+                    allDeclared <- Set.add key allDeclared
+
+                    let mutable braceDepth = max 0 (countChar '{' line - countChar '}' line)
+                    let mutable hasDefault = false
+                    i <- i + 1
+
+                    while i < lines.Length && braceDepth > 0 do
+                        let inner = lines.[i]
+                        braceDepth <- max 0 (braceDepth + countChar '{' inner - countChar '}' inner)
+
+                        if terraformDefaultAssignmentRegex.IsMatch inner then
+                            hasDefault <- true
+
+                        i <- i + 1
+
+                    if not hasDefault then
+                        required <- Set.add key required
+                else
+                    i <- i + 1
+
+        Ok(allDeclared, required)
+    with ex ->
+        Error(sprintf "cannot read *.tf files under %s: %s" root ex.Message)
+
+let private tfvarsKeyRegex =
+    Regex(@"^([A-Za-z_][A-Za-z0-9_]*)\s*=", RegexOptions.Compiled)
+
+/// Parses `root/terraform.tfvars.example` for `KEY = ...` declarations,
+/// returning an empty set (not an error) when the file does not exist
+/// [Repo-grounded — `validate.rs::parse_tfvars_example`].
+///
+/// # Errors
+///
+/// Returns an error when the file exists but cannot be read.
+let parseTfvarsExample (root: string) : Result<Set<string>, string> =
+    let path = Path.Combine(root, "terraform.tfvars.example")
+
+    if not (File.Exists path) then
+        Ok Set.empty
+    else
+        try
+            File.ReadAllLines path
+            |> Array.filter (fun line ->
+                let trimmed = line.Trim()
+                trimmed <> "" && not (trimmed.StartsWith("#", StringComparison.Ordinal)))
+            |> Array.choose (fun line ->
+                let m = tfvarsKeyRegex.Match line
+                if m.Success then Some m.Groups.[1].Value else None)
+            |> Set.ofArray
+            |> Ok
+        with ex ->
+            Error(sprintf "cannot read %s: %s" path ex.Message)
+
+/// Validates a `Terraform`-kind surface: keys in `terraform.tfvars.example`
+/// with no matching `variable` block are [`ExampleNotDeclared`]; required
+/// variables (no `default`) missing from `terraform.tfvars.example` are
+/// [`RequiredMissingFromExample`] [Repo-grounded —
+/// `validate.rs::validate_terraform`]. Scans `root` directly (not
+/// `root/src`) — unlike the `App`-surface scanners above, a
+/// Terraform/Ansible surface's files live at its root.
+///
+/// # Errors
+///
+/// Returns an error when a `*.tf` file or `terraform.tfvars.example` cannot
+/// be read.
+let validateTerraform (root: string) (allowlist: string list) : Result<ValidationResult, string> =
+    match scanTerraformVariables root with
+    | Error e -> Error e
+    | Ok(declaredKeys, requiredKeys) ->
+        match parseTfvarsExample root with
+        | Error e -> Error e
+        | Ok exampleKeys ->
+            let allow = Set.ofList allowlist
+
+            let exampleNotDeclared =
+                Set.difference exampleKeys declaredKeys
+                |> Set.filter (fun key -> not (Set.contains key allow))
+                |> Set.toList
+                |> List.sortWith (fun a b -> String.CompareOrdinal(a, b))
+
+            let requiredMissingFromExample =
+                Set.difference requiredKeys exampleKeys
+                |> Set.filter (fun key -> not (Set.contains key allow))
+                |> Set.toList
+                |> List.sortWith (fun a b -> String.CompareOrdinal(a, b))
+
+            Ok
+                { SurfaceRoot = root
+                  DeclaredNotRead = []
+                  ReadNotDeclared = []
+                  ExampleNotDeclared = exampleNotDeclared
+                  RequiredMissingFromExample = requiredMissingFromExample
+                  ConsumedNotDeclared = [] }
+
+let private ansibleBuiltinLookupRegex =
+    Regex(@"lookup\(\s*'ansible\.builtin\.env'\s*,\s*'([A-Z_][A-Z0-9_]*)'\s*\)", RegexOptions.Compiled)
+
+let private ansibleShortLookupRegex =
+    Regex(@"lookup\(\s*'env'\s*,\s*'([A-Z_][A-Z0-9_]*)'\s*\)", RegexOptions.Compiled)
+
+/// Scans every `playbook-*.yml` file recursively under `root` for
+/// `lookup('ansible.builtin.env', 'KEY')` and `lookup('env', 'KEY')` calls
+/// [Repo-grounded — `validate.rs::scan_ansible_playbooks`].
+///
+/// # Errors
+///
+/// Returns an error when a playbook file cannot be read.
+let scanAnsiblePlaybooks (root: string) : Result<Set<string>, string> =
+    try
+        let playbookFiles =
+            allFilesUnder root
+            |> List.filter (fun p ->
+                let name = Path.GetFileName p
+
+                name.StartsWith("playbook-", StringComparison.Ordinal)
+                && name.EndsWith(".yml", StringComparison.Ordinal))
+
+        let keys = HashSet<string>()
+
+        for path in playbookFiles do
+            let content = File.ReadAllText path
+
+            for m in ansibleBuiltinLookupRegex.Matches content do
+                keys.Add(m.Groups.[1].Value) |> ignore
+
+            for m in ansibleShortLookupRegex.Matches content do
+                keys.Add(m.Groups.[1].Value) |> ignore
+
+        Ok(Set.ofSeq keys)
+    with ex ->
+        Error(sprintf "cannot read playbook files under %s: %s" root ex.Message)
+
+/// Parses `root/.env.example` for declared keys, treating a commented-out
+/// declaration (`# KEY=value`) as declared and returning an empty set (not
+/// an error) when the file does not exist [Repo-grounded —
+/// `validate.rs::parse_env_example_with_comments`]. Deliberately more
+/// permissive than [`parseDeclaredKeys`] above — no [`isEnvVarName`]
+/// filtering — ported separately because `validate.rs` itself keeps the two
+/// parsers distinct.
+///
+/// # Errors
+///
+/// Returns an error when the file exists but cannot be read.
+let parseEnvExampleWithComments (root: string) : Result<Set<string>, string> =
+    let path = Path.Combine(root, ".env.example")
+
+    if not (File.Exists path) then
+        Ok Set.empty
+    else
+        try
+            File.ReadAllLines path
+            |> Array.filter (fun line -> line.Trim() <> "")
+            |> Array.choose (fun line ->
+                let trimmed = line.Trim()
+
+                let effective =
+                    if trimmed.StartsWith("#", StringComparison.Ordinal) then
+                        trimmed.TrimStart('#').Trim()
+                    else
+                        trimmed
+
+                match effective.IndexOf('=') with
+                | -1 -> None
+                | eqPos ->
+                    let key = effective.Substring(0, eqPos).Trim()
+                    if key = "" then None else Some key)
+            |> Set.ofArray
+            |> Ok
+        with ex ->
+            Error(sprintf "cannot read %s: %s" path ex.Message)
+
+/// Validates an `Ansible`-kind surface: an env-var lookup in a playbook with
+/// no matching declaration in `.env.example` is [`ConsumedNotDeclared`]
+/// [Repo-grounded — `validate.rs::validate_ansible`]. Scans `root` directly,
+/// same rationale as [`validateTerraform`].
+///
+/// # Errors
+///
+/// Returns an error when a playbook or `.env.example` file cannot be read.
+let validateAnsible (root: string) (allowlist: string list) : Result<ValidationResult, string> =
+    match scanAnsiblePlaybooks root with
+    | Error e -> Error e
+    | Ok consumed ->
+        match parseEnvExampleWithComments root with
+        | Error e -> Error e
+        | Ok declared ->
+            let allow = Set.ofList allowlist
+
+            let consumedNotDeclared =
+                Set.difference consumed declared
+                |> Set.filter (fun key -> not (Set.contains key allow))
+                |> Set.toList
+                |> List.sortWith (fun a b -> String.CompareOrdinal(a, b))
+
+            Ok
+                { SurfaceRoot = root
+                  DeclaredNotRead = []
+                  ReadNotDeclared = []
+                  ExampleNotDeclared = []
+                  RequiredMissingFromExample = []
+                  ConsumedNotDeclared = consumedNotDeclared }
+
+/// Validates every surface declared in `contract`, dispatching on each
+/// surface's [`SurfaceKind`]: `App` surfaces run the code↔`.env.example`
+/// drift scan, `Terraform` and `Ansible` surfaces run the real IaC drift
+/// validators above [Repo-grounded — `validate.rs::validate_all`]. A repo
+/// that declares no `Terraform`/`Ansible` surfaces simply never invokes
+/// those validators — the no-op is driven by data (which surfaces are
+/// declared), not by a source stub.
+///
+/// # Errors
+///
+/// Returns an error when any surface fails validation.
 let validateAll (repoRoot: string) (contract: Contract) : Result<Finding list, string> =
     let rec go (surfaces: SurfaceConfig list) (acc: Finding list) : Result<Finding list, string> =
         match surfaces with
@@ -1493,13 +1782,13 @@ let validateAll (repoRoot: string) (contract: Contract) : Result<Finding list, s
                 match validateAppSurface repoRoot surface with
                 | Error e -> Error e
                 | Ok findings -> go rest (acc @ findings)
-            | Terraform
+            | Terraform ->
+                match validateTerraform (Path.Combine(repoRoot, surface.Root)) surface.Allowlist with
+                | Error e -> Error e
+                | Ok result -> go rest (acc @ resultToFindings surface.Root result)
             | Ansible ->
-                Error(
-                    sprintf
-                        "%s surface at \"%s\": terraform/ansible env-validate surfaces are PR7 scope, not yet implemented"
-                        (surface.Kind.ToString())
-                        surface.Root
-                )
+                match validateAnsible (Path.Combine(repoRoot, surface.Root)) surface.Allowlist with
+                | Error e -> Error e
+                | Ok result -> go rest (acc @ resultToFindings surface.Root result)
 
     go contract.Surfaces []

--- a/apps/rhino-cli/src-fsharp/project.json
+++ b/apps/rhino-cli/src-fsharp/project.json
@@ -112,7 +112,7 @@
     "specs:behavior:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-backup.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-init.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-restore.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-validate-app-drift.feature apps/rhino-cli/src-fsharp"
+        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-backup.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-init.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-restore.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env/env-validate-app-drift.feature specs/apps/rhino/behavior/rhino-cli/gherkin/env-contract/iac-env-validation.feature apps/rhino-cli/src-fsharp"
       },
       "cache": true,
       "inputs": ["{workspaceRoot}/specs/apps/rhino/behavior/rhino-cli/gherkin/**/*.feature", "{projectRoot}/**/*.fs"]

--- a/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+++ b/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
@@ -27,6 +27,8 @@
     <Compile Include="Steps/EnvRestoreUnitTests.fs" />
     <Compile Include="Steps/EnvValidateSteps.fs" />
     <Compile Include="Steps/EnvValidateUnitTests.fs" />
+    <Compile Include="Steps/EnvContractIacSteps.fs" />
+    <Compile Include="Steps/EnvContractIacUnitTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvContractIacSteps.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvContractIacSteps.fs
@@ -1,0 +1,234 @@
+/// TickSpec step definitions binding
+/// `iac-env-validation.feature`'s single scenario to
+/// `RhinoCli.Application.Env`'s `validateAll` dispatch [Repo-grounded —
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/env-contract/iac-env-validation.feature`,
+/// `apps/rhino-cli/src/application/env/validate.rs::validate_all`].
+///
+/// Follows `EnvValidateSteps.fs`'s `FeatureRunner`/`extractScenario`
+/// boilerplate convention: the scenario is extracted from the real, frozen
+/// feature file rather than a duplicated/rewritten copy of its wording. The
+/// scenario's "ose-private"/"ose-public" wording names narrative shapes, not
+/// this repository's live `repo-config.yml` — both sides are built as
+/// hermetic, synthetic fixtures under a temp directory so the test passes
+/// identically in either physical repo this code is mirrored into. "ose-
+/// private declares terraform and ansible surfaces" is modeled as one
+/// synthetic [`Contract`] whose `Terraform`/`Ansible` surfaces are backed by
+/// fixture files with a deliberate mismatch (so real drift exists);
+/// "ose-public, which declares no such surfaces" is modeled as a second
+/// synthetic [`Contract`] with an empty surface list.
+module RhinoCli.Tests.Unit.Steps.EnvContractIacSteps
+
+open System
+open System.IO
+open TickSpec
+open Xunit
+open RhinoCli.Application.Env
+
+/// Instance step-definition container — see `ConventionSteps.fs`'s module
+/// doc comment for why TickSpec's one-instance-per-scenario lifecycle makes
+/// instance-level mutable fields the idiomatic state-threading mechanism
+/// here.
+type EnvContractIacSteps() =
+    let mutable driftRepoRoot: string option = None
+    let mutable driftContract: Contract option = None
+    let mutable driftFindingsResult: Result<Finding list, string> option = None
+    let mutable ownedDirs: string list = []
+
+    let newTempDir (prefix: string) : string =
+        let dir =
+            Path.Combine(
+                Path.GetTempPath(),
+                "rhino-cli-env-contract-iac-" + prefix + "-" + Guid.NewGuid().ToString("N")
+            )
+
+        Directory.CreateDirectory(dir) |> ignore
+        ownedDirs <- dir :: ownedDirs
+        dir
+
+    let writeFile (root: string) (relativePath: string) (content: string) =
+        let full = Path.Combine(root, relativePath)
+        Directory.CreateDirectory(Path.GetDirectoryName(full)) |> ignore
+        File.WriteAllText(full, content)
+
+    // ---- Given ----
+
+    [<Given>]
+    member _.``ose-private declares terraform and ansible surfaces in repo-config.yml``() =
+        let root = newTempDir "with-drift"
+
+        // Terraform surface: `terraform.tfvars.example` declares BOGUS_KEY
+        // (no matching `variable` block: ExampleNotDeclared) and omits
+        // REQUIRED_KEY, which has no `default` (RequiredMissingFromExample).
+        writeFile
+            root
+            "infra/terraform-surface/main.tf"
+            "variable \"DECLARED_KEY\" {\n  default = \"value\"\n}\n\nvariable \"REQUIRED_KEY\" {\n  description = \"no default, so required\"\n}\n"
+
+        writeFile root "infra/terraform-surface/terraform.tfvars.example" "DECLARED_KEY = \"x\"\nBOGUS_KEY = \"y\"\n"
+
+        // Ansible surface: playbook consumes CONSUMED_KEY via
+        // `lookup('ansible.builtin.env', ...)`, absent from `.env.example`
+        // (ConsumedNotDeclared).
+        writeFile
+            root
+            "infra/ansible-surface/playbook-deploy.yml"
+            "- name: deploy\n  tasks:\n    - debug: msg={{ lookup('ansible.builtin.env', 'CONSUMED_KEY') }}\n"
+
+        writeFile root "infra/ansible-surface/.env.example" "# no vars declared\n"
+
+        driftRepoRoot <- Some root
+
+        driftContract <-
+            Some
+                { Surfaces =
+                    [ { Root = "infra/terraform-surface"
+                        Kind = Terraform
+                        Lang = ""
+                        Allowlist = [] }
+                      { Root = "infra/ansible-surface"
+                        Kind = Ansible
+                        Lang = ""
+                        Allowlist = [] } ] }
+
+    // ---- When ----
+
+    [<When>]
+    member _.``env validate runs``() =
+        let root =
+            match driftRepoRoot with
+            | Some r -> r
+            | None -> failwith "no repo root has been prepared by a Given step"
+
+        let contract =
+            match driftContract with
+            | Some c -> c
+            | None -> failwith "no contract has been prepared by a Given step"
+
+        driftFindingsResult <- Some(validateAll root contract)
+
+    // ---- Then ----
+
+    [<Then>]
+    member _.``validate_terraform and validate_ansible execute and report drift``() =
+        let findings =
+            match driftFindingsResult with
+            | Some(Ok findings) -> findings
+            | Some(Error message) ->
+                failwith (sprintf "expected env validate to return findings, got error: %s" message)
+            | None -> failwith "no command has been run by a When step"
+
+        Assert.NotEmpty findings
+
+        Assert.Contains(
+            findings,
+            fun (f: Finding) ->
+                f.Drift = ExampleNotDeclared
+                && f.Key = "BOGUS_KEY"
+                && f.Root = "infra/terraform-surface"
+        )
+
+        Assert.Contains(
+            findings,
+            fun (f: Finding) ->
+                f.Drift = RequiredMissingFromExample
+                && f.Key = "REQUIRED_KEY"
+                && f.Root = "infra/terraform-surface"
+        )
+
+        Assert.Contains(
+            findings,
+            fun (f: Finding) ->
+                f.Drift = ConsumedNotDeclared
+                && f.Key = "CONSUMED_KEY"
+                && f.Root = "infra/ansible-surface"
+        )
+
+    [<Then>]
+    member _.``ose-public, which declares no such surfaces, skips validation by data, not by stub``() =
+        let root = newTempDir "without-surfaces"
+        let emptyContract: Contract = { Surfaces = [] }
+
+        match validateAll root emptyContract with
+        | Ok findings -> Assert.Empty findings
+        | Error message ->
+            Assert.Fail(
+                sprintf
+                    "expected a repo with no terraform/ansible surfaces to validate cleanly (skip by data), got error: %s"
+                    message
+            )
+
+    [<AfterScenario>]
+    member _.Cleanup() =
+        for dir in ownedDirs do
+            if Directory.Exists dir then
+                Directory.Delete(dir, true)
+
+/// Reads the single `Scenario:` block out of the real, frozen
+/// `iac-env-validation.feature` file (leaving the file itself untouched) and
+/// runs it through TickSpec bound only against `EnvContractIacSteps` — see
+/// `EnvValidateSteps.fs`'s `FeatureRunner` for why this is per-scenario
+/// rather than per-file.
+module private FeatureRunner =
+
+    let private featurePath: string =
+        Path.GetFullPath(
+            Path.Combine(
+                __SOURCE_DIRECTORY__,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "specs",
+                "apps",
+                "rhino",
+                "behavior",
+                "rhino-cli",
+                "gherkin",
+                "env-contract",
+                "iac-env-validation.feature"
+            )
+        )
+
+    let private extractScenario (featureLines: string[]) (scenarioTitle: string) : string[] =
+        let featureLine =
+            featureLines
+            |> Array.find (fun l -> l.TrimStart().StartsWith("Feature:", StringComparison.Ordinal))
+
+        let scenarioHeader = sprintf "Scenario: %s" scenarioTitle
+
+        let startIdx = featureLines |> Array.findIndex (fun l -> l.Trim() = scenarioHeader)
+
+        let endIdx =
+            featureLines
+            |> Array.skip (startIdx + 1)
+            |> Array.tryFindIndex (fun l ->
+                let trimmed = l.Trim()
+
+                trimmed.StartsWith("Scenario:", StringComparison.Ordinal)
+                || trimmed.StartsWith("Scenario Outline:", StringComparison.Ordinal)
+                // iac-env-validation.feature tags only the feature itself
+                // (`@env-contract-iac`), with no per-scenario tags — a
+                // `@`-prefixed line still ends the slice, matching
+                // `EnvValidateSteps.fs`'s tag-aware convention, even though
+                // no scenario here actually carries one.
+                || trimmed.StartsWith("@", StringComparison.Ordinal))
+            |> Option.map (fun relativeIdx -> startIdx + 1 + relativeIdx)
+            |> Option.defaultValue featureLines.Length
+
+        Array.append [| featureLine; "" |] featureLines.[startIdx .. endIdx - 1]
+
+    /// Runs the single scenario named `scenarioTitle` from
+    /// `iac-env-validation.feature`, bound against `EnvContractIacSteps`.
+    let run (scenarioTitle: string) : unit =
+        let allLines = File.ReadAllLines featurePath
+        let snippet = extractScenario allLines scenarioTitle
+        let definitions = StepDefinitions([| typeof<EnvContractIacSteps> |])
+        let feature = definitions.GenerateFeature(featurePath, snippet)
+        let scenario = Seq.exactlyOne feature.Scenarios
+        scenario.Action.Invoke()
+
+[<Fact>]
+let ``IaC env-validation is preserved in the canonical`` () =
+    FeatureRunner.run "IaC env-validation is preserved in the canonical"

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvContractIacUnitTests.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvContractIacUnitTests.fs
@@ -1,0 +1,386 @@
+/// Plain xunit tests for `RhinoCli.Application.Env`'s `Terraform`/`Ansible`
+/// env-contract validators — behaviour with no dedicated Gherkin scenario,
+/// or exercised only indirectly there (mirrors the rationale
+/// `EnvValidateUnitTests.fs`'s module doc comment states for its own split
+/// from `EnvValidateSteps.fs`). Ported case-for-case from
+/// `apps/rhino-cli/src/application/env/validate.rs`'s `#[cfg(test)] mod
+/// tests::terraform_validator`/`mod tests::ansible_validator` [Repo-grounded
+/// — `apps/rhino-cli/src/application/env/validate.rs`].
+module RhinoCli.Tests.Unit.Steps.EnvContractIacUnitTests
+
+open System
+open System.IO
+open Xunit
+open RhinoCli.Application.Env
+
+let private newTempDir () : string =
+    let dir =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-env-contract-iac-unit-" + Guid.NewGuid().ToString("N"))
+
+    Directory.CreateDirectory(dir) |> ignore
+    dir
+
+let private writeFile (root: string) (relativePath: string) (content: string) =
+    let full = Path.Combine(root, relativePath)
+    Directory.CreateDirectory(Path.GetDirectoryName(full)) |> ignore
+    File.WriteAllText(full, content)
+
+// ---- scanTerraformVariables ----
+
+[<Fact>]
+let ``scanTerraformVariables detects a variable with a default as declared but not required`` () =
+    let root = newTempDir ()
+    writeFile root "main.tf" "variable \"OPTIONAL_KEY\" {\n  default = \"fallback\"\n}\n"
+
+    match scanTerraformVariables root with
+    | Ok(declared, required) ->
+        Assert.Contains("OPTIONAL_KEY", declared)
+        Assert.DoesNotContain("OPTIONAL_KEY", required)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanTerraformVariables detects a variable with no default as required`` () =
+    let root = newTempDir ()
+    writeFile root "main.tf" "variable \"REQUIRED_KEY\" {\n  description = \"required\"\n}\n"
+
+    match scanTerraformVariables root with
+    | Ok(declared, required) ->
+        Assert.Contains("REQUIRED_KEY", declared)
+        Assert.Contains("REQUIRED_KEY", required)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanTerraformVariables returns empty sets when no .tf file exists`` () =
+    let root = newTempDir ()
+
+    match scanTerraformVariables root with
+    | Ok(declared, required) ->
+        Assert.Empty(declared)
+        Assert.Empty(required)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+// ---- parseTfvarsExample ----
+
+[<Fact>]
+let ``parseTfvarsExample collects a KEY = value declaration`` () =
+    let root = newTempDir ()
+    writeFile root "terraform.tfvars.example" "DB_URL = \"x\"\n"
+
+    match parseTfvarsExample root with
+    | Ok keys -> Assert.Contains("DB_URL", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``parseTfvarsExample ignores a comment line`` () =
+    let root = newTempDir ()
+    writeFile root "terraform.tfvars.example" "# empty\n"
+
+    match parseTfvarsExample root with
+    | Ok keys -> Assert.Empty(keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``parseTfvarsExample returns an empty set, not an error, when the file does not exist`` () =
+    let root = newTempDir ()
+
+    match parseTfvarsExample root with
+    | Ok keys -> Assert.Empty(keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+// ---- validateTerraform ----
+
+[<Fact>]
+let ``validateTerraform flags a tfvars key with no matching variable block as example-not-declared`` () =
+    let root = newTempDir ()
+    writeFile root "terraform.tfvars.example" "BOGUS = \"x\"\n"
+    writeFile root "main.tf" "# no variables\n"
+
+    match validateTerraform root [] with
+    | Ok result -> Assert.Contains("BOGUS", result.ExampleNotDeclared)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``validateTerraform flags a required variable missing from tfvars as required-missing-from-example`` () =
+    let root = newTempDir ()
+    writeFile root "main.tf" "variable \"REQUIRED_KEY\" {\n  description = \"required\"\n}\n"
+    writeFile root "terraform.tfvars.example" "# empty\n"
+
+    match validateTerraform root [] with
+    | Ok result -> Assert.Contains("REQUIRED_KEY", result.RequiredMissingFromExample)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``validateTerraform does not flag an optional variable absent from tfvars`` () =
+    let root = newTempDir ()
+    writeFile root "main.tf" "variable \"OPTIONAL_KEY\" {\n  default = \"fallback\"\n}\n"
+    writeFile root "terraform.tfvars.example" "# empty\n"
+
+    match validateTerraform root [] with
+    | Ok result -> Assert.Empty(result.RequiredMissingFromExample)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``validateTerraform is clean when the tf variable and tfvars example match`` () =
+    let root = newTempDir ()
+    writeFile root "main.tf" "variable \"DB_URL\" {\n  description = \"db\"\n}\n"
+    writeFile root "terraform.tfvars.example" "DB_URL = \"x\"\n"
+
+    match validateTerraform root [] with
+    | Ok result -> Assert.True(ValidationResult.isClean result, "expected a clean result")
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``validateTerraform omits an allowlisted example-not-declared key`` () =
+    let root = newTempDir ()
+    writeFile root "terraform.tfvars.example" "ALLOWED = \"x\"\n"
+    writeFile root "main.tf" "# no variables\n"
+
+    match validateTerraform root [ "ALLOWED" ] with
+    | Ok result -> Assert.Empty(result.ExampleNotDeclared)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+// ---- scanAnsiblePlaybooks ----
+
+[<Fact>]
+let ``scanAnsiblePlaybooks detects the ansible.builtin.env lookup form`` () =
+    let root = newTempDir ()
+
+    writeFile
+        root
+        "playbook-site.yml"
+        "- name: test\n  tasks:\n    - debug: msg={{ lookup('ansible.builtin.env', 'FULL_KEY') }}\n"
+
+    match scanAnsiblePlaybooks root with
+    | Ok keys -> Assert.Contains("FULL_KEY", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanAnsiblePlaybooks detects the short env lookup form`` () =
+    let root = newTempDir ()
+    writeFile root "playbook-deploy.yml" "tasks:\n  - set_fact: val={{ lookup('env', 'SHORT_KEY') }}\n"
+
+    match scanAnsiblePlaybooks root with
+    | Ok keys -> Assert.Contains("SHORT_KEY", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``scanAnsiblePlaybooks skips a non-playbook file`` () =
+    let root = newTempDir ()
+    writeFile root "vars.yml" "tasks:\n  - debug: msg={{ lookup('env', 'SKIPPED_KEY') }}\n"
+
+    match scanAnsiblePlaybooks root with
+    | Ok keys -> Assert.DoesNotContain("SKIPPED_KEY", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+// ---- parseEnvExampleWithComments ----
+
+[<Fact>]
+let ``parseEnvExampleWithComments counts a commented-out declaration as declared`` () =
+    let root = newTempDir ()
+    writeFile root ".env.example" "# OPTIONAL_KEY=xxx\n"
+
+    match parseEnvExampleWithComments root with
+    | Ok keys -> Assert.Contains("OPTIONAL_KEY", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``parseEnvExampleWithComments counts an active declaration as declared`` () =
+    let root = newTempDir ()
+    writeFile root ".env.example" "SHORT_KEY=val\n"
+
+    match parseEnvExampleWithComments root with
+    | Ok keys -> Assert.Contains("SHORT_KEY", keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``parseEnvExampleWithComments returns an empty set, not an error, when the file does not exist`` () =
+    let root = newTempDir ()
+
+    match parseEnvExampleWithComments root with
+    | Ok keys -> Assert.Empty(keys)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+// ---- validateAnsible ----
+
+[<Fact>]
+let ``validateAnsible flags a playbook lookup absent from .env.example as consumed-not-declared`` () =
+    let root = newTempDir ()
+
+    writeFile
+        root
+        "playbook-site.yml"
+        "- name: test\n  tasks:\n    - debug: msg={{ lookup('ansible.builtin.env', 'UNDECLARED') }}\n"
+
+    writeFile root ".env.example" "# no vars\n"
+
+    match validateAnsible root [] with
+    | Ok result -> Assert.Contains("UNDECLARED", result.ConsumedNotDeclared)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``validateAnsible treats a commented-out .env.example key as declared`` () =
+    let root = newTempDir ()
+    writeFile root ".env.example" "# OPTIONAL_KEY=xxx\n"
+
+    writeFile root "playbook-site.yml" "- name: test\n  tasks:\n    - debug: msg={{ lookup('env', 'OPTIONAL_KEY') }}\n"
+
+    match validateAnsible root [] with
+    | Ok result -> Assert.Empty(result.ConsumedNotDeclared)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``validateAnsible is clean when the short lookup syntax matches .env.example`` () =
+    let root = newTempDir ()
+    writeFile root ".env.example" "SHORT_KEY=val\n"
+    writeFile root "playbook-deploy.yml" "tasks:\n  - set_fact: val={{ lookup('env', 'SHORT_KEY') }}\n"
+
+    match validateAnsible root [] with
+    | Ok result -> Assert.True(ValidationResult.isClean result, "expected a clean result")
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``validateAnsible does not scan a non-playbook file`` () =
+    let root = newTempDir ()
+    writeFile root "vars.yml" "tasks:\n  - debug: msg={{ lookup('env', 'SKIPPED_KEY') }}\n"
+    writeFile root ".env.example" "# nothing\n"
+
+    match validateAnsible root [] with
+    | Ok result -> Assert.Empty(result.ConsumedNotDeclared)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``validateAnsible omits an allowlisted consumed-not-declared key`` () =
+    let root = newTempDir ()
+
+    writeFile root "playbook-site.yml" "- name: test\n  tasks:\n    - debug: msg={{ lookup('env', 'ALLOWED_KEY') }}\n"
+
+    writeFile root ".env.example" "# no vars\n"
+
+    match validateAnsible root [ "ALLOWED_KEY" ] with
+    | Ok result -> Assert.Empty(result.ConsumedNotDeclared)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+// ---- ValidationResult.isClean ----
+
+[<Fact>]
+let ``ValidationResult isClean is true when all five lists are empty`` () =
+    let result =
+        { SurfaceRoot = "surface"
+          DeclaredNotRead = []
+          ReadNotDeclared = []
+          ExampleNotDeclared = []
+          RequiredMissingFromExample = []
+          ConsumedNotDeclared = [] }
+
+    Assert.True(ValidationResult.isClean result)
+
+[<Fact>]
+let ``ValidationResult isClean is false when any one list is non-empty`` () =
+    let result =
+        { SurfaceRoot = "surface"
+          DeclaredNotRead = []
+          ReadNotDeclared = []
+          ExampleNotDeclared = [ "SOME_KEY" ]
+          RequiredMissingFromExample = []
+          ConsumedNotDeclared = [] }
+
+    Assert.False(ValidationResult.isClean result)
+
+// ---- resultToFindings ----
+
+[<Fact>]
+let ``resultToFindings converts all three IaC drift lists into tagged, sorted Findings`` () =
+    let result =
+        { SurfaceRoot = "surface"
+          DeclaredNotRead = []
+          ReadNotDeclared = []
+          ExampleNotDeclared = [ "ZEBRA_EXAMPLE" ]
+          RequiredMissingFromExample = [ "ALPHA_REQUIRED" ]
+          ConsumedNotDeclared = [ "MID_CONSUMED" ] }
+
+    let findings = resultToFindings "surface" result
+
+    Assert.Equal<string list>(
+        [ "ALPHA_REQUIRED"; "MID_CONSUMED"; "ZEBRA_EXAMPLE" ],
+        findings |> List.map (fun f -> f.Key)
+    )
+
+    Assert.Contains(findings, fun (f: Finding) -> f.Drift = ExampleNotDeclared && f.Key = "ZEBRA_EXAMPLE")
+    Assert.Contains(findings, fun (f: Finding) -> f.Drift = RequiredMissingFromExample && f.Key = "ALPHA_REQUIRED")
+    Assert.Contains(findings, fun (f: Finding) -> f.Drift = ConsumedNotDeclared && f.Key = "MID_CONSUMED")
+
+[<Fact>]
+let ``resultToFindings returns an empty list for a clean ValidationResult`` () =
+    let result =
+        { SurfaceRoot = "surface"
+          DeclaredNotRead = []
+          ReadNotDeclared = []
+          ExampleNotDeclared = []
+          RequiredMissingFromExample = []
+          ConsumedNotDeclared = [] }
+
+    Assert.Empty(resultToFindings "surface" result)
+
+// ---- validateAll dispatch ----
+
+[<Fact>]
+let ``validateAll dispatches a Terraform surface to validateTerraform and reports its drift`` () =
+    let repoRoot = newTempDir ()
+    writeFile repoRoot "infra/terraform-surface/terraform.tfvars.example" "BOGUS = \"x\"\n"
+    writeFile repoRoot "infra/terraform-surface/main.tf" "# no variables\n"
+
+    let contract: Contract =
+        { Surfaces =
+            [ { Root = "infra/terraform-surface"
+                Kind = Terraform
+                Lang = ""
+                Allowlist = [] } ] }
+
+    match validateAll repoRoot contract with
+    | Ok findings ->
+        Assert.Contains(
+            findings,
+            fun (f: Finding) ->
+                f.Drift = ExampleNotDeclared
+                && f.Key = "BOGUS"
+                && f.Root = "infra/terraform-surface"
+        )
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``validateAll dispatches an Ansible surface to validateAnsible and reports its drift`` () =
+    let repoRoot = newTempDir ()
+
+    writeFile
+        repoRoot
+        "infra/ansible-surface/playbook-site.yml"
+        "- name: test\n  tasks:\n    - debug: msg={{ lookup('env', 'UNDECLARED') }}\n"
+
+    writeFile repoRoot "infra/ansible-surface/.env.example" "# no vars\n"
+
+    let contract: Contract =
+        { Surfaces =
+            [ { Root = "infra/ansible-surface"
+                Kind = Ansible
+                Lang = ""
+                Allowlist = [] } ] }
+
+    match validateAll repoRoot contract with
+    | Ok findings ->
+        Assert.Contains(
+            findings,
+            fun (f: Finding) ->
+                f.Drift = ConsumedNotDeclared
+                && f.Key = "UNDECLARED"
+                && f.Root = "infra/ansible-surface"
+        )
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``validateAll returns no findings, not an error, when the contract declares zero surfaces`` () =
+    let repoRoot = newTempDir ()
+    let contract: Contract = { Surfaces = [] }
+
+    match validateAll repoRoot contract with
+    | Ok findings -> Assert.Empty(findings)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)

--- a/repo-config.yml
+++ b/repo-config.yml
@@ -169,7 +169,7 @@ coverage:
     # option that does not regress the still-canonical Rust side.
     - name: rhino-cli-fsharp
       levels: [unit, integration]
-      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention/**,repo-config/**,repo-config-validate/**,env/env-backup.feature,env/env-init.feature,env/env-restore.feature,env/env-validate-app-drift.feature}"
+      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention/**,repo-config/**,repo-config-validate/**,env/env-backup.feature,env/env-init.feature,env/env-restore.feature,env/env-validate-app-drift.feature,env-contract/iac-env-validation.feature}"
 
     # ose domain
     - name: ose-be


### PR DESCRIPTION
## Summary
- Ports the Terraform and Ansible IaC surface validators (`ValidationResult`, `resultToFindings`, `scanTerraformVariables`, `parseTfvarsExample`, `validateTerraform`, `scanAnsiblePlaybooks`, `parseEnvExampleWithComments`, `validateAnsible`) to F#, completing `env validate`'s three-way `SurfaceKind` dispatch started in PR6 (`App`/`Terraform`/`Ansible` all now dispatch to real validators — no more placeholder error).
- Satisfies `env-contract/iac-env-validation.feature`'s single scenario.
- The scenario's "ose-private"/"ose-public" wording names narrative shapes (a repo with vs. without terraform/ansible surfaces declared), not either repo's live `repo-config.yml` — both sides are modeled as hermetic synthetic `Contract` fixtures under a temp directory, so the test passes identically in whichever physical repo this code is mirrored into (ose-private's real `env-contract:` section does declare both kinds; ose-public's does not — confirmed via direct inspection, not asserted on at test time).

## Cost/benefit
New F# code ported line-for-line from `apps/rhino-cli/src/application/env/validate.rs`'s Terraform/Ansible validator sections (originally ported into that Rust file from ose-private). No new runtime dependencies. Cost is the added `Env.fs` surface area (+353/-37 net) and two new test files, offset by closing Wave B's final `env`/`env-contract` Gherkin scenario.

## Test plan
- [x] `nx run rhino-cli-fsharp:typecheck` — 0 errors
- [x] `nx run rhino-cli-fsharp:lint` (fantomas, fsharplint, G-Research analyzers) — 0 warnings
- [x] `nx run rhino-cli-fsharp:test:unit` — 307/307 passed
- [x] `nx run rhino-cli-fsharp:test:coverage` — 92.09% line coverage (≥90% threshold)
- [x] `nx run rhino-cli-fsharp:specs:behavior:coverage` — all covered after widening `--shared-steps`/`repo-config.yml` glob
- [x] `nx run rhino-cli-fsharp:specs:structure-validation` — 0 findings
- [x] `nx run-many -t test:quick -p rhino-cli,rhino-cli-fsharp` — both projects pass
- [x] Parity manifest regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)