### PR TITLE
docs: permit justified file-budget exceptions

### DIFF
--- a/.agents/skills/plan-validating-quality/reference/delivery-checklist-validation-part2.md
+++ b/.agents/skills/plan-validating-quality/reference/delivery-checklist-validation-part2.md
@@ -62,7 +62,10 @@
   Delivery Boundaries, PR-size/addition rules, atomicity, or the phase/boundary distinction. Treat
   500 handwritten code additions as a strong recommendation, not a hard ceiling: above 500 require
   measured size, a natural cohesive seam, rejected split alternatives, and review proof. Enforce
-  the independent other/document, hand-authored-file, and machine ceilings as hard bounds unless
-  their canonical exception applies.
+  the independent other/document and machine ceilings as hard bounds. A plan exceeding the default
+  20 hand-authored-file budget is valid only with the canonical binding-specific file-budget
+  natural-seam exception: exact finite allocation; measured C/O/hand-authored/total counts;
+  build-validity constraint; viable rejected splits; review proof; recovery; and matching plan/PR
+  disclosure. Missing any field is **HIGH**.
 - Phase transitions have explicit verification steps (e.g. "Verify `nx run app:typecheck` passes").
 - Input/Outcome/Proof prose is not a task; every action checkbox is an independent harness task.

--- a/.claude/agents/plan/plan-execution-checker.md
+++ b/.claude/agents/plan/plan-execution-checker.md
@@ -58,7 +58,8 @@ against the delivered state. Rule propagation and exact as-built C4 reconciliati
 their changing phase; recovery ends executed or `Not triggered` with evidence.
 Outcome cohesion does not relax natural delivery seams, PR-size rules, or atomicity. Above the
 strong 500-line code target, require evidence of the natural seam, rejected splits, and review
-proof; never fail on size alone, and retain all hard bounds. Do
+proof; never fail on size alone, retain the hard other/document and machine bounds, and permit a
+default 20-file-budget exceedance only with its canonical binding-specific plan/PR disclosure. Do
 not report migration findings
 against archived plans or the existing Rhino plan.
 Before archival, verify the completion date was resolved only after all pre-archival gates,

--- a/.claude/agents/plan/plan-fixer.md
+++ b/.claude/agents/plan/plan-fixer.md
@@ -73,7 +73,8 @@ Do not add copied Gherkin or detail-free/keystroke checkboxes. Preserve phase ga
 executor ownership, natural seams/PR-size rules, worktree/delivery mode, manual/operational proof,
 and Knowledge Capture. Never migrate archived plans or the Rhino plan. Never split only to force
 code below the strong 500-line target. Above it require a natural seam, measured size, rejected
-viable splits, review proof, and all hard bounds.
+viable splits, and review proof. Retain hard other/document and machine bounds; a default
+20-file-budget exceedance requires the canonical binding-specific plan/PR record.
 Replace any prospectively hardcoded archival date with an execution-time `<completion-date>` step:
 run `rtk date +%F` only after completion proof, then reuse that output for the move and indexes.
 When a finding exposes missing rule-impact handling, independently confirm the affected repository

--- a/.claude/skills/plan-validating-quality/reference/delivery-checklist-validation-part2.md
+++ b/.claude/skills/plan-validating-quality/reference/delivery-checklist-validation-part2.md
@@ -62,7 +62,10 @@
   Delivery Boundaries, PR-size/addition rules, atomicity, or the phase/boundary distinction. Treat
   500 handwritten code additions as a strong recommendation, not a hard ceiling: above 500 require
   measured size, a natural cohesive seam, rejected split alternatives, and review proof. Enforce
-  the independent other/document, hand-authored-file, and machine ceilings as hard bounds unless
-  their canonical exception applies.
+  the independent other/document and machine ceilings as hard bounds. A plan exceeding the default
+  20 hand-authored-file budget is valid only with the canonical binding-specific file-budget
+  natural-seam exception: exact finite allocation; measured C/O/hand-authored/total counts;
+  build-validity constraint; viable rejected splits; review proof; recovery; and matching plan/PR
+  disclosure. Missing any field is **HIGH**.
 - Phase transitions have explicit verification steps (e.g. "Verify `nx run app:typecheck` passes").
 - Input/Outcome/Proof prose is not a task; every action checkbox is an independent harness task.

