### PR TITLE
feat(rhino-cli-fsharp): port doctor cargo-target-share (Wave C PR1)

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -3,8 +3,9 @@
 51f04bc4a3f84b9b73386a760312757e62af4fa5ed4a6d357b6d9b0a266cf48e  apps/rhino-cli/LICENSE
 b5f5e511ac5697c2d2949d898633f079abbce9c7211205aad6f7521f17746df2  apps/rhino-cli/project.json
 22b1d0652e8937a20c83841966e4f8b1c451d671d34dd27fb5fa13f11d340a4d  apps/rhino-cli/src-fsharp/.gitignore
-96bd05860d32d93030016db7fa582a1fbb772328d6875cf03fff8957f47b1e90  apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
+eb108ed1244727bd09b23be089eafdec40cae8ee44e6f142df9414140a310a04  apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
 11fe7ec2e5e08b432e2d1cedae59e1a555e17e22a1f11494bd83b80c36964b5c  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Convention.fs
+98fd5bd6357a098d7fca884a08453366b7d91f48795feaa21676e21706aa5d31  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Doctor.fs
 ba223d446b461cce0e427e278e340a87330ed423885f92a674c5039fd755cb5b  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
 2f8085bcb8089f174e9548e609530471c9318c31b1bcab4a867e33880cec9e57  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Parity.fs
 f68a2a01380e02ce7fa8f5774a0800e9f1281c39d3c90b3c03947c1448799f2d  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/RepoConfig.fs
@@ -20,12 +21,14 @@ bb55f3c8d4d3daffa7e334ecdacff8bfd9462b12a7098e239943d84a3edf915f  apps/rhino-cli
 631376afb9e4d7c5192d38f51b533c18b64cca83c18ed5c50982ba9acce51d74  apps/rhino-cli/src-fsharp/RhinoCli.Program/RhinoCli.Program.fsproj
 153a226f5ef1d6916aa6e6425b278a606a48659fcba9623c9d01e5cf3b2589a5  apps/rhino-cli/src-fsharp/RhinoCli.Program/src/Program.fs
 822f6ec8446562a4de9a3b1a2481af50fac01bbedc32e1963142709e5f48ec13  apps/rhino-cli/src-fsharp/fsharplint.json
-efd26a97efb8edd30979b3b2373aa0be51856134fcee10933bc06e419ad380ea  apps/rhino-cli/src-fsharp/project.json
+67b77ab29e7ef0ab0d42d33804b6da2ccc3aaf2c22c8ba03eaaf3ffa03032e72  apps/rhino-cli/src-fsharp/project.json
 f7dacc8dd923488c70eebabe298843022ec5a3ba94b8b7568634a779f24b8da4  apps/rhino-cli/src-fsharp/tests/integration/RhinoCli.IntegrationTests.fsproj
-452254ab4107551489fc4b15c04cc38f743d6bf5986781d369338c31d23b3132  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+8a72dee8dd1a0775d08a202baf8d3b7b05c11167ae8de14b80e35ef2afe9640f  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
 85ba308ad0a88485db55b305120d99b9a4ec328d2379536110f73e51f4797fe2  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionSteps.fs
 a909884a9d8816e2b476cc8c00be03ac4085b849cbe83c4b18e0213ac9cad1d7  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionUnitTests.fs
 30802281ed9b0bab54acba75ee2da33d47048045a1daab5e14aa59402635e13e  apps/rhino-cli/src-fsharp/tests/unit/Steps/DispatchUnitTests.fs
+4418d5a132ea4891e10ee4b396bdb67dd6a76f9f098bdf3566c2c650f912d3d8  apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs
+b829ffe10b89481d1952522f4b30f2aaae7812adb20d0d461314c2a033a05fb8  apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorUnitTests.fs
 8d1559277686544b82b919a21387186f237243a5207ad50a598f98fed9b10248  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvContractIacSteps.fs
 cd1f6eae969b1d5fbc2c751680401ead3e6f916648ec5e20d7d7b21f7d0fc681  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvContractIacUnitTests.fs
 ad360c992e3e47ccf8f47693a8f3c42581085a24efa1303204da2ff9963ede58  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvInitSteps.fs

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="src/Parity.fs" />
     <Compile Include="src/RepoConfig.fs" />
     <Compile Include="src/Env.fs" />
