### PR TITLE
feat(rhino-cli-fsharp): port governance readme-index core audit (Wave D PR8a)

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -3,10 +3,11 @@
 51f04bc4a3f84b9b73386a760312757e62af4fa5ed4a6d357b6d9b0a266cf48e  apps/rhino-cli/LICENSE
 b5f5e511ac5697c2d2949d898633f079abbce9c7211205aad6f7521f17746df2  apps/rhino-cli/project.json
 22b1d0652e8937a20c83841966e4f8b1c451d671d34dd27fb5fa13f11d340a4d  apps/rhino-cli/src-fsharp/.gitignore
-98f96e762c5d8cb79def991ad30d2af1da09a1656930f79a89a7622b0c77c606  apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
+5fc5c20f9e2467a943d7ff76246326a03d1a87b74e31eeb18beb5891c5f62139  apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
 11fe7ec2e5e08b432e2d1cedae59e1a555e17e22a1f11494bd83b80c36964b5c  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Convention.fs
 015c281c498a64930d705b4806ef139de008a78fcd1197f8a7851cea7586cd85  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Doctor.fs
 ba223d446b461cce0e427e278e340a87330ed423885f92a674c5039fd755cb5b  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Env.fs
+91776e5a2af9efa1ba86be5fc1e314b187946c12ce7ac45791b880f2845817b9  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Governance.fs
 d6444dd71836d812c5933c2b391e56bfe9aa4475b4f4b3ad45832beee975a08d  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Md.fs
 2f8085bcb8089f174e9548e609530471c9318c31b1bcab4a867e33880cec9e57  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Parity.fs
 d4bdb1646d8e18a40245bbd3fb2ac96ac1acf1adf38355a0b567d7b8d4cc6e48  apps/rhino-cli/src-fsharp/RhinoCli.Application/src/RepoConfig.fs
@@ -25,7 +26,7 @@ b185e1073cc014e7c83b8de74cabca6e581bd05ccbd012c84c6d118b2a99eb2c  apps/rhino-cli
 822f6ec8446562a4de9a3b1a2481af50fac01bbedc32e1963142709e5f48ec13  apps/rhino-cli/src-fsharp/fsharplint.json
 bdc135af02f4326bef414ef8b26f57b71688296a7c172b772ef74574406870f3  apps/rhino-cli/src-fsharp/project.json
 f7dacc8dd923488c70eebabe298843022ec5a3ba94b8b7568634a779f24b8da4  apps/rhino-cli/src-fsharp/tests/integration/RhinoCli.IntegrationTests.fsproj
-b5e2d7235fa11e8584e2be7be22bba583f54fca9064149c6a2a8b41e3badbf76  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+0d2bfb2a1a6166ef8b162839039cd114ffa21c4488c17b3e2d6bbee5eaca6710  apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
 85ba308ad0a88485db55b305120d99b9a4ec328d2379536110f73e51f4797fe2  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionSteps.fs
 a909884a9d8816e2b476cc8c00be03ac4085b849cbe83c4b18e0213ac9cad1d7  apps/rhino-cli/src-fsharp/tests/unit/Steps/ConventionUnitTests.fs
 e7ef73e5c7ced17c7c47813e81fd4b78060de7d765c584b791256cfd6a00b68f  apps/rhino-cli/src-fsharp/tests/unit/Steps/DispatchUnitTests.fs
@@ -49,6 +50,7 @@ d43395cc8b45ab5197772682e18ba229bba6194507ca40c77053bf3ccd0929a9  apps/rhino-cli
 c99dc72ba90a55126c8f080d98b2ce2cc80037d936398ff42a93353ab7cdc481  apps/rhino-cli/src-fsharp/tests/unit/Steps/FsharpToolInvocationSteps.fs
 df2d2403e3dbf9b7cde5eae9ff273fb26d62ee0841ba72bbbf81c91ed8c8527d  apps/rhino-cli/src-fsharp/tests/unit/Steps/FsharpToolInvocationUnitTests.fs
 413baab2577c13102e7eb36979cbea9d75735929a5c429591a05ca85cf69cbec  apps/rhino-cli/src-fsharp/tests/unit/Steps/GitRootUnitTests.fs
+58368b183eae37503f3d47c56bb380bb0d92eef9a9a2e61530598f9677db0292  apps/rhino-cli/src-fsharp/tests/unit/Steps/GovernanceSteps.fs
 ae657d69f14610a7fa31ea57a6e3e24b74961a8ea3da944ad96b409c232c4c67  apps/rhino-cli/src-fsharp/tests/unit/Steps/MdSteps.fs
 b8a8fbf79e78dee93f32944d3bbae2daccf33876ce5988ae31b1259c2f5ce201  apps/rhino-cli/src-fsharp/tests/unit/Steps/ParityUnitTests.fs
 76ee39dfa9f270aeffdbee896cf4f521f8685dea723f8ec41acb24d3f80abf47  apps/rhino-cli/src-fsharp/tests/unit/Steps/RepoConfigSteps.fs

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/RhinoCli.Application.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="src/Doctor.fs" />
     <Compile Include="src/TestCoverage.fs" />
     <Compile Include="src/Md.fs" />