--- a/.codex/agents/plan-execution-checker.toml
+++ b/.codex/agents/plan-execution-checker.toml
@@ -44,7 +44,8 @@ against the delivered state. Rule propagation and exact as-built C4 reconciliati
 their changing phase; recovery ends executed or `Not triggered` with evidence.
 Outcome cohesion does not relax natural delivery seams, PR-size rules, or atomicity. Above the
 strong 500-line code target, require evidence of the natural seam, rejected splits, and review
-proof; never fail on size alone, and retain all hard bounds. Do
+proof; never fail on size alone, retain the hard other/document and machine bounds, and permit a
+default 20-file-budget exceedance only with its canonical binding-specific plan/PR disclosure. Do
 not report migration findings
 against archived plans or the existing Rhino plan.
 Before archival, verify the completion date was resolved only after all pre-archival gates,

--- a/.codex/agents/plan-fixer.toml
+++ b/.codex/agents/plan-fixer.toml
@@ -56,7 +56,8 @@ Do not add copied Gherkin or detail-free/keystroke checkboxes. Preserve phase ga
 executor ownership, natural seams/PR-size rules, worktree/delivery mode, manual/operational proof,
 and Knowledge Capture. Never migrate archived plans or the Rhino plan. Never split only to force
 code below the strong 500-line target. Above it require a natural seam, measured size, rejected
-viable splits, review proof, and all hard bounds.
+viable splits, and review proof. Retain hard other/document and machine bounds; a default
+20-file-budget exceedance requires the canonical binding-specific plan/PR record.
 Replace any prospectively hardcoded archival date with an execution-time `<completion-date>` step:
 run `rtk date +%F` only after completion proof, then reuse that output for the move and indexes.
 When a finding exposes missing rule-impact handling, independently confirm the affected repository

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,8 +22,8 @@ See repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-
 
 - **Start here:**
 - **Skip these paths:** <!-- e.g. generated mirrors: .agents/, .opencode/, .codex/ -->
-- **Size:** <!-- Added lines only: code/program C has a strong target of 500, not a hard ceiling; other/document O≤1,000; no combined ceiling; deletions count zero; hand-authored files≤20.
-  When C exceeds 500, state the measured C, natural cohesive seam, viable split points considered and rejected, and how the larger diff was reviewed and proved. Size alone is not a reason to split a natural seam.
+- **Size:** <!-- Added lines only: code/program C has a strong target of 500, not a hard ceiling; other/document O≤1,000; no combined ceiling; deletions count zero; 20 hand-authored files is the default review budget; total files≤300.
+  When C exceeds 500 or hand-authored files exceed 20, state the measured C, O, hand-authored-file, and total-file counts; natural cohesive seam; exact finite allocation; viable split points considered and rejected; build-validity constraint; review/proof approach; recovery; and matching plan record. Size alone is not a reason to split a natural seam.
   If claiming the narrow plan-document LOC exemption, state whether this is initial establishment or a pure backlog/in-progress move. Confirm the entire hand-authored diff contains only qualifying plan Markdown documents and indexes plus referenced required non-executable plan assets: high-fidelity binary mockups, exported images, and editable diagram/design sources under the plan's assets/ directory.
   Executable source or scripts, runtime/build/tool configuration or manifests, automated tests or fixtures, runnable prototypes, unreferenced assets, and unrelated files revoke the exemption. -->
 

--- a/.opencode/agents/plan-execution-checker.md
+++ b/.opencode/agents/plan-execution-checker.md
@@ -62,7 +62,8 @@ against the delivered state. Rule propagation and exact as-built C4 reconciliati
 their changing phase; recovery ends executed or `Not triggered` with evidence.
 Outcome cohesion does not relax natural delivery seams, PR-size rules, or atomicity. Above the
 strong 500-line code target, require evidence of the natural seam, rejected splits, and review
-proof; never fail on size alone, and retain all hard bounds. Do
+proof; never fail on size alone, retain the hard other/document and machine bounds, and permit a
+default 20-file-budget exceedance only with its canonical binding-specific plan/PR disclosure. Do
 not report migration findings
 against archived plans or the existing Rhino plan.
 Before archival, verify the completion date was resolved only after all pre-archival gates,

