### PR TITLE
docs(plans): relocate env-staged-guard to wave B per DD-4

### DIFF
--- a/plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md
+++ b/plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md
@@ -269,10 +269,10 @@ the Phase 2 gate re-measures them so a spec change during execution cannot silen
 | Wave  | Phase | Spec directories                                                           | Scenarios | Feature files | Namespaces flipped at the end of the wave |
 | ----- | ----- | -------------------------------------------------------------------------- | --------- | ------------- | ----------------------------------------- |
 | A     | 3     | `convention`                                                               | 11        | 3             | `convention`, `parity`                    |
-| B     | 4     | `repo-config`, `repo-config-validate`, `env`, `env-contract`               | 59        | 7             | `repo-config`, `env`                      |
+| B     | 4     | `repo-config`, `repo-config-validate`, `env`, `env-contract`               | 62        | 8             | `repo-config`, `env`                      |
 | C     | 5     | `system`, `test-coverage`                                                  | 53        | 6             | `doctor`, `test-coverage`                 |
 | D     | 6     | `md`, `governance`, `git` (resequenced)                                    | 128       | 11            | `md`, `governance`, `git`                 |
-| E     | 7     | `harness`, `specs`, `spec-coverage`, `contracts`, `repo-governance`, `ddd` | 188       | 38            | `harness`, `specs`, `repo-governance`     |
+| E     | 7     | `harness`, `specs`, `spec-coverage`, `contracts`, `repo-governance`, `ddd` | 185       | 37            | `harness`, `specs`, `repo-governance`     |
 | F     | 8     | `gate`                                                                     | 89        | 7             | `gate`                                    |
 | Total |       |                                                                            | **528**   | **72**        | all 13                                    |
 
@@ -1228,9 +1228,16 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
 
 ## Phase 4: Wave B — `repo-config`, `repo-config-validate`, `env`, `env-contract`
 
-> **59 scenarios across 7 feature files**
-> [Repo-grounded — counted over `specs/apps/rhino/behavior/rhino-cli/gherkin/`].
-> **PR seam**: one feature file is one PR, so this wave is 7 implementation PRs
+> **62 scenarios across 8 feature files**
+> [Repo-grounded — counted over `specs/apps/rhino/behavior/rhino-cli/gherkin/`]. Includes
+> `specs/env-staged-guard.feature` (3 scenarios) — its Gherkin file sits under the `gherkin/specs/`
+> directory for historical reasons, but its CLI verb is `env staged-guard validate`, and
+> [tech-docs.md DD-4](./tech-docs.md)'s ~1,598-LOC Wave B figure already sums in
+> `env_staged_guard.rs`'s 210 lines. An earlier draft of this checklist misfiled its cycles under
+> Phase 7 (Wave E) by directory instead of by CLI namespace; relocated here to match DD-4 before
+> Wave B's flip, since `rhino-bin.sh` routes `FSHARP_NAMESPACES` on argv[0] only — flipping `env`
+> without `staged-guard` ported would silently break the pre-commit hook's real-`.env`-file guard.
+> **PR seam**: one feature file is one PR, so this wave is 8 implementation PRs
 > plus one flip PR.
 >
 > `env` touches real `.env*` files. Every fixture is a temporary directory; no scenario in this wave may read or write a real `.env` outside the fixture root.
