### PR TITLE
feat(rhino-cli-fsharp): port docs validate-heading-hierarchy (Wave D PR2)

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -7,7 +7,7 @@ b5f5e511ac5697c2d2949d898633f079abbce9c7211205aad6f7521f17746df2  apps/rhino-cli
 11fe7ec2e5e08b432e2d1cedae59e1a555e17e22a1f11494bd83b80c36964b5c  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Convention.fs
 015c281c498a64930d705b4806ef139de008a78fcd1197f8a7851cea7586cd85  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Doctor.fs
 ba223d446b461cce0e427e278e340a87330ed423885f92a674c5039fd755cb5b  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
-a72ee56cd87ec7ea7592574148fd58a4f1120cbbdc84ec2b96cac2facdc7b117  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Md.fs
+c13b9d4f3b7b72a68838845a0b8fef0dd9912699854802be2bdaee07fc3f5d2b  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Md.fs
 2f8085bcb8089f174e9548e609530471c9318c31b1bcab4a867e33880cec9e57  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Parity.fs
 d4bdb1646d8e18a40245bbd3fb2ac96ac1acf1adf38355a0b567d7b8d4cc6e48  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/RepoConfig.fs
 3c52c83f35ed710cadc6008cc22bbd4767d43d824be4aa56700698c2bff4c2cf  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/TestCoverage.fs
@@ -23,7 +23,7 @@ b185e1073cc014e7c83b8de74cabca6e581bd05ccbd012c84c6d118b2a99eb2c  apps/rhino-cli
 631376afb9e4d7c5192d38f51b533c18b64cca83c18ed5c50982ba9acce51d74  apps/rhino-cli/src-fsharp/RhinoCli.Program/RhinoCli.Program.fsproj
 153a226f5ef1d6916aa6e6425b278a606a48659fcba9623c9d01e5cf3b2589a5  apps/rhino-cli/src-fsharp/RhinoCli.Program/src/Program.fs
 822f6ec8446562a4de9a3b1a2481af50fac01bbedc32e1963142709e5f48ec13  apps/rhino-cli/src-fsharp/fsharplint.json
-e33ebd8e6470da7025ff13e36882542b7fde3a5c28ff140e59ca16e259ae53f2  apps/rhino-cli/src-fsharp/project.json
+ce2c99eda814337db63b1c692f9e94839e1ebd3809acb801b1e2972b65c0967e  apps/rhino-cli/src-fsharp/project.json
 f7dacc8dd923488c70eebabe298843022ec5a3ba94b8b7568634a779f24b8da4  apps/rhino-cli/src-fsharp/tests/integration/RhinoCli.IntegrationTests.fsproj
 b5e2d7235fa11e8584e2be7be22bba583f54fca9064149c6a2a8b41e3badbf76  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
 85ba308ad0a88485db55b305120d99b9a4ec328d2379536110f73e51f4797fe2  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionSteps.fs
@@ -49,7 +49,7 @@ d43395cc8b45ab5197772682e18ba229bba6194507ca40c77053bf3ccd0929a9  apps/rhino-cli
 c99dc72ba90a55126c8f080d98b2ce2cc80037d936398ff42a93353ab7cdc481  apps/rhino-cli/src-fsharp/tests/unit/Steps/FsharpToolInvocationSteps.fs
 df2d2403e3dbf9b7cde5eae9ff273fb26d62ee0841ba72bbbf81c91ed8c8527d  apps/rhino-cli/src-fsharp/tests/unit/Steps/FsharpToolInvocationUnitTests.fs
 413baab2577c13102e7eb36979cbea9d75735929a5c429591a05ca85cf69cbec  apps/rhino-cli/src-fsharp/tests/unit/Steps/GitRootUnitTests.fs
-7f9b1b2eef1556c9b5fae26f6952d49996f30981bc5562ab6a492cb12e268780  apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs
+de0f0c81ae1ba2e202eec033f6e1bdfa1036a9ad834140ebb7e0ad3683cb1706  apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs
 b8a8fbf79e78dee93f32944d3bbae2daccf33876ce5988ae31b1259c2f5ce201  apps/rhino-cli/src-fsharp/tests/unit/Steps/ParityUnitTests.fs
 76ee39dfa9f270aeffdbee896cf4f521f8685dea723f8ec41acb24d3f80abf47  apps/rhino-cli/src-fsharp/tests/unit/Steps/RepoConfigSteps.fs
 7d6558430a23078b4306c31a0198fb7ff0a5775f03e0100ee7a62cec7f4aa932  apps/rhino-cli/src-fsharp/tests/unit/Steps/RepoConfigUnitTests.fs

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Md.fs
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Md.fs
@@ -1,29 +1,36 @@
-/// Port of the Rust `md` namespace's `docs validate-frontmatter` validator
+/// Port of the Rust `md` namespace's `docs validate-frontmatter` and
+/// `docs validate-heading-hierarchy` validators
 /// [Repo-grounded — `apps/rhino-cli/src/application/docs/frontmatter.rs`,
-/// `apps/rhino-cli/src/commands/md_validate_frontmatter.rs`] for
+/// `apps/rhino-cli/src/commands/md_validate_frontmatter.rs`,
+/// `apps/rhino-cli/src/application/docs/heading_hierarchy.rs`,
+/// `apps/rhino-cli/src/commands/md_validate_heading_hierarchy.rs`] for
 /// `specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-frontmatter.feature`'s