--- a/.opencode/agents/plan-fixer.md
+++ b/.opencode/agents/plan-fixer.md
@@ -80,7 +80,8 @@ Do not add copied Gherkin or detail-free/keystroke checkboxes. Preserve phase ga
 executor ownership, natural seams/PR-size rules, worktree/delivery mode, manual/operational proof,
 and Knowledge Capture. Never migrate archived plans or the Rhino plan. Never split only to force
 code below the strong 500-line target. Above it require a natural seam, measured size, rejected
-viable splits, review proof, and all hard bounds.
+viable splits, and review proof. Retain hard other/document and machine bounds; a default
+20-file-budget exceedance requires the canonical binding-specific plan/PR record.
 Replace any prospectively hardcoded archival date with an execution-time `<completion-date>` step:
 run `rtk date +%F` only after completion proof, then reuse that output for the move and indexes.
 When a finding exposes missing rule-impact handling, independently confirm the affected repository

--- a/repo-governance/conventions/structure/plans.md
+++ b/repo-governance/conventions/structure/plans.md
@@ -68,7 +68,7 @@ Standards for organizing planning documents in `plans/` — temporary, distinct 
 - [PRs Open — Rules 5-7](./plans/prs-open-at-delivery-boundaries-rules-continued.md) — remaining rules.
 - [PRs Open — Boundary Test](./plans/prs-open-at-delivery-boundaries-boundary-test.md) — qualification.
 - [PRs Open — PR Size](./plans/prs-open-at-delivery-boundaries-pr-size.md) — surface bounds.
-- [PRs Open — Addition Targets and Limits](./plans/prs-open-at-delivery-boundaries-pr-size-addition-limits.md) — strong C target, hard O/file bounds, and plan-doc exemption.
+- [PRs Open — Addition Targets and Limits](./plans/prs-open-at-delivery-boundaries-pr-size-addition-limits.md) — strong C target, hard O/machine bounds, conditional file-budget exception, and plan-doc exemption.
 - [PRs Open — Atomicity](./plans/prs-open-at-delivery-boundaries-pr-size-atomicity.md) — rule 5.
 - [PRs Open — PR Body](./plans/prs-open-at-delivery-boundaries-pr-body.md) — why, entry, skip.
 - [Delivery Boundaries](./plans/delivery-boundaries-and-applicability.md) — table.

--- a/repo-governance/conventions/structure/plans/README.md
+++ b/repo-governance/conventions/structure/plans/README.md
@@ -40,7 +40,7 @@ when_to_use: "Read this index to find the right Plans Organization Convention ch
 - [Rules 5-7 and \*-to-pr Scope](./prs-open-at-delivery-boundaries-rules-continued.md) — Deciding whether work may share a PR or await another merge.
 - [Boundary Test](./prs-open-at-delivery-boundaries-boundary-test.md) — Testing a delivery boundary.
 - [Bounding PR Size](./prs-open-at-delivery-boundaries-pr-size.md) — Splitting an oversized sweep by surface, with a file backstop.
-- [Addition Targets, Limits, and Plan-Document Exemption](./prs-open-at-delivery-boundaries-pr-size-addition-limits.md) — Strong C=500, hard O/file bounds, and the plan-document LOC exemption.
+- [Addition Limits, File-Budget Exception, and Plan-Document Exemption](./prs-open-at-delivery-boundaries-pr-size-addition-limits.md) — C=500, hard O/machine bounds, file-budget exception, and plan-document LOC exemption.
 - [The Atomicity Exception (PR-Size Rule 5)](./prs-open-at-delivery-boundaries-pr-size-atomicity.md) — A convention and its binding must merge together past the size bound.
 - [What Every PR Body Must Carry](./prs-open-at-delivery-boundaries-pr-body.md) — Writing or reviewing a PR description.
 - [Delivery Boundaries Declaration and Applicability](./delivery-boundaries-and-applicability.md) — Writing a Delivery Boundaries table, or checking whether a grandfathered plan must retrofit gates.

--- a/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-body.md
+++ b/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-body.md
@@ -30,9 +30,11 @@ academic paper. `.github/pull_request_template.md` prompts for each in compact f
 4. **Which paths to skip** — generated mirrors and mechanical churn, named explicitly.
 5. **What was verified and what could go wrong.** Name the checks run, the remaining risk, and the
    safe rollback or containment step.