@@ -2729,16 +2736,104 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Env.fs` formats no output itself.
 
+#### `specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature` — 3 scenarios
+
+> **PR seam**: the cycles under this heading are one PR. Relocated from Phase 7 (Wave E) — see the
+> Phase 4 header note above.
+
+- [ ] [AI] **RED**: Add the step definitions for this scenario in
+      `apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvStagedGuardSteps.fs`
+      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
+      — acceptance: this scenario fails because `RhinoCli.Application.Env` does not implement it.
+      **Gherkin (binds) →** "Committing a real .env file is rejected" — `specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature`
+
+  ```gherkin
+    Scenario: Committing a real .env file is rejected
+      Given a real .env file is staged for commit
+      When the pre-commit hook runs rhino-cli env staged-guard validate
+      Then it exits non-zero and names the offending file
+      And the commit is aborted
+  ```
+
+- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+      `apps/rhino-cli/src-fsharp/RhinoCli.Application/Env.fs`
+      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
+      — acceptance: this scenario passes and no previously passing scenario breaks.
+
+- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+      `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
+      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
+      — acceptance: all tests still pass and `Env.fs` formats no output itself.
+
+- [ ] [AI] **RED**: Add the step definitions for this scenario in
+      `apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvStagedGuardSteps.fs`
+      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
+      — acceptance: this scenario fails because `RhinoCli.Application.Env` does not implement it.
+      **Gherkin (binds) →** "Staging .env.example is allowed" — `specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature`
+
+  ```gherkin
+    Scenario: Staging .env.example is allowed
+      Given only .env.example is staged for commit
+      When the pre-commit hook runs rhino-cli env staged-guard validate
+      Then it exits zero and does not block the commit
+  ```
+
+- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+      `apps/rhino-cli/src-fsharp/RhinoCli.Application/Env.fs`
+      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
+      — acceptance: this scenario passes and no previously passing scenario breaks.
+
+- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+      `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
+      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
+      — acceptance: all tests still pass and `Env.fs` formats no output itself.
+
+- [ ] [AI] **RED**: Add the step definitions for this scenario in
+      `apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvStagedGuardSteps.fs`
+      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
+      — acceptance: this scenario fails because `RhinoCli.Application.Env` does not implement it.
+      **Gherkin (binds) →** "Staging any real env file is rejected at commit time" — `specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature`
+
+  ```gherkin
+    Scenario Outline: Staging any real env file is rejected at commit time
+      Given a git index with "<file>" staged
+      When "rhino-cli env staged-guard validate" runs
+      Then the command exits non-zero
+      And the output names "<file>" as offending
+
+      Examples:
+        | file              |
+        | .env              |
+        | .env.local        |
+        | .env.test         |
+        | .env.prod         |
+        | .env.stag         |
+        | apps/x/.env.local |
+  ```
+
+- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+      `apps/rhino-cli/src-fsharp/RhinoCli.Application/Env.fs`
+      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
+      — acceptance: this scenario passes and no previously passing scenario breaks.
+
+- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+      `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
+      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
+      — acceptance: all tests still pass and `Env.fs` formats no output itself.
+
 ### Wave B integration
 
 > **PR seam**: the flip is its own PR, separate from the implementation PRs above. It is a
 > shim edit plus measurements, so it stays far inside the size bound, and it is the single
 > commit a reviewer reverts to withdraw the wave.
 
-- [ ] [AI] Widen the coverage scope by exactly this wave's spec directories — `repo-config/`, `repo-config-validate/`, `env/`, and `env-contract/` — in
-      **both** places, in this same PR: `rhino-cli-fsharp`'s `specs:behavior:coverage` specs-dirs
-      argument and its `repo-config.yml` `coverage.projects` glob. Widening one without the other
-      either leaves scenarios unmeasured or fails the level-envelope check — acceptance:
+- [ ] [AI] Widen the coverage scope by exactly this wave's spec directories — `repo-config/`,
+      `repo-config-validate/`, `env/`, and `env-contract/` — plus the one file-scoped exception
+      `specs/env-staged-guard.feature` (it lives under `gherkin/specs/`, a directory Wave E also
+      owns feature files in, so it is added by file, not by widening the whole `specs/` directory
+      early) — in **both** places, in this same PR: `rhino-cli-fsharp`'s `specs:behavior:coverage`
+      specs-dirs argument and its `repo-config.yml` `coverage.projects` glob. Widening one without
+      the other either leaves scenarios unmeasured or fails the level-envelope check — acceptance:
       `npx nx run rhino-cli-fsharp:specs:behavior:coverage` exits 0 **and** reports a scenario count
       equal to this wave's count from the wave map, and temporarily deleting one **step definition** from a
       wave-B `Steps/*.fs` file turns it red with a `Missing steps` count, restored afterwards.
@@ -2787,7 +2882,7 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
 
 > All checks below must pass before starting Phase 5.
 
-- [ ] [AI] All 59 Wave B scenarios pass under
+- [ ] [AI] All 62 Wave B scenarios pass under
       `dotnet test apps/rhino-cli/src-fsharp/tests/unit` in both repos.
 - [ ] [AI] `apps/rhino-cli/scripts/shadow-diff.sh repo-config env` reports zero differences in both
       repos.
@@ -7468,9 +7563,11 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
 
 ## Phase 7: Wave E — `harness`, `specs`, `spec-coverage`, `contracts`, `repo-governance`, `ddd`
 
-> **188 scenarios across 38 feature files**
-> [Repo-grounded — counted over `specs/apps/rhino/behavior/rhino-cli/gherkin/`].
-> **PR seam**: one feature file is one PR, so this wave is 38 implementation PRs
+> **185 scenarios across 37 feature files**
+> [Repo-grounded — counted over `specs/apps/rhino/behavior/rhino-cli/gherkin/`]. Excludes
+> `specs/env-staged-guard.feature` (3 scenarios), relocated to Phase 4 (Wave B) — see that phase's
+> header note.
+> **PR seam**: one feature file is one PR, so this wave is 37 implementation PRs
 > plus one flip PR.
 >
 > The largest wave, 38 feature files. `harness` generates the binding mirrors, so a defect here corrupts `.opencode/`, `.codex/`, and `.agents/`; the wave gate re-runs `npm run generate:bindings` and asserts a clean `git diff`.