+    <Compile Include="src/Doctor.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Doctor.fs
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Doctor.fs
@@ -1,0 +1,595 @@
+/// Port of `rhino-cli doctor`'s cargo shared-target-directory symlinking and
+/// prune-cache GC step for
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/system/cargo-target-share.feature`'s
+/// 18 scenarios [Repo-grounded —
+/// `apps/rhino-cli/src/application/doctor/target_share.rs`,
+/// `apps/rhino-cli/src/commands/doctor.rs`]. Redirects each Rust crate's
+/// `target/` directory to a symlink into a shared, persistent cache keyed by
+/// repo name and crate leaf name (`<cache_root>/<repo_name>/<crate_leaf>`),
+/// so every git worktree of the same repo shares one physical build
+/// directory per crate.
+///
+/// Scope: this PR ports only the pure, testable `target_share.rs` slice
+/// (discovery, cache-root/shared-path resolution, worktree enumeration,
+/// check/fix/prune/sweep, and their text formatters) — the general `doctor`
+/// tool-check command and its CLI wiring
+/// (`specs/apps/rhino/behavior/rhino-cli/gherkin/system/doctor.feature`) are
+/// a separate, later PR in this same wave.
+///
+/// # Deviation from the Rust source's ambient-environment reads
+///
+/// Mirroring `target_share.rs`'s own module-level "Deviation" note: every
+/// function below takes explicit parameters (`ci`, `home`, `overrideDir`,
+/// `cargoSweepPresent`) instead of reading `CI`/`GITHUB_ACTIONS`/
+/// `OSE_CARGO_TARGET_CACHE`/`HOME`/`PATH` directly, so each stays a pure,
+/// deterministic unit under test. Each parameterized function has a matching
+/// `*Ambient` sibling that reads the real environment once.
+module RhinoCli.Application.Doctor
+
+open System
+open System.Diagnostics
+open System.IO
+
+// ---------------------------------------------------------------------------
+// CI detection
+// ---------------------------------------------------------------------------
+
+/// Returns `true` when the process should be treated as running under CI —
+/// either the `CI` or `GITHUB_ACTIONS` signal being set is sufficient
+/// [Repo-grounded — `target_share.rs::is_ci`].
+///
+/// Gherkin (underpins) — "the doctor symlink step no-ops under CI":
+///   Given the environment variable CI is set
+///   When the developer runs the doctor command with the fix flag
+///   Then no target symlink is created for any crate
+///   And the command exits successfully with a message that CI was detected
+let isCi (ciEnvSet: bool) (ghaEnvSet: bool) : bool = ciEnvSet || ghaEnvSet
+
+/// Reads the real `CI`/`GITHUB_ACTIONS` environment variables and returns
+/// [`isCi`]'s verdict for the current process.
+let isCiAmbient () : bool =
+    isCi
+        (not (String.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI"))))
+        (not (String.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"))))
+
+// ---------------------------------------------------------------------------
+// Crate discovery
+// ---------------------------------------------------------------------------
+
+/// Discovers every Rust crate directory under `repoRoot/apps/*` and
+/// `repoRoot/libs/*` that contains a `Cargo.toml`
+/// [Repo-grounded — `target_share.rs::discover_crates`].
+///
+/// Walks the two top-level directories — no hardcoded crate list — so a
+/// newly-added crate is picked up automatically. A top-level directory that
+/// does not exist contributes zero entries rather than an error. The
+/// returned list is sorted and deduplicated for deterministic iteration
+/// order.
+///
+/// Gherkin (binds) — "dynamic discovery covers every crate under apps and
+/// libs":
+///   Given a repo checkout contains multiple Rust crates under apps and libs outside CI
+///   When the developer runs the doctor command with the fix flag
+///   Then every discovered crate's target is a symlink into the shared cache
+///   And no crate is skipped due to a hardcoded crate list
+let discoverCrates (repoRoot: string) : string list =
+    [ "apps"; "libs" ]
+    |> List.collect (fun top ->
+        let topDir = Path.Combine(repoRoot, top)
+
+        if Directory.Exists(topDir) then
+            Directory.GetDirectories(topDir)
+            |> Array.filter (fun d -> File.Exists(Path.Combine(d, "Cargo.toml")))
+            |> Array.toList
+        else
+            [])
+    |> List.distinct
+    |> List.sort
+
+// ---------------------------------------------------------------------------
+// Cache-root / shared-path resolution
+// ---------------------------------------------------------------------------
+
+/// Resolves the shared-cache root directory
+/// [Repo-grounded — `target_share.rs::cache_root_from`].
+///
+/// `overrideDir` mirrors the `OSE_CARGO_TARGET_CACHE` environment variable
+/// (an explicit override wins outright); `home` mirrors `HOME`, used to
+/// build the default `<home>/.cache/ose-cargo-target` when no override is
+/// given. Returns a relative path (`.cache/ose-cargo-target`) when neither is
+/// available — a degenerate case the real [`cacheRootAmbient`] caller never
+/// hits in practice.
+let cacheRootFrom (overrideDir: string option) (home: string option) : string =
+    match overrideDir with
+    | Some dir -> dir
+    | None ->
+        match home with
+        | Some h -> Path.Combine(h, ".cache", "ose-cargo-target")
+        | None -> Path.Combine(".cache", "ose-cargo-target")
+
+/// Reads the real `OSE_CARGO_TARGET_CACHE`/`HOME` environment variables and
+/// returns [`cacheRootFrom`]'s verdict for the current process.
+let cacheRootAmbient () : string =
+    let envOpt (name: string) : string option =
+        match Environment.GetEnvironmentVariable(name) with
+        | null
+        | "" -> None
+        | value -> Some value
+
+    cacheRootFrom (envOpt "OSE_CARGO_TARGET_CACHE") (envOpt "HOME")
+
+/// Returns the basename of the directory containing the git common dir
+/// [Repo-grounded — `target_share.rs::repo_name`].
+///
+/// `commonDir` is the value of
+/// `git rev-parse --path-format=absolute --git-common-dir` (typically
+/// `<repo-root>/.git`). Using the common dir — rather than the worktree
+/// path — is what makes every linked worktree of the same repo resolve to
+/// the same cache namespace. Returns an empty string when `commonDir` has no
+/// parent (degenerate input; not expected from a real git invocation).
+///
+/// Gherkin (underpins) — "two worktrees of the same repo share one physical
+/// target":
+///   Given two worktrees of the same repo each have a crate's target symlinked by the doctor
+///   When both symlinks are resolved
+///   Then both point at the same shared-cache directory for that repo and crate
+///   And a disk usage measurement across the worktrees counts that directory only once
+let repoName (commonDir: string) : string =
+    let parent = Path.GetDirectoryName(commonDir: string)
+
+    if String.IsNullOrEmpty(parent) then
+        ""
+    else
+        match Path.GetFileName(parent) with
+        | null -> ""
+        | name -> name
+
+/// Returns the shared-cache path a crate's `target/` should be symlinked to:
+/// `<cacheRoot>/<repoName>/<crateLeaf>`, where `crateLeaf` is `crateDir`'s
+/// final path component (e.g. `rhino-cli`)
+/// [Repo-grounded — `target_share.rs::shared_target_path`].
+let sharedTargetPath (cacheRoot: string) (repoNameValue: string) (crateDir: string) : string =
+    let leaf =
+        match Path.GetFileName(crateDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)) with
+        | null -> ""
+        | name -> name
+
+    Path.Combine(cacheRoot, repoNameValue, leaf)
+
+// ---------------------------------------------------------------------------
+// Symlink primitives
+// ---------------------------------------------------------------------------
+
+/// Returns the raw, unresolved symlink target stored at `path`, or `None`
+/// when `path` is not a symlink (including when nothing exists there at
+/// all) — mirrors `std::fs::read_link`'s "does not follow, works on broken
+/// links" contract via .NET's `FileSystemInfo.LinkTarget`.
+let private linkTargetOf (path: string) : string option =
+    match DirectoryInfo(path).LinkTarget with
+    | null -> None
+    | target -> Some target
+
+/// Returns `true` when `link` is a symlink whose raw target equals
+/// `expectedTarget` [Repo-grounded — `target_share.rs::is_correct_symlink`].
+let private isCorrectSymlink (link: string) (expectedTarget: string) : bool =
+    match linkTargetOf link with
+    | Some actual -> actual = expectedTarget
+    | None -> false
+
+/// Discards whatever currently exists at `path` — a symlink (whatever it
+/// resolves to), a plain directory, or a plain file — leaving nothing behind.
+/// Returns `true` when the discarded entry was a plain, rebuildable
+/// directory (never a symlink), matching `FixOutcome.ReplacedPlainDir`'s
+/// semantics [Repo-grounded — `target_share.rs::fix_target_shares`'s
+/// `symlink_metadata` match].
+///
+/// `Directory.Delete` never follows a symlink into its target's contents —
+/// documented .NET behavior since .NET Core 3.0 — so deleting a directory
+/// -type symlink here removes only the link itself, exactly like Rust's
+/// `remove_file` branch for the symlink case.
+let private removeExistingEntry (path: string) : bool =
+    match linkTargetOf path with
+    | Some _ ->
+        Directory.Delete(path, false)
+        false
+    | None ->
+        if Directory.Exists(path) then
+            Directory.Delete(path, true)
+            true
+        elif File.Exists(path) then
+            File.Delete(path)
+            false
+        else
+            false
+
+// ---------------------------------------------------------------------------
+// Git worktree enumeration
+// ---------------------------------------------------------------------------
+
+/// Runs `git worktree list --porcelain` from `repoRoot` and returns every
+/// listed worktree path, sorted and deduplicated, or `None` when the
+/// enumeration itself fails (spawn error or non-zero exit)
+/// [Repo-grounded — `target_share.rs::worktree_roots`].
+let private worktreeRoots (repoRoot: string) : string list option =
+    use proc = new Process()
+    proc.StartInfo.FileName <- "git"
+    proc.StartInfo.ArgumentList.Add("worktree")
+    proc.StartInfo.ArgumentList.Add("list")
+    proc.StartInfo.ArgumentList.Add("--porcelain")
+    proc.StartInfo.WorkingDirectory <- repoRoot
+    proc.StartInfo.EnvironmentVariables.Remove("GIT_DIR")
+    proc.StartInfo.EnvironmentVariables.Remove("GIT_WORK_TREE")
+    proc.StartInfo.RedirectStandardOutput <- true
+    proc.StartInfo.RedirectStandardError <- true
+    proc.StartInfo.UseShellExecute <- false
+
+    try
+        proc.Start() |> ignore
+        let stdout = proc.StandardOutput.ReadToEnd()
+        proc.StandardError.ReadToEnd() |> ignore
+        proc.WaitForExit()
+
+        if proc.ExitCode <> 0 then
+            None
+        else
+            stdout.Split('\n')
+            |> Array.choose (fun line ->
+                if line.StartsWith("worktree ", StringComparison.Ordinal) then
+                    Some(line.Substring("worktree ".Length))
+                else
+                    None)
+            |> Array.distinct
+            |> Array.sort
+            |> Array.toList
+            |> Some
+    with :? System.ComponentModel.Win32Exception ->
+        None
+
+/// [`worktreeRoots`] with the fix/check step's degraded fallback applied:
+/// falls back to just `repoRoot` when the enumeration fails
+/// [Repo-grounded — `target_share.rs::roots_or_self`].
+let private rootsOrSelf (repoRoot: string) : string list =
+    worktreeRoots repoRoot |> Option.defaultValue [ repoRoot ]
+
+/// Lexically normalizes `path` for stable equality comparison, falling back
+/// to the raw string when normalization fails — mirrors
+/// `std::path::Path::canonicalize`'s "resolve, fall back to the original on
+/// failure" contract from `target_share.rs::live_referenced_entries`/
+/// `prune_orphans`, without requiring the path to exist.
+let private canonicalize (path: string) : string =
+    try
+        Path.GetFullPath(path)
+    with _ ->
+        path
+
+/// Returns the shared-cache path currently referenced by every crate's
+/// `target/` symlink across every live worktree (plus the main checkout) of
+/// the repo rooted at `repoRoot`
+/// [Repo-grounded — `target_share.rs::live_referenced_entries`].
+///
+/// Returns `None` when the query itself fails. `None` is distinct from
+/// `Some (empty set)`: a successful enumeration that finds no referencing
+/// symlinks is a genuine empty live set (prune may delete orphans), whereas
+/// a *failed* enumeration means we cannot know what is referenced, so the
+/// caller must fail closed and delete nothing.
+let private liveReferencedEntries (repoRoot: string) : Set<string> option =
+    worktreeRoots repoRoot
+    |> Option.map (fun worktrees ->
+        worktrees
+        |> List.collect discoverCrates
+        |> List.choose (fun crateDir -> linkTargetOf (Path.Combine(crateDir, "target")))
+        |> List.map canonicalize
+        |> Set.ofList)
+
+// ---------------------------------------------------------------------------
+// check
+// ---------------------------------------------------------------------------
+
+/// One crate whose `target/` is not yet the correct shared-cache symlink
+/// [Repo-grounded — `target_share.rs::TargetShareStatus`].
+type TargetShareStatus =
+    { CrateDir: string; SharedPath: string }
+
+/// Reports every crate in every checkout of this repo — the main checkout
+/// and each linked worktree — whose `target/` is not yet the correct symlink
+/// into the shared cache. Read-only — never mutates the filesystem. Returns
+/// an empty list under CI [Repo-grounded —
+/// `target_share.rs::check_target_shares`].
+///
+/// Gherkin (binds) — "doctor check reports a crate whose target is not yet
+/// shared":
+///   Given a crate's target is a plain directory not yet symlinked into the shared cache
+///   When the developer runs the doctor command without the fix flag
+///   Then the output reports that crate's target as needing to be shared
+///   And the plain target directory is left unchanged
+let checkTargetShares
+    (repoRoot: string)
+    (cacheRoot: string)
+    (repoNameValue: string)
+    (ci: bool)
+    : TargetShareStatus list =
+    if ci then
+        []
+    else
+        rootsOrSelf repoRoot
+        |> List.collect discoverCrates
+        |> List.choose (fun crateDir ->
+            let target = Path.Combine(crateDir, "target")
+            let sharedPath = sharedTargetPath cacheRoot repoNameValue crateDir
+
+            if isCorrectSymlink target sharedPath then
+                None
+            else
+                Some
+                    { CrateDir = crateDir
+                      SharedPath = sharedPath })
+
+// ---------------------------------------------------------------------------
+// fix
+// ---------------------------------------------------------------------------
+
+/// Outcome of a [`fixTargetShares`] run
+/// [Repo-grounded — `target_share.rs::FixOutcome`].
+type FixOutcome =
+    { Created: int
+      AlreadyCorrect: int
+      ReplacedPlainDir: int
+      SkippedCi: bool }
+
+/// Creates or repairs each discovered crate's `target/` symlink into the
+/// shared cache, across the main checkout **and every linked worktree**. No
+/// -ops entirely under CI [Repo-grounded —
+/// `target_share.rs::fix_target_shares`].
+///
+/// Gherkin (binds) — "doctor --fix symlinks a crate's target into the shared
+/// cache":
+///   Given a Rust crate with a plain target directory exists in a repo checkout outside CI
+///   When the developer runs the doctor command with the fix flag
+///   Then the crate's target becomes a symlink into the shared cargo-target cache
+///   And the symlink resolves under the repo's own shared-cache namespace
+let fixTargetShares (repoRoot: string) (cacheRoot: string) (repoNameValue: string) (ci: bool) : FixOutcome =
+    if ci then
+        { Created = 0
+          AlreadyCorrect = 0
+          ReplacedPlainDir = 0
+          SkippedCi = true }
+    else
+        rootsOrSelf repoRoot
+        |> List.collect discoverCrates
+        |> List.fold
+            (fun acc crateDir ->
+                let target = Path.Combine(crateDir, "target")
+                let sharedPath = sharedTargetPath cacheRoot repoNameValue crateDir
+                Directory.CreateDirectory(sharedPath) |> ignore
+
+                if isCorrectSymlink target sharedPath then
+                    { acc with
+                        AlreadyCorrect = acc.AlreadyCorrect + 1 }
+                else
+                    let replacedPlainDir = removeExistingEntry target
+
+                    try
+                        Directory.CreateSymbolicLink(target, sharedPath) |> ignore
+
+                        { acc with
+                            Created = acc.Created + 1
+                            ReplacedPlainDir = acc.ReplacedPlainDir + (if replacedPlainDir then 1 else 0) }
+                    with _ ->
+                        acc)
+            { Created = 0
+              AlreadyCorrect = 0
+              ReplacedPlainDir = 0
+              SkippedCi = false }
+
+// ---------------------------------------------------------------------------
+// prune
+// ---------------------------------------------------------------------------
+
+/// Outcome of a [`pruneOrphans`] run
+/// [Repo-grounded — `target_share.rs::PruneOutcome`].
+type PruneOutcome =
+    { Deleted: string list
+      Preserved: string list
+      Candidates: string list
+      SkippedCi: bool
+      EnumerationFailed: bool }
+
+/// The zero-valued [`PruneOutcome`] shared by every early-return branch.
+let private prunedNothing =
+    { Deleted = []
+      Preserved = []
+      Candidates = []
+      SkippedCi = false
+      EnumerationFailed = false }
+
+/// Deletes shared-cache entries under `<cacheRoot>/<repoNameValue>/*` that no
+/// live worktree or checkout of the repo references. Never touches an entry
+/// present in [`liveReferencedEntries`]'s result
+/// [Repo-grounded — `target_share.rs::prune_orphans`].
+///
+/// Gherkin (binds) — "prune removes an orphaned shared-cache entry":
+///   Given the shared cache holds an entry for a crate that no longer exists in the repo outside CI
+///   When the developer runs the doctor command with the prune flag
+///   Then the orphaned cache entry is deleted
+///   And every entry still referenced by a live worktree or checkout is preserved
+let pruneOrphans
+    (repoRoot: string)
+    (cacheRoot: string)
+    (repoNameValue: string)
+    (dryRun: bool)
+    (ci: bool)
+    : PruneOutcome =
+    if ci then
+        { prunedNothing with SkippedCi = true }
+    else
+        match liveReferencedEntries repoRoot with
+        | None ->
+            { prunedNothing with
+                EnumerationFailed = true }
+        | Some live ->
+            let repoCacheDir = Path.Combine(cacheRoot, repoNameValue)
+
+            if not (Directory.Exists(repoCacheDir)) then
+                prunedNothing
+            else
+                Directory.GetDirectories(repoCacheDir)
+                |> Array.toList
+                |> List.fold
+                    (fun acc entryPath ->
+                        if Set.contains (canonicalize entryPath) live then
+                            { acc with
+                                Preserved = acc.Preserved @ [ entryPath ] }
+                        elif dryRun then
+                            { acc with
+                                Candidates = acc.Candidates @ [ entryPath ] }
+                        else
+                            Directory.Delete(entryPath, true)
+
+                            { acc with
+                                Deleted = acc.Deleted @ [ entryPath ] })
+                    prunedNothing
+
+// ---------------------------------------------------------------------------
+// sweep
+// ---------------------------------------------------------------------------
+
+/// Outcome of a [`sweepStale`] run
+/// [Repo-grounded — `target_share.rs::SweepOutcome`].
+type SweepOutcome =
+    { Skipped: bool
+      SkippedCi: bool
+      Ran: bool }
+
+/// Returns `true` when the `cargo-sweep` binary is present on `PATH`
+/// [Repo-grounded — `target_share.rs::cargo_sweep_present`].
+let cargoSweepPresent () : bool =
+    match Environment.GetEnvironmentVariable("PATH") with
+    | null -> false
+    | pathVar ->
+        pathVar.Split(Path.PathSeparator)
+        |> Array.exists (fun dir -> dir <> "" && File.Exists(Path.Combine(dir, "cargo-sweep")))
+
+/// The repo-scoped subtree `cargo-sweep` reclaims within —
+/// `<cacheRoot>/<repoNameValue>`, never the whole shared `cacheRoot`
+/// [Repo-grounded — `target_share.rs::sweep_scope`].
+let private sweepScope (cacheRoot: string) (repoNameValue: string) : string = Path.Combine(cacheRoot, repoNameValue)
+
+/// Runs `cargo-sweep`'s stale-artifact reclamation over this repo's cache
+/// namespace when the binary is present, degrading gracefully to `Skipped`
+/// (never an error) when it is absent
+/// [Repo-grounded — `target_share.rs::sweep_stale`].
+///
+/// Gherkin (binds) — "stale-artifact sweep degrades gracefully when
+/// cargo-sweep is absent":
+///   Given cargo-sweep is not installed on the developer's PATH
+///   When the developer runs the doctor command with the prune flag
+///   Then the sweep step is reported as skipped rather than failing the command
+///   And the command exits successfully
+let sweepStale
+    (cacheRoot: string)
+    (repoNameValue: string)
+    (dryRun: bool)
+    (cargoSweepPresentValue: bool)
+    (ci: bool)
+    : SweepOutcome =
+    if ci then
+        { Skipped = false
+          SkippedCi = true
+          Ran = false }
+    elif not cargoSweepPresentValue then
+        { Skipped = true
+          SkippedCi = false
+          Ran = false }
+    elif dryRun then
+        { Skipped = false
+          SkippedCi = false
+          Ran = false }
+    else
+        use proc = new Process()
+        proc.StartInfo.FileName <- "cargo-sweep"
+        proc.StartInfo.ArgumentList.Add("--time")
+        proc.StartInfo.ArgumentList.Add("30")
+        proc.StartInfo.ArgumentList.Add("--recursive")
+        proc.StartInfo.ArgumentList.Add(sweepScope cacheRoot repoNameValue)
+        proc.StartInfo.RedirectStandardOutput <- true
+        proc.StartInfo.RedirectStandardError <- true
+        proc.StartInfo.UseShellExecute <- false
+
+        (try
+            proc.Start() |> ignore
+            proc.WaitForExit()
+         with _ ->
+             ())
+
+        { Skipped = false
+          SkippedCi = false
+          Ran = true }
+
+// ---------------------------------------------------------------------------
+// Text formatters [Repo-grounded — `commands/doctor.rs::run_target_share_step`]
+// ---------------------------------------------------------------------------
+
+/// Formats a [`checkTargetShares`] report as the plain text
+/// `doctor` prints ahead of any `--fix`/`--prune-cargo-cache` output.
+///
+/// Gherkin (binds) — "the doctor symlink step no-ops under CI":
+///   Given the environment variable CI is set
+///   When the developer runs the doctor command with the fix flag
+///   Then no target symlink is created for any crate
+///   And the command exits successfully with a message that CI was detected
+let formatCheckReport (statuses: TargetShareStatus list) (ci: bool) : string =
+    if ci then
+        "\nTarget-share: CI detected — skipped."
+    elif List.isEmpty statuses then
+        "\nTarget-share: all crates already share their target/ via the cache."
+    else
+        statuses
+        |> List.map (fun s -> sprintf "  %s" s.CrateDir)
+        |> String.concat "\n"
+        |> sprintf "\nTarget-share: %d crate(s) need sharing:\n%s" (List.length statuses)
+
+/// Formats a [`fixTargetShares`] outcome as the plain text `doctor --fix`
+/// prints for the target-share step.
+let formatFixReport (outcome: FixOutcome) : string =
+    if outcome.SkippedCi then
+        "Target-share fix: CI detected — skipped."
+    else
+        sprintf
+            "Target-share fix: %d created, %d already correct, %d plain dir(s) replaced"
+            outcome.Created
+            outcome.AlreadyCorrect
+            outcome.ReplacedPlainDir
+
+/// Formats a [`pruneOrphans`] outcome as the plain text
+/// `doctor --prune-cargo-cache` prints.
+///
+/// Gherkin (binds) — "prune dry-run previews deletions without removing
+/// anything":
+///   Given the shared cache holds at least one orphaned entry outside CI
+///   When the developer runs the doctor command with the prune and dry-run flags
+///   Then the orphaned entry is reported as a candidate for deletion
+///   And no cache entry is actually removed
+let formatPruneReport (outcome: PruneOutcome) (dryRun: bool) : string =
+    if outcome.SkippedCi then
+        "Prune: CI detected — skipped."
+    elif outcome.EnumerationFailed then
+        "Prune: could not enumerate worktrees — skipped (nothing deleted)."
+    elif dryRun then
+        outcome.Candidates
+        |> List.map (fun c -> sprintf "  %s" c)
+        |> String.concat "\n"
+        |> sprintf "Prune (dry-run): %d candidate(s) for deletion\n%s" (List.length outcome.Candidates)
+    else
+        sprintf "Prune: %d orphaned entrie(s) deleted" (List.length outcome.Deleted)
+
+/// Formats a [`sweepStale`] outcome as the plain text
+/// `doctor --prune-cargo-cache` prints for the sweep sub-step. Returns an
+/// empty string when the sweep neither skipped nor was CI-guarded (i.e. it
+/// ran), matching `run_target_share_step`'s "only print on skip" behaviour.
+let formatSweepReport (outcome: SweepOutcome) : string =
+    if outcome.SkippedCi then
+        "Sweep: CI detected — skipped."
+    elif outcome.Skipped then
+        "Sweep: cargo-sweep not installed — skipped."
+    else
+        ""

--- a/apps/rhino-cli/src-fsharp/project.json
+++ b/apps/rhino-cli/src-fsharp/project.json
@@ -55,7 +55,7 @@
     "test:unit": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "if grep -rn -E --include='*.fs' 'Skip\\s*=' apps/rhino-cli/src-fsharp/tests/unit; then echo 'ERROR: xunit Skip= attribute found in test files above'; exit 1; fi && dotnet test apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj"
+        "command": "if grep -rn -E --include='*.fs' 'Skip\\s*=' apps/rhino-cli/src-fsharp/tests/unit; then echo 'ERROR: xunit Skip= attribute found in test files above'; exit 1; fi && env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR dotnet test apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj"
       },
       "cache": true,
       "inputs": [
@@ -67,14 +67,14 @@
     "test:integration": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "if grep -rn -E --include='*.fs' 'Skip\\s*=' apps/rhino-cli/src-fsharp/tests/integration; then echo 'ERROR: xunit Skip= attribute found in test files above'; exit 1; fi && dotnet test apps/rhino-cli/src-fsharp/tests/integration/RhinoCli.IntegrationTests.fsproj"
+        "command": "if grep -rn -E --include='*.fs' 'Skip\\s*=' apps/rhino-cli/src-fsharp/tests/integration; then echo 'ERROR: xunit Skip= attribute found in test files above'; exit 1; fi && env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR dotnet test apps/rhino-cli/src-fsharp/tests/integration/RhinoCli.IntegrationTests.fsproj"
       },
       "cache": false
     },
     "test:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "dotnet test apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj /p:CollectCoverage=true /p:Threshold=90 /p:ThresholdType=line \"/p:ExcludeByFile=**/RhinoCli.Program/src/Program.fs\""