-6. **How the size remains reviewable.** State measured `C`, `O`, and hand-authored-file totals. When
-   `C` exceeds the strong 500-line recommendation, name the natural cohesive seam, viable split
-   points considered and rejected, and the review/proof approach. State any hard-bound exemption
+6. **How the size remains reviewable.** State measured `C`, `O`, hand-authored-file, and total-file
+   counts. When `C` exceeds the strong 500-line recommendation or the default 20 hand-authored-file
+   budget is exceeded, name the natural cohesive seam, exact finite allocation, viable split points
+   considered and rejected, and the review/proof approach. For a file-budget exception, also state the
+   build-validity constraint, recovery, and matching plan record. State any hard-bound exemption
    separately.
 
 **Why this binds prose PRs too.** [Code as

--- a/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size-addition-limits.md
+++ b/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size-addition-limits.md
@@ -1,6 +1,6 @@
 ---
-title: "Bounding PR Size — Addition Targets, Limits, and Plan-Document Exemption"
-description: "Defines the strong code-addition target, hard PR limits, file categories, exclusions, and the narrow plan-document LOC exemption."
+title: "Bounding PR Size — Addition Limits, File-Budget Exception, and Plan-Document Exemption"
+description: "Defines the code target, hard PR limits, default file budget, exception, categories, exclusions, and plan-document LOC exemption."
 category: explanation
 subcategory: conventions
 tags:
@@ -9,10 +9,10 @@ tags:
   - pr-review
   - organization
 created: 2026-08-25
-when_to_use: "Use when assessing rule 4, documenting a natural-seam exception, or deciding whether a plan-document PR is LOC-exempt."
+when_to_use: "Use when assessing rule 4, an exception, or plan-document LOC exemption."
 ---
 
-# Addition Targets, Limits, and Plan-Document Exemption (PR-Size Rule 4)
+# Addition Limits, File-Budget Exception, and Plan-Document Exemption (PR-Size Rule 4)
 
 Every PR is human-readable; there are no machine-only PRs. A person must review it unaided.
 
@@ -24,7 +24,8 @@ Count handwritten **added** lines and hand-authored files:
 - Other/document-type additions (`O`) must not exceed **1,000**.
 - `C` and `O` are measured independently; a mixed PR has no combined ceiling.
 - Deleted lines count as zero.
-- The PR must not exceed **20 hand-authored files**.
+- A PR should contain no more than **20 hand-authored files**. This is the default review budget;
+  the narrow [File-Budget Natural-Seam Exception](#file-budget-natural-seam-exception) may apply.
 
 Code/program-type files include source, scripts, configuration, data, and manifests, including
 `.ts`, `.fs`, and `.json`. Other/document-type files include `.md`.
@@ -44,8 +45,24 @@ by itself a failure. The PR body must record the measured `C`, name the seam, li
 points considered and why each was rejected, and state how the larger diff will be reviewed and
 proved. A size-only preference, convenience, or unrelated ride-along is not an exception.
 
-This exception changes only the 500 code target. It does not waive `O = 1,000`, the 20 hand-authored
-file ceiling, the 300-file machine ceiling, surface boundaries, or scope discipline.
+This exception changes only the 500 code target. It does not waive `O = 1,000`, the default
+hand-authored-file budget, the 300-file machine ceiling, surface boundaries, or scope discipline.
+
+## File-Budget Natural-Seam Exception
+
+A named delivery binding may exceed the default 20-file budget only when its exact, finite allocation
+has no smaller real boundary that remains build-valid, independently reviewable, verifiable, and
+revertible. It is never plan-wide and excludes inventory/dynamic discovery, convenience, and unrelated
+ride-along work.
+
+Before implementation, the plan record and prospective size gate state: binding; `C`/`O`/hand-authored/
+total counts; exact allocation; cohesive seam/build constraint; every rejected viable split; review/proof;
+recovery; and matching PR declaration. Final delivery remeasures the whole diff and rejects a missing,
+stale, incomplete, or mismatched record. The PR body repeats counts, seam, splits, proof, and recovery.
+
+The exception never waives `O = 1,000`, the 300-file ceiling, surface/scope rules, verification, or
+recovery. It is invalid if a smaller build-valid seam exists, allocation is not finite before editing,
+or a split is rejected only to reduce PR count or effort.
 
 ## Narrow Plan-Document LOC Exemption
 
@@ -57,27 +74,21 @@ these:
 - A pure move between `plans/backlog/` and `plans/in-progress/` in either direction, plus the
   required index updates.
 
-For either case, qualifying artifacts are the plan's Markdown documents and indexes plus required,
-non-executable assets referenced by those documents: high-fidelity binary mockups, exported
-images, and editable diagram/design sources under the plan's `assets/`. Binary assets add zero
-lines but remain hand-authored files. Executable source or scripts, runtime/build/tool
-configuration or manifests, automated tests or fixtures, runnable prototypes, unreferenced assets,
-and unrelated files revoke the exemption even when stored below the plan directory. Apply this
-same taxonomy to initial establishment and pure moves.
+Qualifying artifacts are plan Markdown/indexes and referenced non-executable `assets/`; binary assets
+add no lines but count as files. Code, scripts, runtime config/manifests, tests/fixtures, prototypes,
+unreferenced assets, and unrelated files revoke the exemption. Apply this taxonomy to both cases.
 
-Later plan edits, moves involving `plans/ideas/` or `plans/done/`, non-plan content, and ride-along
-changes restore the other/document ceiling. The 500 code target, 20-file cap, 300-file machine
-ceiling, and PR-size rules 1-3 remain in force.
+Later edits, moves involving `plans/ideas/` or `plans/done/`, non-plan content, and ride-alongs restore
+the other/document ceiling. The code target, default file budget, 300-file ceiling, and rules 1-3 remain.
 
 [The Atomicity Exception](./prs-open-at-delivery-boundaries-pr-size-atomicity.md) is broader: it may
 exceed any rule-4 bound when splitting paired rule surfaces would make `main` inconsistent.
 
 ## Enforcement
 
-**Enforcement disposition — unenforced by decision.** No deterministic gate can decide whether a
-larger code diff is one natural seam, classify every handwritten file, or decide whether a plan diff
-is initial establishment or a pure move. The PR template exposes category totals, split reasoning,
-and exemption claims for author and reviewer inspection.
+**Enforcement disposition — unenforced by decision.** A gate can prove counts, allocation, and required
+fields, but cannot decide whether a split preserves a natural seam. The PR template exposes the claim
+for author and reviewer inspection.
 
 ## Related
 

--- a/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size-atomicity.md
+++ b/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size-atomicity.md
@@ -19,9 +19,10 @@ delivery-boundary rule 5; qualify it when citing.
 
 [Bounding PR Size](./prs-open-at-delivery-boundaries-pr-size.md) rule 1 splits a sweep by surface.
 [Rule 4](./prs-open-at-delivery-boundaries-pr-size-addition-limits.md) sets the strong 500-code
-target plus hard other/document and file caps. Its natural-seam record governs code diffs above 500,
-and its narrow plan-document exemption waives only the applicable hard LOC ceiling. Atomicity is
-broader: a remaining hard rule-4 bound may yield.
+target, hard other/document and machine limits, and a default hand-authored-file budget. Its
+natural-seam records govern code diffs above 500 and narrowly justified file-budget exceptions, and
+its narrow plan-document exemption waives only the applicable hard LOC ceiling. Atomicity is broader:
+a remaining hard rule-4 bound may yield.
 
 ## The Rule
 
@@ -29,15 +30,16 @@ broader: a remaining hard rule-4 bound may yield.
 when each states a rule the others do not. Where one rule is stated on two — a `repo-governance/`
 convention and the `.claude/` binding executing it — those two are **one slice**, merged together,
 even past any rule-4 bound. A size bound never outranks correctness: a `main` stating one rule two
-contradicting ways is worse than a large PR.
+contradicting ways is worse than a large PR. The default file budget separately requires its own
+exact natural-seam record; atomicity does not erase that disclosure.
 
 ## What the Exception Does Not Carry
 
 It admits **only the paired surfaces, and only for rules this PR changes**. Nothing else rides
 along — an unrelated fix in a file the slice happens to touch is still scope creep, and rules 1-3
 still bound what enters. Outside atomicity and rule 4's narrow plan-document added-line exemption,
-the remaining hard rule-4 bounds stay binding. The 500 code target separately permits a documented
-natural-seam exception.
+the remaining hard rule-4 bounds stay binding. The 500 code target and the default file budget each
+separately permit only their documented natural-seam exception.
 
 **A surface is a rule-1 category, not a directory.** Governance text is one surface however many
 subdirectories of `repo-governance/` a rule spans; agents plus their mirrors are one surface across

--- a/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size.md
+++ b/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size.md
@@ -28,7 +28,7 @@ repo's own posted reviews all ran against PRs of 15,000-56,000 lines and 160-3,5
    the primary split.
 2. **A machine ceiling sits above everything: 300 changed files**, past which a hosted AI
    code-review assistant refuses outright — **observed behavior, not a published limit**, seen only
-   in its runtime error text. Rule 4's 20-file cap normally holds every PR far below it.
+   in its runtime error text. Rule 4's default 20-file budget normally holds every PR far below it.
 3. **Split PRs run sequentially from one reused worktree**, never one per PR — land a slice,
    fast-forward from `origin/main`, open the next. This preserves merge precondition (c): each
    slice is reviewed against a base already on `main`, not stacked on an unmerged sibling. See
@@ -41,9 +41,11 @@ repo's own posted reviews all ran against PRs of 15,000-56,000 lines and 160-3,5
    not a hard ceiling. A larger code diff is valid when it remains one natural, cohesive,
    independently reviewable, verifiable, and revertible seam; declare its measured size, seam,
    rejected split alternatives, and review proof. The independent **1,000** other/document-type
-   ceiling and **20** hand-authored-file ceiling remain hard; deletions count as zero. The child
-   defines file categories, generated-mirror exclusions, the natural-seam exception record, and
-   the narrow plan-document exemption.
+   ceiling and **300** changed-file machine ceiling remain hard. **20** hand-authored files is the
+   default review budget; a named delivery may exceed it only through the child rule's exact,
+   plan-and-PR-disclosed file-budget natural-seam exception. Deletions count as zero. The child
+   defines file categories, generated-mirror exclusions, both natural-seam records, and the narrow
+   plan-document exemption.
    **Use one PR for as much of one natural, independently stable seam as belongs together.** Split
    at a real seam, never solely to make the code counter read 500 or less.
 5. **A slice must be self-consistent on `main` the moment it merges** — see
@@ -52,9 +54,9 @@ repo's own posted reviews all ran against PRs of 15,000-56,000 lines and 160-3,5
    hard rule-4 bound; the linked plan-document exemption waives only its applicable hard LOC
    ceiling.
 
-**Enforcement disposition — unenforced by decision.** No deterministic gate can decide whether a
-larger code diff is one natural seam, classify every handwritten file, or decide whether a plan diff
-is initial establishment or a pure move. The PR template exposes category totals, split reasoning,
-and exception claims for author and reviewer inspection.
+**Enforcement disposition — unenforced by decision.** A deterministic gate can measure the diff and
+validate an exception record, but cannot decide whether a proposed split preserves a natural seam.
+The PR template exposes category totals, split reasoning, and exception claims for author and
+reviewer inspection.
 
 **See**: [What Every PR Body Must Carry](./prs-open-at-delivery-boundaries-pr-body.md).


### PR DESCRIPTION
## Outcome and Why

Preserve natural delivery seams when a finite, build-valid rule/binding change cannot fit the default 20 hand-authored-file budget, while retaining measurable review controls.

## Scope

- **In scope:** The conditional file-budget exception contract, its plan-quality bindings, PR template, and generated mirrors.
- **Deliberately not in scope, and why:** No delivery-specific exception is claimed here; executable-path repair and plan amendment are separate seams.

## Summary

- Make 20 hand-authored files a default review budget, not an unconditional split trigger.
- Require exact finite allocation, counts, natural seam, build-validity, rejected splits, review proof, recovery, and matching plan/PR disclosure for any exception.
- Retain hard other/document and machine ceilings.

## Reading Guide

- **Start here:** `repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size-addition-limits.md`
- **Skip these paths:** `.agents/`, `.opencode/`, and `.codex/` mirrors generated from canonical `.claude` guidance.
- **Size:** C=0; O=81; hand-authored files=11; total files=15. No file-budget exception is used by this rules-only PR.

## Verification

- `rtk npm run generate:bindings` — pass (195/195 bindings).
- Targeted Prettier and Markdown lint — pass.
- `git diff --check` — pass.
- Pre-push quality gates — pass; repository-wide README-index findings and word-budget target warnings are pre-existing/non-blocking.

## Risk and Rollback

Risk is limited to delivery-governance interpretation. Revert this one commit to restore the hard 20-file cap; application behavior is unchanged.