@@ -10011,90 +10108,6 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Specs.fs` formats no output itself.
 
-#### `specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature` — 3 scenarios
-
-> **PR seam**: the cycles under this heading are one PR.
-
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
-      `apps/rhino-cli/src-fsharp/tests/unit/Steps/SpecsSteps.fs`
-      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
-      — acceptance: this scenario fails because `RhinoCli.Application.Specs` does not implement it.
-      **Gherkin (binds) →** "Committing a real .env file is rejected" — `specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature`
-
-  ```gherkin
-    Scenario: Committing a real .env file is rejected
-      Given a real .env file is staged for commit
-      When the pre-commit hook runs rhino-cli env staged-guard validate
-      Then it exits non-zero and names the offending file
-      And the commit is aborted
-  ```
-
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
-      `apps/rhino-cli/src-fsharp/RhinoCli.Application/Specs.fs`
-      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
-      — acceptance: this scenario passes and no previously passing scenario breaks.
-
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
-      `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
-      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
-      — acceptance: all tests still pass and `Specs.fs` formats no output itself.
-
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
-      `apps/rhino-cli/src-fsharp/tests/unit/Steps/SpecsSteps.fs`
-      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
-      — acceptance: this scenario fails because `RhinoCli.Application.Specs` does not implement it.
-      **Gherkin (binds) →** "Staging .env.example is allowed" — `specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature`
-
-  ```gherkin
-    Scenario: Staging .env.example is allowed
-      Given only .env.example is staged for commit
-      When the pre-commit hook runs rhino-cli env staged-guard validate
-      Then it exits zero and does not block the commit
-  ```
-
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
-      `apps/rhino-cli/src-fsharp/RhinoCli.Application/Specs.fs`
-      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
-      — acceptance: this scenario passes and no previously passing scenario breaks.
-
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
-      `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
-      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
-      — acceptance: all tests still pass and `Specs.fs` formats no output itself.
-
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
-      `apps/rhino-cli/src-fsharp/tests/unit/Steps/SpecsSteps.fs`
-      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
-      — acceptance: this scenario fails because `RhinoCli.Application.Specs` does not implement it.
-      **Gherkin (binds) →** "Staging any real env file is rejected at commit time" — `specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature`
-
-  ```gherkin
-    Scenario Outline: Staging any real env file is rejected at commit time
-      Given a git index with "<file>" staged
-      When "rhino-cli env staged-guard validate" runs
-      Then the command exits non-zero
-      And the output names "<file>" as offending
-
-      Examples:
-        | file              |
-        | .env              |
-        | .env.local        |
-        | .env.test         |
-        | .env.prod         |
-        | .env.stag         |
-        | apps/x/.env.local |
-  ```
-
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
-      `apps/rhino-cli/src-fsharp/RhinoCli.Application/Specs.fs`
-      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
-      — acceptance: this scenario passes and no previously passing scenario breaks.
-
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
-      `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
-      — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
-      — acceptance: all tests still pass and `Specs.fs` formats no output itself.
-
 #### `specs/apps/rhino/behavior/rhino-cli/gherkin/specs/gherkin-cardinality.feature` — 1 scenario
 
 > **PR seam**: the cycles under this heading are one PR.
@@ -12276,7 +12289,7 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
 
 > All checks below must pass before starting Phase 8.
 
-- [ ] [AI] All 188 Wave E scenarios pass under
+- [ ] [AI] All 185 Wave E scenarios pass under
       `dotnet test apps/rhino-cli/src-fsharp/tests/unit` in both repos.
 - [ ] [AI] `apps/rhino-cli/scripts/shadow-diff.sh harness specs repo-governance` reports zero differences in both
       repos.

--- a/plans/in-progress/rewrite-rhino-cli-to-fsharp/tech-docs.md
+++ b/plans/in-progress/rewrite-rhino-cli-to-fsharp/tech-docs.md
@@ -361,10 +361,10 @@ is already proven. Wave ordering by measured size:
 | Wave | Namespaces                            | Rust command LOC | Scenarios | Rationale                                                     |
 | ---- | ------------------------------------- | ---------------- | --------- | ------------------------------------------------------------- |
 | A    | `convention`, `parity`                | ~735             | 11        | Smallest; proves the shim, the harness, and the CI wiring     |
-| B    | `repo-config`, `env`                  | ~1,598           | 59        | Self-contained, well-specified by feature files               |
+| B    | `repo-config`, `env`                  | ~1,598           | 62        | Self-contained, well-specified by feature files               |
 | C    | `doctor`, `test-coverage`             | ~650             | 53        | External-process heavy; exercises the shell layer             |
 | D    | `md`, `governance`, `git`             | ~3,344           | 128       | Largest parser surface; also absorbs the resequenced `git`    |