+        "command": "env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR dotnet test apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj /p:CollectCoverage=true /p:Threshold=90 /p:ThresholdType=line \"/p:ExcludeByFile=**/RhinoCli.Program/src/Program.fs\""
       },
       "cache": true,
       "inputs": ["{projectRoot}/**/*.fs", "{projectRoot}/tests/unit/**/*.fs"],
@@ -112,7 +112,7 @@
     "specs:behavior:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env specs/apps/rhino/behavior/rhino-cli/gherkin/env-contract specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature apps/rhino-cli/src-fsharp"
+        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env specs/apps/rhino/behavior/rhino-cli/gherkin/env-contract specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature specs/apps/rhino/behavior/rhino-cli/gherkin/system/cargo-target-share.feature apps/rhino-cli/src-fsharp"
       },
       "cache": true,
       "inputs": ["{workspaceRoot}/specs/apps/rhino/behavior/rhino-cli/gherkin/**/*.feature", "{projectRoot}/**/*.fs"]

--- a/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+++ b/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
@@ -31,6 +31,8 @@
     <Compile Include="Steps/EnvContractIacUnitTests.fs" />
     <Compile Include="Steps/EnvStagedGuardSteps.fs" />
     <Compile Include="Steps/EnvStagedGuardUnitTests.fs" />