-/// 11 scenarios.
+/// 11 scenarios and
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-heading-hierarchy.feature`'s
+/// 12 scenarios.
 ///
-/// Scope: this PR ports only the frontmatter validator — the `md` namespace's
-/// other five feature files (heading-hierarchy, links, mermaid, naming,
-/// audit) land in later Wave D PRs against this same file. Findings reuse
-/// the shared `RhinoCli.Domain.Types.Finding` record (`Severity`/`Message`/
-/// `Path`) rather than a bespoke `DocsFrontmatterFinding` type, matching
-/// `Convention.fs`'s established "shared Finding over bespoke per-validator
-/// types" precedent — the Rust source's separate `kind` field (e.g.
-/// `"missing-title"`) is folded into each finding's `Message` text instead of
-/// becoming a fourth field on the shared record, since every Rust `kind`
-/// value is already reproduced verbatim inside its finding's message text,
-/// and no scenario here needs the two split apart.
+/// Scope: this PR (Wave D PR2) additionally ports the heading-hierarchy
+/// validator — the `md` namespace's remaining three feature files (links,
+/// mermaid, naming, audit) land in later Wave D PRs against this same file.
+/// Findings reuse the shared `RhinoCli.Domain.Types.Finding` record
+/// (`Severity`/`Message`/`Path`) rather than a bespoke `DocsHeadingFinding`
+/// type, matching `Convention.fs`'s established "shared Finding over bespoke
+/// per-validator types" precedent and this file's own frontmatter-validator
+/// precedent — the Rust source's separate `kind` and `line` fields are
+/// folded into each finding's `Message` text instead of becoming extra
+/// fields on the shared record, since every Rust `kind` value is already
+/// reproduced verbatim inside its finding's message text and no scenario
+/// here asserts on an exact line number.
 ///
 /// `md` is not yet listed in `FSHARP_NAMESPACES` (that flip is later,
 /// separate Wave D integration work), so — matching `TestCoverage.fs`'s
-/// `validate`-before-the-Wave-C-flip precedent — this validator is called
-/// directly by its step definitions with a path list built by hand, not
-/// parsed from CLI argv. No text/JSON/Markdown rendering lives in this file
-/// for the same reason `reporter.rs`'s formatting stays out of `Doctor.fs`
-/// until a scenario needs it: none of this feature file's 11 scenarios
-/// assert on rendered output, only on the structured `Finding` list.
+/// `validate`-before-the-Wave-C-flip precedent — both validators are called
+/// directly by their step definitions with a path list (or repo root) built
+/// by hand, not parsed from CLI argv. No text/JSON/Markdown rendering lives
+/// in this file for the same reason `reporter.rs`'s formatting stays out of
+/// `Doctor.fs` until a scenario needs it: none of these feature files'
+/// scenarios assert on rendered output, only on the structured `Finding`
+/// list.
 module RhinoCli.Application.Md
 
 open System
@@ -53,6 +60,24 @@ let private validCategories: Set<string> =
 /// [Repo-grounded — `frontmatter.rs::SKIP_DIRS`].
 let private skipDirs: Set<string> =
     Set.ofList [ "node_modules"; ".git"; ".next"; "dist"; "build"; "target" ]
+
+/// Directory names that are skipped during the heading-hierarchy validator's
+/// recursive walks — the Rust source keeps this as a second, separate
+/// constant (`frontmatter.rs::SKIP_DIRS` above vs. `naming.rs::SKIP_DIRS`
+/// here) rather than a single shared list, so this port mirrors that split
+/// instead of merging them. A superset of `skipDirs` above: the same six
+/// names, plus `generated-reports`
+/// [Repo-grounded — `heading_hierarchy.rs`'s `use super::naming::SKIP_DIRS`,
+/// `naming.rs::SKIP_DIRS`].
+let private namingSkipDirs: Set<string> =
+    Set.ofList
+        [ "node_modules"
+          ".git"
+          ".next"
+          "dist"
+          "build"
+          "target"
+          "generated-reports" ]
 
 /// Classifies a markdown file as belonging to a known documentation area
 /// [Repo-grounded — `frontmatter.rs::DocArea`].
@@ -280,10 +305,13 @@ let private scanFrontmatterFile (path: string) (area: DocArea) : Finding list =
             [ mkFail path (sprintf "frontmatter is not valid YAML: %s" ex.Message) ]
 
 /// Recursively collects every file path reachable from `root`, skipping
-/// directories named in `skipDirs`. Mirrors `WalkDir`'s ability to accept
-/// either a single file or a directory as its root
-/// [Repo-grounded — `frontmatter.rs::walk_frontmatter_path`'s `WalkDir` use].
-let rec private collectFiles (root: string) : string list =
+/// directories named in `skip`. Mirrors `WalkDir`'s ability to accept either
+/// a single file or a directory as its root
+/// [Repo-grounded — `frontmatter.rs::walk_frontmatter_path`'s and
+/// `heading_hierarchy.rs::walk_heading_hierarchy_path`'s shared `WalkDir`
+/// use — parameterised over which `SKIP_DIRS` constant applies, since the
+/// two validators use different lists].
+let rec private collectFilesSkipping (skip: Set<string>) (root: string) : string list =
     if File.Exists root then
         [ root ]
     elif Directory.Exists root then
@@ -292,14 +320,19 @@ let rec private collectFiles (root: string) : string list =
         |> Array.toList
         |> List.collect (fun entry ->
             if Directory.Exists entry then
-                if Set.contains (Path.GetFileName entry) skipDirs then
+                if Set.contains (Path.GetFileName entry) skip then
                     []
                 else
-                    collectFiles entry
+                    collectFilesSkipping skip entry
             else
                 [ entry ])
     else
         []
+
+/// `collectFilesSkipping` specialised to the frontmatter validator's
+/// `skipDirs` [Repo-grounded — `frontmatter.rs::walk_frontmatter_path`'s
+/// `WalkDir` use].
+let private collectFiles (root: string) : string list = collectFilesSkipping skipDirs root
 
 /// Walks `root` recursively and collects frontmatter findings from every
 /// markdown file in a recognised documentation area. Returns an empty list
@@ -391,5 +424,245 @@ let validateDocsFrontmatter (paths: string list) : Result<Finding list, string> 
     else
         paths
         |> List.collect walkFrontmatterPath
+        |> List.sortBy (fun f -> (f.Path |> Option.defaultValue "", f.Message))
+        |> Ok
+
+// ---------------------------------------------------------------------------
+// docs validate-heading-hierarchy
+// ---------------------------------------------------------------------------
+
+/// One parsed ATX heading: its one-based source line number and level (1-6)
+/// [Repo-grounded — `heading_hierarchy.rs::Heading`].
+type private Heading = { Line: int; Level: int }
+
+/// Parses the opening of a fenced code block from the start of a
+/// (leading-whitespace-trimmed) line. Returns `Some (fenceChar, length)`
+/// when the line begins with three or more identical backtick or tilde
+/// characters; otherwise `None`
+/// [Repo-grounded — `heading_hierarchy.rs::parse_fence_open`].
+let private parseFenceOpen (s: string) : (char * int) option =
+    if String.IsNullOrEmpty s then
+        None
+    else
+        let first = s.[0]
+
+        if first <> '`' && first <> '~' then
+            None
+        else
+            let mutable n = 0
+            let mutable i = 0
+
+            while i < s.Length && s.[i] = first do
+                n <- n + 1
+                i <- i + 1
+
+            if n < 3 then None else Some(first, n)
+
+/// Parses the ATX heading level (1-6) from the start of a
+/// (leading-whitespace-trimmed) line. Returns `None` when the line is not a
+/// valid ATX heading (wrong prefix, no space/tab after the `#` run, or empty
+/// heading text) [Repo-grounded — `heading_hierarchy.rs::parse_heading_level`].
+let private parseHeadingLevel (s: string) : int option =
+    if String.IsNullOrEmpty s || s.[0] <> '#' then
+        None
+    else
+        let mutable level = 0
+
+        while level < s.Length && s.[level] = '#' do
+            level <- level + 1
+
+        if level < 1 || level > 6 then
+            None
+        elif level >= s.Length then
+            None
+        else
+            let next = s.[level]
+
+            if next <> ' ' && next <> '\t' then
+                None
+            else
+                let rest = s.Substring(level + 1).Trim()
+                if rest = "" then None else Some level
+
+/// Parses all ATX headings from `content`, skipping lines inside fenced code
+/// blocks. A line that opens or closes a fence is itself never treated as a
+/// heading candidate, matching the Rust source's `continue`-before-heading-
+/// check ordering [Repo-grounded — `heading_hierarchy.rs::collect_headings`].
+let private collectHeadings (content: string) : Heading list =
+    let lines = content.Split('\n')
+    let mutable inFence = false
+    let mutable fenceChar = ' '
+    let mutable fenceLen = 0
+    let headings = ResizeArray<Heading>()
+
+    for i in 0 .. lines.Length - 1 do
+        let lineNum = i + 1
+        let trimmed = lines.[i].TrimStart([| ' '; '\t' |])
+
+        match parseFenceOpen trimmed with
+        | Some(ch, length) ->
+            if not inFence then
+                inFence <- true
+                fenceChar <- ch
+                fenceLen <- length
+            elif ch = fenceChar && length >= fenceLen then
+                inFence <- false
+                fenceChar <- ' '
+                fenceLen <- 0
+        | None ->
+            if not inFence then
+                match parseHeadingLevel trimmed with
+                | Some level -> headings.Add { Line = lineNum; Level = level }
+                | None -> ()
+
+    headings |> List.ofSeq
+
+/// Applies the H1-uniqueness and no-level-skipping rules to a file's parsed
+/// headings. Returns an empty list when `headings` is empty (the file has no
+/// headings at all) [Repo-grounded — `heading_hierarchy.rs::analyze_headings`].
+///
+/// Gherkin (binds) — "Tree where every .md has exactly one H1 and no skipped
+/// levels passes", "File with two H1 headings fails", "File with H2 followed
+/// directly by H4 (skipping H3) fails", and "Single-line file with no
+/// headings is ignored (passes)" — all from
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-heading-hierarchy.feature`.
+let private analyzeHeadings (path: string) (headings: Heading list) : Finding list =
+    match headings with
+    | [] -> []
+    | _ ->
+        let h1s = headings |> List.filter (fun h -> h.Level = 1)
+        let h1Count = h1s.Length
+
+        let h1Finding =
+            match h1Count with
+            | 0 -> [ mkFail path "markdown file has no H1 heading; every documented file must have exactly one H1" ]
+            | 1 -> []
+            | _ ->
+                let firstH1Line = h1s.[0].Line
+
+                [ mkFail
+                      path
+                      (sprintf
+                          "markdown file has %d H1 headings (first at line %d); every file must have exactly one H1"
+                          h1Count
+                          firstH1Line) ]
+
+        let skipFindings =
+            headings
+            |> List.pairwise
+            |> List.choose (fun (prev, cur) ->
+                if cur.Level > prev.Level + 1 then
+                    Some(
+                        mkFail
+                            path
+                            (sprintf
+                                "H%d heading follows H%d, skipping H%d; heading levels must not skip"
+                                cur.Level
+                                prev.Level
+                                (prev.Level + 1))
+                    )
+                else
+                    None)
+
+        h1Finding @ skipFindings
+
+/// Reads `path`, extracts its headings, and applies the hierarchy rules
+/// [Repo-grounded — `heading_hierarchy.rs::scan_file_heading_hierarchy`].
+let private scanFileHeadingHierarchy (path: string) : Finding list =
+    File.ReadAllText(path) |> collectHeadings |> analyzeHeadings path
+
+/// Walks `root` recursively and validates each markdown file. Returns an
+/// empty list when `root` does not exist on the filesystem
+/// [Repo-grounded — `heading_hierarchy.rs::walk_heading_hierarchy_path`].
+let private walkHeadingHierarchyPath (root: string) : Finding list =
+    collectFilesSkipping namingSkipDirs root
+    |> List.filter (fun p -> p.EndsWith(".md", StringComparison.Ordinal))
+    |> List.collect scanFileHeadingHierarchy
+
+/// Returns `true` when the repository-relative path `repoRel` is in the
+/// heading-hierarchy validator's prose allowlist:
+/// `docs/`, `repo-governance/`, `plans/` (except `plans/done/`), `specs/`,
+/// root-level `*.md` files, `apps/<name>/README.md` and
+/// `libs/<name>/README.md`, and `apps/<name>/docs/**` and
+/// `libs/<name>/docs/**`. Everything else — including `.claude/`,
+/// `.opencode/`, deep `apps/`/`libs/` internals, `plans/done/`, and noise
+/// directories — is default-deny
+/// [Repo-grounded — `heading_hierarchy.rs::is_prose_allowlisted`].
+let private isProseAllowlisted (repoRel: string) : bool =
+    let r = repoRel.Replace('\\', '/')
+
+    let stripPrefix (prefix: string) (value: string) : string option =
+        if value.StartsWith(prefix, StringComparison.Ordinal) then
+            Some(value.Substring(prefix.Length))
+        else
+            None
+
+    if r.StartsWith("plans/done/", StringComparison.Ordinal) || r = "plans/done" then
+        false
+    elif
+        r.StartsWith("docs/", StringComparison.Ordinal)
+        || r.StartsWith("repo-governance/", StringComparison.Ordinal)
+        || r.StartsWith("plans/", StringComparison.Ordinal)
+        || r.StartsWith("specs/", StringComparison.Ordinal)
+    then
+        true
+    elif not (r.Contains('/')) && r.EndsWith(".md", StringComparison.Ordinal) then
+        true
+    else
+        match stripPrefix "apps/" r |> Option.orElse (stripPrefix "libs/" r) with
+        | None -> false
+        | Some rest ->
+            match rest.IndexOf('/') with
+            | -1 -> false
+            | idx ->
+                let tail = rest.Substring(idx + 1)
+                tail = "README.md" || tail.StartsWith("docs/", StringComparison.Ordinal)
+
+/// Performs an allowlisted heading-hierarchy scan rooted at `repoRoot`. Only
+/// files whose repository-relative path satisfies `isProseAllowlisted` are
+/// checked; `excludePrefixes` are additional repository-relative prefixes to
+/// skip, applied after the allowlist filter. The returned list is sorted by
+/// file path, then by message
+/// [Repo-grounded — `heading_hierarchy.rs::validate_docs_heading_hierarchy_allowlisted`].
+///
+/// Gherkin (binds) — "prose-allowlist-runs — docs file triggers a heading
+/// finding", "agent-skill-file-exempt — no finding for agent or skill
+/// files", "plans-done-excluded — no finding for plans/done files",
+/// "exclude-flag-suppresses-tree — --exclude docs suppresses docs findings",
+/// "specs-allowlisted — specs tree triggers a heading finding",
+/// "app-readme-allowlisted — project-root README triggers a heading
+/// finding", "app-internals-default-deny — deep app files yield no finding",
+/// and "project-docs-subtree-allowlisted — app and lib docs trees trigger
+/// findings" — all from
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-heading-hierarchy.feature`.
+let validateDocsHeadingHierarchyAllowlisted (repoRoot: string) (excludePrefixes: string list) : Finding list =
+    collectFilesSkipping namingSkipDirs repoRoot
+    |> List.filter (fun p -> p.EndsWith(".md", StringComparison.Ordinal))
+    |> List.choose (fun path ->
+        let rel = Path.GetRelativePath(repoRoot, path).Replace('\\', '/')
+
+        if not (isProseAllowlisted rel) then
+            None
+        elif
+            excludePrefixes
+            |> List.exists (fun pfx -> rel.StartsWith(pfx, StringComparison.Ordinal))
+        then
+            None
+        else
+            Some path)
+    |> List.collect scanFileHeadingHierarchy
+    |> List.sortBy (fun f -> (f.Path |> Option.defaultValue "", f.Message))
+
+/// Validates heading hierarchy in every markdown file reachable from
+/// `paths`, without any prose-allowlist filtering — the counterpart callers
+/// use when they already know every supplied path should be checked. The
+/// returned list is sorted by file path, then by message
+/// [Repo-grounded — `heading_hierarchy.rs::validate_docs_heading_hierarchy`].
+let validateDocsHeadingHierarchy (paths: string list) : Result<Finding list, string> =
+    if List.isEmpty paths then
+        Error "at least one path is required"
+    else
+        paths
+        |> List.collect walkHeadingHierarchyPath
         |> List.sortBy (fun f -> (f.Path |> Option.defaultValue "", f.Message))
         |> Ok

--- a/apps/rhino-cli/src-fsharp/project.json
+++ b/apps/rhino-cli/src-fsharp/project.json
@@ -112,7 +112,7 @@
     "specs:behavior:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env specs/apps/rhino/behavior/rhino-cli/gherkin/env-contract specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature specs/apps/rhino/behavior/rhino-cli/gherkin/system specs/apps/rhino/behavior/rhino-cli/gherkin/test-coverage specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-frontmatter.feature apps/rhino-cli/src-fsharp"
+        "command": "cargo run --release --quiet --manifest-path apps/rhino-cli/Cargo.toml -- specs behavior-coverage validate --shared-steps specs/apps/rhino/behavior/rhino-cli/gherkin/convention specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config specs/apps/rhino/behavior/rhino-cli/gherkin/repo-config-validate specs/apps/rhino/behavior/rhino-cli/gherkin/env specs/apps/rhino/behavior/rhino-cli/gherkin/env-contract specs/apps/rhino/behavior/rhino-cli/gherkin/specs/env-staged-guard.feature specs/apps/rhino/behavior/rhino-cli/gherkin/system specs/apps/rhino/behavior/rhino-cli/gherkin/test-coverage specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-frontmatter.feature specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-heading-hierarchy.feature apps/rhino-cli/src-fsharp"
       },
       "cache": true,
       "inputs": ["{workspaceRoot}/specs/apps/rhino/behavior/rhino-cli/gherkin/**/*.feature", "{projectRoot}/**/*.fs"]

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs
@@ -1,10 +1,15 @@
-/// TickSpec step definitions binding
-/// `docs-validate-frontmatter.feature`'s 11 scenarios to
-/// `RhinoCli.Application.Md.validateDocsFrontmatter`
+/// TickSpec step definitions binding `docs-validate-frontmatter.feature`'s 11
+/// scenarios to `RhinoCli.Application.Md.validateDocsFrontmatter` and
+/// `docs-validate-heading-hierarchy.feature`'s 12 scenarios to
+/// `RhinoCli.Application.Md.validateDocsHeadingHierarchy`/
+/// `validateDocsHeadingHierarchyAllowlisted`
 /// [Repo-grounded —
 /// `specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-frontmatter.feature`,
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-heading-hierarchy.feature`,
 /// `apps/rhino-cli/src/application/docs/frontmatter.rs`,
-/// `apps/rhino-cli/src/commands/md_validate_frontmatter.rs`].
+/// `apps/rhino-cli/src/commands/md_validate_frontmatter.rs`,
+/// `apps/rhino-cli/src/application/docs/heading_hierarchy.rs`,
+/// `apps/rhino-cli/src/commands/md_validate_heading_hierarchy.rs`].
 ///
 /// Follows `ConventionSteps.fs`'s/`TestCoverageSteps.fs`'s per-scenario
 /// slicing convention: each xunit `[<Fact>]` below runs exactly one scenario,
@@ -12,8 +17,15 @@
 /// `FSHARP_NAMESPACES` (that flip is later, separate Wave D integration
 /// work), so — matching `TestCoverageSteps.fs`'s own precedent for
 /// `test-coverage validate` before its Wave C flip — every scenario below
-/// calls `RhinoCli.Application.Md.validateDocsFrontmatter` directly with a
-/// path list built by hand rather than parsing an argv string.
+/// calls one of `RhinoCli.Application.Md`'s validators directly with a path
+/// list (or a repo root standing in for it) built by hand rather than
+/// parsing an argv string. The heading-hierarchy scenarios that exercise the
+/// prose allowlist (`docs`/`.claude`/`plans/done`/`specs`/`apps`/`libs`
+/// trees) set the `useAllowlist` instance field from their `Given` step so
+/// the single shared "the developer runs docs validate-heading-hierarchy"
+/// `When` step — reused verbatim by both the plain-tree and the
+/// allowlist-tree scenarios — knows which of the two validator entry points
+/// to call.
 module RhinoCli.Tests.Unit.Steps.MdSteps
 
 open System
@@ -30,11 +42,27 @@ open RhinoCli.Domain.Types
 type MdSteps() =
     let mutable rootDir: string option = None
     let mutable outcome: Result<Finding list, string> option = None
+    let mutable useAllowlist = false
 
     let root () =
         match rootDir with
         | Some dir -> dir
         | None -> failwith "no repository root has been prepared by a Given step"
+
+    /// Returns the scenario's shared temp-dir root, creating it on first
+    /// use — lets a scenario with more than one `Given`/`And` fixture step
+    /// (e.g. heading-hierarchy's "exclude-flag-suppresses-tree") write into
+    /// the same tree instead of each step getting its own temp dir.
+    let ensureRoot () =
+        match rootDir with
+        | Some dir -> dir
+        | None ->
+            let dir =
+                Path.Combine(Path.GetTempPath(), "rhino-cli-md-" + Guid.NewGuid().ToString("N"))
+
+            Directory.CreateDirectory(dir) |> ignore
+            rootDir <- Some dir
+            dir
 
     let theOutcome () : Result<Finding list, string> =
         outcome
@@ -43,18 +71,12 @@ type MdSteps() =
     let theFindings () : Finding list =
         match theOutcome () with
         | Ok findings -> findings
-        | Error message ->
-            failwith (sprintf "expected docs validate-frontmatter to produce findings, got error: %s" message)
+        | Error message -> failwith (sprintf "expected the md validator to produce findings, got error: %s" message)
 
-    let newTempDir () =
-        let dir =
-            Path.Combine(Path.GetTempPath(), "rhino-cli-md-frontmatter-" + Guid.NewGuid().ToString("N"))
-
-        Directory.CreateDirectory(dir) |> ignore
-        dir
+    let newTempDir () = ensureRoot ()
 
     let writeDoc (relativePath: string) (content: string) =
-        let full = Path.Combine(root (), relativePath)
+        let full = Path.Combine(ensureRoot (), relativePath)
         Directory.CreateDirectory(Path.GetDirectoryName(full)) |> ignore
         File.WriteAllText(full, content)
 
@@ -66,6 +88,57 @@ type MdSteps() =
             fun (f: Finding) ->
                 f.Severity = Severity.Blocking
                 && f.Message.Contains(needle, StringComparison.Ordinal)
+        )
+
+    /// Substring unique to `analyzeHeadings`'s duplicate-H1 finding message
+    /// (e.g. `"markdown file has 2 H1 headings (first at line 1); ..."`) —
+    /// distinct from the missing-H1 message's "documented file must have
+    /// exactly one H1" wording.
+    let duplicateH1Needle = "H1 headings (first at line"
+
+    /// Substring unique to `analyzeHeadings`'s skipped-level finding
+    /// message.
+    let skippedLevelNeedle = "heading levels must not skip"
+
+    let assertHasBlockingFindingWithMessageAndPath (messageNeedle: string) =
+        let findings = theFindings ()
+
+        Assert.Contains(
+            findings,
+            fun (f: Finding) ->
+                f.Severity = Severity.Blocking
+                && f.Message.Contains(messageNeedle, StringComparison.Ordinal)
+                && (f.Path |> Option.isSome)
+        )
+
+    let assertHasBlockingFindingInPathWithMessage (pathNeedle: string) (messageNeedle: string) =
+        let findings = theFindings ()
+
+        Assert.Contains(
+            findings,
+            fun (f: Finding) ->
+                f.Severity = Severity.Blocking
+                && f.Message.Contains(messageNeedle, StringComparison.Ordinal)
+                && (f.Path |> Option.defaultValue "").Replace('\\', '/').Contains(pathNeedle, StringComparison.Ordinal)
+        )
+
+    let assertHasBlockingFindingInPath (pathNeedle: string) =
+        let findings = theFindings ()
+
+        Assert.Contains(
+            findings,
+            fun (f: Finding) ->
+                f.Severity = Severity.Blocking
+                && (f.Path |> Option.defaultValue "").Replace('\\', '/').Contains(pathNeedle, StringComparison.Ordinal)
+        )
+
+    let assertNoFindingInPath (pathNeedle: string) =
+        let findings = theFindings ()
+
+        Assert.DoesNotContain(
+            findings,
+            fun (f: Finding) ->
+                (f.Path |> Option.defaultValue "").Replace('\\', '/').Contains(pathNeedle, StringComparison.Ordinal)
         )
 
     // ---- Given ----
@@ -167,11 +240,84 @@ type MdSteps() =
             "docs/explanation/software-engineering/foo.md"
             "---\ntitle: T\ndescription: D\ncategory: software\nsubcategory: S\ntags: [a]\n---\nbody\n"
 
+    // ---- Given (docs-validate-heading-hierarchy.feature) ----
+
+    [<Given>]
+    member _.``a documentation tree where every markdown file has exactly one H1 and no skipped heading levels``() =
+        writeDoc "a.md" "# Title\n\n## Section\n\n### Sub\n\n## Section Two\n"
+        writeDoc "sub/b.md" "# Other\n\n## X\n"
+
+    [<Given>]
+    member _.``a documentation tree containing a markdown file with two H1 headings``() =
+        writeDoc "a.md" "# First\n\n# Second\n"
+
+    [<Given>]
+    member _.``a documentation tree containing a markdown file with an H2 followed directly by an H4``() =
+        writeDoc "a.md" "## Two\n\n#### Four\n"
+
+    [<Given>]
+    member _.``a documentation tree containing a single-line markdown file with no headings``() =
+        writeDoc "a.md" "just a single line\n"
+
+    [<Given>]
+    member _.``a docs directory containing a markdown file with two H1 headings``() =
+        useAllowlist <- true
+        writeDoc "docs/page.md" "# First\n\n# Second\n"
+
+    [<Given>]
+    member _.``a .claude/agents directory containing a markdown file with no H1 heading``() =
+        useAllowlist <- true
+        writeDoc ".claude/agents/my-agent.md" "## Not H1\n\n### Also not H1\n"
+
+    [<Given>]
+    member _.``a plans/done directory containing a markdown file with a skipped heading level``() =
+        useAllowlist <- true
+        writeDoc "plans/done/2024-01-01__old-plan/delivery.md" "# T\n\n### Skip\n"
+
+    [<Given>]
+    member _.``a repo-governance directory containing a markdown file with two H1 headings``() =
+        useAllowlist <- true
+        writeDoc "repo-governance/rule.md" "# X\n\n# Y\n"
+
+    [<Given>]
+    member _.``a specs directory containing a markdown file with two H1 headings``() =
+        useAllowlist <- true
+        writeDoc "specs/apps/foo/overview.md" "# A\n\n# B\n"
+
+    [<Given>]
+    member _.``an apps/example directory whose README.md contains a skipped heading level``() =
+        useAllowlist <- true
+        writeDoc "apps/example/README.md" "# App\n\n### Skip\n"
+
+    [<Given>]
+    member _.``an apps/example/src directory containing a markdown file with no H1 heading``() =
+        useAllowlist <- true
+        writeDoc "apps/example/src/notes.md" "## No H1\n"
+
+    [<Given>]
+    member _.``a libs/example/docs directory containing a markdown file with two H1 headings``() =
+        useAllowlist <- true
+        writeDoc "libs/example/docs/guide.md" "# A\n\n# B\n"
+
     // ---- When ----
 
     [<When>]
     member _.``the developer runs docs validate-frontmatter``() =
         outcome <- Some(validateDocsFrontmatter [ root () ])
+
+    [<When>]
+    member _.``the developer runs docs validate-heading-hierarchy``() =
+        outcome <-
+            Some(
+                if useAllowlist then
+                    Ok(validateDocsHeadingHierarchyAllowlisted (root ()) [])
+                else
+                    validateDocsHeadingHierarchy [ root () ]
+            )
+
+    [<When>]
+    member _.``the developer runs docs validate-heading-hierarchy with --exclude docs``() =
+        outcome <- Some(Ok(validateDocsHeadingHierarchyAllowlisted (root ()) [ "docs" ]))
 
     // ---- Then ----
 
@@ -183,7 +329,7 @@ type MdSteps() =
                 findings |> List.exists (fun f -> f.Severity = Severity.Blocking),
                 "expected no fail-level findings"
             )
-        | Error message -> failwith (sprintf "expected docs validate-frontmatter to succeed, got error: %s" message)
+        | Error message -> failwith (sprintf "expected the md command to succeed, got error: %s" message)
 
     [<Then>]
     member _.``the command exits with a failure code``() =
@@ -222,20 +368,59 @@ type MdSteps() =
     member _.``the frontmatter output identifies the missing description field``() =
         assertHasBlockingFindingContaining "\"description\" is missing"
 
+    // ---- Then (docs-validate-heading-hierarchy.feature) ----
+
+    [<Then>]
+    member _.``the output reports zero docs heading hierarchy findings``() = Assert.Empty(theFindings ())
+
+    [<Then>]
+    member _.``the output identifies the offending file and the duplicate H1 violation``() =
+        assertHasBlockingFindingWithMessageAndPath duplicateH1Needle
+
+    [<Then>]
+    member _.``the output identifies the offending file and the skipped heading level``() =
+        assertHasBlockingFindingWithMessageAndPath skippedLevelNeedle
+
+    [<Then>]
+    member _.``the output identifies the duplicate H1 violation in the docs file``() =
+        assertHasBlockingFindingInPathWithMessage "/docs/" duplicateH1Needle
+
+    [<Then>]
+    member _.``the output does not mention the docs file``() = assertNoFindingInPath "/docs/"
+
+    [<Then>]
+    member _.``the output identifies the repo-governance file``() =
+        assertHasBlockingFindingInPath "/repo-governance/"
+
+    [<Then>]
+    member _.``the output identifies the duplicate H1 violation in the specs file``() =
+        assertHasBlockingFindingInPathWithMessage "/specs/" duplicateH1Needle
+
+    [<Then>]
+    member _.``the output identifies the skipped heading level in the app README``() =
+        assertHasBlockingFindingInPathWithMessage "apps/example/README.md" skippedLevelNeedle
+
+    [<Then>]
+    member _.``the output identifies the duplicate H1 violation in the lib docs file``() =
+        assertHasBlockingFindingInPathWithMessage "/libs/example/docs/" duplicateH1Needle
+
     [<AfterScenario>]
     member _.Cleanup() =
         match rootDir with
         | Some dir when Directory.Exists dir -> Directory.Delete(dir, true)
         | _ -> ()
 
-/// Reads one named `Scenario:` block out of the real, frozen
-/// `docs-validate-frontmatter.feature` file (leaving the file itself
-/// untouched) and runs it through TickSpec bound only against `MdSteps` —
-/// see `ConventionSteps.fs`'s `FeatureRunner` for why this is per-scenario
-/// rather than per-file.
+/// Reads one named `Scenario:` block out of a real, frozen `*.feature` file
+/// under the `md` Gherkin directory (leaving the file itself untouched) and
+/// runs it through TickSpec bound only against `MdSteps` — see
+/// `ConventionSteps.fs`'s `FeatureRunner` for why this is per-scenario
+/// rather than per-file. Parameterised over the feature file name (rather
+/// than one module per feature file) because `MdSteps` already binds more
+/// than one feature file's scenarios; splitting this module per file would
+/// duplicate `extractScenario`/`run` for no behavioral difference.
 module private FeatureRunner =
 
-    let private featurePath: string =
+    let private featureDir: string =
         Path.GetFullPath(
             Path.Combine(
                 __SOURCE_DIRECTORY__,
@@ -251,8 +436,7 @@ module private FeatureRunner =
                 "behavior",
                 "rhino-cli",
                 "gherkin",
-                "md",
-                "docs-validate-frontmatter.feature"
+                "md"
             )
         )
 
@@ -279,9 +463,11 @@ module private FeatureRunner =
 
         Array.append [| featureLine; "" |] featureLines.[startIdx .. endIdx - 1]
 
-    /// Runs the single scenario named `scenarioTitle` from
-    /// `docs-validate-frontmatter.feature`, bound against `MdSteps`.
-    let run (scenarioTitle: string) : unit =
+    /// Runs the single scenario named `scenarioTitle` from `featureFileName`
+    /// (a `*.feature` file under the `md` Gherkin directory), bound against
+    /// `MdSteps`.
+    let run (featureFileName: string) (scenarioTitle: string) : unit =
+        let featurePath = Path.Combine(featureDir, featureFileName)
         let allLines = File.ReadAllLines featurePath
         let snippet = extractScenario allLines scenarioTitle
         let definitions = StepDefinitions([| typeof<MdSteps> |])
@@ -291,44 +477,128 @@ module private FeatureRunner =
 
 [<Fact>]
 let ``Software-engineering doc with all required frontmatter fields passes`` () =
-    FeatureRunner.run "Software-engineering doc with all required frontmatter fields passes"
+    FeatureRunner.run
+        "docs-validate-frontmatter.feature"
+        "Software-engineering doc with all required frontmatter fields passes"
 
 [<Fact>]
 let ``Software-engineering doc missing title fails`` () =
-    FeatureRunner.run "Software-engineering doc missing title fails"
+    FeatureRunner.run "docs-validate-frontmatter.feature" "Software-engineering doc missing title fails"
 
 [<Fact>]
 let ``Software-engineering doc missing category field fails`` () =
-    FeatureRunner.run "Software-engineering doc missing category field fails"
+    FeatureRunner.run "docs-validate-frontmatter.feature" "Software-engineering doc missing category field fails"
 
 [<Fact>]
 let ``Software-engineering doc with category other than software fails`` () =
-    FeatureRunner.run "Software-engineering doc with category other than software fails"
+    FeatureRunner.run
+        "docs-validate-frontmatter.feature"
+        "Software-engineering doc with category other than software fails"
 
 [<Fact>]
 let ``Governance doc with only title fails once when_to_use and description are armed`` () =
-    FeatureRunner.run "Governance doc with only title fails once when_to_use and description are armed"
+    FeatureRunner.run
+        "docs-validate-frontmatter.feature"
+        "Governance doc with only title fails once when_to_use and description are armed"
 
 [<Fact>]
 let ``Governance doc with title, description, and when_to_use passes the lighter schema`` () =
-    FeatureRunner.run "Governance doc with title, description, and when_to_use passes the lighter schema"
+    FeatureRunner.run
+        "docs-validate-frontmatter.feature"
+        "Governance doc with title, description, and when_to_use passes the lighter schema"
 
 [<Fact>]
 let ``Software-engineering doc with Diataxis tutorial category passes`` () =
-    FeatureRunner.run "Software-engineering doc with Diataxis tutorial category passes"
+    FeatureRunner.run
+        "docs-validate-frontmatter.feature"
+        "Software-engineering doc with Diataxis tutorial category passes"
 
 [<Fact>]
 let ``Software-engineering doc with Diataxis how-to category passes`` () =
-    FeatureRunner.run "Software-engineering doc with Diataxis how-to category passes"
+    FeatureRunner.run
+        "docs-validate-frontmatter.feature"
+        "Software-engineering doc with Diataxis how-to category passes"
 
 [<Fact>]
 let ``Software-engineering doc with Diataxis reference category passes`` () =
-    FeatureRunner.run "Software-engineering doc with Diataxis reference category passes"
+    FeatureRunner.run
+        "docs-validate-frontmatter.feature"
+        "Software-engineering doc with Diataxis reference category passes"
 
 [<Fact>]
 let ``Software-engineering doc with Diataxis explanation category passes`` () =
-    FeatureRunner.run "Software-engineering doc with Diataxis explanation category passes"
+    FeatureRunner.run
+        "docs-validate-frontmatter.feature"
+        "Software-engineering doc with Diataxis explanation category passes"
 
 [<Fact>]
 let ``Software-engineering doc with deprecated software category emits warn not fail`` () =
-    FeatureRunner.run "Software-engineering doc with deprecated software category emits warn not fail"
+    FeatureRunner.run
+        "docs-validate-frontmatter.feature"
+        "Software-engineering doc with deprecated software category emits warn not fail"
+
+[<Fact>]
+let ``Tree where every .md has exactly one H1 and no skipped levels passes`` () =
+    FeatureRunner.run
+        "docs-validate-heading-hierarchy.feature"
+        "Tree where every .md has exactly one H1 and no skipped levels passes"
+
+[<Fact>]
+let ``File with two H1 headings fails`` () =
+    FeatureRunner.run "docs-validate-heading-hierarchy.feature" "File with two H1 headings fails"
+
+[<Fact>]
+let ``File with H2 followed directly by H4 (skipping H3) fails`` () =
+    FeatureRunner.run
+        "docs-validate-heading-hierarchy.feature"
+        "File with H2 followed directly by H4 (skipping H3) fails"
+
+[<Fact>]
+let ``Single-line file with no headings is ignored (passes)`` () =
+    FeatureRunner.run "docs-validate-heading-hierarchy.feature" "Single-line file with no headings is ignored (passes)"
+
+[<Fact>]
+let ``prose-allowlist-runs — docs file triggers a heading finding`` () =
+    FeatureRunner.run
+        "docs-validate-heading-hierarchy.feature"
+        "prose-allowlist-runs — docs file triggers a heading finding"
+
+[<Fact>]
+let ``agent-skill-file-exempt — no finding for agent or skill files`` () =
+    FeatureRunner.run
+        "docs-validate-heading-hierarchy.feature"
+        "agent-skill-file-exempt — no finding for agent or skill files"
+
+[<Fact>]
+let ``plans-done-excluded — no finding for plans/done files`` () =
+    FeatureRunner.run "docs-validate-heading-hierarchy.feature" "plans-done-excluded — no finding for plans/done files"
+
+[<Fact>]
+let ``exclude-flag-suppresses-tree — --exclude docs suppresses docs findings`` () =
+    FeatureRunner.run
+        "docs-validate-heading-hierarchy.feature"
+        "exclude-flag-suppresses-tree — --exclude docs suppresses docs findings"
+
+[<Fact>]
+let ``specs-allowlisted — specs tree triggers a heading finding`` () =
+    FeatureRunner.run
+        "docs-validate-heading-hierarchy.feature"
+        "specs-allowlisted — specs tree triggers a heading finding"
+
+[<Fact>]
+let ``app-readme-allowlisted — project-root README triggers a heading finding`` () =
+    FeatureRunner.run
+        "docs-validate-heading-hierarchy.feature"
+        "app-readme-allowlisted — project-root README triggers a heading finding"
+
+[<Fact>]
+let ``app-internals-default-deny — deep app files yield no finding`` () =
+    FeatureRunner.run
+        "docs-validate-heading-hierarchy.feature"
+        "app-internals-default-deny — deep app files yield no finding"
+
+[<Fact>]
+let ``project-docs-subtree-allowlisted — app and lib docs trees trigger findings`` () =
+    FeatureRunner.run
+        "docs-validate-heading-hierarchy.feature"
+        "project-docs-subtree-allowlisted — app and lib docs trees trigger findings"

--- a/plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md
+++ b/plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md
@@ -4829,7 +4829,7 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
 
 > **PR seam**: the cycles under this heading are one PR.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4843,17 +4843,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the output reports zero docs heading hierarchy findings
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4867,17 +4867,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the output identifies the offending file and the duplicate H1 violation
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4891,17 +4891,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the output identifies the offending file and the skipped heading level
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4915,17 +4915,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the output reports zero docs heading hierarchy findings
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4939,17 +4939,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the output identifies the duplicate H1 violation in the docs file
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4963,17 +4963,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the output reports zero docs heading hierarchy findings
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -4987,17 +4987,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the output reports zero docs heading hierarchy findings
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -5013,17 +5013,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       But the output identifies the repo-governance file
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -5037,17 +5037,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the output identifies the duplicate H1 violation in the specs file
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -5061,17 +5061,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the output identifies the skipped heading level in the app README
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -5085,17 +5085,17 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the output reports zero docs heading hierarchy findings
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.
 
-- [ ] [AI] **RED**: Add the step definitions for this scenario in
+- [x] [AI] **RED**: Add the step definitions for this scenario in
       `apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario fails because `RhinoCli.Application.Md` does not implement it.
