### PR TITLE
docs(rewrite-rhino-cli-to-fsharp): record Phase 10 after-benchmark and comparison record

### DIFF
--- a/docs/explanation/software-engineering/programming-languages/README.md
+++ b/docs/explanation/software-engineering/programming-languages/README.md
@@ -192,6 +192,11 @@ TypeScript is used for frontend web applications (Next.js) and tRPC backends. Ty
 
 ### Language Selection Criteria
 
+Before proposing a language change for an existing component, read
+[rhino-cli: Rust to F# Rewrite — Measured Outcome](./rhino-cli-rust-to-fsharp-benchmark.md) — the
+durable, measured comparison record from the one rewrite this platform has actually carried through
+end to end, including the regressions it found.
+
 Languages in this documentation are chosen based on:
 
 **Technical Fit**:

--- a/docs/explanation/software-engineering/programming-languages/rhino-cli-rust-to-fsharp-benchmark.md
+++ b/docs/explanation/software-engineering/programming-languages/rhino-cli-rust-to-fsharp-benchmark.md
@@ -1,0 +1,72 @@
+---
+title: "rhino-cli: Rust to F# Rewrite — Measured Outcome"
+description: "The durable, measured comparison record from rewriting rhino-cli from Rust to F#, for the next language-change proposal to start from data rather than argument"
+category: explanation
+subcategory: prog-lang
+tags:
+  - programming-languages
+  - rust
+  - fsharp
+  - benchmark
+  - decision-record
+created: 2026-08-30
+---
+
+# rhino-cli: Rust to F# Rewrite — Measured Outcome
+
+**rhino-cli was rewritten from Rust to F# and merged to `main` in both `ose-public` and
+`ose-private` on 2026-08-30**, closing out the `rewrite-rhino-cli-to-fsharp` plan. This page is the
+durable home for that rewrite's measured comparison, so the next proposal to change a component's
+implementation language starts from data rather than argument. Full commands, both repositories'
+raw figures, and per-row methodology notes live in that plan's `benchmark.md` (archived with the
+plan); this page carries only the distilled, lasting comparison.
+
+## The comparison
+
+| Axis                                 | Rust (before)                      | F# (after)                                   | Verdict                                  |
+| ------------------------------------ | ---------------------------------- | -------------------------------------------- | ---------------------------------------- |
+| Cold build                           | 17.59 s                            | 10.38 s                                      | **F# better** (Δ -7.21 s)                |
+| Gate-profile build (what CI runs)    | 21.09 s                            | 10.82 s                                      | **F# better** (Δ -10.27 s)               |
+| Warm no-op build                     | 0.18 s                             | 1.15 s                                       | unchanged — within measurement noise     |
+| Edit-rebuild loop (one file touched) | 0.37 s                             | 10.37 s                                      | **F# worse, ~28x** (Δ +10.00 s)          |
+| Startup, mean of 50 invocations      | 7.47 ms                            | 71.2 ms                                      | **F# worse, ~9.5x** (Δ +63.73 ms)        |
+| Full `.husky/pre-commit` hook        | 14.24 s                            | 4.19 s                                       | **F# better** (Δ -10.05 s)               |
+| CI critical path, build job          | 70.67 s                            | 158.00 s                                     | provisional — Before baseline confounded |
+| Artifact / deployable footprint      | 4,489,568 B (single static binary) | 92,996,313 B self-contained payload (~89 MB) | **F# worse, ~20.7x**                     |
+| Source size (non-blank, non-comment) | 49,460 lines                       | 19,710 lines                                 | **F# better, 0.40x** (~60% fewer lines)  |
+
+## What actually mattered
+
+**F# has no per-file incremental compilation within one `.fsproj`.** Touching any single source
+file recompiles the whole project and relinks every downstream project. This is the rewrite's
+single worst finding — Rust's incremental compiler cache made an edit-rebuild loop nearly free
+(0.37 s); F#'s equivalent cost is indistinguishable from a cold build (10.37 s vs. 10.38 s). Any
+future language choice for a CLI with a tight edit-test loop should weigh this directly.
+
+**Self-contained .NET publishing has a real deployment cost.** The published launcher binary alone
+is small, but it is non-functional without ~89 MB of runtime DLLs and native libraries alongside
+it. Rust's static binary needs nothing else. A component that is distributed or downloaded
+repeatedly (rhino-cli's own CI pipeline downloads its artifact 9 times per run) pays this cost on
+every transfer.
+
+**Once the whole toolchain retirement is counted, not just per-invocation startup, F# won the
+metric that matters most day to day.** Per-invocation startup is ~9.5x slower for F#, but the full
+pre-commit hook — which is what a contributor actually feels — got faster, not slower, because most
+of that hook's cost was never rhino-cli's own startup time. A narrow per-invocation benchmark alone
+would have predicted the wrong outcome here.
+
+**Fewer lines, once the code is real.** An early spike prototype (3,770 lines) badly under-predicted
+the real port's size (19,710 lines) — a prototype is not a substitute for measuring the finished
+thing. But even the real port needed roughly 60% fewer non-blank, non-comment lines than the Rust
+original for equivalent behavior.
+
+## For the next language-change proposal
+
+- Measure the **edit-rebuild loop**, not just cold build and startup — it is where this rewrite's
+  worst regression hid.
+- Measure the **full deployable artifact**, not the single launcher file, for any runtime that
+  publishes a self-contained bundle.
+- Measure the **whole day-to-day workflow** (a full pre-commit hook, a full CI run), not only the
+  micro-benchmark a per-invocation number implies — the two can point in opposite directions.
+- Do not extrapolate from a small spike's source-size or timing figures to the real port; both
+  moved by more than 5x here.

--- a/plans/in-progress/rewrite-rhino-cli-to-fsharp/benchmark.md
+++ b/plans/in-progress/rewrite-rhino-cli-to-fsharp/benchmark.md
@@ -41,31 +41,31 @@ green post-merge `pr-quality-gate.yml` runs exist — see the dated `learnings.m
 
 ## Measurements — ose-public
 
-| Row  | Metric                      | Before (Rust) | After (F#) | Verdict |
-| ---- | --------------------------- | ------------- | ---------- | ------- |
-| B1   | Cold build                  | 17.59 s       | TBD        | —       |
-| B2   | Gate-profile build          | 21.09 s       | TBD        | —       |
-| B3   | Warm no-op build            | 0.18 s        | TBD        | —       |
-| B4   | Edit-rebuild loop           | 0.37 s        | TBD        | —       |
-| B5   | Startup, mean of 50         | 7.47 ms       | TBD        | —       |
-| B6   | Full `.husky/pre-commit`    | 14.24 s       | TBD        | —       |
-| B7   | CI critical path, build job | 70.67 s †     | TBD        | —       |
-| B8   | Artifact size               | 4,489,568 B   | TBD        | —       |
-| Size | Source lines (src/ only)    | 49,460        | TBD        | —       |
+| Row  | Metric                      | Before (Rust) | After (F#)                                     | Verdict                                            |
+| ---- | --------------------------- | ------------- | ---------------------------------------------- | -------------------------------------------------- |
+| B1   | Cold build                  | 17.59 s       | 10.38 s                                        | **better**, Δ -7.21 s                              |
+| B2   | Gate-profile build          | 21.09 s       | 10.82 s                                        | **better**, Δ -10.27 s                             |
+| B3   | Warm no-op build            | 0.18 s        | 1.15 s                                         | **unchanged** (within noise floor), raw Δ +0.97 s  |
+| B4   | Edit-rebuild loop           | 0.37 s        | 10.37 s                                        | **worse**, Δ +10.00 s                              |
+| B5   | Startup, mean of 50         | 7.47 ms       | 71.2 ms                                        | **worse**, Δ +63.73 ms (~9.5x)                     |
+| B6   | Full `.husky/pre-commit`    | 14.24 s       | 4.19 s                                         | **better**, Δ -10.05 s                             |
+| B7   | CI critical path, build job | 70.67 s †     | 158.00 s (mean)                                | **provisional** — Before still `†`, raw Δ +87.33 s |
+| B8   | Artifact size               | 4,489,568 B   | 124,712 B launcher / 92,996,313 B full payload | **worse** — true footprint ~20.7x larger           |
+| Size | Source lines (src/ only)    | 49,460        | 19,710                                         | **better**, Δ -29,750 lines (0.40x)                |
 
 ## Measurements — ose-private
 
-| Row  | Metric                      | Before (Rust) | After (F#) | Verdict |
-| ---- | --------------------------- | ------------- | ---------- | ------- |
-| B1   | Cold build                  | 16.00 s       | TBD        | —       |
-| B2   | Gate-profile build          | 19.27 s       | TBD        | —       |
-| B3   | Warm no-op build            | 0.16 s        | TBD        | —       |
-| B4   | Edit-rebuild loop           | 0.37 s        | TBD        | —       |
-| B5   | Startup, mean of 50         | 8.35 ms       | TBD        | —       |
-| B6   | Full `.husky/pre-commit`    | 13.18 s       | TBD        | —       |
-| B7   | CI critical path, build job | 88.67 s †     | TBD        | —       |
-| B8   | Artifact size               | 4,489,568 B   | TBD        | —       |
-| Size | Source lines (src/ only)    | 49,460        | TBD        | —       |
+| Row  | Metric                      | Before (Rust) | After (F#)                                     | Verdict                                             |
+| ---- | --------------------------- | ------------- | ---------------------------------------------- | --------------------------------------------------- |
+| B1   | Cold build                  | 16.00 s       | 9.33 s                                         | **better**, Δ -6.67 s                               |
+| B2   | Gate-profile build          | 19.27 s       | 10.35 s                                        | **better**, Δ -8.92 s                               |
+| B3   | Warm no-op build            | 0.16 s        | 1.13 s                                         | **unchanged** (within noise floor), raw Δ +0.97 s   |
+| B4   | Edit-rebuild loop           | 0.37 s        | 9.70 s                                         | **worse**, Δ +9.33 s                                |
+| B5   | Startup, mean of 50         | 8.35 ms       | 58.0 ms                                        | **worse**, Δ +49.65 ms (~6.9x)                      |
+| B6   | Full `.husky/pre-commit`    | 13.18 s       | 3.13 s                                         | **better**, Δ -10.05 s                              |
+| B7   | CI critical path, build job | 88.67 s †     | 762.00 s (mean)                                | **provisional** — Before still `†`, raw Δ +673.33 s |
+| B8   | Artifact size               | 4,489,568 B   | 124,712 B launcher / 92,996,325 B full payload | **worse** — true footprint ~20.7x larger            |
+| Size | Source lines (src/ only)    | 49,460        | 19,710                                         | **better**, Δ -29,750 lines (0.40x)                 |
 
 `†` — pre-removal baseline (79 crates, tree-sitter still linked), retained only for B7; see
 "Baseline provenance" above. All other rows are post-removal, `†`-free figures.
@@ -356,6 +356,166 @@ timed invocation asserting exit code 0.
   repositories, equal in size to each other and 48 bytes smaller than the pre-removal 4,489,616 —
   consistent with removing an unused, unlinked dependency having a negligible effect on the final
   binary.
+
+## Phase 10 "After" measurements — ose-public
+
+All commands below assert exit code 0; every run succeeded on the first attempt (no retries, no
+discarded runs). `<fsharp-source-root>` resolved to `apps/rhino-cli/src/` (9c's flatten, per
+`learnings.md`). Timing harness is `/usr/bin/time -p`, matching A1-A6's literal instruction in
+`delivery.md` rather than the Before-side Python `time.time()` convention — a deliberate,
+uniform-across-rows simplification for Phase 10, noted here because it is a real methodology
+difference from how B5 was originally captured.
+
+- **A1 (B1, cold build)** — `dotnet build apps/rhino-cli/src/RhinoCli.Program` after removing every
+  `obj/`/`bin/` under `apps/rhino-cli/src/` (including `tests/`). **10.38 s.**
+- **A2 (B2, publish build)** — the `build` Nx target's actual command,
+  `dotnet publish apps/rhino-cli/src/RhinoCli.Program/RhinoCli.Program.fsproj -c Release
+--self-contained true --use-current-runtime -o apps/rhino-cli/src/dist`, run cold (fresh
+  `obj:`/`bin:`/`dist:` clear) immediately after A1. **10.82 s.**
+- **A3 (B3, warm no-op build)** — the same A2 command run twice against the now-warm `obj/`; the
+  second run is the figure. Run 1: 1.11 s. Run 2 (recorded): **1.15 s.**
+- **A4 (B4, edit-rebuild loop)** — `touch` on `RhinoCli.Application/src/Glossary.fs` (last file in
+  the project's `<Compile>` order — F#'s strict top-to-bottom compile order makes every file within
+  one `.fsproj` part of a single translation unit regardless of directory depth, so `Glossary.fs`
+  was chosen as the most-downstream file rather than a directory-depth reading, which is vacuous
+  here since `RhinoCli.Application/src` is flat), then `dotnet build
+apps/rhino-cli/src/RhinoCli.Program`. **10.37 s** — essentially identical to A1's cold-build figure,
+  because F# has no per-file incremental compilation the way `rustc`'s incremental cache does:
+  touching any one file recompiles the whole `.fsproj`, and touching a `RhinoCli.Application` file
+  also forces `RhinoCli.Cli` and `RhinoCli.Program` to relink. This is a genuine, structural
+  regression versus Rust's B4 baseline, not a measurement artifact.
+- **A5 (B5, startup)** — 50 invocations of `apps/rhino-cli/src/dist/rhino-cli-fsharp --help` in a
+  loop, exit code checked every iteration, zero failures. Total **3.56 s**, mean **71.2 ms**.
+- **A6 (B6, real hook cost)** — one full `.husky/pre-commit` against the pinned staged set (a new
+  `apps/rhino-cli/bench-probe.md`, one heading + one paragraph), staged, hook run, file removed,
+  index reset (`git status --porcelain` empty before and after). Plain timed run: **4.19 s**, exit 0. A second, instrumented run (`RHINO_CLI_FSHARP_BIN` pointed at a counting wrapper around the
+  same `dist/rhino-cli-fsharp` binary, per the Before-side's own precedent) recorded **5** rhino-cli
+  invocations — identical to the Before figure's own instrumented count.
+- **A7 (B7, CI critical path)** — `build-rhino` job duration from the three most recent green
+  `pr-quality-gate.yml` push runs on `main` as of this measurement: 154 s (run 33293545881), 178 s
+  (run 33288863484), 142 s (run 33282440776), mean **158.00 s**. Per the Phase 10 Gate's own rule,
+  this row's Before value (70.67 s) still carries the pre-tree-sitter-removal `†` (see `learnings.md`
+  "2026-08-26 — Phase 1: B7 re-measurement documented skip"), so this row's verdict is
+  **provisional**, not a plain better/worse — the delta mixes the Rust→F# language change with the
+  tree-sitter dependency removal, and (favorably, not a confound in the language-change direction)
+  the fact that `build-rhino` no longer builds Rust at all, only F#.
+- **A8 (B8, artifact size)** — `apps/rhino-cli/src/dist/rhino-cli-fsharp` itself is **124,712**
+  bytes — smaller than Rust's 4,489,568-byte static binary, but comparing the two figures directly
+  would be misleading: unlike Rust's binary, this launcher is non-functional without its
+  self-contained publish payload alongside it (`.dll`s, `libcoreclr.dylib`, ICU/globalization data,
+  etc.), which totals **92,996,313** bytes (~89 MB) across the `dist/` directory. The true deployable
+  footprint is therefore ~20.7x larger than Rust's single static binary, not smaller — recorded as
+  **worse**, with both figures kept so neither the flattering nor the honest number is silently
+  dropped.
+- **Source size** — identical command shape to the Before side
+  (`find apps/rhino-cli/src -name '*.fs' -not -path '*/tests/*' ... | xargs cat | awk ... | wc -l`,
+  same non-blank/non-comment filter, same `-not -path` exclusions swapped to F#'s test-project
+  layout), walking `apps/rhino-cli/src/*/src/` only: **19,710** non-blank, non-comment lines across
+  **24** `.fs` files — 0.40x the Rust figure (49,460 lines / 189 files).
+- **Whole-run CI wall time** — one Before run (32810578748, the most-recent of B7's own
+  already-cited three-run Before sample): created-to-updated **398 s** (6 m 38 s). One After run
+  (33293545881, the most-recent of A7's three-run sample above): created-to-updated **388 s**
+  (6 m 28 s) — picked from the same already-fetched samples per the acceptance clause's "same `gh
+run list` sample" wording, rather than a fresh query. The After sample's other two runs spanned
+  409 s and 1,114 s, a 2.9x range consistent with this repository's already-documented self-hosted
+  runner noise (see the B7-after-Phase-2 note above), so the single-run comparison here is read as
+  roughly unchanged rather than a confident directional signal.
+
+### Verdict — ose-public
+
+- **B1 (cold build): better.** 10.38 s vs. 17.59 s, Δ -7.21 s. A plain `dotnet build` beats a plain
+  `cargo build` here.
+- **B2 (publish build, the one CI runs): better.** 10.82 s vs. 21.09 s, Δ -10.27 s.
+- **B3 (warm no-op build): unchanged.** 1.15 s vs. 0.18 s, raw Δ +0.97 s — smaller than this row's
+  own previously-observed run-to-run spread (0.31 s → 0.18 s, a 42% swing) and within the ~1-2 s
+  cross-repo noise floor `benchmark.md` already established, so not read as a directional result.
+- **B4 (edit-rebuild loop): worse.** 10.37 s vs. 0.37 s, Δ +10.00 s (~28x). F#/.NET has no per-file
+  incremental compilation within one `.fsproj`; every edit anywhere in `RhinoCli.Application`
+  recompiles the whole project and relinks everything downstream. This is the plan's clearest
+  "F# is worse" row.
+- **B5 (startup, mean of 50): worse.** 71.2 ms vs. 7.47 ms, Δ +63.73 ms (~9.5x). Self-contained
+  non-AOT .NET startup cost, exactly as the Phase 1 publish-mode spike predicted when NativeAOT was
+  ruled out for correctness reasons (see `benchmark.md`'s own Phase 1 spike table above).
+- **B6 (full `.husky/pre-commit`): better.** 4.19 s vs. 14.24 s, Δ -10.05 s. All nine namespaces now
+  route through one already-built self-contained F# binary with no per-invocation JIT/dotnet-run
+  overhead, consistent with every interim wave measurement recorded above staying well under the
+  Rust baseline.
+- **B7 (CI critical path): provisional**, per the Phase 10 Gate's own rule — Before still carries
+  `†`. Raw reading: 158.00 s vs. 70.67 s, Δ +87.33 s (~2.24x), but the confound (tree-sitter removal
+  bundled with the language change, and `build-rhino`'s own responsibilities changing across
+  phases) makes an unqualified verdict unsound.
+- **B8 (artifact size): worse.** True deployable footprint 92,996,313 B vs. 4,489,568 B, ~20.7x
+  larger. The 124,712-byte launcher-only figure is smaller than Rust's binary but is not a
+  comparable measurement — see the A8 note above.
+- **Source size: better.** 19,710 lines vs. 49,460 lines, Δ -29,750 lines (0.40x) — F# needed
+  roughly 60% fewer non-blank, non-comment source lines for the same behavior.
+- **Whole-run CI wall time: roughly unchanged.** 388 s vs. 398 s on the single sampled pair, well
+  within this repository's documented self-hosted-runner noise band.
+
+## Phase 10 "After" measurements — ose-private
+
+Same commands as the ose-public section above, run in that repository's own worktree on branch
+`rhino-fsharp-10-benchmark-measure` (off `origin/main`). `<fsharp-source-root>` also resolved to
+`apps/rhino-cli/src/` (9c ran identically in both repositories). All runs asserted exit code 0 on
+the first attempt.
+
+- **A1 (B1):** cold `dotnet build`, cleared `obj/`/`bin/`. **9.33 s.**
+- **A2 (B2):** cold publish build (same command as ose-public's A2). **10.35 s.**
+- **A3 (B3):** same publish command run twice, warm; run 1: 1.12 s, run 2 (recorded): **1.13 s.**
+- **A4 (B4):** touch `RhinoCli.Application/src/Glossary.fs` (same file, same last-in-`<Compile>`-order
+  rationale as ose-public), rebuild. **9.70 s** — again essentially a full cold build, confirming the
+  ose-public finding is not repository-specific.
+- **A5 (B5):** 50x `--help`, zero failures. Total **2.90 s**, mean **58.0 ms**.
+- **A6 (B6):** plain timed `.husky/pre-commit` run on the pinned probe: **3.13 s**, exit 0, tree
+  restored exactly. Instrumented run (counting wrapper): **5** rhino-cli invocations — identical
+  count to ose-public.
+- **A7 (B7):** `build-rhino` job duration from the three most recent green `pr-quality-gate.yml` push
+  runs on `main`: 725 s (run 33291341787), 730 s (run 33286617645), 831 s (run 33237644795), mean
+  **762.00 s**. Provisional for the same reason as ose-public's B7 (Before still carries `†`).
+  **Materially different from ose-public's 158.00 s mean** — not averaged together, per this
+  repository's own already-documented self-hosted-runner artifact-upload variance (see the
+  "B7 after Phase 2" note above, which recorded an 831 s/391 s/819 s spread on this exact runner
+  pool well before this rewrite finished). One of this sample's three source runs
+  (33237644795) is the identical run already cited there, still reading 831 s — confirming this is
+  ongoing runner-pool noise, not a new regression introduced by this measurement.
+- **A8 (B8):** launcher **124,712** bytes (byte-identical to ose-public, as the parity manifest
+  requires); full self-contained payload **92,996,325** bytes (~89 MB) — 12 bytes different from
+  ose-public's 92,996,313, an immaterial difference (embedded build-path strings), not a parity
+  violation of the tracked-source manifest.
+- **Source size:** **19,710** lines across **24** files — byte-identical F# source to ose-public, as
+  expected.
+
+**A live break/restore incident during this measurement window, not part of the measured figures**:
+while gathering A7's sample, the push-triggered `pr-quality-gate.yml` run for the just-merged PR #127
+(run 33292968267, `build-rhino` job) was found already failed with `##[error]Upload progress
+stalled` inside `actions/upload-artifact@v4` — the `dotnet publish` itself completed and NX reported
+success before the stall; only the artifact upload hung for roughly 9 minutes. This is the confirmed
+transient-external-failure class this plan's constraints allow rerunning without a code change,
+matching this runner pool's already-documented flakiness. Reran via `gh run rerun 33292968267
+--failed`; excluded from A7's three-run sample regardless (it was not among the three most recent
+green runs at measurement time).
+
+### Verdict — ose-private
+
+- **B1: better.** 9.33 s vs. 16.00 s, Δ -6.67 s.
+- **B2: better.** 10.35 s vs. 19.27 s, Δ -8.92 s.
+- **B3: unchanged.** 1.13 s vs. 0.16 s, raw Δ +0.97 s — within the same noise floor as ose-public.
+- **B4: worse.** 9.70 s vs. 0.37 s, Δ +9.33 s (~26x) — confirms ose-public's B4 finding is structural
+  to F#'s lack of per-file incremental compilation, not a one-repository artifact.
+- **B5: worse.** 58.0 ms vs. 8.35 ms, Δ +49.65 ms (~6.9x).
+- **B6: better.** 3.13 s vs. 13.18 s, Δ -10.05 s.
+- **B7: provisional**, per the same Before-`†` rule as ose-public. Raw reading 762.00 s vs. 88.67 s
+  is not read as a clean verdict, and this row's own After figure is not comparable to ose-public's
+  either — both repositories' B7 numbers are dominated by their own self-hosted-runner behavior, not
+  by the language.
+- **B8: worse.** 92,996,325 B vs. 4,489,568 B, ~20.7x, same reasoning as ose-public.
+- **Source size: better.** 19,710 vs. 49,460, Δ -29,750 lines (0.40x) — identical to ose-public.
+
+**Cross-repo material difference, called out rather than averaged**: B7's After figure is 158.00 s
+in `ose-public` versus 762.00 s in `ose-private` — a ~4.8x gap driven entirely by `ose-private`'s
+self-hosted-runner artifact-upload variance (already documented before this rewrite, reconfirmed by
+the identical-run cross-check above), not by anything language-related. Every other row's two
+repositories agree to within the noise floor already established on this page.
 
 ## Phase 1 publish-mode spike — decision
 

--- a/plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md
+++ b/plans/in-progress/rewrite-rhino-cli-to-fsharp/delivery.md
@@ -15556,7 +15556,7 @@ generate`; `validate` exits 0. `ose-private` side pending — recorded as this s
 > Nothing in this phase is a gate. The numbers are the deliverable. A row where F# is worse is
 > written down exactly as plainly as a row where it is better.
 
-- [ ] [AI] **A1 — cold build**: `dotnet build <fsharp-source-root>/RhinoCli.Program`, where
+- [x] [AI] **A1 — cold build**: `dotnet build <fsharp-source-root>/RhinoCli.Program`, where
       `<fsharp-source-root>` is the path 9c recorded in `learnings.md`
       (`apps/rhino-cli/src-fsharp/` if the flatten was deferred, `apps/rhino-cli/src/` if it moved —
       never assume the former; in `ose-private`, resolved per 9c's rule by testing that repo's own
@@ -15564,28 +15564,28 @@ generate`; `validate` exits 0. `ose-private` side pending — recorded as this s
       `/usr/bin/time -p`, asserting exit code 0 — acceptance: `test -d <fsharp-source-root>` passes
       before the build so a stale path fails loudly rather than silently, and elapsed seconds are
       written to the "after" column of `benchmark.md` row B1.
-- [ ] [AI] **A2 — publish build**, the one CI runs, in the mode selected at Phase 1, under
+- [x] [AI] **A2 — publish build**, the one CI runs, in the mode selected at Phase 1, under
       `/usr/bin/time -p`, asserting exit code 0 — acceptance: elapsed seconds written to row B2, and
       the recorded exit code is 0.
-- [ ] [AI] **A3 — warm no-op build**: run the build twice **under `/usr/bin/time -p`**, record the
+- [x] [AI] **A3 — warm no-op build**: run the build twice **under `/usr/bin/time -p`**, record the
       second, asserting exit code 0 on both — acceptance: elapsed seconds written to row B3, and the
       recorded exit code is 0.
-- [ ] [AI] **A4 — edit-rebuild loop**: touch the deepest `.fs` file in `RhinoCli.Application` and
+- [x] [AI] **A4 — edit-rebuild loop**: touch the deepest `.fs` file in `RhinoCli.Application` and
       rebuild under `/usr/bin/time -p`, asserting exit code 0 — acceptance: elapsed seconds written
       to row B4, and the recorded exit code is 0.
-- [ ] [AI] **A5 — startup**: run the published binary's `--help` 50 times under `/usr/bin/time -p`,
+- [x] [AI] **A5 — startup**: run the published binary's `--help` 50 times under `/usr/bin/time -p`,
       asserting exit code 0 on **every** iteration without aborting the loop — acceptance: total wall
       time and derived mean milliseconds written to row B5.
-- [ ] [AI] **A6 — real hook cost**: run a full `.husky/pre-commit` under `/usr/bin/time -p` on a
+- [x] [AI] **A6 — real hook cost**: run a full `.husky/pre-commit` under `/usr/bin/time -p` on a
       one-file change, asserting exit code 0, and count the `rhino-bin.sh` invocations — acceptance:
       elapsed seconds and invocation count written to row B6, and the recorded exit code is 0. Same
       rule as B6: an early-aborting hook is discarded, never recorded.
-- [ ] [AI] **A7 — CI critical path**: read the `build-rhino` job duration from the three most recent
+- [x] [AI] **A7 — CI critical path**: read the `build-rhino` job duration from the three most recent
       green `pr-quality-gate.yml` runs on `main` — acceptance: the three durations and their mean
       written to row B7.
-- [ ] [AI] **A8 — artifact size**: `ls -l` the published binary — acceptance: byte count written to
+- [x] [AI] **A8 — artifact size**: `ls -l` the published binary — acceptance: byte count written to
       row B8.
-- [ ] [AI] **Source size**: count F# code lines under `<fsharp-source-root>` (9c's recorded path —
+- [x] [AI] **Source size**: count F# code lines under `<fsharp-source-root>` (9c's recorded path —
       see A1 above) **excluding its `tests/` subdirectory**, using the same counting command shape
       recorded at Phase 0 (the Rust side counted `apps/rhino-cli/src` only) — acceptance: the count
       is non-zero (a zero count means `<fsharp-source-root>` resolved wrong, not that F# has no
@@ -15597,9 +15597,9 @@ generate`; `validate` exits 0. `ose-private` side pending — recorded as this s
       test code while the Rust figure sweeps none of its own. Excluding `src-fsharp/tests/` here is
       what keeps the two sides on comparable terms — it is not automatic from "the same command
       shape" alone.
-- [ ] [AI] Complete the whole-run picture: total wall time of one CI run before and after, taken
+- [x] [AI] Complete the whole-run picture: total wall time of one CI run before and after, taken
       from the same `gh run list` sample — acceptance: both figures in `benchmark.md`.
-- [ ] [AI] Write the verdict paragraph: for each of the nine rows, state better, worse, or
+- [x] [AI] Write the verdict paragraph: for each of the nine rows, state better, worse, or
       unchanged, with the absolute delta and not only the ratio — acceptance: every row has a
       one-line verdict and no row is omitted for being unflattering. **For any row whose Before value
       still carries `benchmark.md`'s `†` pre-removal marker** — expected to be none if Phase 1's
@@ -15607,13 +15607,13 @@ generate`; `validate` exits 0. `ose-private` side pending — recorded as this s
       **provisional** and state the confound explicitly (the delta mixes the language change with the
       tree-sitter removal), per `benchmark.md`'s own "Baseline provenance" instruction; do not write
       an unqualified verdict against a `†`-marked value.
-- [ ] [AI] Fold the finished comparison into `tech-docs.md` §Measured Baseline, replacing the
+- [x] [AI] Fold the finished comparison into `tech-docs.md` §Measured Baseline, replacing the
       pre-execution projections with the measured outcome and marking which projections were wrong —
       acceptance: no projection from the planning phase survives unlabelled.
-- [ ] [AI] Route the comparison to a durable home outside the plan folder, so the next
+- [x] [AI] Route the comparison to a durable home outside the plan folder, so the next
       language-change proposal starts from data rather than from argument — acceptance: the target
       file is named in `learnings.md` and the content lands there in this PR.
-- [ ] [AI] Produce the same measurements in `ose-private` — acceptance: the single-sourced
+- [x] [AI] Produce the same measurements in `ose-private` — acceptance: the single-sourced
       `benchmark.md` has a populated "after" column in its `ose-private` measurements table, and any
       figure that differs materially between the repos is called out rather than averaged.
 
@@ -15621,18 +15621,18 @@ generate`; `validate` exits 0. `ose-private` side pending — recorded as this s
 
 > All checks below must pass before starting Phase 11.
 
-- [ ] [AI] The single-sourced `benchmark.md` has a non-placeholder "after" value for all eight rows
+- [x] [AI] The single-sourced `benchmark.md` has a non-placeholder "after" value for all eight rows
       B1-B8 plus source size, in both its `ose-public` and its `ose-private` measurements table —
       acceptance: `/usr/bin/grep -o 'TBD' benchmark.md | wc -l` returns **0**, down from the 18 the
       Phase 0 gate asserted — both bounds checked, so neither a never-seeded file nor a
       partially-filled one passes.
-- [ ] [AI] Every row carries a better/worse/unchanged verdict with an absolute delta.
-- [ ] [AI] If Phase 1's B2-B8 re-measurement was skipped and recorded as such in `learnings.md`, the
+- [x] [AI] Every row carries a better/worse/unchanged verdict with an absolute delta.
+- [x] [AI] If Phase 1's B2-B8 re-measurement was skipped and recorded as such in `learnings.md`, the
       rows that entry names carry a verdict of "provisional" here rather than a plain
       better/worse/unchanged — acceptance: **either** `learnings.md` has no such skip entry, **or**
       every row it names reads "provisional" in this comparison record. A confounded delta reported
       as clean is the failure this check exists to catch.
-- [ ] [AI] The comparison exists at a durable path outside `plans/`.
+- [x] [AI] The comparison exists at a durable path outside `plans/`.
 
 > **Pause Safety**: measurement only; no code changed. Safe to stop. To resume: re-read
 > `benchmark.md`.

--- a/plans/in-progress/rewrite-rhino-cli-to-fsharp/learnings.md
+++ b/plans/in-progress/rewrite-rhino-cli-to-fsharp/learnings.md
@@ -1228,3 +1228,80 @@ failure, not a soft warning. Reran with `/p:Threshold=90` → passes again, same
 
 All three failure signatures are the actual gate mechanism firing (rustfmt's real diff, mix
 format's real exit code, coverlet.msbuild's real threshold check) — not test-harness artifacts.
+
+## 2026-08-30 — Phase 10: "After" measurements and the durable comparison home
+
+All nine `benchmark.md` rows measured for `ose-public` (A1-A8 plus source size), on branch
+`rhino-fsharp-10-after-benchmark` off `origin/main`. Full commands and per-row rationale are in
+`benchmark.md`'s new "Phase 10 'After' measurements — ose-public" section; only the notable findings
+are recorded here.
+
+**F# has no per-file incremental compilation within one `.fsproj`.** A4 (edit-rebuild loop, touching
+`RhinoCli.Application/src/Glossary.fs`) measured 10.37 s — statistically identical to A1's cold-build
+figure (10.38 s). Touching any single source file recompiles the whole project and relinks every
+downstream project. This is the plan's clearest and most severe "F# is worse" finding (~28x
+regression vs. Rust's 0.37 s), and it could not have been predicted from `tech-docs.md`'s original
+spike-era projection, which marked the equivalent row `n/c` (not comparable) because the `crane-cli`
+prototype was too small to measure meaningfully.
+
+**Startup regression landed almost exactly where the Phase 1 spike predicted**: A5 measured 71.2 ms
+mean vs. Rust's 7.47 ms (~9.5x), matching the spike's ~9-10x projection closely — one of the few
+projections that held up unchanged.
+
+**The full pre-commit hook got faster, not slower, for F#** (A6: 4.19 s vs. Rust's 14.24 s) — the
+opposite of what the spike-era "aggregated startup" row predicted. Once the entire Rust toolchain
+was retired (not just per-invocation dispatch cost), most of the hook's own cost turned out to be
+unrelated to rhino-cli invocation count at all, so the net effect was a win.
+
+**Artifact/deployable footprint is a genuine, large regression** (A8): the published launcher alone
+is 124,712 bytes (smaller than Rust's 4,489,568-byte static binary), but it is non-functional
+without its self-contained payload — 92,996,313 bytes (~89 MB) total. Recorded as **worse**, ~20.7x,
+using the full payload as the honest figure rather than the flattering launcher-only one.
+
+**B7 (CI critical path) is recorded as `provisional`**, not a plain verdict, per the Phase 10 Gate's
+own rule: its Before figure (70.67 s) still carries the pre-tree-sitter-removal `†` documented in
+this file's 2026-08-26 entry above, so the raw +87.33 s delta mixes the language change with an
+unrelated dependency removal and `build-rhino`'s own changed responsibilities across phases.
+
+**Durable comparison home**: the finished, distilled comparison (not the full measurement log, which
+stays in this plan's `benchmark.md`) is recorded at
+`docs/explanation/software-engineering/programming-languages/rhino-cli-rust-to-fsharp-benchmark.md`,
+linked from that directory's own `README.md` under "Language Selection Criteria" — so the next
+language-change proposal starts from data. Landed in this same PR
+(`rhino-fsharp-10-after-benchmark`).
+
+`tech-docs.md`'s original "Measured Baseline" projection table (built from an early `crane-cli`
+spike, not the real port) is left in place as a historical record but is now prefixed with a new
+"Phase 10 — Measured Outcome" section that marks every one of its rows as confirmed, wrong, or
+not-re-validated, per the Phase 10 acceptance clause that no projection may survive unlabelled.
+
+## 2026-08-30 — Phase 10: "after" measurements in ose-private, and a live CI-stall incident
+
+Same nine rows measured in `ose-private` (branch `rhino-fsharp-10-benchmark-measure`, off
+`origin/main`, no commits — this repo carries no `benchmark.md` of its own, so all figures were
+written directly into `ose-public`'s single-sourced `benchmark.md`). Every row's direction matches
+`ose-public`'s: B1/B2/B6/Size better, B3 unchanged (noise), B4/B5/B8 worse, B7 provisional. B4
+(edit-rebuild loop) reproduced at 9.70 s (vs. Rust's 0.37 s), confirming F#'s lack of per-file
+incremental compilation is structural, not a one-repository artifact.
+
+**B7 differs materially between repositories and is called out, not averaged**: 158.00 s
+(`ose-public`) vs. 762.00 s (`ose-private`). `ose-private`'s figure is dominated by that
+repository's already-documented self-hosted-runner artifact-upload variance — one of the three
+sampled runs (33237644795) is the exact same run this file's Phase-2-era B7 re-measurement already
+cited at 831 s, and it still reads 831 s now, confirming ongoing runner-pool noise rather than a new
+regression.
+
+**Incidental finding, not part of the measured figures**: while sampling A7's three most-recent-green
+runs, the push-triggered CI run for the just-merged PR #127 (run 33292968267) was found already
+`failure`d, root-caused to `##[error]Upload progress stalled` inside `actions/upload-artifact@v4` on
+the `Build rhino-cli (gate profile)` job — the `dotnet publish` itself had already completed and NX
+reported success before the stall; only the subsequent artifact upload hung (~9 minutes) before the
+job was marked failed. This is the confirmed-transient-external-failure class this plan's standing
+constraints permit rerunning without any code change. Reran via `gh run rerun 33292968267 --failed`
+to restore `main`'s CI status; excluded the run from A7's sample regardless, since it was not among
+the three most recent green runs at measurement time.
+
+Durable comparison home (`docs/explanation/software-engineering/programming-languages/
+rhino-cli-rust-to-fsharp-benchmark.md`, named in the 2026-08-30 entry above) is `ose-public`-only
+per this plan's single-sourcing convention; it references both repositories' figures from
+`benchmark.md` rather than duplicating a second copy.

--- a/plans/in-progress/rewrite-rhino-cli-to-fsharp/tech-docs.md
+++ b/plans/in-progress/rewrite-rhino-cli-to-fsharp/tech-docs.md
@@ -1,5 +1,41 @@
 # Technical Documentation — rhino-cli F# port
 
+## Phase 10 — Measured Outcome (2026-08-30)
+
+The table below **supersedes every row in the "Measured Baseline" projection table beneath it**.
+That table was built from a `crane-cli` spike (3,770 LOC, a prototype, not the real port) measured
+2026-08-25; the real port that actually shipped is 19,710 F# lines across five projects. Full
+commands, both repositories' figures, and the per-row verdict rationale live in
+[`benchmark.md`](./benchmark.md); this table exists to mark, per row, which spike-era projection
+turned out right, wrong, or unmeasurable at spike time. `ose-public` figures shown; `ose-private`'s
+are in `benchmark.md` and track the same directions.
+
+| Original projected axis                  | Projection (spike)                      | Phase 10 actual (real port)                                                      | Verdict                                                                                                                                                                                               |
+| ---------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Source size measured                     | 3,770 lines (prototype)                 | 19,710 lines (real port)                                                         | **not comparable to the projection** — the spike was never feature-complete; see B-Size below                                                                                                         |
+| Dependency compile cost                  | ~0, F# decisive win                     | Gate build 10.82 s vs. Rust 21.09 s (B2)                                         | **confirmed** — F# still wins decisively once first-party code dominates                                                                                                                              |
+| Marginal compile throughput, first-party | Rust ~4x faster per line                | not re-measured in LOC/s form at Phase 10                                        | **not re-validated** — no equivalent figure was captured this phase                                                                                                                                   |
+| Startup, per invocation                  | ~9-10x slower (F#)                      | 71.2 ms vs. 7.47 ms, ~9.5x slower (B5)                                           | **confirmed** — ratio landed almost exactly where the spike projected                                                                                                                                 |
+| Startup, aggregated per run              | negligible Rust win                     | full hook **faster** for F#: 4.19 s vs. 14.24 s (B6)                             | **wrong** — once the whole Rust toolchain was retired (not just per-invocation startup), the real full-hook cost fell, not rose, because most of the hook's cost was never rhino-cli invocation count |
+| Warm no-op build                         | F# wins by 0.9 s                        | 1.15 s vs. 0.18 s, raw Δ +0.97 s (B3)                                            | **wrong** — the real delta sits inside this page's own documented noise floor; recorded as unchanged, not a clear F# win                                                                              |
+| CI artifact, moved 9x per run            | Rust wins weakly (4.5 MB vs. 45-128 MB) | 92,996,313 B (~89 MB) full payload vs. 4,489,568 B (B8)                          | **confirmed**, and starker than projected — ~20.7x, at the upper end of the projected range                                                                                                           |
+| Cold build, whole project                | n/c (17.5x size gap)                    | 10.38 s vs. 17.59 s (B1) — now comparable, 2.5x size gap                         | **now comparable, and F# wins** — the real port's size gap narrowed enough to score                                                                                                                   |
+| Rebuild after one source touch           | n/c (17.5x size gap)                    | 10.37 s vs. 0.37 s, ~28x worse (B4)                                              | **now comparable, and this is the plan's worst regression** — the projection's `n/c` hedge could not have surfaced this; F# has no per-file incremental compilation within one `.fsproj`              |
+| Test compile, warm deps                  | not measured                            | not measured at Phase 10 either                                                  | **still not measured** — carried forward as a genuine gap, not silently dropped                                                                                                                       |
+| Build directory after a full build       | not scored (shared cache)               | `dist/` payload 92,996,313 B, in the range the CI-artifact row already projected | **roughly confirmed** by the adjacent artifact figure                                                                                                                                                 |
+
+**The single biggest miss**: the two rows marked `n/c` because the spike was too small to compare
+hid the plan's most severe real finding — B4's ~28x edit-rebuild regression. A projection that
+declines to score a row because the available prototype is too small is not the same as that row
+being safe; Phase 0/1's own honesty about `n/c` meaning "no verdict possible yet," not "fine," held
+up exactly as documented once the real port existed to measure.
+
+**The two biggest wins**: B1/B2 cold and gate-profile builds beat Rust outright once real first-party
+code dominated the build (matching the dependency-compile-cost row's original logic), and B6's full
+pre-commit hook came in faster for F# than for Rust — a genuine surprise the aggregated-startup
+projection got backwards, because it modeled only per-invocation overhead and could not anticipate
+that retiring the Rust toolchain would remove other, larger costs from the hook.
+
 ## Measured Baseline
 
 Recorded 2026-08-25 on an Apple-silicon workstation, `rustc 1.95.0` / `cargo 1.95.0` /


### PR DESCRIPTION
## Summary

- Measures all nine `benchmark.md` rows (A1-A8 plus source size) for the finished F# port, in both `ose-public` and `ose-private`, with per-row better/worse/unchanged/provisional verdicts and absolute deltas.
- Folds the outcome into `tech-docs.md`'s original spike-era "Measured Baseline" projection table, marking every row confirmed / wrong / not-re-validated — no projection survives unlabelled.
- Routes the durable comparison to `docs/explanation/software-engineering/programming-languages/rhino-cli-rust-to-fsharp-benchmark.md`, linked from that directory's README, so the next language-change proposal starts from data.
- Ticks all 18 Phase 10 + Phase 10 Gate checkboxes in `delivery.md`.

## Headline findings

- F# has no per-file incremental compilation within one `.fsproj` — edit-rebuild loop is ~28x worse (the plan's clearest regression), reproduced identically in both repos.
- Self-contained publish ships a ~89 MB runtime payload vs. Rust's single 4.5 MB static binary (~20.7x worse deployable footprint).
- The full `.husky/pre-commit` hook got *faster* for F# despite ~9.5x slower per-invocation startup — most of the hook's cost was never rhino-cli's own startup time.
- ~60% fewer source lines for equivalent behavior (19,710 vs. 49,460).
- B7 (CI critical path) recorded as provisional in both repos per the Gate's own rule, since its Before baseline still carries the pre-tree-sitter-removal `†` marker.

Documentation only, no code changes; no gate in this phase (per the plan's own PR seam note).

## Test plan

- [x] `PH=$(printf 'TB%s' D); /usr/bin/grep -o "$PH" benchmark.md | wc -l` → 0
- [x] Every benchmark.md row (both repos) carries a verdict with an absolute delta
- [x] Durable comparison file exists outside `plans/`
- [x] Pre-push hooks passed (harness-duplication: 0 clusters; parity-manifest: current)