+    <Compile Include="Steps/DoctorSteps.fs" />
+    <Compile Include="Steps/DoctorUnitTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs
@@ -1,0 +1,887 @@
+/// TickSpec step definitions binding `cargo-target-share.feature`'s 18
+/// scenarios to `RhinoCli.Application.Doctor`'s cargo target-share port
+/// [Repo-grounded —
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/system/cargo-target-share.feature`,
+/// `apps/rhino-cli/tests/cargo_target_share.rs`].
+///
+/// Follows `EnvInitSteps.fs`'s per-scenario slicing convention: each xunit
+/// `[<Fact>]` below runs exactly one scenario, extracted from the real,
+/// frozen feature file. Unlike the Rust reference (a cucumber-rs suite that
+/// drives the *compiled binary*), these steps call `RhinoCli.Application
+/// .Doctor`'s pure functions directly — the same "call the internal function
+/// directly" precedent `EnvInitSteps.fs`/`EnvStagedGuardSteps.fs` already
+/// establish for this port — composing them the same way
+/// `commands/doctor.rs::run_target_share_step` does, into one accumulated
+/// text report a `Then` step can assert against.
+///
+/// # Deviations from the literal Gherkin text
+///
+/// Mirrors `apps/rhino-cli/tests/cargo_target_share.rs`'s own documented
+/// deviations for the two scenarios no single-process suite can literally
+/// exercise:
+///
+/// - **"the doctor change is byte-identical across the parity repos"**: proxied
+///   by running `fixTargetShares` against two identically-shaped synthetic
+///   repos literally named `ose-public`/`ose-private`, proving the resulting
+///   symlink targets differ only in the repo-name path segment.
+/// - **"Nx build caching is unaffected for crates that emit only dist"**:
+///   proxied by running the fix step twice and asserting a representative
+///   Nx-managed `project.json` file's bytes are untouched — the precondition
+///   Nx's own cache-hit behavior depends on.
+///
+/// All fixture git usage below follows the [Git Fixture Isolation
+/// Convention](../../../../../../repo-governance/development/quality/git-fixture-isolation.md);
+/// `GIT_DIR`/`GIT_WORK_TREE` are stripped from every shelled `git` call the
+/// same way `ParityUnitTests.fs`/`GitRootUnitTests.fs` already do.
+module RhinoCli.Tests.Unit.Steps.DoctorSteps
+
+open System
+open System.Diagnostics
+open System.IO
+open System.Text.Json
+open TickSpec
+open Xunit
+open RhinoCli.Application.Doctor
+
+// ---------------------------------------------------------------------------
+// Fixture helpers (duplicated per-file rather than shared, matching
+// ParityUnitTests.fs's / GitRootUnitTests.fs's own precedent).
+// ---------------------------------------------------------------------------
+
+let private runGit (cwd: string) (args: string list) : unit =
+    use proc = new Process()
+    proc.StartInfo.FileName <- "git"
+    args |> List.iter proc.StartInfo.ArgumentList.Add
+    proc.StartInfo.WorkingDirectory <- cwd
+    proc.StartInfo.RedirectStandardOutput <- true
+    proc.StartInfo.RedirectStandardError <- true
+    proc.StartInfo.UseShellExecute <- false
+    proc.StartInfo.EnvironmentVariables.Remove("GIT_DIR")
+    proc.StartInfo.EnvironmentVariables.Remove("GIT_WORK_TREE")
+    proc.Start() |> ignore
+    let stderr = proc.StandardError.ReadToEnd()
+    proc.WaitForExit()
+
+    if proc.ExitCode <> 0 then
+        failwithf "git %s failed in %s: %s" (String.concat " " args) cwd stderr
+
+let private writeCargoToml (dir: string) (name: string) =
+    Directory.CreateDirectory(dir) |> ignore
+
+    File.WriteAllText(
+        Path.Combine(dir, "Cargo.toml"),
+        sprintf "[package]\nname = \"%s\"\nversion = \"0.1.0\"\nedition = \"2021\"\n" name
+    )
+
+    let src = Path.Combine(dir, "src")
+    Directory.CreateDirectory(src) |> ignore
+
+    File.WriteAllText(
+        Path.Combine(src, "main.rs"),
+        "fn main() {}\n\n#[test]\nfn trivial_pass() {\n    assert!(true);\n}\n"
+    )
+
+let private makeCrate (repoRoot: string) (name: string) : string =
+    let crateDir = Path.Combine(repoRoot, "apps", name)
+    writeCargoToml crateDir name
+    crateDir
+
+let private buildThrowawayRepo (repoDir: string) =
+    Directory.CreateDirectory(repoDir) |> ignore
+    runGit repoDir [ "init"; "-q"; "-b"; "main" ]
+    runGit repoDir [ "config"; "user.name"; "Rhino CLI Test" ]
+    runGit repoDir [ "config"; "user.email"; "rhino-cli-test@example.invalid" ]
+    File.WriteAllText(Path.Combine(repoDir, "README.md"), "throwaway fixture")
+    runGit repoDir [ "add"; "." ]
+    runGit repoDir [ "commit"; "-m"; "init" ]
+
+let private commitAll (repoDir: string) (message: string) =
+    runGit repoDir [ "add"; "." ]
+    runGit repoDir [ "commit"; "-m"; message ]
+
+let private addWorktree (repoDir: string) (worktreeDir: string) =
+    runGit repoDir [ "worktree"; "add"; "--detach"; worktreeDir ]
+
+// ---------------------------------------------------------------------------
+// project.json git-state-isolation regression helpers (scenario 18)
+// ---------------------------------------------------------------------------
+
+let private fsharpProjectJsonPath: string =
+    Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "..", "..", "project.json"))
+
+let private gitStateScrub = "env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR "
+
+let private knownTestTargets = [ "test:unit"; "test:integration"; "test:coverage" ]
+
+/// Reads `command`s that directly invoke `dotnet test` out of
+/// `test:unit`/`test:integration`/`test:coverage` — the F# project's direct
+/// test-execution targets, analogous to Rust's `test:unit`/`test:integration`/
+/// `test:coverage` in `apps/rhino-cli/project.json`.
+let private commandsForKnownTargets (projectJsonPath: string) : (string * string) list =
+    let json = File.ReadAllText(projectJsonPath)
+    use doc = JsonDocument.Parse(json)
+    let targets = doc.RootElement.GetProperty("targets")
+
+    knownTestTargets
+    |> List.map (fun name ->
+        let command =
+            targets.GetProperty(name).GetProperty("options").GetProperty("command").GetString()
+
+        (name, command))
+
+/// Scans the entire `project.json` text for every occurrence of the literal
+/// substring `"dotnet test "` not immediately preceded by
+/// [`gitStateScrub`], returning a short snippet around each offender. An
+/// empty result proves every direct `dotnet test` invocation anywhere in the
+/// file — not just the three known targets above — clears inherited
+/// `GIT_DIR`/`GIT_WORK_TREE`/`GIT_COMMON_DIR` first, so a new target added
+/// later cannot silently bypass the guard.
+let private unguardedDotnetTestOccurrences (projectJsonPath: string) : string list =
+    let text = File.ReadAllText(projectJsonPath)
+    let marker = "dotnet test "
+
+    let rec scan (fromIdx: int) (acc: string list) : string list =
+        let found = text.IndexOf(marker, fromIdx, StringComparison.Ordinal)
+
+        if found < 0 then
+            List.rev acc
+        else
+            let precedingStart = found - gitStateScrub.Length
+
+            let guarded =
+                precedingStart >= 0
+                && text.Substring(precedingStart, gitStateScrub.Length) = gitStateScrub
+
+            let nextAcc =
+                if guarded then
+                    acc
+                else
+                    let snippetStart = max 0 (found - 20)
+                    let snippetLength = min 80 (text.Length - snippetStart)
+                    text.Substring(snippetStart, snippetLength) :: acc
+
+            scan (found + marker.Length) nextAcc
+
+    scan 0 []
+
+// ---------------------------------------------------------------------------
+// Step-definition container
+// ---------------------------------------------------------------------------
+
+/// Instance step-definition container — see `ConventionSteps.fs`'s module
+/// doc comment for why TickSpec's one-instance-per-scenario lifecycle makes
+/// instance-level mutable fields the idiomatic state-threading mechanism
+/// here.
+type DoctorSteps() =
+    let ownedDirs = ResizeArray<string>()
+
+    let newTempDir (prefix: string) : string =
+        let dir =
+            Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-steps-" + prefix + "-" + Guid.NewGuid().ToString("N"))
+
+        Directory.CreateDirectory(dir) |> ignore
+        ownedDirs.Add(dir)
+        dir
+
+    let repoRoot = newTempDir "repo"
+    let cacheRoot = newTempDir "cache"
+    do buildThrowawayRepo repoRoot
+    let repoNameValue = Path.GetFileName(repoRoot: string)
+
+    let mutable ci = false
+    let mutable fix = false
+    let mutable prune = false
+    let mutable dryRun = false
+    let mutable scrubCargoSweep = false
+    let mutable crateDir: string option = None
+    let mutable secondWorktree: (string * string) option = None
+    let mutable checkStatuses: TargetShareStatus list = []
+    let mutable fixOutcome: FixOutcome option = None
+    let mutable pruneOutcome: PruneOutcome option = None
+    let mutable sweepOutcome: SweepOutcome option = None
+    let mutable outputText = ""
+    let mutable repoNameResults: (string * string) list = []
+    let mutable configBefore: byte[] option = None
+    let mutable configAfter: byte[] option = None
+    let mutable gitStateCommands: (string * string) list = []
+
+    let effectiveCargoSweepPresent () =
+        if scrubCargoSweep then false else cargoSweepPresent ()
+
+    /// Runs the check/fix/prune/sweep pipeline against `targetRepoRoot`,
+    /// mirroring `commands/doctor.rs::run_target_share_step`'s composition —
+    /// see this file's module doc comment for why this calls straight into
+    /// `Doctor`'s functions rather than spawning a compiled binary.
+    let runDoctorAgainst (targetRepoRoot: string) : unit =
+        let sb = Text.StringBuilder()
+        let statuses = checkTargetShares targetRepoRoot cacheRoot repoNameValue ci
+        checkStatuses <- statuses
+        sb.Append(formatCheckReport statuses ci).Append('\n') |> ignore
+
+        if fix then
+            let outcome = fixTargetShares targetRepoRoot cacheRoot repoNameValue ci
+            fixOutcome <- Some outcome
+            sb.Append(formatFixReport outcome).Append('\n') |> ignore
+
+        if prune then
+            let pOutcome = pruneOrphans targetRepoRoot cacheRoot repoNameValue dryRun ci
+            pruneOutcome <- Some pOutcome
+            sb.Append(formatPruneReport pOutcome dryRun).Append('\n') |> ignore
+
+            let sOutcome =
+                sweepStale cacheRoot repoNameValue dryRun (effectiveCargoSweepPresent ()) ci
+
+            sweepOutcome <- Some sOutcome
+            let sweepText = formatSweepReport sOutcome
+
+            if sweepText <> "" then
+                sb.Append(sweepText).Append('\n') |> ignore
+
+        outputText <- sb.ToString()
+
+    let exec () = runDoctorAgainst repoRoot
+
+    let orphanEntry () =
+        Path.Combine(cacheRoot, repoNameValue, "orphan-crate")
+
+    // ---- Given ----
+
+    [<Given>]
+    member _.``a Rust crate with a plain target directory exists in a repo checkout outside CI``() =
+        let cd = makeCrate repoRoot "foo"
+        Directory.CreateDirectory(Path.Combine(cd, "target")) |> ignore
+        ci <- false
+        crateDir <- Some cd
+
+    [<Given>]
+    member _.``a crate's target is already the correct symlink into the shared cache``() =
+        let cd = makeCrate repoRoot "foo"
+        crateDir <- Some cd
+        fix <- true
+        exec ()
+
+    [<Given>]
+    member _.``a crate's target is a plain rebuildable directory containing stale artifacts``() =
+        let cd = makeCrate repoRoot "foo"
+        let target = Path.Combine(cd, "target")
+        Directory.CreateDirectory(target) |> ignore
+        File.WriteAllText(Path.Combine(target, "stale.txt"), "stale artifact")
+        ci <- false
+        crateDir <- Some cd
+
+    [<Given>]
+    member _.``a crate's target is a plain directory not yet symlinked into the shared cache``() =
+        let cd = makeCrate repoRoot "foo"
+        Directory.CreateDirectory(Path.Combine(cd, "target")) |> ignore
+        crateDir <- Some cd
+
+    [<Given>]
+    member _.``the environment variable CI is set``() =
+        let cd = makeCrate repoRoot "foo"
+        Directory.CreateDirectory(Path.Combine(cd, "target")) |> ignore
+        crateDir <- Some cd
+        Directory.CreateDirectory(orphanEntry ()) |> ignore
+        ci <- true
+
+    [<Given>]
+    member _.``a repo checkout contains multiple Rust crates under apps and libs outside CI``() =
+        makeCrate repoRoot "a" |> ignore
+        makeCrate repoRoot "b" |> ignore
+        writeCargoToml (Path.Combine(repoRoot, "libs", "c")) "c"
+        ci <- false
+
+    [<Given>]
+    member _.``two worktrees of the same repo each have a crate's target symlinked by the doctor``() =
+        let cd = makeCrate repoRoot "foo"
+        commitAll repoRoot "add apps/foo"
+        crateDir <- Some cd
+        fix <- true
+        exec ()
+
+        let wtHolder = newTempDir "wtholder"
+        let wtPath = Path.Combine(wtHolder, "linked-wt")
+        addWorktree repoRoot wtPath
+        let wtCrateDir = Path.Combine(wtPath, "apps", "foo")
+        runDoctorAgainst wtPath
+        secondWorktree <- Some(wtHolder, wtCrateDir)
+
+    [<Given>]
+    member _.``a linked worktree holds a crate whose target is still a plain directory outside CI``() =
+        let cd = makeCrate repoRoot "foo"
+        commitAll repoRoot "add apps/foo"
+        crateDir <- Some cd
+
+        let wtHolder = newTempDir "wtholder"
+        let wtPath = Path.Combine(wtHolder, "linked-wt")
+        addWorktree repoRoot wtPath
+        let wtCrateDir = Path.Combine(wtPath, "apps", "foo")
+        let wtTarget = Path.Combine(wtCrateDir, "target")
+        Directory.CreateDirectory(wtTarget) |> ignore
+        File.WriteAllText(Path.Combine(wtTarget, "stale.txt"), "stale")
+        secondWorktree <- Some(wtHolder, wtCrateDir)
+        ci <- false
+
+    [<Given>]
+    member _.``a crate's target is a symlink into the shared cache``() =
+        let cd = makeCrate repoRoot "foo"
+        crateDir <- Some cd
+        fix <- true
+        exec ()
+
+    [<Given>]
+    member _.``the doctor target-share change is delivered to ose-public and ose-private``() =
+        // Deviation — see the module doc comment: the real invariant (a
+        // cross-repository diff) is out of this single-suite's reach; the
+        // subsequent When step builds the named synthetic repos this
+        // scenario's proxy actually drives.
+        ()
+
+    [<Given>]
+    member _.``the ose-public CLIs no longer list the whole target directory in build outputs``() =
+        let cd = makeCrate repoRoot "foo"
+        let projectJson = Path.Combine(cd, "project.json")
+        let content = "{\"targets\":{\"build\":{\"outputs\":[\"{projectRoot}/dist\"]}}}"
+        File.WriteAllText(projectJson, content)
+        crateDir <- Some cd
+        configBefore <- Some(File.ReadAllBytes projectJson)
+
+    [<Given>]
+    member _.``the shared cache holds an entry for a crate that no longer exists in the repo outside CI``() =
+        let orphan = orphanEntry ()
+        Directory.CreateDirectory(orphan) |> ignore
+        File.WriteAllText(Path.Combine(orphan, "marker.txt"), "stale")
+        ci <- false
+
+    [<Given>]
+    member _.``a shared-cache entry is the symlink target of a crate in a live worktree``() =
+        let cd = makeCrate repoRoot "foo"
+        crateDir <- Some cd
+        fix <- true
+        exec ()
+        fix <- false
+        Directory.CreateDirectory(orphanEntry ()) |> ignore
+
+    [<Given>]
+    member _.``the shared cache holds at least one orphaned entry outside CI``() =
+        Directory.CreateDirectory(orphanEntry ()) |> ignore
+        ci <- false
+
+    [<Given>]
+    member _.``cargo-sweep is not installed on the developer's PATH``() =
+        scrubCargoSweep <- true
+        ci <- false
+
+    [<Given>]
+    member _.``a shared-cache entry is referenced only by a crate in a separate linked worktree``() =
+        let cd = makeCrate repoRoot "foo"
+        commitAll repoRoot "add apps/foo"
+        crateDir <- Some cd
+
+        let wtHolder = newTempDir "wtholder"
+        let wtPath = Path.Combine(wtHolder, "linked-wt")
+        addWorktree repoRoot wtPath
+        let wtCrateDir = Path.Combine(wtPath, "apps", "foo")
+        fix <- true
+        runDoctorAgainst wtPath
+        fix <- false
+
+        // `fix` is repo-global via `rootsOrSelf`: the run above also shared
+        // the main checkout's crate (both worktrees live under one repo).
+        // Drop the main checkout's symlink so this scenario's precondition
+        // holds — the entry must be referenced ONLY by the linked worktree.
+        let mainTarget = Path.Combine(repoRoot, "apps", "foo", "target")
+
+        if not (isNull (DirectoryInfo(mainTarget).LinkTarget)) then
+            Directory.Delete(mainTarget, false)
+
+        let orphan = orphanEntry ()
+        Directory.CreateDirectory(orphan) |> ignore
+        File.WriteAllText(Path.Combine(orphan, "marker.txt"), "stale")
+
+        secondWorktree <- Some(wtHolder, wtCrateDir)
+        ci <- false
+
+    [<Given>]
+    member _.``a rhino-cli test target is invoked with inherited GIT_DIR, GIT_WORK_TREE and GIT_COMMON_DIR``() =
+        gitStateCommands <- commandsForKnownTargets fsharpProjectJsonPath
+
+    // ---- When ----
+
+    [<When>]
+    member _.``the developer runs the doctor command with the fix flag``() =
+        fix <- true
+        exec ()
+
+    [<When>]
+    member _.``the developer runs the doctor command with the fix flag from the main checkout``() =
+        fix <- true
+        exec ()
+
+    [<When>]
+    member _.``the developer runs the doctor command with the fix flag a second time``() =
+        let before =
+            crateDir
+            |> Option.map (fun cd -> DirectoryInfo(Path.Combine(cd, "target")).LinkTarget)
+
+        fix <- true
+        exec ()
+
+        match before, crateDir with
+        | Some beforeLink, Some cd ->
+            let afterLink = DirectoryInfo(Path.Combine(cd, "target")).LinkTarget
+            Assert.Equal(beforeLink, afterLink)
+        | _ -> ()
+
+    [<When>]
+    member _.``the developer runs the doctor command with the fix flag outside CI``() =
+        ci <- false
+        fix <- true
+        exec ()
+
+    [<When>]
+    member _.``the developer runs the doctor command without the fix flag``() =
+        fix <- false
+        exec ()
+
+    [<When>]
+    member _.``both symlinks are resolved``() =
+        // The Given step already ran fix in both the main worktree and the
+        // linked worktree; resolution itself is asserted in the Then step.
+        ()
+
+    [<When>]
+    member _.``the developer builds and tests that crate through Nx``() =
+        // Deviation — see the module doc comment: builds/tests the synthetic
+        // crate directly via `cargo` (a throwaway tempdir fixture, not a
+        // real Nx project), proving the toolchain resolves correctly
+        // through the real symlinked `target/` this step creates.
+        let cd = crateDir |> Option.defaultWith (fun () -> failwith "crateDir set by Given")
+        let manifest = Path.Combine(cd, "Cargo.toml")
+
+        let run (args: string list) : Process =
+            let proc = new Process()
+            proc.StartInfo.FileName <- "cargo"
+            args |> List.iter proc.StartInfo.ArgumentList.Add
+            proc.StartInfo.ArgumentList.Add("--manifest-path")
+            proc.StartInfo.ArgumentList.Add(manifest)
+            proc.StartInfo.RedirectStandardOutput <- true
+            proc.StartInfo.RedirectStandardError <- true
+            proc.StartInfo.UseShellExecute <- false
+            proc.Start() |> ignore
+            proc.StandardOutput.ReadToEnd() |> ignore
+            proc.StandardError.ReadToEnd() |> ignore
+            proc.WaitForExit()
+            proc
+
+        use build = run [ "build"; "--quiet" ]
+        Assert.Equal(0, build.ExitCode)
+        use test = run [ "test"; "--quiet" ]
+        Assert.Equal(0, test.ExitCode)
+
+    [<When>]
+    member _.``the rhino-cli source and its Gherkin specs are diffed pairwise across the parity repos``() =
+        // Deviation — see the module doc comment: proxy — run `fixTargetShares`
+        // against two identically-shaped synthetic repos literally named
+        // `ose-public`/`ose-private`, sharing one cache root.
+        let parent = newTempDir "parity-parent"
+
+        let results =
+            [ "ose-public"; "ose-private" ]
+            |> List.map (fun name ->
+                let repoDir = Path.Combine(parent, name)
+                buildThrowawayRepo repoDir
+                let cd = makeCrate repoDir "rhino-cli"
+                let outcome = fixTargetShares repoDir cacheRoot name false
+                Assert.Equal(1, outcome.Created)
+                let link = DirectoryInfo(Path.Combine(cd, "target")).LinkTarget
+                Assert.NotNull(link)
+                (name, link))
+
+        repoNameResults <- results
+
+    [<When>]
+    member _.``one of those crates is built twice with no source change``() =
+        // Deviation — see the module doc comment: run fix twice (idempotent,
+        // per the unit tests) as the closest in-scope proxy for "built twice
+        // with no source change", then snapshot the Nx config file's bytes
+        // to prove doctor never touched it.
+        let cd = crateDir |> Option.defaultWith (fun () -> failwith "crateDir set by Given")
+        fix <- true
+        exec ()
+        exec ()
+        configAfter <- Some(File.ReadAllBytes(Path.Combine(cd, "project.json")))
+
+    [<When>]
+    member _.``the developer runs the doctor command with the prune flag``() =
+        prune <- true
+        exec ()
+
+    [<When>]
+    member _.``the developer runs the doctor command with the prune and dry-run flags``() =
+        prune <- true
+        dryRun <- true
+        exec ()
+
+    [<When>]
+    member _.``Nx launches the Rust test or coverage command``() = ()
+
+    // ---- Then ----
+
+    [<Then>]
+    member _.``the crate's target becomes a symlink into the shared cargo-target cache``() =
+        let cd = crateDir |> Option.defaultWith (fun () -> failwith "crateDir set by Given")
+        Assert.NotNull(DirectoryInfo(Path.Combine(cd, "target")).LinkTarget)
+
+    [<Then>]
+    member _.``the symlink resolves under the repo's own shared-cache namespace``() =
+        let cd = crateDir |> Option.defaultWith (fun () -> failwith "crateDir set by Given")
+        let link = DirectoryInfo(Path.Combine(cd, "target")).LinkTarget
+        Assert.StartsWith(cacheRoot, link)
+
+    [<Then>]
+    member _.``the command exits successfully without recreating or altering the symlink``() = ()
+
+    [<Then>]
+    member _.``the plain directory is discarded and the target becomes a symlink into the shared cache``() =
+        let cd = crateDir |> Option.defaultWith (fun () -> failwith "crateDir set by Given")
+        let target = Path.Combine(cd, "target")
+        let link = DirectoryInfo(target).LinkTarget
+        Assert.NotNull(link)
+        Assert.False(File.Exists(Path.Combine(link, "stale.txt")))
+
+    [<Then>]
+    member _.``the output reports that crate's target as needing to be shared``() =
+        Assert.Contains("need", outputText)
+        Assert.Contains("foo", outputText)
+
+    [<Then>]
+    member _.``the plain target directory is left unchanged``() =
+        let cd = crateDir |> Option.defaultWith (fun () -> failwith "crateDir set by Given")
+        let target = Path.Combine(cd, "target")
+        Assert.True(Directory.Exists(target))
+        Assert.Null(DirectoryInfo(target).LinkTarget)
+
+    [<Then>]
+    member _.``no target symlink is created for any crate``() =
+        let cd = crateDir |> Option.defaultWith (fun () -> failwith "crateDir set by Given")
+        Assert.Null(DirectoryInfo(Path.Combine(cd, "target")).LinkTarget)
+
+    [<Then>]
+    member _.``the command exits successfully with a message that CI was detected``() =
+        Assert.Contains("CI detected", outputText)
+
+    [<Then>]
+    member _.``no cache entry is deleted``() =
+        Assert.True(Directory.Exists(orphanEntry ()))
+
+    [<Then>]
+    member _.``every discovered crate's target is a symlink into the shared cache``() =
+        for rel in [ "apps/a"; "apps/b"; "libs/c" ] do
+            let target =
+                Path.Combine(repoRoot, rel.Replace('/', Path.DirectorySeparatorChar), "target")
+
+            Assert.NotNull(DirectoryInfo(target).LinkTarget)
+
+    [<Then>]
+    member _.``no crate is skipped due to a hardcoded crate list``() =
+        match fixOutcome with
+        | Some outcome -> Assert.Equal(3, outcome.Created)
+        | None -> failwith "fixOutcome set by When"
+
+    [<Then>]
+    member _.``both point at the same shared-cache directory for that repo and crate``() =
+        let cd = crateDir |> Option.defaultWith (fun () -> failwith "crateDir set by Given")
+
+        let (_, wtCrateDir) =
+            secondWorktree
+            |> Option.defaultWith (fun () -> failwith "secondWorktree set by Given")
+
+        let mainLink = DirectoryInfo(Path.Combine(cd, "target")).LinkTarget
+        let wtLink = DirectoryInfo(Path.Combine(wtCrateDir, "target")).LinkTarget
+        Assert.Equal(mainLink, wtLink)
+
+    [<Then>]
+    member _.``a disk usage measurement across the worktrees counts that directory only once``() =
+        let cd = crateDir |> Option.defaultWith (fun () -> failwith "crateDir set by Given")
+
+        let (_, wtCrateDir) =
+            secondWorktree
+            |> Option.defaultWith (fun () -> failwith "secondWorktree set by Given")
+
+        let mainCanonical =
+            Path.GetFullPath(DirectoryInfo(Path.Combine(cd, "target")).LinkTarget)
+
+        let wtCanonical =
+            Path.GetFullPath(DirectoryInfo(Path.Combine(wtCrateDir, "target")).LinkTarget)
+
+        Assert.Equal(mainCanonical, wtCanonical)
+
+    [<Then>]
+    member _.``the build emits the expected dist binary``() =
+        let cd = crateDir |> Option.defaultWith (fun () -> failwith "crateDir set by Given")
+        let bin = Path.Combine(cd, "target", "debug", "foo")
+        Assert.True(File.Exists(bin), sprintf "expected a built binary at %s" bin)
+
+    [<Then>]
+    member _.``the tests pass without reference to a per-worktree target directory``() =
+        // Asserted directly by the When step's exit-code checks; nothing
+        // further to inspect here.
+        ()
+
+    [<Then>]
+    member _.``the diff is empty for every apps/rhino-cli source file and every specs/apps/rhino feature file``() =
+        Assert.Equal(2, List.length repoNameResults)
+
+        let leaves =
+            repoNameResults
+            |> List.map (fun (name, link) ->
+                let expectedSuffix = Path.Combine(name, "rhino-cli")
+
+                Assert.True(
+                    link.EndsWith(expectedSuffix, StringComparison.Ordinal),
+                    sprintf "%s must end in %s" link expectedSuffix
+                )
+
+                Path.GetDirectoryName(Path.GetDirectoryName(link: string)))
+
+        Assert.True(leaves |> List.forall (fun l -> l = leaves.[0]))
+
+    [<Then>]
+    member _.``the second run is served from the Nx cache``() =
+        Assert.Equal<byte[]>(configBefore |> Option.defaultValue [||], configAfter |> Option.defaultValue [||])
+
+    [<Then>]
+    member _.``its dist binary is present after both runs``() =
+        let cd = crateDir |> Option.defaultWith (fun () -> failwith "crateDir set by Given")
+        Assert.NotNull(DirectoryInfo(Path.Combine(cd, "target")).LinkTarget)
+
+    [<Then>]
+    member _.``the orphaned cache entry is deleted``() =
+        Assert.False(Directory.Exists(orphanEntry ()))
+
+    [<Then>]
+    member _.``every entry still referenced by a live worktree or checkout is preserved``() =
+        match crateDir with
+        | Some cd ->
+            let target = Path.Combine(cd, "target")
+            let link = DirectoryInfo(target).LinkTarget
+
+            if not (isNull link) then
+                Assert.True(Directory.Exists(link))
+        | None -> ()
+
+    [<Then>]
+    member _.``that referenced cache entry is left in place``() =
+        let cd = crateDir |> Option.defaultWith (fun () -> failwith "crateDir set by Given")
+        let link = DirectoryInfo(Path.Combine(cd, "target")).LinkTarget
+        Assert.True(Directory.Exists(link))
+
+    [<Then>]
+    member _.``that linked worktree's crate target becomes a symlink into the shared cache``() =
+        let (_, wtCrateDir) =
+            secondWorktree
+            |> Option.defaultWith (fun () -> failwith "secondWorktree set by Given")
+
+        let wtTarget = Path.Combine(wtCrateDir, "target")
+        Assert.NotNull(DirectoryInfo(wtTarget).LinkTarget)
+        let shared = Path.Combine(cacheRoot, repoNameValue, "foo")
+        Assert.False(File.Exists(Path.Combine(shared, "stale.txt")))
+
+    [<Then>]
+    member _.``it resolves to the same shared-cache entry as the main checkout's crate``() =
+        let (_, wtCrateDir) =
+            secondWorktree
+            |> Option.defaultWith (fun () -> failwith "secondWorktree set by Given")
+
+        let cd = crateDir |> Option.defaultWith (fun () -> failwith "crateDir set by Given")
+        let wtLink = DirectoryInfo(Path.Combine(wtCrateDir, "target")).LinkTarget
+        let mainLink = DirectoryInfo(Path.Combine(cd, "target")).LinkTarget
+        Assert.Equal(wtLink, mainLink)
+        Assert.Equal(Path.Combine(cacheRoot, repoNameValue, "foo"), wtLink)
+
+    [<Then>]
+    member _.``only entries with no live referrer are removed``() =
+        Assert.False(Directory.Exists(orphanEntry ()))
+
+    [<Then>]
+    member _.``the entry referenced only by the linked worktree is left in place``() =
+        let (_, wtCrateDir) =
+            secondWorktree
+            |> Option.defaultWith (fun () -> failwith "secondWorktree set by Given")
+
+        let link = DirectoryInfo(Path.Combine(wtCrateDir, "target")).LinkTarget
+        Assert.True(Directory.Exists(link))
+
+    [<Then>]
+    member _.``the orphaned entry is reported as a candidate for deletion``() =
+        Assert.Contains("candidate", outputText)
+
+    [<Then>]
+    member _.``no cache entry is actually removed``() =
+        Assert.True(Directory.Exists(orphanEntry ()))
+
+    [<Then>]
+    member _.``the sweep step is reported as skipped rather than failing the command``() =
+        Assert.Contains("skipped", outputText.ToLowerInvariant())
+
+    [<Then>]
+    member _.``the command exits successfully``() = ()
+
+    [<Then>]
+    member _.``all three inherited variables are cleared for that command``() =
+        Assert.NotEmpty(gitStateCommands)
+
+        for name, command in gitStateCommands do
+            Assert.True(
+                command.Contains(gitStateScrub + "dotnet test", StringComparison.Ordinal),
+                sprintf
+                    "%s must clear GIT_DIR, GIT_WORK_TREE, and GIT_COMMON_DIR before dotnet test; got %s"
+                    name
+                    command
+            )
+
+    [<Then>]
+    member _.``a regression test protects the target configuration before any downstream copy``() =
+        let offenders = unguardedDotnetTestOccurrences fsharpProjectJsonPath
+        Assert.Empty(offenders)
+
+    [<AfterScenario>]
+    member _.Cleanup() =
+        for dir in ownedDirs do
+            if Directory.Exists dir then
+                Directory.Delete(dir, true)
+
+// ---------------------------------------------------------------------------
+// FeatureRunner
+// ---------------------------------------------------------------------------
+
+/// Reads one named `Scenario:` block out of the real, frozen
+/// `cargo-target-share.feature` file (leaving the file itself untouched) and
+/// runs it through TickSpec bound only against `DoctorSteps` — see
+/// `EnvSteps.fs`'s `FeatureRunner` for why this is per-scenario rather than
+/// per-file.
+module private FeatureRunner =
+
+    let private featurePath: string =
+        Path.GetFullPath(
+            Path.Combine(
+                __SOURCE_DIRECTORY__,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "specs",
+                "apps",
+                "rhino",
+                "behavior",
+                "rhino-cli",
+                "gherkin",
+                "system",
+                "cargo-target-share.feature"
+            )
+        )
+
+    let private extractScenario (featureLines: string[]) (scenarioTitle: string) : string[] =
+        let featureLine =
+            featureLines
+            |> Array.find (fun l -> l.TrimStart().StartsWith("Feature:", StringComparison.Ordinal))
+
+        let scenarioHeader = sprintf "Scenario: %s" scenarioTitle
+        let startIdx = featureLines |> Array.findIndex (fun l -> l.Trim() = scenarioHeader)
+
+        let endIdx =
+            featureLines
+            |> Array.skip (startIdx + 1)
+            |> Array.tryFindIndex (fun l ->
+                let trimmed = l.Trim()
+
+                trimmed.StartsWith("Scenario:", StringComparison.Ordinal)
+                || trimmed.StartsWith("@", StringComparison.Ordinal))
+            |> Option.map (fun relativeIdx -> startIdx + 1 + relativeIdx)
+            |> Option.defaultValue featureLines.Length
+
+        Array.append [| featureLine; "" |] featureLines.[startIdx .. endIdx - 1]
+
+    /// Runs the single scenario named `scenarioTitle` from
+    /// `cargo-target-share.feature`, bound against `DoctorSteps`.
+    let run (scenarioTitle: string) : unit =
+        let allLines = File.ReadAllLines featurePath
+        let snippet = extractScenario allLines scenarioTitle
+        let definitions = StepDefinitions([| typeof<DoctorSteps> |])
+        let feature = definitions.GenerateFeature(featurePath, snippet)
+        let scenario = Seq.exactlyOne feature.Scenarios
+        scenario.Action.Invoke()
+
+[<Fact>]
+let ``doctor --fix symlinks a crate's target into the shared cache`` () =
+    FeatureRunner.run "doctor --fix symlinks a crate's target into the shared cache"
+
+[<Fact>]
+let ``the doctor fix step is idempotent`` () =
+    FeatureRunner.run "the doctor fix step is idempotent"
+
+[<Fact>]
+let ``doctor --fix replaces an existing plain target directory with a symlink`` () =
+    FeatureRunner.run "doctor --fix replaces an existing plain target directory with a symlink"
+
+[<Fact>]
+let ``doctor check reports a crate whose target is not yet shared`` () =
+    FeatureRunner.run "doctor check reports a crate whose target is not yet shared"
+
+[<Fact>]
+let ``the doctor symlink step no-ops under CI`` () =
+    FeatureRunner.run "the doctor symlink step no-ops under CI"
+
+[<Fact>]
+let ``dynamic discovery covers every crate under apps and libs`` () =
+    FeatureRunner.run "dynamic discovery covers every crate under apps and libs"
+
+[<Fact>]
+let ``two worktrees of the same repo share one physical target`` () =
+    FeatureRunner.run "two worktrees of the same repo share one physical target"
+
+[<Fact>]
+let ``doctor --fix from the main checkout also shares every linked worktree's target`` () =
+    FeatureRunner.run "doctor --fix from the main checkout also shares every linked worktree's target"
+
+[<Fact>]
+let ``builds and tests resolve through the symlink`` () =
+    FeatureRunner.run "builds and tests resolve through the symlink"
+
+[<Fact>]
+let ``the doctor change is byte-identical across the parity repos`` () =
+    FeatureRunner.run "the doctor change is byte-identical across the parity repos"
+
+[<Fact>]
+let ``Nx build caching is unaffected for crates that emit only dist`` () =
+    FeatureRunner.run "Nx build caching is unaffected for crates that emit only dist"
+
+[<Fact>]
+let ``prune removes an orphaned shared-cache entry`` () =
+    FeatureRunner.run "prune removes an orphaned shared-cache entry"
+
+[<Fact>]
+let ``prune preserves a cache entry referenced by a live worktree`` () =
+    FeatureRunner.run "prune preserves a cache entry referenced by a live worktree"
+
+[<Fact>]
+let ``prune from the main worktree preserves an entry referenced only by a linked worktree`` () =
+    FeatureRunner.run "prune from the main worktree preserves an entry referenced only by a linked worktree"
+
+[<Fact>]
+let ``the prune step no-ops under CI`` () =
+    FeatureRunner.run "the prune step no-ops under CI"
+
+[<Fact>]
+let ``prune dry-run previews deletions without removing anything`` () =
+    FeatureRunner.run "prune dry-run previews deletions without removing anything"
+
+[<Fact>]
+let ``stale-artifact sweep degrades gracefully when cargo-sweep is absent`` () =
+    FeatureRunner.run "stale-artifact sweep degrades gracefully when cargo-sweep is absent"
+
+[<Fact>]
+let ``Rust test targets ignore inherited Git process state`` () =
+    FeatureRunner.run "Rust test targets ignore inherited Git process state"

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorUnitTests.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorUnitTests.fs
@@ -1,0 +1,503 @@
+/// Plain xunit tests for `RhinoCli.Application.Doctor`'s pure/testable
+/// cargo target-share helpers — behaviour with no dedicated Gherkin scenario,
+/// or exercised only indirectly there (mirrors the rationale
+/// `EnvStagedGuardUnitTests.fs`'s module doc comment states for its own split
+/// from `DoctorSteps.fs`). Ported from
+/// `apps/rhino-cli/src/application/doctor/target_share.rs`'s
+/// `#[cfg(test)] mod tests`.
+///
+/// `sweep_scope_is_repo_namespaced` is not ported: `sweepScope` is a private
+/// helper (not part of `Doctor`'s public surface, unlike Rust's
+/// `pub(crate)`-equivalent test-only visibility), and the property it guards
+/// — the sweep never touching a sibling repo's cache namespace — is already
+/// exercised end-to-end by every `pruneOrphans`/`sweepStale` test below,
+/// which all pass a repo-scoped `cacheRoot/repoName` path.
+module RhinoCli.Tests.Unit.Steps.DoctorUnitTests
+
+open System
+open System.Diagnostics
+open System.IO
+open Xunit
+open RhinoCli.Application.Doctor
+
+// ---- isCi ----
+
+[<Fact>]
+let ``isCi is true when either signal is set`` () =
+    Assert.True(isCi true false, "CI set alone must report true")
+    Assert.True(isCi false true, "GITHUB_ACTIONS set alone must report true")
+    Assert.True(isCi true true, "both set must report true")
+    Assert.False(isCi false false, "neither set must report false")
+
+// ---- discoverCrates ----
+
+let private writeCargoToml (dir: string) =
+    Directory.CreateDirectory(dir) |> ignore
+    File.WriteAllText(Path.Combine(dir, "Cargo.toml"), "[package]\nname = \"x\"\n")
+
+[<Fact>]
+let ``discoverCrates walks apps and libs`` () =
+    let root =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-discover-" + Guid.NewGuid().ToString("N"))
+
+    try
+        writeCargoToml (Path.Combine(root, "apps", "a"))
+        writeCargoToml (Path.Combine(root, "apps", "b"))
+        writeCargoToml (Path.Combine(root, "libs", "c"))
+        // A non-crate directory (no Cargo.toml) must NOT be discovered.
+        Directory.CreateDirectory(Path.Combine(root, "apps", "not-a-crate")) |> ignore
+
+        let found = discoverCrates root |> List.sort
+
+        let expected =
+            [ Path.Combine(root, "apps", "a")
+              Path.Combine(root, "apps", "b")
+              Path.Combine(root, "libs", "c") ]
+            |> List.sort
+
+        Assert.Equal<string list>(expected, found)
+    finally
+        Directory.Delete(root, true)
+
+// ---- cacheRootFrom / repoName / sharedTargetPath ----
+
+[<Fact>]
+let ``cacheRootFrom honors an explicit override`` () =
+    Assert.Equal("/override/dir", cacheRootFrom (Some "/override/dir") None)
+
+[<Fact>]
+let ``cacheRootFrom falls back to home cache dir when no override is given`` () =
+    Assert.Equal(Path.Combine("/home/dev", ".cache", "ose-cargo-target"), cacheRootFrom None (Some "/home/dev"))
+
+[<Fact>]
+let ``repoName returns the basename of the common dir's parent`` () =
+    Assert.Equal("my-repo", repoName (Path.Combine("/some/path/my-repo", ".git")))
+
+[<Fact>]
+let ``sharedTargetPath composes cache root, repo name, and crate leaf`` () =
+    Assert.Equal(
+        Path.Combine("/cache", "my-repo", "rhino-cli"),
+        sharedTargetPath "/cache" "my-repo" (Path.Combine("/some/path/my-repo", "apps", "rhino-cli"))
+    )
+
+// ---- git fixture helpers (mirrors ParityUnitTests.fs's own self-contained fixture) ----
+
+let private runGit (cwd: string) (args: string list) : unit =
+    use proc = new Process()
+    proc.StartInfo.FileName <- "git"
+    args |> List.iter proc.StartInfo.ArgumentList.Add
+    proc.StartInfo.WorkingDirectory <- cwd
+    proc.StartInfo.RedirectStandardOutput <- true
+    proc.StartInfo.RedirectStandardError <- true
+    proc.StartInfo.UseShellExecute <- false
+    proc.StartInfo.EnvironmentVariables.Remove("GIT_DIR")
+    proc.StartInfo.EnvironmentVariables.Remove("GIT_WORK_TREE")
+    proc.Start() |> ignore
+    let stderr = proc.StandardError.ReadToEnd()
+    proc.WaitForExit()
+
+    if proc.ExitCode <> 0 then
+        failwithf "git %s failed in %s: %s" (String.concat " " args) cwd stderr
+
+/// A fresh `git init` repository with a committable identity configured
+/// locally (never touches global/user git config).
+let private newGitFixture (prefix: string) : string =
+    let dir =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-" + prefix + "-" + Guid.NewGuid().ToString("N"))
+
+    Directory.CreateDirectory(dir) |> ignore
+    runGit dir [ "init"; "-q"; "-b"; "main" ]
+    runGit dir [ "config"; "user.name"; "Rhino CLI Test" ]
+    runGit dir [ "config"; "user.email"; "rhino-cli-test@example.invalid" ]
+    File.WriteAllText(Path.Combine(dir, "README.md"), "throwaway fixture")
+    runGit dir [ "add"; "." ]
+    runGit dir [ "commit"; "-m"; "init" ]
+    dir
+
+let private addWorktree (repoDir: string) (worktreeDir: string) : unit =
+    runGit repoDir [ "worktree"; "add"; "--detach"; worktreeDir ]
+
+let private makeCrate (repoRoot: string) (name: string) : string =
+    let crateDir = Path.Combine(repoRoot, "apps", name)
+    writeCargoToml crateDir
+    crateDir
+
+// ---- checkTargetShares ----
+
+[<Fact>]
+let ``checkTargetShares reports unshared target without mutating it`` () =
+    let repoRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-check-" + Guid.NewGuid().ToString("N"))
+
+    let cacheRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-cache-" + Guid.NewGuid().ToString("N"))
+
+    try
+        let crateDir = makeCrate repoRoot "foo"
+        let targetDir = Path.Combine(crateDir, "target")
+        Directory.CreateDirectory(targetDir) |> ignore
+        File.WriteAllText(Path.Combine(targetDir, "marker.txt"), "stale")
+
+        let report = checkTargetShares repoRoot cacheRoot "myrepo" false
+        Assert.Equal(1, List.length report)
+        Assert.Equal(crateDir, report.[0].CrateDir)
+        Assert.Equal(Path.Combine(cacheRoot, "myrepo", "foo"), report.[0].SharedPath)
+
+        // No mutation: the plain directory and its stale marker file survive.
+        Assert.True(Directory.Exists(targetDir))
+        Assert.True(File.Exists(Path.Combine(targetDir, "marker.txt")))
+
+        let ciReport = checkTargetShares repoRoot cacheRoot "myrepo" true
+        Assert.Empty(ciReport)
+    finally
+        Directory.Delete(repoRoot, true)
+
+        if Directory.Exists(cacheRoot) then
+            Directory.Delete(cacheRoot, true)
+
+// ---- fixTargetShares ----
+
+[<Fact>]
+let ``fixTargetShares creates a symlink into the shared cache`` () =
+    let repoRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-fix-" + Guid.NewGuid().ToString("N"))
+
+    let cacheRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-cache-" + Guid.NewGuid().ToString("N"))
+
+    try
+        let crateDir = makeCrate repoRoot "foo"
+
+        let outcome = fixTargetShares repoRoot cacheRoot "myrepo" false
+        Assert.Equal(1, outcome.Created)
+
+        let target = Path.Combine(crateDir, "target")
+        let expectedShared = Path.Combine(cacheRoot, "myrepo", "foo")
+        Assert.NotNull(DirectoryInfo(target).LinkTarget)
+        Assert.Equal(expectedShared, DirectoryInfo(target).LinkTarget)
+    finally
+        Directory.Delete(repoRoot, true)
+
+        if Directory.Exists(cacheRoot) then
+            Directory.Delete(cacheRoot, true)
+
+[<Fact>]
+let ``fixTargetShares is idempotent on a second run`` () =
+    let repoRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-fix2-" + Guid.NewGuid().ToString("N"))
+
+    let cacheRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-cache-" + Guid.NewGuid().ToString("N"))
+
+    try
+        let crateDir = makeCrate repoRoot "foo"
+
+        let first = fixTargetShares repoRoot cacheRoot "myrepo" false
+        Assert.Equal(1, first.Created)
+
+        let target = Path.Combine(crateDir, "target")
+        let linkBefore = DirectoryInfo(target).LinkTarget
+
+        let second = fixTargetShares repoRoot cacheRoot "myrepo" false
+        Assert.Equal(1, second.AlreadyCorrect)
+        Assert.Equal(0, second.Created)
+
+        Assert.Equal(linkBefore, DirectoryInfo(target).LinkTarget)
+    finally
+        Directory.Delete(repoRoot, true)
+
+        if Directory.Exists(cacheRoot) then
+            Directory.Delete(cacheRoot, true)
+
+[<Fact>]
+let ``fixTargetShares replaces a plain target directory with a symlink`` () =
+    let repoRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-fix3-" + Guid.NewGuid().ToString("N"))
+
+    let cacheRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-cache-" + Guid.NewGuid().ToString("N"))
+
+    try
+        let crateDir = makeCrate repoRoot "foo"
+        let target = Path.Combine(crateDir, "target")
+        Directory.CreateDirectory(target) |> ignore
+        File.WriteAllText(Path.Combine(target, "stale.txt"), "stale artifact")
+
+        let outcome = fixTargetShares repoRoot cacheRoot "myrepo" false
+        Assert.Equal(1, outcome.ReplacedPlainDir)
+        Assert.NotNull(DirectoryInfo(target).LinkTarget)
+
+        let sharedPath = Path.Combine(cacheRoot, "myrepo", "foo")
+        Assert.False(File.Exists(Path.Combine(sharedPath, "stale.txt")))
+    finally
+        Directory.Delete(repoRoot, true)
+
+        if Directory.Exists(cacheRoot) then
+            Directory.Delete(cacheRoot, true)
+
+[<Fact>]
+let ``fixTargetShares no-ops under CI`` () =
+    let repoRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-fixci-" + Guid.NewGuid().ToString("N"))
+
+    let cacheRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-cache-" + Guid.NewGuid().ToString("N"))
+
+    try
+        let crateDir = makeCrate repoRoot "foo"
+        let target = Path.Combine(crateDir, "target")
+        Directory.CreateDirectory(target) |> ignore
+
+        let outcome = fixTargetShares repoRoot cacheRoot "myrepo" true
+        Assert.True(outcome.SkippedCi)
+        Assert.Equal(0, outcome.Created)
+        Assert.Equal(0, outcome.ReplacedPlainDir)
+        Assert.True(Directory.Exists(target))
+        Assert.Null(DirectoryInfo(target).LinkTarget)
+    finally
+        Directory.Delete(repoRoot, true)
+
+        if Directory.Exists(cacheRoot) then
+            Directory.Delete(cacheRoot, true)
+
+[<Fact>]
+let ``fixTargetShares run from the main checkout also shares a linked worktree's crate`` () =
+    let repo = newGitFixture "fix-linked"
+
+    let cacheRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-cache-" + Guid.NewGuid().ToString("N"))
+
+    let linked =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-linked-" + Guid.NewGuid().ToString("N"))
+
+    try
+        makeCrate repo "foo" |> ignore
+        addWorktree repo linked
+        let linkedCrate = makeCrate linked "foo"
+        let linkedTarget = Path.Combine(linkedCrate, "target")
+        Directory.CreateDirectory(linkedTarget) |> ignore
+
+        let outcome = fixTargetShares repo cacheRoot "myrepo" false
+        Assert.Equal(2, outcome.Created)
+
+        let shared = Path.Combine(cacheRoot, "myrepo", "foo")
+        Assert.Equal(shared, DirectoryInfo(linkedTarget).LinkTarget)
+        Assert.Equal(shared, DirectoryInfo(Path.Combine(repo, "apps", "foo", "target")).LinkTarget)
+    finally
+        (try
+            runGit repo [ "worktree"; "remove"; "--force"; linked ]
+         with _ ->
+             ())
+
+        Directory.Delete(repo, true)
+
+        if Directory.Exists(linked) then
+            Directory.Delete(linked, true)
+
+        if Directory.Exists(cacheRoot) then
+            Directory.Delete(cacheRoot, true)
+
+// ---- pruneOrphans ----
+
+[<Fact>]
+let ``pruneOrphans removes an orphaned shared-cache entry`` () =
+    let repo = newGitFixture "prune-orphan"
+
+    let cacheRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-cache-" + Guid.NewGuid().ToString("N"))
+
+    try
+        let orphanDir = Path.Combine(cacheRoot, "myrepo", "orphan-crate")
+        Directory.CreateDirectory(orphanDir) |> ignore
+        File.WriteAllText(Path.Combine(orphanDir, "marker.txt"), "stale")
+
+        let outcome = pruneOrphans repo cacheRoot "myrepo" false false
+        Assert.Equal<string list>([ orphanDir ], outcome.Deleted)
+        Assert.False(Directory.Exists(orphanDir))
+    finally
+        Directory.Delete(repo, true)
+
+        if Directory.Exists(cacheRoot) then
+            Directory.Delete(cacheRoot, true)
+
+[<Fact>]
+let ``pruneOrphans fails closed when worktree enumeration fails`` () =
+    let nonRepo =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-nonrepo-" + Guid.NewGuid().ToString("N"))
+
+    let cacheRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-cache-" + Guid.NewGuid().ToString("N"))
+
+    Directory.CreateDirectory(nonRepo) |> ignore
+
+    try
+        let entryDir = Path.Combine(cacheRoot, "myrepo", "some-crate")
+        Directory.CreateDirectory(entryDir) |> ignore
+        File.WriteAllText(Path.Combine(entryDir, "marker.txt"), "keep")
+
+        let outcome = pruneOrphans nonRepo cacheRoot "myrepo" false false
+        Assert.True(outcome.EnumerationFailed)
+        Assert.Empty(outcome.Deleted)
+        Assert.True(Directory.Exists(entryDir))
+    finally
+        Directory.Delete(nonRepo, true)
+
+        if Directory.Exists(cacheRoot) then
+            Directory.Delete(cacheRoot, true)
+
+[<Fact>]
+let ``pruneOrphans preserves an entry referenced by a live worktree`` () =
+    let repo = newGitFixture "prune-live"
+
+    let cacheRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-cache-" + Guid.NewGuid().ToString("N"))
+
+    try
+        let liveDir = Path.Combine(cacheRoot, "myrepo", "foo")
+        Directory.CreateDirectory(liveDir) |> ignore
+
+        let crateDir = makeCrate repo "foo"
+
+        Directory.CreateSymbolicLink(Path.Combine(crateDir, "target"), liveDir)
+        |> ignore
+
+        let outcome = pruneOrphans repo cacheRoot "myrepo" false false
+        Assert.Empty(outcome.Deleted)
+        Assert.True(Directory.Exists(liveDir))
+    finally
+        Directory.Delete(repo, true)
+
+        if Directory.Exists(cacheRoot) then
+            Directory.Delete(cacheRoot, true)
+
+[<Fact>]
+let ``pruneOrphans no-ops under CI`` () =
+    let repoRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-pruneci-" + Guid.NewGuid().ToString("N"))
+
+    let cacheRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-cache-" + Guid.NewGuid().ToString("N"))
+
+    Directory.CreateDirectory(repoRoot) |> ignore
+
+    try
+        let orphanDir = Path.Combine(cacheRoot, "myrepo", "orphan-crate")
+        Directory.CreateDirectory(orphanDir) |> ignore
+
+        let outcome = pruneOrphans repoRoot cacheRoot "myrepo" false true
+        Assert.True(outcome.SkippedCi)
+        Assert.Empty(outcome.Deleted)
+        Assert.True(Directory.Exists(orphanDir))
+    finally
+        Directory.Delete(repoRoot, true)
+
+        if Directory.Exists(cacheRoot) then
+            Directory.Delete(cacheRoot, true)
+
+[<Fact>]
+let ``pruneOrphans dry-run reports without deleting`` () =
+    let repo = newGitFixture "prune-dry"
+
+    let cacheRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-cache-" + Guid.NewGuid().ToString("N"))
+
+    try
+        let orphanDir = Path.Combine(cacheRoot, "myrepo", "orphan-crate")
+        Directory.CreateDirectory(orphanDir) |> ignore
+
+        let outcome = pruneOrphans repo cacheRoot "myrepo" true false
+        Assert.Equal<string list>([ orphanDir ], outcome.Candidates)
+        Assert.Empty(outcome.Deleted)
+        Assert.True(Directory.Exists(orphanDir))
+    finally
+        Directory.Delete(repo, true)
+
+        if Directory.Exists(cacheRoot) then
+            Directory.Delete(cacheRoot, true)
+
+// ---- sweepStale ----
+
+[<Fact>]
+let ``sweepStale reports Skipped when cargo-sweep is absent`` () =
+    let cacheRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-sweep-" + Guid.NewGuid().ToString("N"))
+
+    Directory.CreateDirectory(cacheRoot) |> ignore
+
+    try
+        let outcome = sweepStale cacheRoot "myrepo" false false false
+        Assert.True(outcome.Skipped)
+        Assert.False(outcome.Ran)
+    finally
+        if Directory.Exists(cacheRoot) then
+            Directory.Delete(cacheRoot, true)
+
+[<Fact>]
+let ``sweepStale is CI-guarded even when cargo-sweep is present`` () =
+    let cacheRoot =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-doctor-sweep2-" + Guid.NewGuid().ToString("N"))
+
+    Directory.CreateDirectory(cacheRoot) |> ignore
+
+    try
+        let outcome = sweepStale cacheRoot "myrepo" false true true
+        Assert.True(outcome.SkippedCi)
+        Assert.False(outcome.Ran)
+        Assert.False(outcome.Skipped)
+    finally
+        if Directory.Exists(cacheRoot) then
+            Directory.Delete(cacheRoot, true)
+
+// ---- format* ----
+
+[<Fact>]
+let ``formatCheckReport reports CI skip`` () =
+    Assert.Contains("CI detected", formatCheckReport [] true)
+
+[<Fact>]
+let ``formatCheckReport reports crates needing sharing`` () =
+    let text =
+        formatCheckReport
+            [ { CrateDir = "apps/foo"
+                SharedPath = "/cache/myrepo/foo" } ]
+            false
+
+    Assert.Contains("1 crate(s) need sharing", text)
+    Assert.Contains("apps/foo", text)
+
+[<Fact>]
+let ``formatFixReport reports the created/already-correct/replaced counts`` () =
+    let text =
+        formatFixReport
+            { Created = 1
+              AlreadyCorrect = 2
+              ReplacedPlainDir = 1
+              SkippedCi = false }
+
+    Assert.Contains("1 created", text)
+    Assert.Contains("2 already correct", text)
+    Assert.Contains("1 plain dir(s) replaced", text)
+
+[<Fact>]
+let ``formatPruneReport reports candidates under dry-run`` () =
+    let text =
+        formatPruneReport
+            { Deleted = []
+              Preserved = []
+              Candidates = [ "/cache/myrepo/orphan" ]
+              SkippedCi = false
+              EnumerationFailed = false }
+            true
+
+    Assert.Contains("candidate", text)
+    Assert.Contains("/cache/myrepo/orphan", text)
+
+[<Fact>]
+let ``formatSweepReport is empty when the sweep ran`` () =
+    Assert.Equal(
+        "",
+        formatSweepReport
+            { Skipped = false
+              SkippedCi = false
+              Ran = true }
+    )

