### PR TITLE
feat(rhino-cli-fsharp): port docs validate-frontmatter (Wave D PR1)

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -3,10 +3,11 @@
 51f04bc4a3f84b9b73386a760312757e62af4fa5ed4a6d357b6d9b0a266cf48e  apps/rhino-cli/LICENSE
 b5f5e511ac5697c2d2949d898633f079abbce9c7211205aad6f7521f17746df2  apps/rhino-cli/project.json
 22b1d0652e8937a20c83841966e4f8b1c451d671d34dd27fb5fa13f11d340a4d  apps/rhino-cli/src-fsharp/.gitignore
-4296efa84396a4685af939bac9c5762ec6b1e86739b53e165b99ae7db5c3ac9a  apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
+98f96e762c5d8cb79def991ad30d2af1da09a1656930f79a89a7622b0c77c606  apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
 11fe7ec2e5e08b432e2d1cedae59e1a555e17e22a1f11494bd83b80c36964b5c  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Convention.fs
 015c281c498a64930d705b4806ef139de008a78fcd1197f8a7851cea7586cd85  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Doctor.fs
 ba223d446b461cce0e427e278e340a87330ed423885f92a674c5039fd755cb5b  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
+a72ee56cd87ec7ea7592574148fd58a4f1120cbbdc84ec2b96cac2facdc7b117  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Md.fs
 2f8085bcb8089f174e9548e609530471c9318c31b1bcab4a867e33880cec9e57  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Parity.fs
 d4bdb1646d8e18a40245bbd3fb2ac96ac1acf1adf38355a0b567d7b8d4cc6e48  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/RepoConfig.fs
 3c52c83f35ed710cadc6008cc22bbd4767d43d824be4aa56700698c2bff4c2cf  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/TestCoverage.fs
@@ -22,9 +23,9 @@ b185e1073cc014e7c83b8de74cabca6e581bd05ccbd012c84c6d118b2a99eb2c  apps/rhino-cli
 631376afb9e4d7c5192d38f51b533c18b64cca83c18ed5c50982ba9acce51d74  apps/rhino-cli/src-fsharp/RhinoCli.Program/RhinoCli.Program.fsproj
 153a226f5ef1d6916aa6e6425b278a606a48659fcba9623c9d01e5cf3b2589a5  apps/rhino-cli/src-fsharp/RhinoCli.Program/src/Program.fs
 822f6ec8446562a4de9a3b1a2481af50fac01bbedc32e1963142709e5f48ec13  apps/rhino-cli/src-fsharp/fsharplint.json
-fa40e1e53158663997e1b702702bb7d1ab2646d16db64e4586e0d8ba11861544  apps/rhino-cli/src-fsharp/project.json
+e33ebd8e6470da7025ff13e36882542b7fde3a5c28ff140e59ca16e259ae53f2  apps/rhino-cli/src-fsharp/project.json
 f7dacc8dd923488c70eebabe298843022ec5a3ba94b8b7568634a779f24b8da4  apps/rhino-cli/src-fsharp/tests/integration/RhinoCli.IntegrationTests.fsproj
-723d690f4ad10a10f7ea09eeac24e05b7534c04daffe1f56f2d93548b8f652c2  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+b5e2d7235fa11e8584e2be7be22bba583f54fca9064149c6a2a8b41e3badbf76  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
 85ba308ad0a88485db55b305120d99b9a4ec328d2379536110f73e51f4797fe2  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionSteps.fs
 a909884a9d8816e2b476cc8c00be03ac4085b849cbe83c4b18e0213ac9cad1d7  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionUnitTests.fs
 e7ef73e5c7ced17c7c47813e81fd4b78060de7d765c584b791256cfd6a00b68f  apps/rhino-cli/src-fsharp/tests/unit/Steps/DispatchUnitTests.fs
@@ -48,6 +49,7 @@ d43395cc8b45ab5197772682e18ba229bba6194507ca40c77053bf3ccd0929a9  apps/rhino-cli
 c99dc72ba90a55126c8f080d98b2ce2cc80037d936398ff42a93353ab7cdc481  apps/rhino-cli/src-fsharp/tests/unit/Steps/FsharpToolInvocationSteps.fs
 df2d2403e3dbf9b7cde5eae9ff273fb26d62ee0841ba72bbbf81c91ed8c8527d  apps/rhino-cli/src-fsharp/tests/unit/Steps/FsharpToolInvocationUnitTests.fs
 413baab2577c13102e7eb36979cbea9d75735929a5c429591a05ca85cf69cbec  apps/rhino-cli/src-fsharp/tests/unit/Steps/GitRootUnitTests.fs
+7f9b1b2eef1556c9b5fae26f6952d49996f30981bc5562ab6a492cb12e268780  apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs
 b8a8fbf79e78dee93f32944d3bbae2daccf33876ce5988ae31b1259c2f5ce201  apps/rhino-cli/src-fsharp/tests/unit/Steps/ParityUnitTests.fs
 76ee39dfa9f270aeffdbee896cf4f521f8685dea723f8ec41acb24d3f80abf47  apps/rhino-cli/src-fsharp/tests/unit/Steps/RepoConfigSteps.fs
 7d6558430a23078b4306c31a0198fb7ff0a5775f03e0100ee7a62cec7f4aa932  apps/rhino-cli/src-fsharp/tests/unit/Steps/RepoConfigUnitTests.fs

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="src/Env.fs" />
     <Compile Include="src/Doctor.fs" />
     <Compile Include="src/TestCoverage.fs" />
