### PR TITLE
docs: correct Rhino preflight executable path

### DIFF
--- a/.agents/skills/repo-validating-governance-rules/reference/preflight-consumption.md
+++ b/.agents/skills/repo-validating-governance-rules/reference/preflight-consumption.md
@@ -3,7 +3,7 @@
 **Inputs**: `preflight-report` plus, for `rules-quality-gate`, exact `delegated-gate-ids` and the
 lifecycle evidence ledger. The report path points to `generated-reports/repo-governance-audit__*.json`,
 produced by the orchestrating workflow (`repo-governance/workflows/rules/rules-quality-gate.md`)
-running `./apps/rhino-cli/dist/rhino-cli repo-governance audit -o json`.
+running `./apps/rhino-cli/src/dist/rhino-cli-fsharp repo-governance audit -o json`.
 
 **Procedure**:
 

--- a/.claude/skills/repo-validating-governance-rules/reference/preflight-consumption.md
+++ b/.claude/skills/repo-validating-governance-rules/reference/preflight-consumption.md
@@ -3,7 +3,7 @@
 **Inputs**: `preflight-report` plus, for `rules-quality-gate`, exact `delegated-gate-ids` and the
 lifecycle evidence ledger. The report path points to `generated-reports/repo-governance-audit__*.json`,
 produced by the orchestrating workflow (`repo-governance/workflows/rules/rules-quality-gate.md`)
-running `./apps/rhino-cli/dist/rhino-cli repo-governance audit -o json`.
+running `./apps/rhino-cli/src/dist/rhino-cli-fsharp repo-governance audit -o json`.
 
 **Procedure**:
 

--- a/repo-governance/workflows/rules/rules-quality-gate/step-0-5-deterministic-preflight-continued.md
+++ b/repo-governance/workflows/rules/rules-quality-gate/step-0-5-deterministic-preflight-continued.md
@@ -12,13 +12,13 @@ when_to_use: Use when running the preflight command, debugging its exit code, or
 
 ```bash
 rtk mkdir -p generated-reports
-rtk ./apps/rhino-cli/dist/rhino-cli repo-governance audit -o json \
+rtk bash -lc './apps/rhino-cli/src/dist/rhino-cli-fsharp repo-governance audit -o json \
   --skip vendor-audit --skip governance-word-budget \
-  > generated-reports/repo-governance-audit__{uuid}__{timestamp}.json
+  > generated-reports/repo-governance-audit__{uuid}__{timestamp}.json'
 ```
 
 The binary must be built first via `rtk nx build rhino-cli`; the prebuilt path is
-`apps/rhino-cli/dist/rhino-cli`.
+`apps/rhino-cli/src/dist/rhino-cli-fsharp`.
 
 > **Recommendation**: Pin `RHINO_AUDIT_NOW=<RFC3339>` per workflow run to enable the SHA-256 hash-reuse optimization (the `ran_at` field is derived from this env var; without it the timestamp defaults to `time.Now()` and the hash always changes). See [`apps/rhino-cli/README.md`](../../../../apps/rhino-cli/README.md#global-flags) for details.
 
@@ -28,7 +28,7 @@ The binary must be built first via `rtk nx build rhino-cli`; the prebuilt path i
   - Exit 1 (findings): Retained domain findings are present; pass the JSON path to the checker and
     count them in the domain result.
   - Exit 2 (invocation error): Terminate with `fail`. Re-run
-    `rtk ./apps/rhino-cli/dist/rhino-cli repo-governance audit -o text --skip vendor-audit --skip governance-word-budget`;
+    `rtk bash -lc './apps/rhino-cli/src/dist/rhino-cli-fsharp repo-governance audit -o text --skip vendor-audit --skip governance-word-budget'`;
     rebuild with `rtk nx build rhino-cli` when needed.
 
 The two lifecycle-owned skips are mandatory in this workflow, not an operator hatch. `--exclude`

--- a/repo-governance/workflows/rules/rules-quality-gate/step-4-re-validate.md
+++ b/repo-governance/workflows/rules/rules-quality-gate/step-4-re-validate.md
@@ -13,13 +13,13 @@ is unchanged, reuse the retained findings section and re-evaluate AI-only domain
 
 ```bash
 rtk mkdir -p generated-reports
-rtk ./apps/rhino-cli/dist/rhino-cli repo-governance audit -o json \
+rtk bash -lc './apps/rhino-cli/src/dist/rhino-cli-fsharp repo-governance audit -o json \
   --skip vendor-audit --skip governance-word-budget \
-  > generated-reports/repo-governance-audit__{uuid}__{timestamp}.json
+  > generated-reports/repo-governance-audit__{uuid}__{timestamp}.json'
 ```
 
 The binary must be built first via `rtk nx build rhino-cli`; the prebuilt path is
-`apps/rhino-cli/dist/rhino-cli`.
+`apps/rhino-cli/src/dist/rhino-cli-fsharp`.
 
 **Agent**: `repo-rules-checker`
 


### PR DESCRIPTION
## Outcome and Why

Make the rules-quality-gate preflight runnable from a fresh build by referencing the actual Rhino executable output.

## Scope

- **In scope:** The preflight workflow steps and their checker-consumption binding.
- **Deliberately not in scope, and why:** Package-script entrypoints are private-repository-specific and belong to the private counterpart; file-budget policy and plan amendment are separate seams.

## Summary

- Point preflight JSON/text commands to the built Rhino executable.
- Keep redirected report generation safe under the command wrapper.
- Update the mirrored checker reference.

## Reading Guide

- **Start here:** `repo-governance/workflows/rules/rules-quality-gate/step-0-5-deterministic-preflight-continued.md`
- **Skip these paths:** `.agents/` — generated mirror.
- **Size:** C=0; O=9; hand-authored files=3; total files=4. No file-budget exception is used.

## Verification

- `rtk npm run generate:bindings` — pass.
- Deterministic preflight executed twice with byte-identical clean output.
- `git diff --check` — pass.
- Pre-push quality gates — pass; existing repository-wide index findings and target warnings are non-blocking.

## Risk and Rollback

Risk is limited to documentation/workflow invocation. Revert this one commit to restore prior wording; no application behavior changes.