--- a/plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md
+++ b/plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md
@@ -2844,8 +2844,8 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       pre-existing `2d1197e39` commit for `repo-config/`, `repo-config-validate/`, `env/**`,
       `env-contract/**`; this PR's rebase onto PR#323 (#323) added the merge-conflict-resolved
       `specs/env-staged-guard.feature` file-scoped entry to both). `npx nx run
-  rhino-cli-fsharp:specs:behavior:coverage` exits 0, reporting `11 specs, 73 scenarios, 331
-  steps — all covered`. Temporarily renaming
+rhino-cli-fsharp:specs:behavior:coverage` exits 0, reporting `11 specs, 73 scenarios, 331
+steps — all covered`. Temporarily renaming
       `EnvStagedGuardSteps.fs`'s `a real .env file is staged for commit` step turned the check
       red with `Missing steps (1)` naming the exact scenario/step, restored afterwards with a clean
       `git diff`.
@@ -2878,7 +2878,7 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       `HOME=<scratch-dir> apps/rhino-cli/scripts/shadow-diff.sh repo-config env` again reports
       `30 invocation(s) compared, 0 difference(s)`. Additionally exercised the shim itself (not just
       shadow-diff's own direct binary comparison): `bash -x apps/rhino-cli/scripts/rhino-bin.sh env
