### PR TITLE
feat(rhino-cli-fsharp): port fsharp-tool-invocation doctor check (Wave C PR3)

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -5,7 +5,7 @@ b5f5e511ac5697c2d2949d898633f079abbce9c7211205aad6f7521f17746df2  apps/rhino-cli
 22b1d0652e8937a20c83841966e4f8b1c451d671d34dd27fb5fa13f11d340a4d  apps/rhino-cli/src-fsharp/.gitignore
 eb108ed1244727bd09b23be089eafdec40cae8ee44e6f142df9414140a310a04  apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
 11fe7ec2e5e08b432e2d1cedae59e1a555e17e22a1f11494bd83b80c36964b5c  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Convention.fs
-87d864f30bb0c42c5ac9791663ddb98f9245bcc7cfbf823a72796996a7360198  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Doctor.fs
+fefd8633322b668b7482b4ad0aca832ce5458ab20d64646be9a7fe47c3278e7a  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Doctor.fs
 ba223d446b461cce0e427e278e340a87330ed423885f92a674c5039fd755cb5b  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
 2f8085bcb8089f174e9548e609530471c9318c31b1bcab4a867e33880cec9e57  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Parity.fs
 d4bdb1646d8e18a40245bbd3fb2ac96ac1acf1adf38355a0b567d7b8d4cc6e48  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/RepoConfig.fs
@@ -21,9 +21,9 @@ bb55f3c8d4d3daffa7e334ecdacff8bfd9462b12a7098e239943d84a3edf915f  apps/rhino-cli
 631376afb9e4d7c5192d38f51b533c18b64cca83c18ed5c50982ba9acce51d74  apps/rhino-cli/src-fsharp/RhinoCli.Program/RhinoCli.Program.fsproj
 153a226f5ef1d6916aa6e6425b278a606a48659fcba9623c9d01e5cf3b2589a5  apps/rhino-cli/src-fsharp/RhinoCli.Program/src/Program.fs
 822f6ec8446562a4de9a3b1a2481af50fac01bbedc32e1963142709e5f48ec13  apps/rhino-cli/src-fsharp/fsharplint.json
-bc9a44342c0ae76cb4d0dedd8c865192d91e1e6ff507d6a1ac63ddd2f2b79a94  apps/rhino-cli/src-fsharp/project.json
+ec617779c17cbfae9d884fa3ac30216cc3c623acbd984971c7f1648f82ee9181  apps/rhino-cli/src-fsharp/project.json
 f7dacc8dd923488c70eebabe298843022ec5a3ba94b8b7568634a779f24b8da4  apps/rhino-cli/src-fsharp/tests/integration/RhinoCli.IntegrationTests.fsproj
-6c0e3bb480e2e07e63b1a6da44cecbb3ef387e7df3c6dcb4d74856aa8167d754  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+9f0d116c98e5f3f86c7663e3ae1134c3bde22f4707579e5eab16669514b7424a  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
 85ba308ad0a88485db55b305120d99b9a4ec328d2379536110f73e51f4797fe2  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionSteps.fs
 a909884a9d8816e2b476cc8c00be03ac4085b849cbe83c4b18e0213ac9cad1d7  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionUnitTests.fs
 30802281ed9b0bab54acba75ee2da33d47048045a1daab5e14aa59402635e13e  apps/rhino-cli/src-fsharp/tests/unit/Steps/DispatchUnitTests.fs
@@ -44,6 +44,8 @@ b49f1f9d865ea485480137d33fbf7a02570ad99b941f7bf6d15bbfa8c96185fe  apps/rhino-cli
 d43395cc8b45ab5197772682e18ba229bba6194507ca40c77053bf3ccd0929a9  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvValidateSteps.fs
 469970513250f3b199e0efee57fe2279c6e5609ef58e198a64f4b53a29e54c23  apps/rhino-cli/src-fsharp/tests/unit/Steps/EnvValidateUnitTests.fs
 66215f95f2afe48729422ebccadf068687c87bc5538fee88dfa7364da2f08028  apps/rhino-cli/src-fsharp/tests/unit/Steps/FormattersUnitTests.fs
+c99dc72ba90a55126c8f080d98b2ce2cc80037d936398ff42a93353ab7cdc481  apps/rhino-cli/src-fsharp/tests/unit/Steps/FsharpToolInvocationSteps.fs
+df2d2403e3dbf9b7cde5eae9ff273fb26d62ee0841ba72bbbf81c91ed8c8527d  apps/rhino-cli/src-fsharp/tests/unit/Steps/FsharpToolInvocationUnitTests.fs
 618efe0b847d0ba54cf58206596663a4470d3032f12c7dabbbf5cc26fb972864  apps/rhino-cli/src-fsharp/tests/unit/Steps/GitRootUnitTests.fs
 b8a8fbf79e78dee93f32944d3bbae2daccf33876ce5988ae31b1259c2f5ce201  apps/rhino-cli/src-fsharp/tests/unit/Steps/ParityUnitTests.fs
 76ee39dfa9f270aeffdbee896cf4f521f8685dea723f8ec41acb24d3f80abf47  apps/rhino-cli/src-fsharp/tests/unit/Steps/RepoConfigSteps.fs

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Doctor.fs
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Doctor.fs
@@ -21,6 +21,14 @@
 /// above, calls straight into this module's pure functions rather than a
 /// wired-up `doctor` verb.
 ///