-| E    | `harness`, `specs`, `repo-governance` | ~5,000           | 188       | Highest coupling to `repo-config.yml`; generates the mirrors  |
+| E    | `harness`, `specs`, `repo-governance` | ~5,000           | 185       | Highest coupling to `repo-config.yml`; generates the mirrors  |
 | F    | `gate`                                | ~6,043           | 89        | Depends on every namespace above; drives the six-group matrix |
 
 Note the ordering is by **risk and dependency**, not by scenario count — wave C is smaller than
@@ -431,10 +431,10 @@ and the Phase 2 gate re-measures them:
 | Wave      | Spec directories                                                           | Feature files | Scenarios |
 | --------- | -------------------------------------------------------------------------- | ------------- | --------- |
 | A         | `convention`                                                               | 3             | 11        |
-| B         | `repo-config`, `repo-config-validate`, `env`, `env-contract`               | 7             | 59        |
+| B         | `repo-config`, `repo-config-validate`, `env`, `env-contract`               | 8             | 62        |
 | C         | `system`, `test-coverage`                                                  | 6             | 53        |
 | D         | `md`, `governance`, `git` (resequenced)                                    | 11            | 128       |
-| E         | `harness`, `specs`, `spec-coverage`, `contracts`, `repo-governance`, `ddd` | 38            | 188       |
+| E         | `harness`, `specs`, `spec-coverage`, `contracts`, `repo-governance`, `ddd` | 37            | 185       |
 | F         | `gate`                                                                     | 7             | 89        |
 | **Total** |                                                                            | **72**        | **528**   |
 
@@ -445,6 +445,16 @@ and the Phase 2 gate re-measures them:
 > surface (`commands/git/lockfile.rs`) had no Gherkin at all; Phase 3 authored
 > `git/git-lockfile.feature` (3 scenarios) and Wave D implements it, bringing the totals from
 > 525 / 71 to 528 / 72.
+>
+> **Wave B also differs from a naive split, the other direction.** `specs/env-staged-guard.feature`
+> sits under `specs/` — a directory otherwise wholly Wave E's — but its three scenarios drive
+> `env staged-guard validate`, and `env_staged_guard.rs`'s 210 lines are already summed into this
+> row's ~1,598 above. `rhino-bin.sh` routes `FSHARP_NAMESPACES` on argv[0] only, so `env` cannot
+> flip at Wave B's integration PR without `staged-guard` ported alongside it — the pre-commit
+> hook's real-`.env`-file guard would otherwise silently route to an F# binary that does not
+> implement it. An earlier delivery.md draft filed this feature's cycles under Wave E by directory;
+> corrected during Wave B's own integration PR once the shadow-diff harness's namespace walk
+> surfaced the gap.
 
 [Repo-grounded — counted over `specs/apps/rhino/behavior/rhino-cli/gherkin/`. `doctor` is specified
 under `system/` (`doctor.feature`, `cargo-target-share.feature`, `fsharp-tool-invocation.feature`),


### PR DESCRIPTION
## Summary
- `specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature` (3 scenarios) was scheduled under Phase 7 (Wave E) in `delivery.md`, grouped by its Gherkin directory (`gherkin/specs/`) rather than by its actual CLI verb, `env staged-guard validate`.
- `tech-docs.md` DD-4's ~1,598-LOC Wave B figure already sums in `env_staged_guard.rs`'s 210 lines (210+165+112+102+108+901=1598), confirming Wave B was always the intended home for this feature by namespace.
- `apps/rhino-cli/scripts/rhino-bin.sh` routes `FSHARP_NAMESPACES` on `argv[0]` only (verified by reading the script directly). Flipping `env` to F# at Wave B's integration PR without `staged-guard` ported alongside it would silently route the pre-commit hook's real-`.env`-file guard to an F# binary that does not implement it — a real production break, not a documentation nicety.
- Relocates the 3-scenario implementation-cycle section from Phase 7 to Phase 4 (fixing its stale `Specs.fs`/`SpecsSteps.fs` module references to the correct `Env.fs`/`EnvStagedGuardSteps.fs`), and updates every scenario/file-count reference this touches: Phase 4 (59→62 scenarios, 7→8 files), Phase 7 (188→185 scenarios, 38→37 files), the wave-summary table, and both DD-4/DD-7-adjacent tables in `tech-docs.md`. Total plan-wide counts (528 scenarios / 72 files) are unchanged — this is a pure relocation.

## Test plan
- [x] `grep -c` before/after confirms the checkbox count moved (9 items) and did not change net
- [x] No orphan `SpecsSteps.fs`/`Specs.fs` references remain for env-staged-guard
- [x] Wave-summary table and DD-4/DD-7 tables in tech-docs.md cross-check against the new delivery.md counts
- [x] Docs-only change; no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)