+    <Compile Include="src/Governance.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Governance.fs
+++ b/apps/rhino-cli/src-fsharp/RhinoCli.Application/src/Governance.fs
@@ -1,0 +1,353 @@
+/// Port of the Rust `governance` namespace's `readme-index` validator —
+/// core sibling-index audit (orphan/ghost/missing detection across a
+/// directory's `README.md` and, for a split directory, its parent's
+/// sibling `<name>.md` index file)
+/// [Repo-grounded — `apps/rhino-cli/src/application/governance/readme_index.rs`,
+/// `apps/rhino-cli/src/commands/governance_validate_readme_index.rs`] for
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/governance/governance-readme-index.feature`'s
+/// scenarios 1-9 ("A complete index passes" through "A generated mirror
+/// directory is not scanned").
+///
+/// This is PR8a of a three-way split (the feature file's 19 scenarios
+/// exceed this repository's per-PR line ceilings — see `delivery.md`'s
+/// `governance-readme-index.feature` heading). PR8b adds the `Unannotated`
+/// finding kind, `hasFailingFinding`, the gate-id-rename registry check,
+/// and the `--paths`/`--fail-kinds` flags (scenarios 10-14); PR8c adds
+/// `generate`/`rewrite-paths` (scenarios 15-19) and asserts
+/// `specs:behavior:coverage` green for the whole feature file.
+///
+/// Findings use a bespoke `ReadmeIndexFinding` record carrying a structured
+/// `Kind` (`Orphan`/`Ghost`/`Missing` here; `Unannotated` arrives in PR8b),
+/// not the shared `RhinoCli.Domain.Types.Finding` record — the eventual
+/// `--fail-kinds` scenario needs to filter on kind structurally, which the
+/// shared record cannot express, same rationale `Md.fs`'s mermaid section
+/// already used for its own bespoke types.
+///
+/// `governance` is not yet listed in `FSHARP_NAMESPACES` (that flip is
+/// later, separate Wave D integration work), so — matching every other
+/// Wave D PR's precedent — `auditReadmeIndex` is called directly by step
+/// definitions with an explicit path list, never through CLI argv parsing.
+module RhinoCli.Application.Governance
+
+open System
+open System.IO
+open System.Text.RegularExpressions
+
+/// Machine-readable violation category
+/// [Repo-grounded — `readme_index.rs::ReadmeIndexFinding::kind`]. The
+/// `Unannotated` case arrives in PR8b.
+[<RequireQualifiedAccess>]
+type ReadmeIndexFindingKind =
+    | Orphan
+    | Ghost
+    | Missing
+
+    /// The lowercase name this kind is addressed by in `--fail-kinds`.
+    member this.Name =
+        match this with
+        | Orphan -> "orphan"
+        | Ghost -> "ghost"
+        | Missing -> "missing"
+
+/// One reported problem from the README index audit
+/// [Repo-grounded — `readme_index.rs::ReadmeIndexFinding`].
+type ReadmeIndexFinding =
+    { File: string
+      Severity: string
+      Kind: ReadmeIndexFindingKind
+      Message: string }
+
+/// Directory names skipped during every recursive walk
+/// [Repo-grounded — `readme_index.rs::SKIP_DIRS`].
+let private skipDirs: Set<string> =
+    set [ "node_modules"; "target"; "dist"; "build"; ".next"; ".git" ]
+
+/// Matches a Markdown link whose href ends with `.md` (optionally with a
+/// fragment or query string), tolerating one level of nested square brackets
+/// in the link text [Repo-grounded — `readme_index.rs::readme_link_re`].
+let private readmeLinkRegex =
+    Regex(@"\[(?:[^\[\]]|\[[^\[\]]*\])+\]\(([^)]*\.md(?:[#?][^)]*)?)\)", RegexOptions.Compiled)
+
+/// Every content tree the repository governs by default when `--paths` is
+/// absent [Repo-grounded —
+/// `governance_validate_readme_index.rs::DEFAULT_PATHS`]. The generated
+/// harness mirrors (`.opencode/`, `.codex/`) are deliberately absent — see
+/// that constant's doc comment.
+let defaultPaths: string list =
+    [ "docs/"; "repo-governance/"; "specs/"; ".claude/" ]
+
+/// Resolves the scan-path list for a `validate` invocation: an explicit,
+/// non-empty `paths` list wins; `defaultPaths` is used unchanged otherwise
+/// [Repo-grounded — `governance_validate_readme_index.rs::resolve_scan_paths`].
+let resolveScanPaths (paths: string list) : string list =
+    if List.isEmpty paths then defaultPaths else paths
+
+/// Splits a raw markdown link target into its path part and any trailing
+/// `#fragment`/`?query` suffix [Repo-grounded —
+/// `readme_index.rs::split_link_suffix`].
+let private splitLinkSuffix (target: string) : string * string =
+    let idx = target.IndexOfAny([| '#'; '?' |])
+
+    if idx >= 0 then
+        target.Substring(0, idx), target.Substring(idx)
+    else
+        target, ""
+
+/// Normalises a raw markdown link target into the canonical sibling-target
+/// form the audit logic compares on, or `None` when it is not a sibling
+/// target at all (empty, absolute, parent-relative, or a URL)
+/// [Repo-grounded — `readme_index.rs::normalize_link_target`].
+let private normalizeLinkTarget (raw: string) : string option =
+    let raw = raw.Trim()
+
+    if raw = "" then
+        None
+    else
+        let raw =
+            if raw.StartsWith("./", StringComparison.Ordinal) then
+                raw.Substring(2)
+            else
+                raw
+
+        let raw, _ = splitLinkSuffix raw
+
+        if
+            raw = ""
+            || raw.StartsWith("/", StringComparison.Ordinal)
+            || raw.StartsWith("..", StringComparison.Ordinal)
+        then
+            None
+        else
+            let colonIdx = raw.IndexOf(':')
+
+            let urlLike =
+                if colonIdx > 0 then
+                    let slashIdx = raw.IndexOf('/')
+                    slashIdx < 0 || colonIdx < slashIdx
+                else
+                    false
+
+            if urlLike then None else Some(raw.Replace('\\', '/'))
+
+/// Extracts every sibling `.md` link target found anywhere in `content`,
+/// normalised by [`normalizeLinkTarget`]
+/// [Repo-grounded — `readme_index.rs::extract_readme_links`].
+let private extractReadmeLinks (content: string) : Set<string> =
+    readmeLinkRegex.Matches(content)
+    |> Seq.cast<Match>
+    |> Seq.choose (fun m -> normalizeLinkTarget m.Groups.[1].Value)
+    |> Set.ofSeq
+
+/// The set of linkable targets adjacent to an index file
+/// [Repo-grounded — `readme_index.rs::SiblingTargets`].
+type private SiblingTargets =
+    { Files: Set<string>
+      SubDirs: Set<string> }
+
+    static member Empty: SiblingTargets =
+        { Files = Set.empty
+          SubDirs = Set.empty }
+
+    /// Every linkable target name, sorted.
+    member this.SortedNames: string list =
+        Set.union this.Files this.SubDirs |> Set.toList |> List.sort
+
+    /// Returns `true` when `link` refers to a file or subdirectory present on
+    /// disk, including a bare-directory link (`"structure"` resolves to
+    /// `"structure/README.md"`).
+    member this.Present(link: string) : bool =
+        let normalized = link.Replace('\\', '/').TrimEnd('/')
+
+        if this.Files.Contains normalized || this.SubDirs.Contains normalized then
+            true
+        else
+            this.SubDirs.Contains(normalized + "/README.md")
+
+/// Lists the sibling `.md` files and subdirectories that contain a
+/// `README.md` adjacent to an index file at `dir`
+/// [Repo-grounded — `readme_index.rs::list_sibling_targets`].
+let private listSiblingTargets (dir: string) : SiblingTargets =
+    if not (Directory.Exists dir) then
+        SiblingTargets.Empty
+    else
+        Directory.GetFileSystemEntries dir
+        |> Array.sort
+        |> Array.fold
+            (fun (acc: SiblingTargets) full ->
+                let name = Path.GetFileName full
+
+                if Directory.Exists full then
+                    if name.StartsWith(".", StringComparison.Ordinal) || skipDirs.Contains name then
+                        acc
+                    else
+                        let subReadme = Path.Combine(full, "README.md")
+
+                        if File.Exists subReadme then
+                            { acc with
+                                SubDirs = Set.add (name + "/README.md") acc.SubDirs }
+                        else
+                            acc
+                elif
+                    name.StartsWith(".", StringComparison.Ordinal)
+                    || name = "README.md"
+                    || not (name.EndsWith(".md", StringComparison.Ordinal))
+                then
+                    acc
+                else
+                    { acc with
+                        Files = Set.add name acc.Files })
+            SiblingTargets.Empty
+
+/// Recursively lists every directory reachable from `root` (including `root`
+/// itself), skipping [`skipDirs`]. Dot-directories are deliberately NOT
+/// skipped by this walker — only by [`listSiblingTargets`]'s per-child
+/// exclusion — since a dot-directory (`.claude/`, `.codex/`) is first-class
+/// governed content, not build junk [Repo-grounded —
+/// `readme_index.rs::list_all_dirs`/`walk_dirs_recursive`].
+let rec private walkDirsRecursive (dir: string) : string list =
+    if not (Directory.Exists dir) then
+        []
+    else
+        Directory.GetDirectories dir
+        |> Array.sort
+        |> Array.filter (fun d -> not (skipDirs.Contains(Path.GetFileName d)))
+        |> Array.toList
+        |> List.collect (fun d -> d :: walkDirsRecursive d)
+
+let private listAllDirs (root: string) : string list =
+    if not (Directory.Exists root) then
+        []
+    else
+        root :: walkDirsRecursive root
+
+/// Returns `Some dirName` when `name` is a subdirectory target
+/// (`"<dirName>/README.md"`), else `None`.
+let private trySubdirName (name: string) : string option =
+    if name.EndsWith("/README.md", StringComparison.Ordinal) then
+        Some(name.Substring(0, name.Length - "/README.md".Length))
+    else
+        None
+
+/// Audits a single index file (`README.md`, or a split directory's sibling
+/// `<name>.md`) against the sibling targets present under `targetDir`:
+/// every sibling target must be linked (`Orphan` otherwise), and every
+/// linked sibling target must exist on disk (`Ghost` otherwise). PR8b adds
+/// the `Unannotated` finding kind to this same function
+/// [Repo-grounded — `readme_index.rs::audit_index_file`].
+let private auditIndexFile (indexPath: string) (targetDir: string) : ReadmeIndexFinding list =
+    let content = File.ReadAllText indexPath
+    let indexDir = Path.GetDirectoryName(indexPath: string)
+
+    // A split-directory index file lives in `targetDir`'s parent, not in
+    // `targetDir` itself, so its link targets carry an explicit
+    // "<targetDir-name>/" prefix that must be stripped before comparing
+    // against `targetDir`'s own sibling names.
+    let linkPrefix =
+        if String.Equals(indexDir, targetDir, StringComparison.Ordinal) then
+            None
+        else
+            Some(Path.GetFileName targetDir + "/")
+
+    let normalize (raw: string) : string =
+        match linkPrefix with
+        | Some p when raw.StartsWith(p, StringComparison.Ordinal) -> raw.Substring(p.Length)
+        | _ -> raw
+
+    let linked = extractReadmeLinks content |> Set.map normalize
+    let targets = listSiblingTargets targetDir
+
+    let orphanFindings =
+        targets.SortedNames
+        |> List.choose (fun name ->
+            if linked.Contains name then
+                None
+            else
+                match trySubdirName name with
+                | Some dirName when linked.Contains(dirName + ".md") -> None
+                | _ ->
+                    let full = Path.Combine(targetDir, name)
+
+                    Some
+                        { File = full
+                          Severity = "high"
+                          Kind = ReadmeIndexFindingKind.Orphan
+                          Message = sprintf "orphan: %s exists but is not linked from %s" name indexPath })
+
+    let ghostFindings =
+        linked
+        |> Set.toList
+        |> List.sort
+        |> List.choose (fun link ->
+            if not (targets.Present link) then
+                let full = Path.Combine(targetDir, link)
+
+                if File.Exists full || Directory.Exists full then
+                    None
+                else
+                    Some
+                        { File = full
+                          Severity = "high"
+                          Kind = ReadmeIndexFindingKind.Ghost
+                          Message = sprintf "ghost: %s references %s but the target does not exist" indexPath link }
+            else
+                None)
+
+    orphanFindings @ ghostFindings
+
+/// Audits a single directory: mandatory-README detection, additive
+/// sibling-index auditing (both a directory's own `README.md` and, for a
+/// split directory, its parent's `<name>.md` sibling index), and
+/// orphan/ghost detection [Repo-grounded — `readme_index.rs::audit_one_dir`].
+let private auditOneDir (dir: string) (root: string) : ReadmeIndexFinding list =
+    let splitIndexFindings =
+        if String.Equals(dir, root, StringComparison.Ordinal) then
+            []
+        else
+            let parent = Path.GetDirectoryName(dir: string)
+            let name = Path.GetFileName dir
+
+            if String.IsNullOrEmpty parent || String.IsNullOrEmpty name then
+                []
+            else
+                let splitIndex = Path.Combine(parent, name + ".md")
+
+                if File.Exists splitIndex then
+                    auditIndexFile splitIndex dir
+                else
+                    []
+
+    let readmePath = Path.Combine(dir, "README.md")
+
+    if File.Exists readmePath then
+        splitIndexFindings @ auditIndexFile readmePath dir
+    elif String.Equals(dir, root, StringComparison.Ordinal) then
+        // The scan root itself is never required to carry a README — a
+        // caller passes a covered-tree root deliberately. A descendant
+        // directory is never exempt.
+        splitIndexFindings
+    else
+        let targets = listSiblingTargets dir
+
+        if not (Set.isEmpty targets.Files) || not (Set.isEmpty targets.SubDirs) then
+            splitIndexFindings
+            @ [ { File = dir
+                  Severity = "high"
+                  Kind = ReadmeIndexFindingKind.Missing
+                  Message = sprintf "missing: %s contains indexable content but has no README.md" dir } ]
+        else
+            splitIndexFindings
+
+/// Audits every directory reachable from `root`
+/// [Repo-grounded — `readme_index.rs::audit_root`].
+let private auditRoot (root: string) : ReadmeIndexFinding list =
+    listAllDirs root |> List.collect (fun d -> auditOneDir d root)
+
+/// Audits every covered directory found under each root in `paths`, relative
+/// to `repoRoot` when a path is not already absolute
+/// [Repo-grounded — `readme_index.rs::audit_readme_index`].
+let auditReadmeIndex (repoRoot: string) (paths: string list) : ReadmeIndexFinding list =
+    paths
+    |> List.collect (fun p ->
+        let full = if Path.IsPathRooted p then p else Path.Combine(repoRoot, p)
+        auditRoot full)
+    |> List.sortBy (fun f -> f.File, f.Kind.Name)