+/// Below the "F# lint-target Fantomas tool-invocation check" banner comment,
+/// this file also carries an F#-native meta-check with no Rust equivalent
+/// (`apps/rhino-cli/src` never invoked Fantomas) for
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/system/fsharp-tool-invocation.feature`'s
+/// 1 scenario: every locally discovered Nx `project.json` `lint` target that
+/// invokes Fantomas must restore the local `.NET` tool manifest first and
+/// must never invoke a bare global `fantomas` binary.
+///
 /// # Deviation from the Rust source's ambient-environment reads
 ///
 /// Mirroring `target_share.rs`'s own module-level "Deviation" note: every
@@ -37,6 +45,7 @@ open System.IO
 open System.Runtime.InteropServices
 open System.Text.Json
 open System.Text.Json.Nodes
+open RhinoCli.Domain.Types
 
 // ---------------------------------------------------------------------------
 // CI detection
@@ -2008,3 +2017,194 @@ let formatDoctorJson (result: DoctorResult) : string =
     let serializeOptions = JsonSerializerOptions()
     serializeOptions.WriteIndented <- true
     root.ToJsonString(serializeOptions)
+
+// ---------------------------------------------------------------------------
+// F# lint-target Fantomas tool-invocation check [F#-native meta-check — no
+// Rust equivalent; `apps/rhino-cli/src` never invoked Fantomas] for
+// `specs/apps/rhino/behavior/rhino-cli/gherkin/system/fsharp-tool-invocation.feature`'s
+// 1 scenario.
+// ---------------------------------------------------------------------------
+
+/// One `project.json` file whose `lint` target's `commands` array invokes
+/// Fantomas at least once, together with that array for evaluation.
+type FsharpLintTarget =
+    { ProjectJsonPath: string
+      Commands: string list }
+
+/// Directory names a `project.json` scan never descends into: build output,
+/// dependency, and VCS directories that are never themselves project
+/// boundaries.
+let private excludedProjectJsonDirNames: Set<string> =
+    Set.ofList [ "node_modules"; "obj"; "bin"; ".git"; ".nx"; "dist" ]
+
+/// Recursively walks `dir`, skipping [`excludedProjectJsonDirNames`],
+/// returning every `project.json` file path found at any depth — deeper than
+/// [`discoverCrates`]'s single-level walk, since an F# Nx project can nest a
+/// `project.json` below its app directory (e.g.
+/// `apps/rhino-cli/src-fsharp/project.json`).
+let rec private findProjectJsonFiles (dir: string) : string list =
+    if not (Directory.Exists dir) then
+        []
+    else
+        let here =
+            let candidate = Path.Combine(dir, "project.json")
+            if File.Exists candidate then [ candidate ] else []
+
+        let nested =
+            Directory.GetDirectories dir
+            |> Array.filter (fun d -> not (Set.contains (Path.GetFileName(d: string)) excludedProjectJsonDirNames))
+            |> Array.toList
+            |> List.collect findProjectJsonFiles
+
+        here @ nested
+
+/// Extracts the `targets.lint.options.commands` JSON string array from the
+/// `project.json` at `projectJsonPath`, returning an empty list when the
+/// file is missing, malformed, or lacks that path.
+let private readLintCommands (projectJsonPath: string) : string list =
+    try
+        use doc = JsonDocument.Parse(File.ReadAllText projectJsonPath)
+
+        match doc.RootElement.TryGetProperty "targets" with
+        | false, _ -> []
+        | true, targetsEl ->
+            match targetsEl.TryGetProperty "lint" with
+            | false, _ -> []
+            | true, lintEl ->
+                match lintEl.TryGetProperty "options" with
+                | false, _ -> []
+                | true, optionsEl ->
+                    match optionsEl.TryGetProperty "commands" with
+                    | true, commandsEl when commandsEl.ValueKind = JsonValueKind.Array ->
+                        commandsEl.EnumerateArray()
+                        |> Seq.choose (fun c ->
+                            if c.ValueKind = JsonValueKind.String then
+                                Some(c.GetString())
+                            else
+                                None)
+                        |> Seq.toList
+                    | _ -> []
+    with _ ->
+        []
+
+/// Returns `true` when `command` invokes Fantomas in any form.
+let private commandInvokesFantomas (command: string) : bool = command.Contains("fantomas")
+
+/// Returns `true` when `command` restores the local `.NET` tool manifest
+/// declared in `.config/dotnet-tools.json`.
+let private commandRestoresToolManifest (command: string) : bool = command.Contains("dotnet tool restore")
+
+/// Returns `true` when `command` invokes Fantomas through the pinned local
+/// tool manifest (`dotnet tool run fantomas`) or the equivalent
+/// `dotnet fantomas` driver form, rather than a bare global `fantomas`
+/// binary call.
+let private commandInvokesFantomasViaLocalTool (command: string) : bool =
+    command.Contains("dotnet tool run fantomas")
+    || command.Contains("dotnet fantomas")
+
+/// Discovers every `project.json` under `repoRoot/apps` and `repoRoot/libs`
+/// (at any depth) whose `lint` target's `commands` array invokes Fantomas at
+/// least once, sorted by repo-relative path for deterministic iteration
+/// order [F#-native meta-check].
+///
+/// Gherkin (binds) — "Every locally discovered F# lint target uses the
+/// pinned local Fantomas tool":
+///   Given the local F# lint targets are discovered
+let discoverFsharpLintTargets (repoRoot: string) : FsharpLintTarget list =
+    [ "apps"; "libs" ]
+    |> List.collect (fun top -> findProjectJsonFiles (Path.Combine(repoRoot, top)))
+    |> List.choose (fun path ->
+        let commands = readLintCommands path
+
+        if commands |> List.exists commandInvokesFantomas then
+            let relative =
+                Path.GetRelativePath(repoRoot, path).Replace(Path.DirectorySeparatorChar, '/')
+
+            Some
+                { ProjectJsonPath = relative
+                  Commands = commands }
+        else
+            None)
+    |> List.sortBy (fun t -> t.ProjectJsonPath)
+
+/// Returns `true` when `commands` runs `dotnet tool restore` at some point
+/// strictly before the first command invoking Fantomas — proving the local
+/// tool manifest is consulted before Fantomas runs. `false` when either
+/// command is absent.
+let private restoresManifestBeforeFantomas (commands: string list) : bool =
+    let fantomasIdx = commands |> List.tryFindIndex commandInvokesFantomas
+    let restoreIdx = commands |> List.tryFindIndex commandRestoresToolManifest
+
+    match restoreIdx, fantomasIdx with
+    | Some r, Some f -> r < f
+    | _ -> false
+
+/// Returns `true` when at least one command invokes Fantomas via a bare
+/// global `fantomas` binary call rather than through the pinned local tool.
+let private invokesFantomasGlobally (commands: string list) : bool =
+    commands
+    |> List.exists (fun c -> commandInvokesFantomas c && not (commandInvokesFantomasViaLocalTool c))
+
+/// Result of evaluating one [`FsharpLintTarget`]: the target itself plus
+/// every [`Finding`] describing a Fantomas-invocation compliance violation
+/// (empty when the target is fully compliant). Reuses the shared `Finding`
+/// record from `RhinoCli.Domain.Types` rather than a bespoke type, following
+/// `Convention.fs`'s "shared Finding over bespoke per-validator types"
+/// precedent.
+type FsharpToolInvocationCheck =
+    { Target: FsharpLintTarget
+      Findings: Finding list }
+
+/// Evaluates one [`FsharpLintTarget`], returning every [`Finding`]
+/// describing a Fantomas-invocation compliance violation.
+let private evaluateOneFsharpLintTarget (target: FsharpLintTarget) : FsharpToolInvocationCheck =
+    let findings =
+        [ if not (restoresManifestBeforeFantomas target.Commands) then
+              { Severity = Severity.Blocking
+                Message = "does not restore the local .NET tool manifest (dotnet tool restore) before running Fantomas"
+                Path = Some target.ProjectJsonPath }
+          if invokesFantomasGlobally target.Commands then
+              { Severity = Severity.Blocking
+                Message =
+                  "invokes the global Fantomas app host directly instead of the pinned local tool (dotnet tool run fantomas / dotnet fantomas)"
+                Path = Some target.ProjectJsonPath } ]
+
+    { Target = target; Findings = findings }
+
+/// Evaluates every locally discovered F# lint target for compliant Fantomas
+/// invocation, returning one [`FsharpToolInvocationCheck`] per target — the
+/// same count as `targets`, whether or not each target is compliant
+/// [F#-native meta-check].
+///
+/// Gherkin (binds) — "Every locally discovered F# lint target uses the
+/// pinned local Fantomas tool":
+///   When every locally discovered F# lint target is evaluated
+///   Then every discovered F# lint target is evaluated
+///   And each target restores its local .NET tool manifest before running Fantomas
+///   And no target invokes the global Fantomas app host directly
+let evaluateFsharpToolInvocation (targets: FsharpLintTarget list) : FsharpToolInvocationCheck list =
+    targets |> List.map evaluateOneFsharpLintTarget
+
+/// Injectable single-file Fantomas format-check probe: given a source-file
+/// path, reports whether Fantomas considers it already formatted, or
+/// `Error` when the probe itself could not run.
+type UnformattedSampleProbe = string -> Result<bool, string>
+
+/// Probes `sampleFile` for Fantomas-detectable formatting drift via `probe`,
+/// but only when at least one F# lint target was discovered — a checkout
+/// with zero F# lint targets never invokes the probe, so an environment
+/// missing the local Fantomas tool never becomes a false failure when there
+/// is no F# code to check in the first place [F#-native meta-check].
+///
+/// Gherkin (binds) — "Every locally discovered F# lint target uses the
+/// pinned local Fantomas tool":
+///   And an unformatted source file is checked only when F# lint targets exist
+let checkUnformattedSample
+    (targets: FsharpLintTarget list)
+    (sampleFile: string)
+    (probe: UnformattedSampleProbe)
+    : Result<bool, string> option =
+    if List.isEmpty targets then
+        None
+    else
+        Some(probe sampleFile)

--- a/apps/rhino-cli/src-fsharp/project.json
+++ b/apps/rhino-cli/src-fsharp/project.json
@@ -112,7 +112,7 @@
     "specs:behavior:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env specs/apps/rhino/behavior/rhino-cli/gherkin/env-contract specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature specs/apps/rhino/behavior/rhino-cli/gherkin/system/cargo-target-share.feature specs/apps/rhino/behavior/rhino-cli/gherkin/system/doctor.feature apps/rhino-cli/src-fsharp"
+        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env specs/apps/rhino/behavior/rhino-cli/gherkin/env-contract specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature specs/apps/rhino/behavior/rhino-cli/gherkin/system/cargo-target-share.feature specs/apps/rhino/behavior/rhino-cli/gherkin/system/doctor.feature specs/apps/rhino/behavior/rhino-cli/gherkin/system/fsharp-tool-invocation.feature apps/rhino-cli/src-fsharp"
       },
       "cache": true,
       "inputs": ["{workspaceRoot}/specs/apps/rhino/behavior/rhino-cli/gherkin/**/*.feature", "{projectRoot}/**/*.fs"]

--- a/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+++ b/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
@@ -35,6 +35,8 @@
     <Compile Include="Steps/DoctorUnitTests.fs" />
     <Compile Include="Steps/DoctorToolCheckSteps.fs" />
     <Compile Include="Steps/DoctorToolCheckUnitTests.fs" />
+    <Compile Include="Steps/FsharpToolInvocationSteps.fs" />
+    <Compile Include="Steps/FsharpToolInvocationUnitTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/FsharpToolInvocationSteps.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/FsharpToolInvocationSteps.fs
@@ -1,0 +1,168 @@
+/// TickSpec step definitions binding `fsharp-tool-invocation.feature`'s 1
+/// scenario to `RhinoCli.Application.Doctor`'s F# lint-target Fantomas
+/// tool-invocation check [Repo-grounded —
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/system/fsharp-tool-invocation.feature`].
+/// No Rust source underlies this feature — `apps/rhino-cli/src` never
+/// invoked Fantomas — so unlike every other `Steps.fs` file in this
+/// directory there is no cucumber-rs counterpart to mirror.
+///
+/// Named `FsharpToolInvocationSteps` rather than reusing `DoctorSteps`
+/// (already bound to `cargo-target-share.feature`) or `DoctorToolCheckSteps`
+/// (already bound to `doctor.feature`) — follows `DoctorToolCheckSteps.fs`'s
+/// own documented precedent of one Steps file per feature file sharing an
+/// application module.
+///
+/// Unlike the synthetic-fixture repos every other Doctor Steps file builds,
+/// this scenario is a genuine self-check of the real, live repository
+/// checkout: `repoRoot` is resolved from this source file's own on-disk
+/// location (the same fixed-offset convention `DoctorSteps.fs`'s
+/// `fsharpProjectJsonPath` already uses to read the real
+/// `src-fsharp/project.json`), so the scenario asserts every F# lint target
+/// actually checked into this repo today is compliant.
+module RhinoCli.Tests.Unit.Steps.FsharpToolInvocationSteps
+
+open System
+open System.IO
+open TickSpec
+open Xunit
+open RhinoCli.Application.Doctor
+open RhinoCli.Domain.Types
+
+type FsharpToolInvocationSteps() =
+    let mutable targets: FsharpLintTarget list = []
+    let mutable checks: FsharpToolInvocationCheck list = []
+
+    /// `tests/unit/Steps` → `tests/unit` → `tests` → `src-fsharp` →
+    /// `rhino-cli` → `apps` → repo root — the same six-level offset
+    /// `FeatureRunner.featurePath` below uses to reach `specs/`.
+    let repoRoot: string =
+        Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "..", "..", "..", "..", ".."))
+
+    // TickSpec 2.0.5's line lexer treats a literal `#` anywhere in a step
+    // line as a comment marker (not just at line-start, unlike the Gherkin
+    // spec) — the same behavior `EnvValidateSteps.fs`'s `` ``an F.*`` `` step
+    // documents and works around. It truncates this scenario's frozen
+    // `Given the local F# lint targets are discovered` line to
+    // `the local F` before step resolution, so no bound pattern can ever see
+    // the text after the `#` at runtime. Step names double as regexes in
+    // TickSpec, so `.*` stands in for everything TickSpec itself never gets
+    // to see: it satisfies TickSpec's truncated match at runtime AND
+    // `speccoverage`'s anchored match against the full, untruncated Gherkin
+    // line.
+    [<Given>]
+    member _.``the local F.*``() =
+        targets <- discoverFsharpLintTargets repoRoot
+
+    [<When>]
+    member _.``every locally discovered F.*``() =
+        checks <- evaluateFsharpToolInvocation targets
+
+    [<Then>]
+    member _.``every discovered F.*``() =
+        Assert.Equal(targets.Length, checks.Length)
+        // Sanity check that discovery genuinely found something in this
+        // real repo checkout, rather than the assertion above passing
+        // vacuously on two empty lists.
+        Assert.NotEmpty(targets)
+
+    [<Then>]
+    member _.``each target restores its local .NET tool manifest before running Fantomas``() =
+        for c in checks do
+            Assert.DoesNotContain(
+                c.Findings,
+                fun (f: Finding) -> f.Message.Contains("does not restore the local .NET tool manifest")
+            )
+
+    [<Then>]
+    member _.``no target invokes the global Fantomas app host directly``() =
+        for c in checks do
+            Assert.DoesNotContain(
+                c.Findings,
+                fun (f: Finding) -> f.Message.Contains("invokes the global Fantomas app host directly")
+            )
+
+    [<Then>]
+    member _.``an unformatted source file is checked only when F.*``() =
+        let mutable probeCalls = 0
+
+        let probe: UnformattedSampleProbe =
+            fun _ ->
+                probeCalls <- probeCalls + 1
+                Ok true
+
+        let result = checkUnformattedSample targets "sample.fs" probe
+
+        if List.isEmpty targets then
+            Assert.Equal(0, probeCalls)
+            Assert.True(Option.isNone result)
+        else
+            Assert.Equal(1, probeCalls)
+            Assert.True(Option.isSome result)
+
+// ---------------------------------------------------------------------------
+// FeatureRunner
+// ---------------------------------------------------------------------------
+
+/// Reads the single `Scenario:` block out of the real, frozen
+/// `fsharp-tool-invocation.feature` file (leaving the file itself untouched)
+/// and runs it through TickSpec bound only against
+/// `FsharpToolInvocationSteps` — see `DoctorToolCheckSteps.fs`'s
+/// `FeatureRunner` for why this is per-scenario rather than per-file.
+module private FeatureRunner =
+
+    let private featurePath: string =
+        Path.GetFullPath(
+            Path.Combine(
+                __SOURCE_DIRECTORY__,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "specs",
+                "apps",
+                "rhino",
+                "behavior",
+                "rhino-cli",
+                "gherkin",
+                "system",
+                "fsharp-tool-invocation.feature"
+            )
+        )
+
+    let private extractScenario (featureLines: string[]) (scenarioTitle: string) : string[] =
+        let featureLine =
+            featureLines
+            |> Array.find (fun l -> l.TrimStart().StartsWith("Feature:", StringComparison.Ordinal))
+
+        let scenarioHeader = sprintf "Scenario: %s" scenarioTitle
+        let startIdx = featureLines |> Array.findIndex (fun l -> l.Trim() = scenarioHeader)
+
+        let endIdx =
+            featureLines
+            |> Array.skip (startIdx + 1)
+            |> Array.tryFindIndex (fun l ->
+                let trimmed = l.Trim()
+
+                trimmed.StartsWith("Scenario:", StringComparison.Ordinal)
+                || trimmed.StartsWith("@", StringComparison.Ordinal))
+            |> Option.map (fun relativeIdx -> startIdx + 1 + relativeIdx)
+            |> Option.defaultValue featureLines.Length
+
+        Array.append [| featureLine; "" |] featureLines.[startIdx .. endIdx - 1]
+
+    /// Runs the single scenario named `scenarioTitle` from
+    /// `fsharp-tool-invocation.feature`, bound against
+    /// `FsharpToolInvocationSteps`.
+    let run (scenarioTitle: string) : unit =
+        let allLines = File.ReadAllLines featurePath
+        let snippet = extractScenario allLines scenarioTitle
+        let definitions = StepDefinitions([| typeof<FsharpToolInvocationSteps> |])
+        let feature = definitions.GenerateFeature(featurePath, snippet)
+        let scenario = Seq.exactlyOne feature.Scenarios
+        scenario.Action.Invoke()
+
+[<Fact>]
+let ``Every locally discovered F# lint target uses the pinned local Fantomas tool`` () =
+    FeatureRunner.run "Every locally discovered F# lint target uses the pinned local Fantomas tool"

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/FsharpToolInvocationUnitTests.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/FsharpToolInvocationUnitTests.fs
@@ -1,0 +1,244 @@
+/// Plain xunit tests for `RhinoCli.Application.Doctor`'s F# lint-target
+/// Fantomas tool-invocation check — behaviour with no dedicated Gherkin
+/// scenario, or exercised only indirectly there (mirrors the rationale
+/// `DoctorToolCheckUnitTests.fs`'s module doc comment states for its own
+/// split from `DoctorToolCheckSteps.fs`). No Rust source underlies this
+/// feature, so unlike most `*UnitTests.fs` files in this directory there is
+/// no `#[cfg(test)] mod tests` counterpart to port from.
+module RhinoCli.Tests.Unit.Steps.FsharpToolInvocationUnitTests
+
+open System
+open System.IO
+open Xunit
+open RhinoCli.Application.Doctor
+open RhinoCli.Domain.Types
+
+let private makeRepo () : string =
+    let dir =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-fsharp-tool-invocation-" + Guid.NewGuid().ToString("N"))
+
+    Directory.CreateDirectory(dir) |> ignore
+    dir
+
+let private writeProjectJson (path: string) (commandsJson: string) : unit =
+    Directory.CreateDirectory(Path.GetDirectoryName(path: string)) |> ignore
+
+    File.WriteAllText(path, sprintf """{ "targets": { "lint": { "options": { "commands": [%s] } } } }""" commandsJson)
+
+// ---- discoverFsharpLintTargets ----
+
+[<Fact>]
+let ``discoverFsharpLintTargets finds a compliant target nested under an app directory`` () =
+    let repoRoot = makeRepo ()
+
+    try
+        writeProjectJson
+            (Path.Combine(repoRoot, "apps", "rhino-cli", "src-fsharp", "project.json"))
+            "\"dotnet tool restore\", \"dotnet tool run fantomas --check apps/rhino-cli/src-fsharp\""
+
+        let targets = discoverFsharpLintTargets repoRoot
+
+        Assert.Equal(1, targets.Length)
+        Assert.Equal("apps/rhino-cli/src-fsharp/project.json", targets.[0].ProjectJsonPath)
+        Assert.Equal(2, targets.[0].Commands.Length)
+    finally
+        Directory.Delete(repoRoot, true)
+
+[<Fact>]
+let ``discoverFsharpLintTargets ignores a lint target that never mentions fantomas`` () =
+    let repoRoot = makeRepo ()
+
+    try
+        writeProjectJson
+            (Path.Combine(repoRoot, "apps", "rhino-cli", "project.json"))
+            "\"cargo fmt --check\", \"cargo clippy\""
+
+        Assert.Empty(discoverFsharpLintTargets repoRoot)
+    finally
+        Directory.Delete(repoRoot, true)
+
+[<Fact>]
+let ``discoverFsharpLintTargets ignores project.json under node_modules`` () =
+    let repoRoot = makeRepo ()
+
+    try
+        writeProjectJson
+            (Path.Combine(repoRoot, "apps", "some-app", "node_modules", "pkg", "project.json"))
+            "\"dotnet tool restore\", \"dotnet tool run fantomas --check .\""
+
+        Assert.Empty(discoverFsharpLintTargets repoRoot)
+    finally
+        Directory.Delete(repoRoot, true)
+
+[<Fact>]
+let ``discoverFsharpLintTargets returns empty when apps and libs are absent`` () =
+    let repoRoot = makeRepo ()
+
+    try
+        Assert.Empty(discoverFsharpLintTargets repoRoot)
+    finally
+        Directory.Delete(repoRoot, true)
+
+[<Fact>]
+let ``discoverFsharpLintTargets tolerates a malformed project.json`` () =
+    let repoRoot = makeRepo ()
+
+    try
+        let path = Path.Combine(repoRoot, "libs", "some-lib", "project.json")
+        Directory.CreateDirectory(Path.GetDirectoryName(path: string)) |> ignore
+        File.WriteAllText(path, "{ not valid json")
+
+        Assert.Empty(discoverFsharpLintTargets repoRoot)
+    finally
+        Directory.Delete(repoRoot, true)
+
+[<Fact>]
+let ``discoverFsharpLintTargets tolerates a project.json with no lint target`` () =
+    let repoRoot = makeRepo ()
+
+    try
+        let path = Path.Combine(repoRoot, "libs", "some-lib", "project.json")
+        Directory.CreateDirectory(Path.GetDirectoryName(path: string)) |> ignore
+        File.WriteAllText(path, """{ "targets": { "build": {} } }""")
+
+        Assert.Empty(discoverFsharpLintTargets repoRoot)
+    finally
+        Directory.Delete(repoRoot, true)
+
+[<Fact>]
+let ``discoverFsharpLintTargets sorts results by repo-relative path`` () =
+    let repoRoot = makeRepo ()
+
+    try
+        writeProjectJson
+            (Path.Combine(repoRoot, "libs", "zeta-lib", "project.json"))
+            "\"dotnet tool restore\", \"dotnet tool run fantomas --check .\""
+
+        writeProjectJson
+            (Path.Combine(repoRoot, "apps", "alpha-app", "project.json"))
+            "\"dotnet tool restore\", \"dotnet tool run fantomas --check .\""
+
+        let targets =
+            discoverFsharpLintTargets repoRoot |> List.map (fun t -> t.ProjectJsonPath)
+
+        Assert.Equal<string list>([ "apps/alpha-app/project.json"; "libs/zeta-lib/project.json" ], targets)
+    finally
+        Directory.Delete(repoRoot, true)
+
+// ---- evaluateFsharpToolInvocation ----
+
+let private target (commands: string list) : FsharpLintTarget =
+    { ProjectJsonPath = "apps/fixture/project.json"
+      Commands = commands }
+
+[<Fact>]
+let ``evaluateFsharpToolInvocation reports no findings for a compliant target`` () =
+    let checks =
+        evaluateFsharpToolInvocation [ target [ "dotnet tool restore"; "dotnet tool run fantomas --check ." ] ]
+
+    Assert.Equal(1, checks.Length)
+    Assert.Empty(checks.[0].Findings)
+
+[<Fact>]
+let ``evaluateFsharpToolInvocation flags a target missing dotnet tool restore entirely`` () =
+    let checks =
+        evaluateFsharpToolInvocation [ target [ "dotnet tool run fantomas --check ." ] ]
+
+    Assert.Contains(
+        checks.[0].Findings,
+        fun (f: Finding) -> f.Message.Contains("does not restore the local .NET tool manifest")
+    )
+
+[<Fact>]
+let ``evaluateFsharpToolInvocation flags a target that restores after invoking Fantomas`` () =
+    let checks =
+        evaluateFsharpToolInvocation [ target [ "dotnet tool run fantomas --check ."; "dotnet tool restore" ] ]
+
+    Assert.Contains(
+        checks.[0].Findings,
+        fun (f: Finding) -> f.Message.Contains("does not restore the local .NET tool manifest")
+    )
+
+[<Fact>]
+let ``evaluateFsharpToolInvocation flags a bare global fantomas invocation`` () =
+    let checks =
+        evaluateFsharpToolInvocation [ target [ "dotnet tool restore"; "fantomas --check ." ] ]
+
+    Assert.Contains(
+        checks.[0].Findings,
+        fun (f: Finding) -> f.Message.Contains("invokes the global Fantomas app host directly")
+    )
+
+[<Fact>]
+let ``evaluateFsharpToolInvocation accepts the dotnet fantomas driver form`` () =
+    let checks =
+        evaluateFsharpToolInvocation [ target [ "dotnet tool restore"; "dotnet fantomas --check ." ] ]
+
+    Assert.Empty(checks.[0].Findings)
+
+[<Fact>]
+let ``evaluateFsharpToolInvocation marks every Finding as Blocking severity`` () =
+    let checks = evaluateFsharpToolInvocation [ target [ "fantomas --check ." ] ]
+
+    for f in checks.[0].Findings do
+        Assert.Equal(Severity.Blocking, f.Severity)
+        Assert.Equal(Some "apps/fixture/project.json", f.Path)
+
+[<Fact>]
+let ``evaluateFsharpToolInvocation evaluates every target regardless of compliance`` () =
+    let checks =
+        evaluateFsharpToolInvocation
+            [ target [ "dotnet tool restore"; "dotnet tool run fantomas --check ." ]
+              target [ "fantomas --check ." ] ]
+
+    Assert.Equal(2, checks.Length)
+
+[<Fact>]
+let ``evaluateFsharpToolInvocation returns an empty list for an empty target list`` () =
+    Assert.Empty(evaluateFsharpToolInvocation [])
+
+// ---- checkUnformattedSample ----
+
+[<Fact>]
+let ``checkUnformattedSample never invokes the probe when no F# lint targets exist`` () =
+    let mutable probed = false
+
+    let probe: UnformattedSampleProbe =
+        fun _ ->
+            probed <- true
+            Ok true
+
+    let result = checkUnformattedSample [] "sample.fs" probe
+
+    Assert.False(probed)
+    Assert.True(Option.isNone result)
+
+[<Fact>]
+let ``checkUnformattedSample invokes the probe when at least one F# lint target exists`` () =
+    let mutable receivedPath = ""
+
+    let probe: UnformattedSampleProbe =
+        fun path ->
+            receivedPath <- path
+            Ok false
+
+    let result =
+        checkUnformattedSample
+            [ target [ "dotnet tool restore"; "dotnet tool run fantomas --check ." ] ]
+            "sample.fs"
+            probe
+
+    Assert.Equal("sample.fs", receivedPath)
+    Assert.Equal(Some(Ok false), result)
+
+[<Fact>]
+let ``checkUnformattedSample propagates a probe error`` () =
+    let probe: UnformattedSampleProbe = fun _ -> Error "fantomas not found"
+
+    let result =
+        checkUnformattedSample
+            [ target [ "dotnet tool restore"; "dotnet tool run fantomas --check ." ] ]
+            "sample.fs"
+            probe
+
+    Assert.Equal(Some(Error "fantomas not found"), result)