+    <Compile Include="src/Md.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Md.fs
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Md.fs
@@ -1,0 +1,395 @@
+/// Port of the Rust `md` namespace's `docs validate-frontmatter` validator
+/// [Repo-grounded — `apps/rhino-cli/src/application/docs/frontmatter.rs`,
+/// `apps/rhino-cli/src/commands/md_validate_frontmatter.rs`] for
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-frontmatter.feature`'s
+/// 11 scenarios.
+///
+/// Scope: this PR ports only the frontmatter validator — the `md` namespace's
+/// other five feature files (heading-hierarchy, links, mermaid, naming,
+/// audit) land in later Wave D PRs against this same file. Findings reuse
+/// the shared `RhinoCli.Domain.Types.Finding` record (`Severity`/`Message`/
+/// `Path`) rather than a bespoke `DocsFrontmatterFinding` type, matching
+/// `Convention.fs`'s established "shared Finding over bespoke per-validator
+/// types" precedent — the Rust source's separate `kind` field (e.g.
+/// `"missing-title"`) is folded into each finding's `Message` text instead of
+/// becoming a fourth field on the shared record, since every Rust `kind`
+/// value is already reproduced verbatim inside its finding's message text,
+/// and no scenario here needs the two split apart.
+///
+/// `md` is not yet listed in `FSHARP_NAMESPACES` (that flip is later,
+/// separate Wave D integration work), so — matching `TestCoverage.fs`'s
+/// `validate`-before-the-Wave-C-flip precedent — this validator is called
+/// directly by its step definitions with a path list built by hand, not
+/// parsed from CLI argv. No text/JSON/Markdown rendering lives in this file
+/// for the same reason `reporter.rs`'s formatting stays out of `Doctor.fs`
+/// until a scenario needs it: none of this feature file's 11 scenarios
+/// assert on rendered output, only on the structured `Finding` list.
+module RhinoCli.Application.Md
+
+open System
+open System.Collections.Generic
+open System.IO
+open YamlDotNet.Serialization
+open RhinoCli.Domain.Types
+
+/// Path fragment that identifies software-engineering explanation documents
+/// [Repo-grounded — `frontmatter.rs::SOFTWARE_DOC_PREFIX`].
+let private softwareDocPrefix = "docs/explanation/software-engineering/"
+
+/// Path fragments that identify governance documents
+/// [Repo-grounded — `frontmatter.rs::GOVERNANCE_DOC_PREFIXES`].
+let private governanceDocPrefixes: string list =
+    [ "repo-governance/conventions/"
+      "repo-governance/principles/"
+      "repo-governance/development/"
+      "repo-governance/workflows/" ]
+
+/// The allowed values for the `category` frontmatter field (Diátaxis
+/// framework) [Repo-grounded — `frontmatter.rs::VALID_CATEGORIES`].
+let private validCategories: Set<string> =
+    Set.ofList [ "tutorial"; "how-to"; "reference"; "explanation" ]
+
+/// Directory names that are skipped during recursive walks
+/// [Repo-grounded — `frontmatter.rs::SKIP_DIRS`].
+let private skipDirs: Set<string> =
+    Set.ofList [ "node_modules"; ".git"; ".next"; "dist"; "build"; "target" ]
+
+/// Classifies a markdown file as belonging to a known documentation area
+/// [Repo-grounded — `frontmatter.rs::DocArea`].
+type private DocArea =
+    /// The file is not in any recognised documentation area.
+    | UnknownArea
+    /// The file is in `docs/explanation/software-engineering/`.
+    | SoftwareArea
+    /// The file is under one of the `repo-governance/` sub-trees.
+    | GovernanceArea
+
+/// Determines which documentation area `path` belongs to
+/// [Repo-grounded — `frontmatter.rs::classify_doc_area`].
+let private classifyDocArea (path: string) : DocArea =
+    let slashed = path.Replace('\\', '/')
+
+    if slashed.Contains(softwareDocPrefix, StringComparison.Ordinal) then
+        SoftwareArea
+    elif
+        governanceDocPrefixes
+        |> List.exists (fun prefix -> slashed.Contains(prefix, StringComparison.Ordinal))
+    then
+        GovernanceArea
+    else
+        UnknownArea
+
+/// Extracts the YAML content between the first pair of `---` fences.
+/// Returns `None` when `content` does not begin with `---` or has no closing
+/// fence [Repo-grounded — `frontmatter.rs::extract_frontmatter`].
+let extractFrontmatter (content: string) : string option =
+    let lines = content.Split('\n')
+
+    if lines.Length = 0 || lines.[0].Trim() <> "---" then
+        None
+    else
+        [ 1 .. lines.Length - 1 ]
+        |> List.tryFind (fun i -> lines.[i].Trim() = "---")
+        |> Option.map (fun i -> String.Join("\n", lines.[1 .. i - 1]))
+
+/// Deserializes raw YAML into `obj` without a naming convention — every
+/// lookup below matches literal frontmatter keys (`title`, `when_to_use`, …)
+/// by exact string equality rather than through a strongly typed DTO, so no
+/// naming-convention translation is needed [Repo-grounded — mirrors
+/// `RepoConfig.fs`'s `checkNoUnknownHarnessKeys` raw-YAML-walk technique].
+let private deserializer: IDeserializer = DeserializerBuilder().Build()
+
+let private asRawMap (value: obj) : IDictionary<obj, obj> option =
+    match value with
+    | :? IDictionary<obj, obj> as dict -> Some dict
+    | _ -> None
+
+let private asRawList (value: obj) : obj list option =
+    match value with
+    | :? IDictionary<obj, obj> -> None
+    | :? Collections.IEnumerable as items when not (value :? string) -> Some(items |> Seq.cast<obj> |> List.ofSeq)
+    | _ -> None
+
+let private tryGetRawValue (dict: IDictionary<obj, obj>) (key: string) : obj option =
+    dict
+    |> Seq.tryFind (fun kv ->
+        match kv.Key with
+        | :? string as candidate -> String.Equals(candidate, key, StringComparison.Ordinal)
+        | _ -> false)
+    |> Option.map (fun kv -> kv.Value)
+
+/// Coerces a raw YAML value to a `String` for display and comparison
+/// purposes. `None`/`null` map to an empty string
+/// [Repo-grounded — `frontmatter.rs::string_value`].
+let private stringValue (value: obj option) : string =
+    match value with
+    | None -> ""
+    | Some null -> ""
+    | Some(:? string as s) -> s
+    | Some(:? bool as b) -> if b then "true" else "false"
+    | Some other -> other.ToString()
+
+/// Returns `true` when `fm[key]` is a non-empty, non-whitespace-only string
+/// [Repo-grounded — `frontmatter.rs::has_non_empty_string`].
+let private hasNonEmptyString (fm: IDictionary<obj, obj>) (key: string) : bool =
+    (stringValue (tryGetRawValue fm key)).Trim() <> ""
+
+/// Returns `true` when `fm[key]` is a YAML sequence with at least one element
+/// [Repo-grounded — `frontmatter.rs::has_non_empty_list`].
+let private hasNonEmptyList (fm: IDictionary<obj, obj>) (key: string) : bool =
+    match tryGetRawValue fm key |> Option.bind asRawList with
+    | Some items -> not (List.isEmpty items)
+    | None -> false
+
+/// Constructs a `Blocking`-severity finding
+/// [Repo-grounded — `frontmatter.rs::mk_fail`].
+let private mkFail (path: string) (message: string) : Finding =
+    { Severity = Severity.Blocking
+      Message = message
+      Path = Some path }
+
+/// Constructs an `Advisory`-severity finding — used only for the deprecated
+/// `category: software` case
+/// [Repo-grounded — `frontmatter.rs::validate_software_schema`'s
+/// `SEVERITY_WARN` branch].
+let private mkWarn (path: string) (message: string) : Finding =
+    { Severity = Severity.Advisory
+      Message = message
+      Path = Some path }
+
+/// Validates the full software-engineering frontmatter schema. Required
+/// fields: `title`, `description`, `category` (one of `validCategories`, or
+/// the deprecated `"software"` value, which reports `Advisory` rather than
+/// `Blocking`), `subcategory`, `tags` (non-empty list)
+/// [Repo-grounded — `frontmatter.rs::validate_software_schema`].
+///
+/// Gherkin (binds) — "Software-engineering doc with all required frontmatter
+/// fields passes", "...category tutorial...", "...category how-to...",
+/// "...category reference...", "...category explanation..." passing
+/// scenarios, and "Software-engineering doc missing title fails", "...missing
+/// category field fails", "...category other than software fails", and
+/// "...deprecated software category emits warn not fail" — all from
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-frontmatter.feature`.
+let private validateSoftwareSchema (path: string) (fm: IDictionary<obj, obj>) : Finding list =
+    let titleFinding =
+        if hasNonEmptyString fm "title" then
+            []
+        else
+            [ mkFail path "required field \"title\" is missing or empty" ]
+
+    let descriptionFinding =
+        if hasNonEmptyString fm "description" then
+            []
+        else
+            [ mkFail path "required field \"description\" is missing or empty" ]
+
+    let categoryFindings =
+        if hasNonEmptyString fm "category" then
+            let v = stringValue (tryGetRawValue fm "category")
+
+            if Set.contains v validCategories then
+                []
+            elif v = "software" then
+                [ mkWarn
+                      path
+                      "field \"category\" value \"software\" is deprecated; use one of: tutorial, how-to, reference, explanation" ]
+            else
+                [ mkFail
+                      path
+                      (sprintf
+                          "field \"category\" must be one of: tutorial, how-to, reference, explanation; found \"%s\""
+                          v) ]
+        else
+            [ mkFail path "required field \"category\" is missing or empty" ]
+
+    let subcategoryFinding =
+        if hasNonEmptyString fm "subcategory" then
+            []
+        else
+            [ mkFail path "required field \"subcategory\" is missing or empty" ]
+
+    let tagsFinding =
+        if hasNonEmptyList fm "tags" then
+            []
+        else
+            [ mkFail path "required field \"tags\" must be a non-empty list" ]
+
+    titleFinding
+    @ descriptionFinding
+    @ categoryFindings
+    @ subcategoryFinding
+    @ tagsFinding
+
+/// Validates the lighter governance-document frontmatter schema. `title` is
+/// required; `description` and `when_to_use` are both `Blocking` too — FR-4
+/// armed at Phase 9/16, matching `frontmatter.rs`'s current (post-dark-launch)
+/// behavior [Repo-grounded — `frontmatter.rs::validate_governance_schema`].
+///
+/// Gherkin (binds) — "Governance doc with only title fails once when_to_use
+/// and description are armed" and "Governance doc with title, description,
+/// and when_to_use passes the lighter schema" —
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-frontmatter.feature`.
+let private validateGovernanceSchema (path: string) (fm: IDictionary<obj, obj>) : Finding list =
+    let titleFinding =
+        if hasNonEmptyString fm "title" then
+            []
+        else
+            [ mkFail path "required field \"title\" is missing or empty" ]
+
+    let descriptionFinding =
+        if hasNonEmptyString fm "description" then
+            []
+        else
+            [ mkFail path "recommended field \"description\" is missing or empty" ]
+
+    let whenToUseFinding =
+        if hasNonEmptyString fm "when_to_use" then
+            []
+        else
+            [ mkFail path "recommended field \"when_to_use\" is missing or empty" ]
+
+    titleFinding @ descriptionFinding @ whenToUseFinding
+
+/// Reads `path`, extracts its frontmatter block, parses it as YAML, and
+/// delegates to the area-specific schema validator. Returns a single
+/// `missing-frontmatter` finding when no `---` fence is found, or a single
+/// `invalid-yaml` finding when the block is not valid YAML. A block that
+/// parses to `null` or a non-mapping scalar (e.g. an empty `---\n---\n`
+/// block) is treated as an empty frontmatter map — matching
+/// `serde_norway::Value::get` returning `None` for every key on a
+/// non-mapping value, rather than as a parse failure
+/// [Repo-grounded — `frontmatter.rs::scan_frontmatter_file`].
+let private scanFrontmatterFile (path: string) (area: DocArea) : Finding list =
+    let data = File.ReadAllText(path)
+
+    match extractFrontmatter data with
+    | None -> [ mkFail path "file has no YAML frontmatter (delimited by `---` fences)" ]
+    | Some frontmatter ->
+        try
+            let parsed = deserializer.Deserialize<obj>(frontmatter)
+
+            let fm =
+                asRawMap parsed
+                |> Option.defaultValue (Dictionary<obj, obj>() :> IDictionary<obj, obj>)
+
+            match area with
+            | SoftwareArea -> validateSoftwareSchema path fm
+            | GovernanceArea -> validateGovernanceSchema path fm
+            | UnknownArea -> []
+        with ex ->
+            [ mkFail path (sprintf "frontmatter is not valid YAML: %s" ex.Message) ]
+
+/// Recursively collects every file path reachable from `root`, skipping
+/// directories named in `skipDirs`. Mirrors `WalkDir`'s ability to accept
+/// either a single file or a directory as its root
+/// [Repo-grounded — `frontmatter.rs::walk_frontmatter_path`'s `WalkDir` use].
+let rec private collectFiles (root: string) : string list =
+    if File.Exists root then
+        [ root ]
+    elif Directory.Exists root then
+        Directory.GetFileSystemEntries(root)
+        |> Array.sort
+        |> Array.toList
+        |> List.collect (fun entry ->
+            if Directory.Exists entry then
+                if Set.contains (Path.GetFileName entry) skipDirs then
+                    []
+                else
+                    collectFiles entry
+            else
+                [ entry ])
+    else
+        []
+
+/// Walks `root` recursively and collects frontmatter findings from every
+/// markdown file in a recognised documentation area. Returns an empty list
+/// when `root` does not exist on the filesystem
+/// [Repo-grounded — `frontmatter.rs::walk_frontmatter_path`].
+let private walkFrontmatterPath (root: string) : Finding list =
+    collectFiles root
+    |> List.filter (fun p -> p.EndsWith(".md", StringComparison.Ordinal))
+    |> List.collect (fun path ->
+        match classifyDocArea path with
+        | UnknownArea -> []
+        | area -> scanFrontmatterFile path area)
+
+/// Validates the YAML frontmatter of every markdown file reachable from
+/// `paths`. Files outside the recognised documentation areas are silently
+/// skipped. The returned list is sorted by file path, then by message
+/// [Repo-grounded — `frontmatter.rs::validate_docs_frontmatter`].
+///
+/// Gherkin (binds) — "Software-engineering doc with all required frontmatter
+/// fields passes":
+///   Given a software-engineering doc with title, description, category, subcategory, and tags frontmatter
+///   When the developer runs docs validate-frontmatter
+///   Then the command exits successfully
+///   And the frontmatter output reports zero fail-level findings
+///
+/// Gherkin (binds) — "Software-engineering doc missing title fails":
+///   Given a software-engineering doc whose frontmatter omits the title field
+///   When the developer runs docs validate-frontmatter
+///   Then the command exits with a failure code
+///   And the frontmatter output identifies the missing title field
+///
+/// Gherkin (binds) — "Software-engineering doc missing category field fails":
+///   Given a software-engineering doc whose frontmatter omits the category field
+///   When the developer runs docs validate-frontmatter
+///   Then the command exits with a failure code
+///   And the frontmatter output identifies the missing category field
+///
+/// Gherkin (binds) — "Software-engineering doc with category other than software fails":
+///   Given a software-engineering doc whose frontmatter declares category as something other than software
+///   When the developer runs docs validate-frontmatter
+///   Then the command exits with a failure code
+///   And the frontmatter output identifies the wrong category value
+///
+/// Gherkin (binds) — "Governance doc with only title fails once when_to_use and description are armed":
+///   Given a governance doc carrying only a title frontmatter field
+///   When the developer runs docs validate-frontmatter
+///   Then the command exits with a failure code
+///   And the frontmatter output identifies the missing when-to-use field
+///   And the frontmatter output identifies the missing description field
+///
+/// Gherkin (binds) — "Governance doc with title, description, and when_to_use passes the lighter schema":
+///   Given a governance doc with title, description, and when_to_use frontmatter
+///   When the developer runs docs validate-frontmatter
+///   Then the command exits successfully
+///   And the frontmatter output reports zero fail-level findings
+///
+/// Gherkin (binds) — "Software-engineering doc with Diataxis tutorial category passes":
+///   Given a software-engineering doc with title, description, category tutorial, subcategory, and tags frontmatter
+///   When the developer runs docs validate-frontmatter
+///   Then the command exits successfully
+///   And the frontmatter output reports zero fail-level findings
+///
+/// Gherkin (binds) — "Software-engineering doc with Diataxis how-to category passes":
+///   Given a software-engineering doc with title, description, category how-to, subcategory, and tags frontmatter
+///   When the developer runs docs validate-frontmatter
+///   Then the command exits successfully
+///   And the frontmatter output reports zero fail-level findings
+///
+/// Gherkin (binds) — "Software-engineering doc with Diataxis reference category passes":
+///   Given a software-engineering doc with title, description, category reference, subcategory, and tags frontmatter
+///   When the developer runs docs validate-frontmatter
+///   Then the command exits successfully
+///   And the frontmatter output reports zero fail-level findings
+///
+/// Gherkin (binds) — "Software-engineering doc with Diataxis explanation category passes":
+///   Given a software-engineering doc with title, description, category explanation, subcategory, and tags frontmatter
+///   When the developer runs docs validate-frontmatter
+///   Then the command exits successfully
+///   And the frontmatter output reports zero fail-level findings
+///
+/// Gherkin (binds) — "Software-engineering doc with deprecated software category emits warn not fail":
+///   Given a software-engineering doc with all required frontmatter fields
+///   When the developer runs docs validate-frontmatter
+///   Then the command exits successfully
+///   And the frontmatter output reports zero fail-level findings
+let validateDocsFrontmatter (paths: string list) : Result<Finding list, string> =
+    if List.isEmpty paths then
+        Error "at least one path is required"
+    else
+        paths
+        |> List.collect walkFrontmatterPath
+        |> List.sortBy (fun f -> (f.Path |> Option.defaultValue "", f.Message))
+        |> Ok

--- a/apps/rhino-cli/src-fsharp/project.json
+++ b/apps/rhino-cli/src-fsharp/project.json
@@ -112,7 +112,7 @@
     "specs:behavior:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env specs/apps/rhino/behavior/rhino-cli/gherkin/env-contract specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature specs/apps/rhino/behavior/rhino-cli/gherkin/system specs/apps/rhino/behavior/rhino-cli/gherkin/test-coverage apps/rhino-cli/src-fsharp"
+        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env specs/apps/rhino/behavior/rhino-cli/gherkin/env-contract specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature specs/apps/rhino/behavior/rhino-cli/gherkin/system specs/apps/rhino/behavior/rhino-cli/gherkin/test-coverage specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-frontmatter.feature apps/rhino-cli/src-fsharp"
       },
       "cache": true,
       "inputs": ["{workspaceRoot}/specs/apps/rhino/behavior/rhino-cli/gherkin/**/*.feature", "{projectRoot}/**/*.fs"]

--- a/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+++ b/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
@@ -39,6 +39,7 @@
     <Compile Include="Steps/FsharpToolInvocationUnitTests.fs" />
     <Compile Include="Steps/TestCoverageSteps.fs" />
     <Compile Include="Steps/TestCoverageUnitTests.fs" />
+    <Compile Include="Steps/MdSteps.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs
@@ -1,0 +1,334 @@
+/// TickSpec step definitions binding
+/// `docs-validate-frontmatter.feature`'s 11 scenarios to
+/// `RhinoCli.Application.Md.validateDocsFrontmatter`
+/// [Repo-grounded —
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-frontmatter.feature`,
+/// `apps/rhino-cli/src/application/docs/frontmatter.rs`,
+/// `apps/rhino-cli/src/commands/md_validate_frontmatter.rs`].
+///
+/// Follows `ConventionSteps.fs`'s/`TestCoverageSteps.fs`'s per-scenario
+/// slicing convention: each xunit `[<Fact>]` below runs exactly one scenario,
+/// extracted from the real, frozen feature file. `md` is not yet listed in
+/// `FSHARP_NAMESPACES` (that flip is later, separate Wave D integration
+/// work), so — matching `TestCoverageSteps.fs`'s own precedent for
+/// `test-coverage validate` before its Wave C flip — every scenario below
+/// calls `RhinoCli.Application.Md.validateDocsFrontmatter` directly with a
+/// path list built by hand rather than parsing an argv string.
+module RhinoCli.Tests.Unit.Steps.MdSteps
+
+open System
+open System.IO
+open TickSpec
+open Xunit
+open RhinoCli.Application.Md
+open RhinoCli.Domain.Types
+
+/// Instance step-definition container — see `ConventionSteps.fs`'s module
+/// doc comment for why TickSpec's one-instance-per-scenario lifecycle makes
+/// instance-level mutable fields the idiomatic state-threading mechanism
+/// here.
+type MdSteps() =
+    let mutable rootDir: string option = None
+    let mutable outcome: Result<Finding list, string> option = None
+
+    let root () =
+        match rootDir with
+        | Some dir -> dir
+        | None -> failwith "no repository root has been prepared by a Given step"
+
+    let theOutcome () : Result<Finding list, string> =
+        outcome
+        |> Option.defaultWith (fun () -> failwith "no command has been run by a When step")
+
+    let theFindings () : Finding list =
+        match theOutcome () with
+        | Ok findings -> findings
+        | Error message ->
+            failwith (sprintf "expected docs validate-frontmatter to produce findings, got error: %s" message)
+
+    let newTempDir () =
+        let dir =
+            Path.Combine(Path.GetTempPath(), "rhino-cli-md-frontmatter-" + Guid.NewGuid().ToString("N"))
+
+        Directory.CreateDirectory(dir) |> ignore
+        dir
+
+    let writeDoc (relativePath: string) (content: string) =
+        let full = Path.Combine(root (), relativePath)
+        Directory.CreateDirectory(Path.GetDirectoryName(full)) |> ignore
+        File.WriteAllText(full, content)
+
+    let assertHasBlockingFindingContaining (needle: string) =
+        let findings = theFindings ()
+
+        Assert.Contains(
+            findings,
+            fun (f: Finding) ->
+                f.Severity = Severity.Blocking
+                && f.Message.Contains(needle, StringComparison.Ordinal)
+        )
+
+    // ---- Given ----
+
+    [<Given>]
+    member _.``a software-engineering doc with title, description, category, subcategory, and tags frontmatter``() =
+        rootDir <- Some(newTempDir ())
+
+        writeDoc
+            "docs/explanation/software-engineering/foo.md"
+            "---\ntitle: T\ndescription: D\ncategory: explanation\nsubcategory: S\ntags: [a]\n---\nbody\n"
+
+    [<Given>]
+    member _.``a software-engineering doc whose frontmatter omits the title field``() =
+        rootDir <- Some(newTempDir ())
+
+        writeDoc
+            "docs/explanation/software-engineering/foo.md"
+            "---\ndescription: D\ncategory: explanation\nsubcategory: S\ntags: [a]\n---\nbody\n"
+
+    [<Given>]
+    member _.``a software-engineering doc whose frontmatter omits the category field``() =
+        rootDir <- Some(newTempDir ())
+
+        writeDoc
+            "docs/explanation/software-engineering/foo.md"
+            "---\ntitle: T\ndescription: D\nsubcategory: S\ntags: [a]\n---\nbody\n"
+
+    [<Given>]
+    member _.``a software-engineering doc whose frontmatter declares category as something other than software``() =
+        rootDir <- Some(newTempDir ())
+
+        writeDoc
+            "docs/explanation/software-engineering/foo.md"
+            "---\ntitle: T\ndescription: D\ncategory: random\nsubcategory: S\ntags: [a]\n---\nbody\n"
+
+    [<Given>]
+    member _.``a governance doc carrying only a title frontmatter field``() =
+        rootDir <- Some(newTempDir ())
+        writeDoc "repo-governance/conventions/foo.md" "---\ntitle: T\n---\nbody\n"
+
+    [<Given>]
+    member _.``a governance doc with title, description, and when_to_use frontmatter``() =
+        rootDir <- Some(newTempDir ())
+
+        writeDoc
+            "repo-governance/conventions/foo.md"
+            "---\ntitle: T\ndescription: D\nwhen_to_use: Use when W.\n---\nbody\n"
+
+    [<Given>]
+    member _.``a software-engineering doc with title, description, category tutorial, subcategory, and tags frontmatter``
+        ()
+        =
+        rootDir <- Some(newTempDir ())
+
+        writeDoc
+            "docs/explanation/software-engineering/foo.md"
+            "---\ntitle: T\ndescription: D\ncategory: tutorial\nsubcategory: S\ntags: [a]\n---\nbody\n"
+
+    [<Given>]
+    member _.``a software-engineering doc with title, description, category how-to, subcategory, and tags frontmatter``
+        ()
+        =
+        rootDir <- Some(newTempDir ())
+
+        writeDoc
+            "docs/explanation/software-engineering/foo.md"
+            "---\ntitle: T\ndescription: D\ncategory: how-to\nsubcategory: S\ntags: [a]\n---\nbody\n"
+
+    [<Given>]
+    member _.``a software-engineering doc with title, description, category reference, subcategory, and tags frontmatter``
+        ()
+        =
+        rootDir <- Some(newTempDir ())
+
+        writeDoc
+            "docs/explanation/software-engineering/foo.md"
+            "---\ntitle: T\ndescription: D\ncategory: reference\nsubcategory: S\ntags: [a]\n---\nbody\n"
+
+    [<Given>]
+    member _.``a software-engineering doc with title, description, category explanation, subcategory, and tags frontmatter``
+        ()
+        =
+        rootDir <- Some(newTempDir ())
+
+        writeDoc
+            "docs/explanation/software-engineering/foo.md"
+            "---\ntitle: T\ndescription: D\ncategory: explanation\nsubcategory: S\ntags: [a]\n---\nbody\n"
+
+    /// The deprecated `category: software` value is itself the "all required
+    /// frontmatter fields" fixture this scenario needs — every required
+    /// field is present, `category` is merely the deprecated-but-recognised
+    /// value, matching `frontmatter.rs::tests::software_deprecated_category_emits_warn`.
+    [<Given>]
+    member _.``a software-engineering doc with all required frontmatter fields``() =
+        rootDir <- Some(newTempDir ())
+
+        writeDoc
+            "docs/explanation/software-engineering/foo.md"
+            "---\ntitle: T\ndescription: D\ncategory: software\nsubcategory: S\ntags: [a]\n---\nbody\n"
+
+    // ---- When ----
+
+    [<When>]
+    member _.``the developer runs docs validate-frontmatter``() =
+        outcome <- Some(validateDocsFrontmatter [ root () ])
+
+    // ---- Then ----
+
+    [<Then>]
+    member _.``the command exits successfully``() =
+        match theOutcome () with
+        | Ok findings ->
+            Assert.False(
+                findings |> List.exists (fun f -> f.Severity = Severity.Blocking),
+                "expected no fail-level findings"
+            )
+        | Error message -> failwith (sprintf "expected docs validate-frontmatter to succeed, got error: %s" message)
+
+    [<Then>]
+    member _.``the command exits with a failure code``() =
+        match theOutcome () with
+        | Ok findings ->
+            Assert.True(
+                findings |> List.exists (fun f -> f.Severity = Severity.Blocking),
+                "expected at least one fail-level finding"
+            )
+        | Error _ -> ()
+
+    [<Then>]
+    member _.``the frontmatter output reports zero fail-level findings``() =
+        let failFindings =
+            theFindings () |> List.filter (fun f -> f.Severity = Severity.Blocking)
+
+        Assert.Empty(failFindings)
+
+    [<Then>]
+    member _.``the frontmatter output identifies the missing title field``() =
+        assertHasBlockingFindingContaining "\"title\" is missing"
+
+    [<Then>]
+    member _.``the frontmatter output identifies the missing category field``() =
+        assertHasBlockingFindingContaining "\"category\" is missing"
+
+    [<Then>]
+    member _.``the frontmatter output identifies the wrong category value``() =
+        assertHasBlockingFindingContaining "must be one of: tutorial, how-to, reference, explanation"
+
+    [<Then>]
+    member _.``the frontmatter output identifies the missing when-to-use field``() =
+        assertHasBlockingFindingContaining "\"when_to_use\" is missing"
+
+    [<Then>]
+    member _.``the frontmatter output identifies the missing description field``() =
+        assertHasBlockingFindingContaining "\"description\" is missing"
+
+    [<AfterScenario>]
+    member _.Cleanup() =
+        match rootDir with
+        | Some dir when Directory.Exists dir -> Directory.Delete(dir, true)
+        | _ -> ()
+
+/// Reads one named `Scenario:` block out of the real, frozen
+/// `docs-validate-frontmatter.feature` file (leaving the file itself
+/// untouched) and runs it through TickSpec bound only against `MdSteps` —
+/// see `ConventionSteps.fs`'s `FeatureRunner` for why this is per-scenario
+/// rather than per-file.
+module private FeatureRunner =
+
+    let private featurePath: string =
+        Path.GetFullPath(
+            Path.Combine(
+                __SOURCE_DIRECTORY__,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "specs",
+                "apps",
+                "rhino",
+                "behavior",
+                "rhino-cli",
+                "gherkin",
+                "md",
+                "docs-validate-frontmatter.feature"
+            )
+        )
+
+    let private extractScenario (featureLines: string[]) (scenarioTitle: string) : string[] =
+        let featureLine =
+            featureLines
+            |> Array.find (fun l -> l.TrimStart().StartsWith("Feature:", StringComparison.Ordinal))
+
+        let scenarioHeader = sprintf "Scenario: %s" scenarioTitle
+
+        let startIdx = featureLines |> Array.findIndex (fun l -> l.Trim() = scenarioHeader)
+
+        let endIdx =
+            featureLines
+            |> Array.skip (startIdx + 1)
+            |> Array.tryFindIndex (fun l ->
+                let trimmed = l.Trim()
+
+                trimmed.StartsWith("Scenario:", StringComparison.Ordinal)
+                || trimmed.StartsWith("Scenario Outline:", StringComparison.Ordinal)
+                || trimmed.StartsWith("@", StringComparison.Ordinal))
+            |> Option.map (fun relativeIdx -> startIdx + 1 + relativeIdx)
+            |> Option.defaultValue featureLines.Length
+
+        Array.append [| featureLine; "" |] featureLines.[startIdx .. endIdx - 1]
+
+    /// Runs the single scenario named `scenarioTitle` from
+    /// `docs-validate-frontmatter.feature`, bound against `MdSteps`.
+    let run (scenarioTitle: string) : unit =
+        let allLines = File.ReadAllLines featurePath
+        let snippet = extractScenario allLines scenarioTitle
+        let definitions = StepDefinitions([| typeof<MdSteps> |])
+        let feature = definitions.GenerateFeature(featurePath, snippet)
+        let scenario = Seq.exactlyOne feature.Scenarios
+        scenario.Action.Invoke()
+
+[<Fact>]
+let ``Software-engineering doc with all required frontmatter fields passes`` () =
+    FeatureRunner.run "Software-engineering doc with all required frontmatter fields passes"
+
+[<Fact>]
+let ``Software-engineering doc missing title fails`` () =
+    FeatureRunner.run "Software-engineering doc missing title fails"
+
+[<Fact>]
+let ``Software-engineering doc missing category field fails`` () =
+    FeatureRunner.run "Software-engineering doc missing category field fails"
+
+[<Fact>]
+let ``Software-engineering doc with category other than software fails`` () =
+    FeatureRunner.run "Software-engineering doc with category other than software fails"
+
+[<Fact>]
+let ``Governance doc with only title fails once when_to_use and description are armed`` () =
+    FeatureRunner.run "Governance doc with only title fails once when_to_use and description are armed"
+
+[<Fact>]
+let ``Governance doc with title, description, and when_to_use passes the lighter schema`` () =
+    FeatureRunner.run "Governance doc with title, description, and when_to_use passes the lighter schema"
+
+[<Fact>]
+let ``Software-engineering doc with Diataxis tutorial category passes`` () =
+    FeatureRunner.run "Software-engineering doc with Diataxis tutorial category passes"
+
+[<Fact>]
+let ``Software-engineering doc with Diataxis how-to category passes`` () =
+    FeatureRunner.run "Software-engineering doc with Diataxis how-to category passes"
+
+[<Fact>]
+let ``Software-engineering doc with Diataxis reference category passes`` () =
+    FeatureRunner.run "Software-engineering doc with Diataxis reference category passes"
+
+[<Fact>]
+let ``Software-engineering doc with Diataxis explanation category passes`` () =
+    FeatureRunner.run "Software-engineering doc with Diataxis explanation category passes"
+
+[<Fact>]
+let ``Software-engineering doc with deprecated software category emits warn not fail`` () =
+    FeatureRunner.run "Software-engineering doc with deprecated software category emits warn not fail"