--- a/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
+++ b/apps/rhino-cli/src-fsharp/tests/unit/RhinoCli.UnitTests.fsproj
@@ -40,6 +40,7 @@
     <Compile Include="Steps/TestCoverageSteps.fs" />
     <Compile Include="Steps/TestCoverageUnitTests.fs" />
     <Compile Include="Steps/MdSteps.fs" />
+    <Compile Include="Steps/GovernanceSteps.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/rhino-cli/src-fsharp/tests/unit/Steps/GovernanceSteps.fs
+++ b/apps/rhino-cli/src-fsharp/tests/unit/Steps/GovernanceSteps.fs
@@ -1,0 +1,398 @@
+/// TickSpec step definitions binding
+/// `governance-readme-index.feature`'s scenarios 1-9 ("A complete index
+/// passes" through "A generated mirror directory is not scanned") to
+/// `RhinoCli.Application.Governance`
+/// [Repo-grounded —
+/// `specs/apps/rhino/behavior/rhino-cli/gherkin/governance/governance-readme-index.feature`,
+/// `apps/rhino-cli/src/application/governance/readme_index.rs`,
+/// `apps/rhino-cli/src/commands/governance_validate_readme_index.rs`].
+///
+/// This is PR8a of a three-way split (the feature file's 19 scenarios
+/// exceed this repository's per-PR line ceilings — see `delivery.md`'s
+/// `governance-readme-index.feature` heading). PR8b adds the `Unannotated`
+/// finding kind, the gate-id-rename registry check, and the
+/// `--paths`/`--fail-kinds` flags (scenarios 10-14); PR8c adds
+/// `generate`/`rewrite-paths` (scenarios 15-19). Both later PRs extend THIS
+/// same file — they do not fork a separate one.
+///
+/// Follows `MdSteps.fs`'s/`EnvStagedGuardSteps.fs`'s per-scenario slicing
+/// convention: each xunit `[<Fact>]` below runs exactly one scenario,
+/// extracted from the real, frozen feature file. `governance` is not yet
+/// listed in `FSHARP_NAMESPACES` (that flip is later, separate Wave D
+/// integration work), so every scenario below calls
+/// `RhinoCli.Application.Governance`'s functions directly with an explicit
+/// path list, never through CLI argv parsing.
+///
+/// Most fixture `Given` steps below name repo-realistic-looking paths (e.g.
+/// `"repo-governance/conventions/formatting/"`, `".claude/skills/grill-me/
+/// reference/"`) purely for narrative flavor: `.claude/skills/grill-me/
+/// reference/` genuinely has a `README.md` in this very repository today, so
+/// a scenario asserting it is missing one is necessarily building an
+/// isolated, throwaway temp-directory fixture, not reading the real tree —
+/// only the final path SEGMENT of each such label is used to name the
+/// on-disk fixture directory (`resolveIndexFile`/the `directory "..."
+/// contains ...` steps below), and every scenario's fixture lives under its
+/// own fresh `scenarioRoot()` temp directory, always passed to
+/// `Governance.auditReadmeIndex` as an explicit, absolute scan root —
+/// mirroring `readme_index.rs`'s own unit tests, which likewise always pass
+/// a throwaway `TempDir` as the scan root rather than exercising
+/// `DEFAULT_PATHS` against the real repository.
+///
+/// The two scenarios that DO need `DEFAULT_PATHS`'s actual routing behavior
+/// ("An uncovered tree is not scanned", "A generated mirror directory is not
+/// scanned") deliberately leave `scanPathsOverride` unset so the shared "the
+/// developer runs governance readme-index validate" `When` step falls back
+/// to `Governance.resolveScanPaths []` — proving a fixture placed outside
+/// `docs/`, `repo-governance/`, `specs/`, `.claude/` is never reached, the
+/// same way `readme_index.rs`'s own
+/// `scenario_a_generated_mirror_directory_is_not_scanned` test only ever
+/// scans a `repo-governance` root and leaves an out-of-scope mirror tree
+/// beside it.
+///
+/// This PR's "the command exits successfully"/"exits with a failure code"
+/// steps check `List.isEmpty lastFindings` directly rather than calling a
+/// `hasFailingFinding` predicate — that predicate (and the `Unannotated`
+/// exemption it exists for) does not arrive until PR8b. The check is
+/// behaviorally identical for scenarios 1-9: none of `Governance.fs`'s
+/// PR8a-scoped finding kinds (`Orphan`/`Ghost`/`Missing`) are ever exempt
+/// from failing, so "any finding exists" and "isEmpty is false" agree.
+module RhinoCli.Tests.Unit.Steps.GovernanceSteps
+
+open System
+open System.IO
+open TickSpec
+open Xunit
+open RhinoCli.Application.Governance
+
+/// Instance step-definition container — see `ConventionSteps.fs`'s module
+/// doc comment for why TickSpec's one-instance-per-scenario lifecycle makes
+/// instance-level mutable fields the idiomatic state-threading mechanism
+/// here.
+type GovernanceSteps() =
+    let mutable scenarioRootDir: string option = None
+    let mutable currentDir: string option = None
+    let mutable scanPathsOverride: string list option = None
+    let mutable lastFindings: ReadmeIndexFinding list = []
+
+    let scenarioRoot () : string =
+        match scenarioRootDir with
+        | Some dir -> dir
+        | None ->
+            let dir =
+                Path.Combine(Path.GetTempPath(), "rhino-cli-governance-" + Guid.NewGuid().ToString("N"))
+
+            Directory.CreateDirectory dir |> ignore
+            scenarioRootDir <- Some dir
+            dir
+
+    /// The final path segment of a repo-realistic-looking label — see this
+    /// module's doc comment for why only the basename is used.
+    let basename (p: string) : string =
+        let trimmed = p.TrimEnd('/')
+        let idx = trimmed.LastIndexOf('/')
+        if idx < 0 then trimmed else trimmed.Substring(idx + 1)
+
+    let dirPrefix (p: string) : string =
+        let trimmed = p.TrimEnd('/')
+        let idx = trimmed.LastIndexOf('/')
+        if idx < 0 then "" else trimmed.Substring(0, idx)
+
+    let useScenarioRootAsScanPath () =
+        scanPathsOverride <- Some [ scenarioRoot () ]
+
+    /// Resolves the on-disk index-file path a `"..." links ...`/`"..." does
+    /// not link ...` step's quoted source label refers to: relative to the
+    /// already-established `currentDir` when one exists, or — for the one
+    /// scenario with no prior `directory "..." contains ...` step — derives
+    /// a fresh directory from the label's own prefix.
+    let resolveIndexFile (label: string) : string =
+        match currentDir with
+        | Some dir -> Path.Combine(dir, basename label)
+        | None ->
+            let prefix = dirPrefix label
+
+            let newRoot =
+                Path.Combine(scenarioRoot (), (if prefix = "" then "root" else basename prefix))
+
+            Directory.CreateDirectory newRoot |> ignore
+            currentDir <- Some newRoot
+            useScenarioRootAsScanPath ()
+            Path.Combine(newRoot, basename label)
+
+    let ensureLinkTarget (baseDir: string) (rawTarget: string) : unit =
+        let cleaned = rawTarget.Replace('\\', '/')
+
+        let cleaned =
+            if cleaned.StartsWith("./", StringComparison.Ordinal) then
+                cleaned.Substring(2)
+            else
+                cleaned
+
+        if cleaned <> "" then
+            let full = Path.Combine(baseDir, cleaned.Replace('/', Path.DirectorySeparatorChar))
+
+            if cleaned.EndsWith("/README.md", StringComparison.Ordinal) then
+                if not (File.Exists full) then
+                    Directory.CreateDirectory(Path.GetDirectoryName(full: string)) |> ignore
+                    File.WriteAllText(full, "# Stub\n")
+            elif not (File.Exists full) then
+                let dir = Path.GetDirectoryName(full: string)
+
+                if not (String.IsNullOrEmpty dir) then
+                    Directory.CreateDirectory dir |> ignore
+
+                File.WriteAllText(full, "x\n")
+
+    let writeLinks (label: string) (links: string list) : unit =
+        let indexPath = resolveIndexFile label
+        let dir = Path.GetDirectoryName(indexPath: string)
+        links |> List.iter (ensureLinkTarget dir)
+        let bullets = links |> List.mapi (fun i l -> sprintf "- [Item %d](%s)" i l)
+        let content = "# Index\n\n" + String.Join("\n", bullets) + "\n"
+        File.WriteAllText(indexPath, content)
+
+    let runValidate () =
+        let paths = scanPathsOverride |> Option.defaultValue (resolveScanPaths [])
+        lastFindings <- auditReadmeIndex (scenarioRoot ()) paths
+
+    // ---- Given: fixture construction ----
+
+    [<Given>]
+    member _.``directory "([^"]+)" contains "([^"]+)", "([^"]+)", "([^"]+)"``
+        (dirLabel: string, f1: string, f2: string, f3: string)
+        =
+        let dir = Path.Combine(scenarioRoot (), basename dirLabel)
+        Directory.CreateDirectory dir |> ignore
+
+        [ f1; f2; f3 ]
+        |> List.iter (fun f ->
+            File.WriteAllText(Path.Combine(dir, f), (if f = "README.md" then "# Index\n" else "x\n")))
+
+        currentDir <- Some dir
+        useScenarioRootAsScanPath ()
+
+    [<Given>]
+    member _.``directory "([^"]+)" contains "([^"]+)"``(dirLabel: string, f1: string) =
+        let dir = Path.Combine(scenarioRoot (), basename dirLabel)
+        Directory.CreateDirectory dir |> ignore
+        File.WriteAllText(Path.Combine(dir, f1), (if f1 = "README.md" then "# Index\n" else "x\n"))
+        currentDir <- Some dir
+        useScenarioRootAsScanPath ()
+
+    [<Given>]
+    member _.``directory "([^"]+)" contains "([^"]+)" and "([^"]+)"``(dirLabel: string, f1: string, f2: string) =
+        let parent = currentDir |> Option.defaultValue (scenarioRoot ())
+        let dir = Path.Combine(parent, basename dirLabel)
+        Directory.CreateDirectory dir |> ignore
+
+        [ f1; f2 ]
+        |> List.iter (fun f -> File.WriteAllText(Path.Combine(dir, f), "x\n"))
+
+    [<Given>]
+    member _.``directory "([^"]+)" contains "([^"]+)" and no "([^"]+)"``
+        (dirLabel: string, f1: string, _readme: string)
+        =
+        // The two "uncovered tree" fixtures always live outside DEFAULT_PATHS
+        // — `scanPathsOverride` is deliberately left unset (see module doc
+        // comment) so the shared validate `When` step falls back to
+        // `resolveScanPaths []`.
+        let dir =
+            Path.Combine(scenarioRoot (), dirLabel.TrimEnd('/').Replace('/', Path.DirectorySeparatorChar))
+
+        Directory.CreateDirectory dir |> ignore
+        File.WriteAllText(Path.Combine(dir, f1), "x\n")
+        currentDir <- Some dir
+
+    [<Given>]
+    member _.``directory "([^"]+)" contains (\d+) agent files``(dirLabel: string, count: int) =
+        let dir =
+            Path.Combine(scenarioRoot (), dirLabel.TrimEnd('/').Replace('/', Path.DirectorySeparatorChar))
+
+        Directory.CreateDirectory dir |> ignore
+
+        for i in 0 .. count - 1 do
+            File.WriteAllText(Path.Combine(dir, sprintf "agent-%d.md" i), "x\n")
+
+        currentDir <- Some dir
+
+    [<Given>]
+    member _.``it contains subdirectory "([^"]+)" containing "([^"]+)"``(subLabel: string, fileName: string) =
+        let parent = currentDir |> Option.defaultValue (scenarioRoot ())
+        let sub = Path.Combine(parent, basename subLabel)
+        Directory.CreateDirectory sub |> ignore
+        File.WriteAllText(Path.Combine(sub, fileName), (if fileName = "README.md" then "# Sub\n" else "x\n"))
+
+    [<Given>]
+    member _.``it contains no "([^"]+)"``(_name: string) = ()
+
+    [<Given>]
+    member _.``"([^"]+)" contains no "([^"]+)"``(_dirLabel: string, _name: string) = ()
+
+    [<Given>]
+    member _.``file "([^"]+)" exists``(path: string) =
+        let dir = Path.Combine(scenarioRoot (), basename (dirPrefix path))
+        Directory.CreateDirectory dir |> ignore
+        File.WriteAllText(Path.Combine(dir, basename path), "# Ai Agents\n")
+        currentDir <- Some dir
+        // The split-directory's parent ("agents/") is itself the scan root
+        // here — it is legitimately exempt from its own missing-README
+        // check even though it holds indexable content (the split-index
+        // file), matching `readme_index.rs::audit_one_dir`'s root-exemption
+        // rationale ("a caller passes a covered-tree root deliberately").
+        // The child directory under test is never exempt.
+        scanPathsOverride <- Some [ dir ]
+
+    [<Given>]
+    member _.``"([^"]+)" links "([^"]+)" and "([^"]+)"``(label: string, l1: string, l2: string) =
+        writeLinks label [ l1; l2 ]
+
+    [<Given>]
+    member _.``"([^"]+)" links "([^"]+)"``(label: string, l1: string) = writeLinks label [ l1 ]
+
+    [<Given>]
+    member _.``"([^"]+)" links "([^"]+)" only``(label: string, l1: string) = writeLinks label [ l1 ]
+
+    [<Given>]
+    member _.``"([^"]+)" does not link "([^"]+)"``(label: string, _target: string) =
+        let indexPath = resolveIndexFile label
+        File.WriteAllText(indexPath, "# Index\n\nNo links here.\n")
+
+    [<Given>]
+    member _.``it does not link "([^"]+)"``(_target: string) = ()
+
+    // ---- When/Then: shared validate runner ----
+
+    [<When>]
+    member _.``the developer runs governance readme-index validate``() = runValidate ()
+
+    [<Then>]
+    member _.``the command exits successfully``() = Assert.True(List.isEmpty lastFindings)
+
+    [<Then>]
+    member _.``the command exits with a failure code``() = Assert.False(List.isEmpty lastFindings)
+
+    [<Then>]
+    member _.``the finding names "([^"]+)" as unindexed``(name: string) =
+        Assert.True(
+            lastFindings
+            |> List.exists (fun f ->
+                f.Kind = ReadmeIndexFindingKind.Orphan
+                && (f.File.Contains name || f.Message.Contains name)),
+            sprintf "expected an orphan finding naming %s: %A" name lastFindings
+        )
+
+    [<Then>]
+    member _.``the finding reports a missing index for that directory``() =
+        Assert.True(
+            lastFindings |> List.exists (fun f -> f.Kind = ReadmeIndexFindingKind.Missing),
+            sprintf "expected a missing-index finding: %A" lastFindings
+        )
+
+    [<AfterScenario>]
+    member _.Cleanup() =
+        match scenarioRootDir with
+        | Some dir when Directory.Exists dir -> Directory.Delete(dir, true)
+        | _ -> ()
+
+/// Reads one named `Scenario:`/`Scenario Outline:` block out of the real,
+/// frozen `governance-readme-index.feature` file (leaving the file itself
+/// untouched) and runs it through TickSpec bound only against
+/// `GovernanceSteps` — see `EnvStagedGuardSteps.fs`'s `FeatureRunner` for why
+/// this is per-scenario rather than per-file, and why a `Scenario Outline`
+/// runs every generated `Examples:` row.
+module private FeatureRunner =
+
+    let private featurePath: string =
+        Path.GetFullPath(
+            Path.Combine(
+                __SOURCE_DIRECTORY__,
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "..",
+                "specs",
+                "apps",
+                "rhino",
+                "behavior",
+                "rhino-cli",
+                "gherkin",
+                "governance",
+                "governance-readme-index.feature"
+            )
+        )
+
+    let private extractScenario (featureLines: string[]) (scenarioTitle: string) : string[] =
+        let featureLine =
+            featureLines
+            |> Array.find (fun l -> l.TrimStart().StartsWith("Feature:", StringComparison.Ordinal))
+
+        let startIdx =
+            featureLines
+            |> Array.findIndex (fun l ->
+                let trimmed = l.Trim()
+
+                trimmed = sprintf "Scenario: %s" scenarioTitle
+                || trimmed = sprintf "Scenario Outline: %s" scenarioTitle)
+
+        let endIdx =
+            featureLines
+            |> Array.skip (startIdx + 1)
+            |> Array.tryFindIndex (fun l ->
+                let trimmed = l.Trim()
+
+                trimmed.StartsWith("Scenario:", StringComparison.Ordinal)
+                || trimmed.StartsWith("Scenario Outline:", StringComparison.Ordinal))
+            |> Option.map (fun relativeIdx -> startIdx + 1 + relativeIdx)
+            |> Option.defaultValue featureLines.Length
+
+        Array.append [| featureLine; "" |] featureLines.[startIdx .. endIdx - 1]
+
+    /// Runs every generated sub-scenario for `scenarioTitle`, bound against
+    /// `GovernanceSteps`. A plain `Scenario:` generates exactly one; the
+    /// `Scenario Outline:` generates one per `Examples:` row.
+    let run (scenarioTitle: string) : unit =
+        let allLines = File.ReadAllLines featurePath
+        let snippet = extractScenario allLines scenarioTitle
+        let definitions = StepDefinitions([| typeof<GovernanceSteps> |])
+        let feature = definitions.GenerateFeature(featurePath, snippet)
+
+        for scenario in feature.Scenarios do
+            scenario.Action.Invoke()
+
+[<Fact>]
+let ``A complete index passes`` () =
+    FeatureRunner.run "A complete index passes"
+
+[<Fact>]
+let ``A missing sibling link fails`` () =
+    FeatureRunner.run "A missing sibling link fails"
+
+[<Fact>]
+let ``A missing subdirectory README link fails`` () =
+    FeatureRunner.run "A missing subdirectory README link fails"
+
+[<Fact>]
+let ``A missing README fails when siblings exist`` () =
+    FeatureRunner.run "A missing README fails when siblings exist"
+
+[<Fact>]
+let ``The rule does not reach grandchildren`` () =
+    FeatureRunner.run "The rule does not reach grandchildren"
+
+[<Fact>]
+let ``A split directory still needs its own README`` () =
+    FeatureRunner.run "A split directory still needs its own README"
+
+[<Fact>]
+let ``A split directory whose parent omits a child fails`` () =
+    FeatureRunner.run "A split directory whose parent omits a child fails"
+
+[<Fact>]
+let ``An uncovered tree is not scanned`` () =
+    FeatureRunner.run "An uncovered tree is not scanned"
+
+[<Fact>]
+let ``A generated mirror directory is not scanned`` () =
+    FeatureRunner.run "A generated mirror directory is not scanned"


### PR DESCRIPTION
Split 1 of 3 for `governance/governance-readme-index.feature` (19 scenarios) — flagged in delivery.md's "nine feature files too big for one PR" list. Ports the core README-sibling-index audit logic (orphan/ghost/missing findings, split-directory detection, generated-mirror exemption) covering scenarios 1-9.

PR8b (flags + gate-registry, scenarios 10-14) and PR8c (generate/rewrite-paths, scenarios 15-19, wires specs:behavior:coverage + parity manifest) follow, stacked on this branch. `specs:behavior:coverage` is only asserted green after PR8c lands, per the plan's split rule.

## Diff measurement
`git diff --numstat main... | awk '{a+=$1} END {print a}'` → 753 added lines, 4 files — under all ceilings (400 program / 900 mixed / 1,000 absolute / 20 files).

## Test plan
- [x] nx run rhino-cli-fsharp:test:unit — 715/715 passed (706 pre-existing + 9 new)
- [x] fantomas --check clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>