--- a/plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md
+++ b/plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md
@@ -3840,8 +3840,8 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
 
 > **PR seam**: the cycles under this heading are one PR.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
-      `apps/rhino-cli/src-fsharp/tests/unit/Steps/DoctorSteps.fs`
+- [x] [AI] **RED**: Add the step definitions for this scenario in
+      `apps/rhino-cli/src-fsharp/tests/unit/Steps/FsharpToolInvocationSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Doctor` does not implement it.
       **Gherkin (binds) →** "Every locally discovered F# lint target uses the pinned local Fantomas tool" — `specs/apps/rhino/behavior/rhino-cli/gherkin/system/fsharp-tool-invocation.feature`
@@ -3856,13 +3856,20 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And an unformatted source file is checked only when F# lint targets exist
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+  Deviation from this heading's own file-path template: bound in a new
+  `FsharpToolInvocationSteps.fs` rather than the already-taken
+  `DoctorSteps.fs` (bound to `cargo-target-share.feature`), following
+  `DoctorToolCheckSteps.fs`'s own documented "one Steps file per feature
+  file" precedent.
+
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Doctor.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
-      `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+      the shared `RhinoCli.Domain.Types.Finding` record (`RhinoCli.Domain/src/Types.fs`
+      — `Finding.fs` was never split out as its own file)
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Doctor.fs` formats no output itself.
 