--- a/plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md
+++ b/plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md
@@ -4560,7 +4560,7 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
 
 > **PR seam**: the cycles under this heading are one PR.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4574,17 +4574,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the frontmatter output reports zero fail-level findings
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4598,17 +4598,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the frontmatter output identifies the missing title field
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4622,17 +4622,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the frontmatter output identifies the missing category field
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4646,17 +4646,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the frontmatter output identifies the wrong category value
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4671,17 +4671,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the frontmatter output identifies the missing description field
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4695,17 +4695,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the frontmatter output reports zero fail-level findings
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4719,17 +4719,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the frontmatter output reports zero fail-level findings
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4743,17 +4743,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the frontmatter output reports zero fail-level findings
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4767,17 +4767,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the frontmatter output reports zero fail-level findings
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4791,17 +4791,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the frontmatter output reports zero fail-level findings
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4815,12 +4815,12 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the frontmatter output reports zero fail-level findings
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.


### PR DESCRIPTION
## Summary

- Ports the Rust `md validate-frontmatter` validator (`apps/rhino-cli/src/application/docs/frontmatter.rs`, `apps/rhino-cli/src/commands/md_validate_frontmatter.rs`) to F# in `RhinoCli.Application/src/Md.fs`, covering all 11 scenarios in `specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-frontmatter.feature` via strict RED→GREEN→REFACTOR TDD.
- Reuses the shared `RhinoCli.Domain.Types.Finding` record (`Severity`/`Message`/`Path`) rather than a bespoke per-validator finding type, matching `Convention.fs`'s established precedent — Rust's separate `kind` field is folded into each finding's `Message` text since no scenario needs the two split apart.
- `md` is not yet listed in `FSHARP_NAMESPACES` (that flip is separate, later Wave D integration work), so this PR is implementation only: `MdSteps.fs` calls `RhinoCli.Application.Md.validateDocsFrontmatter` directly, matching `TestCoverageSteps.fs`'s established precedent for a Rust-wired command before its own namespace flip.
- Widens `rhino-cli-fsharp:specs:behavior:coverage`'s `--shared-steps` argument list with this feature file (per-PR precedent from Wave C).
- Regenerates `apps/rhino-cli/parity-manifest.sha256` in its own commit.
- Ticks all 33 RED/GREEN/REFACTOR checklist items for this feature file's 11 scenarios in `plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md`.

## Test plan

- [x] `dotnet test apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj` — 636/636 passing (625 pre-existing + 11 new `MdSteps` scenarios)
- [x] `npx nx run rhino-cli-fsharp:test:quick` — typecheck, lint (Fantomas + fsharplint + G-Research analyzers), test:unit, test:specs all green
- [x] `cargo run ... -- specs behavior-coverage validate --shared-steps ... specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-frontmatter.feature apps/rhino-cli/src-fsharp` — "Spec coverage valid! 18 specs, 137 scenarios, 586 steps — all covered."
- [x] `apps/rhino-cli/scripts/rhino-bin.sh parity manifest validate` — "apps/rhino-cli/parity-manifest.sha256 is current"
- [x] Mutation check: temporarily corrupted the "wrong category value" message text and confirmed the corresponding scenario test failed, then restored and re-verified green (confirms assertions are load-bearing, not vacuous)

No dispatch/integration wiring touched — `FSHARP_NAMESPACES` is unchanged, so `md` namespace commands remain Rust-served in production. Per standing instruction, the PR-review maker/fixer cycle is skipped for this PR — requesting merge once CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)