@@ -5109,12 +5109,12 @@ Each cycle below binds exactly one Gherkin scenario, copied verbatim from its `.
       And the output identifies the duplicate H1 violation in the lib docs file
   ```
 
-- [ ] [AI] **GREEN**: Implement only what this scenario requires in
+- [x] [AI] **GREEN**: Implement only what this scenario requires in
       `apps/rhino-cli/src-fsharp/RhinoCli.Application/Md.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: this scenario passes and no previously passing scenario breaks.
 
-- [ ] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
+- [x] [AI] **REFACTOR**: Fold any duplication this cycle introduced into
       `apps/rhino-cli/src-fsharp/RhinoCli.Domain/Finding.fs`
       — command: `dotnet test apps/rhino-cli/src-fsharp/tests/unit`
       — acceptance: all tests still pass and `Md.fs` formats no output itself.


### PR DESCRIPTION
## Summary

- Ports the Rust `md validate-heading-hierarchy` validator (`apps/rhino-cli/src/application/docs/heading_hierarchy.rs`, `apps/rhino-cli/src/commands/md_validate_heading_hierarchy.rs`) to F#, extending the same `Md.fs`/`MdSteps.fs` files Wave D PR1 (#335) created for `docs validate-frontmatter`.
- Adds `validateDocsHeadingHierarchy` (plain path-list walk) and `validateDocsHeadingHierarchyAllowlisted` (prose-allowlist repo-wide scan, with `--exclude` prefix support) to `RhinoCli.Application.Md`, covering the H1-uniqueness rule, the no-skipped-heading-levels rule, and the fenced-code-block-aware ATX heading parser (including the nested-fence-does-not-close-outer-fence edge case).
- Covers all 12 scenarios in `specs/apps/rhino/behavior/rhino-cli/gherkin/md/docs-validate-heading-hierarchy.feature` via strict per-scenario RED→GREEN→REFACTOR TDD.
- `md` is not yet listed in `FSHARP_NAMESPACES`, so this PR is implementation only — no dispatch wiring, no CLI text/JSON/Markdown rendering (matching PR1's and `TestCoverage.fs`'s established precedent for pre-flip validators).
- Widens `rhino-cli-fsharp`'s `specs:behavior:coverage` `--shared-steps` argument to include `docs-validate-heading-hierarchy.feature`, mirroring the exact `project.json` edit PR1 made for `docs-validate-frontmatter.feature`.
- Ticks all 36 RED/GREEN/REFACTOR checklist items for this PR's cycles in `plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md`.
- Regenerates `apps/rhino-cli/parity-manifest.sha256` in its own commit.

## Test plan

- [x] `dotnet build` on `RhinoCli.Application` and `tests/unit` — 0 errors, 0 warnings.
- [x] `dotnet test apps/rhino-cli/src-fsharp/tests/unit --filter FullyQualifiedName~MdSteps` — 23/23 passed (11 frontmatter + 12 heading-hierarchy).
- [x] `npx nx run rhino-cli-fsharp:test:quick` — typecheck, lint (Fantomas + FSharpLint + G-Research analyzers), 648/648 unit tests, specs structure validation, and `specs:behavior:coverage` (19 specs, 149 scenarios, 636 steps — all covered) all green.
- [x] `cargo run ... -- parity manifest validate` — `apps/rhino-cli/parity-manifest.sha256 is current`.

No behavioral discrepancies were found against the Rust implementation that required a design deviation — findings reuse the shared `Finding` record exactly as PR1 established (Rust's `kind`/`line` fields folded into the `Message` text, since no scenario asserts on an exact line number or on rendered JSON/text output).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>