--- a/repo-config.yml
+++ b/repo-config.yml
@@ -171,7 +171,7 @@ coverage:
     # glob widens to directory-level like `convention/` did.
     - name: rhino-cli-fsharp
       levels: [unit, integration]
-      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention/**,repo-config/**,repo-config-validate/**,env/**,env-contract/**,specs/env-staged-guard.feature,system/cargo-target-share.feature,system/doctor.feature}"
+      specs: "specs/apps/rhino/behavior/rhino-cli/gherkin/{convention/**,repo-config/**,repo-config-validate/**,env/**,env-contract/**,specs/env-staged-guard.feature,system/cargo-target-share.feature,system/doctor.feature,system/fsharp-tool-invocation.feature}"
 
     # ose domain
     - name: ose-be


### PR DESCRIPTION
## Summary

- Adds an F#-native meta-check with no Rust equivalent (`apps/rhino-cli/src` never invoked Fantomas): every Nx `project.json` `lint` target that invokes Fantomas must restore the local `.NET` tool manifest (`dotnet tool restore`) before running it, and must never invoke a bare global `fantomas` binary — only `dotnet tool run fantomas` / `dotnet fantomas` are accepted.
- Discovery walks `apps/` and `libs/` recursively for `project.json` files whose `lint` target `commands` array mentions `fantomas`; evaluation reuses the shared `RhinoCli.Domain.Types.Finding` record for violations, following `Convention.fs`'s established "shared Finding over bespoke per-validator types" precedent.
- Binds the single scenario in `specs/apps/rhino/behavior/rhino-cli/gherkin/system/fsharp-tool-invocation.feature` via a new `FsharpToolInvocationSteps.fs` (one Steps file per feature file, per `DoctorToolCheckSteps.fs`'s documented precedent) — the scenario is a genuine self-check of this repo's real, live `project.json` files, not a synthetic fixture.
- Widens `specs:behavior:coverage`'s `--shared-steps` argument in `apps/rhino-cli/src-fsharp/project.json` and `repo-config.yml`'s `rhino-cli-fsharp` `specs:` glob to cover the new feature file.
- Regenerates and validates `apps/rhino-cli/parity-manifest.sha256` for the changed/added `src-fsharp` files.
- Ticks the RED/GREEN/REFACTOR checkboxes for this PR seam in `plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md`.

## Test plan

- [x] `dotnet test apps/rhino-cli/src-fsharp/tests/unit` — 513 passed, 0 failed
- [x] `dotnet tool run fantomas --check apps/rhino-cli/src-fsharp` — clean
- [x] `dotnet fsharplint lint` for all 5 F# projects — 0 warnings each
- [x] `dotnet fsharp-analyzers` for all 5 F# projects — exit 0, no findings
- [x] `npx nx run rhino-cli-fsharp:test:quick` — typecheck/lint/test:unit/test:specs all green; spec coverage valid (14 specs, 109 scenarios, 477 steps — all covered)
- [x] `npx nx run rhino-cli-fsharp:test:coverage` — all 4 modules ≥90% line coverage (Domain 100%, Infrastructure 100%, Application 92.65%, Cli 93.11%)
- [x] `cargo run --manifest-path apps/rhino-cli/Cargo.toml -- parity manifest validate` — current

🤖 Generated with [Claude Code](https://claude.com/claude-code)