-  validate` shows `exec .../src-fsharp/dist/rhino-cli-fsharp env validate`, confirming
+validate` shows `exec .../src-fsharp/dist/rhino-cli-fsharp env validate`, confirming
       `repo-config`/`env` now route to the published F# binary end-to-end.
 - [x] [AI] Re-measure 50-invocation startup of the F# binary now that it carries the namespaces
       flipped so far — acceptance: the figure is appended to `benchmark.md` as a running row labelled
@@ -2910,7 +2910,7 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       identical to its post-flip state). With `FSHARP_NAMESPACES=("convention" "parity")` (entries
       removed), `apps/rhino-cli/scripts/shadow-diff.sh repo-config env` reports
       `30 invocation(s) compared, 0 difference(s)` — routed to Rust. `gate list --surface=ci
-  --format=json --by-group` against the removed-entries shim differs from
+--format=json --by-group` against the removed-entries shim differs from
       `evidence/gate-before-ose-public.json` only in JSON array line-wrapping (the tracked file was
       prettier-formatted after capture); a Python `json.load` structural comparison of the two
       confirms `SEMANTICALLY EQUAL`. With `FSHARP_NAMESPACES` restored to
@@ -2931,10 +2931,10 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       **Date**: 2026-08-27. **Status**: done. **Files Changed**: none (verification only).
       `grep -n "dotnet run\|dotnet build" .github/workflows/*.yml` returns exactly one hit: a code
       comment inside the unrelated `.NET quality gate` (`dotnet`) job explaining a `dotnet build
-  --no-restore` prerequisite for that job's own `typecheck` target — not an invocation, and not
+--no-restore` prerequisite for that job's own `typecheck` target — not an invocation, and not
       in a job that executes a flipped namespace. Every job that shells to `rhino-bin.sh` for a gate
       command (`gate`, `format`) sets `RHINO_CLI_FSHARP_BIN:
-  ${{ github.workspace }}/apps/rhino-cli/src-fsharp/dist/rhino-cli-fsharp`, and all such jobs
+${{ github.workspace }}/apps/rhino-cli/src-fsharp/dist/rhino-cli-fsharp`, and all such jobs
       `needs: build-rhino` (directly or transitively via `enumerate`), so the binary those jobs run
       is always `build-rhino`'s uploaded artifact, never a from-source rebuild.
 - [ ] [AI] Land every Wave B change in the `ose-private` worktree, authored there rather than
@@ -2965,7 +2965,7 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       **Date**: 2026-08-27. **Status**: done (`ose-public` only; `benchmark.md` is per-repo and this
       PR does not touch `ose-private`). **Files Changed**:
       `plans/in-progress/rewrite-rhino-cli-to-fsharp/benchmark.md`. `grep -c 'after wave B'
-  benchmark.md` returns `1`; that one section contains both the B5 (startup) and B6
+benchmark.md` returns `1`; that one section contains both the B5 (startup) and B6
       (pre-commit) rows.
 
 > **Pause Safety**: the namespaces flipped so far run on F#, the rest still run on Rust, and both

--- a/plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md
+++ b/plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md
@@ -2844,8 +2844,8 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       pre-existing `2d1197e39` commit for `repo-config/`, `repo-config-validate/`, `env/**`,
       `env-contract/**`; this PR's rebase onto PR#323 (#323) added the merge-conflict-resolved
       `specs/env-staged-guard.feature` file-scoped entry to both). `npx nx run
-    rhino-cli-fsharp:specs:behavior:coverage` exits 0, reporting `11 specs, 73 scenarios, 331
-    steps — all covered`. Temporarily renaming
+  rhino-cli-fsharp:specs:behavior:coverage` exits 0, reporting `11 specs, 73 scenarios, 331
+  steps — all covered`. Temporarily renaming
       `EnvStagedGuardSteps.fs`'s `a real .env file is staged for commit` step turned the check
       red with `Missing steps (1)` naming the exact scenario/step, restored afterwards with a clean
       `git diff`.
@@ -2878,7 +2878,7 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       `HOME=<scratch-dir> apps/rhino-cli/scripts/shadow-diff.sh repo-config env` again reports
       `30 invocation(s) compared, 0 difference(s)`. Additionally exercised the shim itself (not just
       shadow-diff's own direct binary comparison): `bash -x apps/rhino-cli/scripts/rhino-bin.sh env
-    validate` shows `exec .../src-fsharp/dist/rhino-cli-fsharp env validate`, confirming
+  validate` shows `exec .../src-fsharp/dist/rhino-cli-fsharp env validate`, confirming
       `repo-config`/`env` now route to the published F# binary end-to-end.
 - [x] [AI] Re-measure 50-invocation startup of the F# binary now that it carries the namespaces
       flipped so far — acceptance: the figure is appended to `benchmark.md` as a running row labelled
@@ -2910,7 +2910,7 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       identical to its post-flip state). With `FSHARP_NAMESPACES=("convention" "parity")` (entries
       removed), `apps/rhino-cli/scripts/shadow-diff.sh repo-config env` reports
       `30 invocation(s) compared, 0 difference(s)` — routed to Rust. `gate list --surface=ci
-    --format=json --by-group` against the removed-entries shim differs from
+  --format=json --by-group` against the removed-entries shim differs from
       `evidence/gate-before-ose-public.json` only in JSON array line-wrapping (the tracked file was
       prettier-formatted after capture); a Python `json.load` structural comparison of the two
       confirms `SEMANTICALLY EQUAL`. With `FSHARP_NAMESPACES` restored to
@@ -2931,10 +2931,10 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       **Date**: 2026-08-27. **Status**: done. **Files Changed**: none (verification only).
       `grep -n "dotnet run\|dotnet build" .github/workflows/*.yml` returns exactly one hit: a code
       comment inside the unrelated `.NET quality gate` (`dotnet`) job explaining a `dotnet build
-    --no-restore` prerequisite for that job's own `typecheck` target — not an invocation, and not
+  --no-restore` prerequisite for that job's own `typecheck` target — not an invocation, and not
       in a job that executes a flipped namespace. Every job that shells to `rhino-bin.sh` for a gate
       command (`gate`, `format`) sets `RHINO_CLI_FSHARP_BIN:
-    ${{ github.workspace }}/apps/rhino-cli/src-fsharp/dist/rhino-cli-fsharp`, and all such jobs
+  ${{ github.workspace }}/apps/rhino-cli/src-fsharp/dist/rhino-cli-fsharp`, and all such jobs
       `needs: build-rhino` (directly or transitively via `enumerate`), so the binary those jobs run
       is always `build-rhino`'s uploaded artifact, never a from-source rebuild.
 - [ ] [AI] Land every Wave B change in the `ose-private` worktree, authored there rather than
@@ -2965,7 +2965,7 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       **Date**: 2026-08-27. **Status**: done (`ose-public` only; `benchmark.md` is per-repo and this
       PR does not touch `ose-private`). **Files Changed**:
       `plans/in-progress/rewrite-rhino-cli-to-fsharp/benchmark.md`. `grep -c 'after wave B'
-    benchmark.md` returns `1`; that one section contains both the B5 (startup) and B6
+  benchmark.md` returns `1`; that one section contains both the B5 (startup) and B6
       (pre-commit) rows.
 
 > **Pause Safety**: the namespaces flipped so far run on F#, the rest still run on Rust, and both
@@ -2992,7 +2992,7 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
 
 > **PR seam**: the cycles under this heading are one PR.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3006,17 +3006,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the symlink resolves under the repo's own shared-cache namespace
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3029,17 +3029,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       Then the command exits successfully without recreating or altering the symlink
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3052,17 +3052,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       Then the plain directory is discarded and the target becomes a symlink into the shared cache
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3076,17 +3076,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the plain target directory is left unchanged
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3100,17 +3100,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the command exits successfully with a message that CI was detected
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3124,17 +3124,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And no crate is skipped due to a hardcoded crate list
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3148,17 +3148,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And a disk usage measurement across the worktrees counts that directory only once
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3172,17 +3172,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And it resolves to the same shared-cache entry as the main checkout's crate
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3196,17 +3196,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the tests pass without reference to a per-worktree target directory
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3219,17 +3219,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       Then the diff is empty for every apps/rhino-cli source file and every specs/apps/rhino feature file
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3243,17 +3243,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And its dist binary is present after both runs
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3267,17 +3267,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And every entry still referenced by a live worktree or checkout is preserved
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3291,17 +3291,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And only entries with no live referrer are removed
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3315,17 +3315,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the orphaned cache entry is deleted
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3339,17 +3339,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the command exits successfully with a message that CI was detected
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3363,17 +3363,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And no cache entry is actually removed
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3387,17 +3387,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the command exits successfully
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
@@ -3411,12 +3411,12 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And a regression test protects the target configuration before any downstream copy
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.

--- a/repo-config.yml
+++ b/repo-config.yml
@@ -171,7 +171,7 @@ coverage:
     # glob widens to directory-level like `convention/` did.
     - name: rhino-cli-fsharp
       levels: [unit, integration]
-      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention/**,repo-config/**,repo-config-validate/**,env/**,env-contract/**,specs/env-staged-guard.feature}"
+      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention/**,repo-config/**,repo-config-validate/**,env/**,env-contract/**,specs/env-staged-guard.feature,system/cargo-target-share.feature}"
 
     # ose domain
     - name: ose-be


### PR DESCRIPTION
## Summary

- Ports `specs/apps/rhino/behavior/rhino-cli/gherkin/system/cargo-target-share.feature`'s 18 scenarios (doctor `--fix`/`--prune-cargo-cache` shared-cargo-target-directory symlinking and GC) from `apps/rhino-cli/src/application/doctor/target_share.rs` to a new `RhinoCli.Application/src/Doctor.fs`, TDD-first, one scenario per RED/GREEN/REFACTOR cycle.
- Adds `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs` (TickSpec step definitions bound to the real, frozen feature file via a per-scenario `FeatureRunner`, one `[<Fact>]` per scenario) and `DoctorUnitTests.fs` (plain xunit tests for the pure functions, mirroring `target_share.rs`'s own `#[cfg(test)]` module).
- Adds the F# project's own `GIT_DIR`/`GIT_WORK_TREE`/`GIT_COMMON_DIR` scrub to `test:unit`/`test:integration`/`test:coverage` in `apps/rhino-cli/src-fsharp/project.json` (matching the Rust project's existing guard), with the 18th scenario ("Rust test targets ignore inherited Git process state") acting as a regression test protecting it.
- Widens `specs:behavior:coverage`'s `--shared-steps` argument and `repo-config.yml`'s `rhino-cli-fsharp` `specs:` glob to include the new file.
- Regenerates `apps/rhino-cli/parity-manifest.sha256` for the new/changed tracked `src-fsharp` files.

## Cost/Benefit

Completes the first of six Wave C implementation PRs (Phase 5 of `plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md`). `cargo-target-share.feature` describes behavior that currently only has a Rust consumer (the crate's own build tooling); it is ported faithfully here per the plan's explicit note that its disposition is decided at Phase 9, not silently dropped. New code: ~500 lines of application logic + ~700 lines of tests, justified by 1:1 behavioral parity with the existing Rust implementation and the plan's TDD/coverage requirements.

## Test Plan

- [x] `npx nx run rhino-cli-fsharp:typecheck` — 0 errors
- [x] `npx nx run rhino-cli-fsharp:lint` — 0 warnings (Fantomas, FSharpLint, G-Research analyzers)
- [x] `npx nx run rhino-cli-fsharp:test:unit` — 396/396 passed (18 new scenario facts + 24 new unit tests)
- [x] `npx nx run rhino-cli-fsharp:test:coverage` — all 4 modules ≥90% line (Application 91.28%, Cli 93.11%, Infrastructure 100%, Domain 100%; aggregate 91.72%)
- [x] `npx nx run rhino-cli-fsharp:test:specs` — `Spec coverage valid! 12 specs, 91 scenarios, 400 steps — all covered.`
- [x] `cargo run ... -- parity manifest validate` — manifest current