### PR TITLE
docs(governance): bound single-source other exception

### DIFF
--- a/.agents/skills/plan-validating-quality/reference/delivery-checklist-validation-part2.md
+++ b/.agents/skills/plan-validating-quality/reference/delivery-checklist-validation-part2.md
@@ -62,8 +62,10 @@
   Delivery Boundaries, PR-size/addition rules, atomicity, or the phase/boundary distinction. Treat
   500 handwritten code additions as a strong recommendation, not a hard ceiling: above 500 require
   measured size, a natural cohesive seam, rejected split alternatives, and review proof. Enforce
-  the independent other/document and machine ceilings as hard bounds. A plan exceeding the default
-  20 hand-authored-file budget is valid only with the canonical binding-specific file-budget
+  the independent default other/document and machine ceilings as hard bounds, admitting only the
+  canonical bounded single-source other/document exception with its exact source, target, `O`
+  measurement, semantic constraint, and plan/PR record. A plan exceeding the default 20
+  hand-authored-file budget is valid only with the canonical binding-specific file-budget
   natural-seam exception: exact finite allocation; measured C/O/hand-authored/total counts;
   build-validity constraint; viable rejected splits; review proof; recovery; and matching plan/PR
   disclosure. Missing any field is **HIGH**.

--- a/.claude/agents/plan/plan-execution-checker.md
+++ b/.claude/agents/plan/plan-execution-checker.md
@@ -58,9 +58,10 @@ against the delivered state. Rule propagation and exact as-built C4 reconciliati
 their changing phase; recovery ends executed or `Not triggered` with evidence.
 Outcome cohesion does not relax natural delivery seams, PR-size rules, or atomicity. Above the
 strong 500-line code target, require evidence of the natural seam, rejected splits, and review
-proof; never fail on size alone, retain the hard other/document and machine bounds, and permit a
-default 20-file-budget exceedance only with its canonical binding-specific plan/PR disclosure. Do
-not report migration findings
+proof; never fail on size alone, retain default-hard other/document and machine bounds, allow the
+bounded single-source other/document exception only with its exact source, target, `O` measurement,
+semantic constraint, and plan/PR record, and permit a default 20-file-budget exceedance only with its
+canonical binding-specific plan/PR disclosure. Do not report migration findings
 against archived plans or the existing Rhino plan.
 Before archival, verify the completion date was resolved only after all pre-archival gates,
 including the preliminary audit, passed and the same repository-local value appears in the

--- a/.claude/agents/plan/plan-fixer.md
+++ b/.claude/agents/plan/plan-fixer.md
@@ -73,8 +73,10 @@ Do not add copied Gherkin or detail-free/keystroke checkboxes. Preserve phase ga
 executor ownership, natural seams/PR-size rules, worktree/delivery mode, manual/operational proof,
 and Knowledge Capture. Never migrate archived plans or the Rhino plan. Never split only to force
 code below the strong 500-line target. Above it require a natural seam, measured size, rejected
-viable splits, and review proof. Retain hard other/document and machine bounds; a default
-20-file-budget exceedance requires the canonical binding-specific plan/PR record.
+viable splits, and review proof. Retain default-hard other/document and machine bounds; allow the
+bounded single-source other/document exception only with its exact source, target, `O` measurement,
+semantic constraint, and plan/PR record; a default 20-file-budget exceedance requires the canonical
+binding-specific plan/PR record.
 Replace any prospectively hardcoded archival date with an execution-time `<completion-date>` step:
 run `rtk date +%F` only after completion proof, then reuse that output for the move and indexes.
 When a finding exposes missing rule-impact handling, independently confirm the affected repository

--- a/.claude/skills/plan-validating-quality/reference/delivery-checklist-validation-part2.md
+++ b/.claude/skills/plan-validating-quality/reference/delivery-checklist-validation-part2.md
@@ -62,8 +62,10 @@
   Delivery Boundaries, PR-size/addition rules, atomicity, or the phase/boundary distinction. Treat
   500 handwritten code additions as a strong recommendation, not a hard ceiling: above 500 require
   measured size, a natural cohesive seam, rejected split alternatives, and review proof. Enforce
-  the independent other/document and machine ceilings as hard bounds. A plan exceeding the default
-  20 hand-authored-file budget is valid only with the canonical binding-specific file-budget
+  the independent default other/document and machine ceilings as hard bounds, admitting only the
+  canonical bounded single-source other/document exception with its exact source, target, `O`
+  measurement, semantic constraint, and plan/PR record. A plan exceeding the default 20
+  hand-authored-file budget is valid only with the canonical binding-specific file-budget
   natural-seam exception: exact finite allocation; measured C/O/hand-authored/total counts;
   build-validity constraint; viable rejected splits; review proof; recovery; and matching plan/PR
   disclosure. Missing any field is **HIGH**.

--- a/.codex/agents/plan-execution-checker.toml
+++ b/.codex/agents/plan-execution-checker.toml
@@ -44,9 +44,10 @@ against the delivered state. Rule propagation and exact as-built C4 reconciliati
 their changing phase; recovery ends executed or `Not triggered` with evidence.
 Outcome cohesion does not relax natural delivery seams, PR-size rules, or atomicity. Above the
 strong 500-line code target, require evidence of the natural seam, rejected splits, and review
-proof; never fail on size alone, retain the hard other/document and machine bounds, and permit a
-default 20-file-budget exceedance only with its canonical binding-specific plan/PR disclosure. Do
-not report migration findings
+proof; never fail on size alone, retain default-hard other/document and machine bounds, allow the
+bounded single-source other/document exception only with its exact source, target, `O` measurement,
+semantic constraint, and plan/PR record, and permit a default 20-file-budget exceedance only with its
+canonical binding-specific plan/PR disclosure. Do not report migration findings
 against archived plans or the existing Rhino plan.
 Before archival, verify the completion date was resolved only after all pre-archival gates,
 including the preliminary audit, passed and the same repository-local value appears in the

--- a/.codex/agents/plan-fixer.toml
+++ b/.codex/agents/plan-fixer.toml
@@ -56,8 +56,10 @@ Do not add copied Gherkin or detail-free/keystroke checkboxes. Preserve phase ga
 executor ownership, natural seams/PR-size rules, worktree/delivery mode, manual/operational proof,
 and Knowledge Capture. Never migrate archived plans or the Rhino plan. Never split only to force
 code below the strong 500-line target. Above it require a natural seam, measured size, rejected
-viable splits, and review proof. Retain hard other/document and machine bounds; a default
-20-file-budget exceedance requires the canonical binding-specific plan/PR record.
+viable splits, and review proof. Retain default-hard other/document and machine bounds; allow the
+bounded single-source other/document exception only with its exact source, target, `O` measurement,
+semantic constraint, and plan/PR record; a default 20-file-budget exceedance requires the canonical
+binding-specific plan/PR record.
 Replace any prospectively hardcoded archival date with an execution-time `<completion-date>` step:
 run `rtk date +%F` only after completion proof, then reuse that output for the move and indexes.
 When a finding exposes missing rule-impact handling, independently confirm the affected repository

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,9 +22,9 @@ See repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-
 
 - **Start here:**
 - **Skip these paths:** <!-- e.g. generated mirrors: .agents/, .opencode/, .codex/ -->
-- **Size:** <!-- Added lines only: code/program C has a strong target of 500, not a hard ceiling; other/document O≤1,000; no combined ceiling; deletions count zero; 20 hand-authored files is the default review budget; total files≤300.
+- **Size:** <!-- Added lines only: code/program C has a strong target of 500, not a hard ceiling; other/document O≤1,000 except the bounded single-source exception O≤1,100; no combined ceiling; deletions count zero; 20 hand-authored files is the default review budget; total files≤300.
   When C exceeds 500 or hand-authored files exceed 20, state the measured C, O, hand-authored-file, and total-file counts; natural cohesive seam; exact finite allocation; viable split points considered and rejected; build-validity constraint; review/proof approach; recovery; and matching plan record. Size alone is not a reason to split a natural seam.
-  If claiming the narrow plan-document LOC exemption, state whether this is initial establishment or a pure backlog/in-progress move. Confirm the entire hand-authored diff contains only qualifying plan Markdown documents and indexes plus referenced required non-executable plan assets: high-fidelity binary mockups, exported images, and editable diagram/design sources under the plan's assets/ directory.
+  For the bounded single-source other/document exception, state the source line count, exact source and canonical target, O, semantic constraint, and matching plan record. If claiming the narrow plan-document LOC exemption, state whether this is initial establishment or a pure backlog/in-progress move. Confirm the entire hand-authored diff contains only qualifying plan Markdown documents and indexes plus referenced required non-executable plan assets: high-fidelity binary mockups, exported images, and editable diagram/design sources under the plan's assets/ directory.
   Executable source or scripts, runtime/build/tool configuration or manifests, automated tests or fixtures, runnable prototypes, unreferenced assets, and unrelated files revoke the exemption. -->
 
 ## Cost/Benefit of Added Code

--- a/.opencode/agents/plan-execution-checker.md
+++ b/.opencode/agents/plan-execution-checker.md
@@ -62,9 +62,10 @@ against the delivered state. Rule propagation and exact as-built C4 reconciliati
 their changing phase; recovery ends executed or `Not triggered` with evidence.
 Outcome cohesion does not relax natural delivery seams, PR-size rules, or atomicity. Above the
 strong 500-line code target, require evidence of the natural seam, rejected splits, and review
-proof; never fail on size alone, retain the hard other/document and machine bounds, and permit a
-default 20-file-budget exceedance only with its canonical binding-specific plan/PR disclosure. Do
-not report migration findings
+proof; never fail on size alone, retain default-hard other/document and machine bounds, allow the
+bounded single-source other/document exception only with its exact source, target, `O` measurement,
+semantic constraint, and plan/PR record, and permit a default 20-file-budget exceedance only with its
+canonical binding-specific plan/PR disclosure. Do not report migration findings
 against archived plans or the existing Rhino plan.
 Before archival, verify the completion date was resolved only after all pre-archival gates,
 including the preliminary audit, passed and the same repository-local value appears in the

--- a/.opencode/agents/plan-fixer.md
+++ b/.opencode/agents/plan-fixer.md
@@ -80,8 +80,10 @@ Do not add copied Gherkin or detail-free/keystroke checkboxes. Preserve phase ga
 executor ownership, natural seams/PR-size rules, worktree/delivery mode, manual/operational proof,
 and Knowledge Capture. Never migrate archived plans or the Rhino plan. Never split only to force
 code below the strong 500-line target. Above it require a natural seam, measured size, rejected
-viable splits, and review proof. Retain hard other/document and machine bounds; a default
-20-file-budget exceedance requires the canonical binding-specific plan/PR record.
+viable splits, and review proof. Retain default-hard other/document and machine bounds; allow the
+bounded single-source other/document exception only with its exact source, target, `O` measurement,
+semantic constraint, and plan/PR record; a default 20-file-budget exceedance requires the canonical
+binding-specific plan/PR record.
 Replace any prospectively hardcoded archival date with an execution-time `<completion-date>` step:
 run `rtk date +%F` only after completion proof, then reuse that output for the move and indexes.
 When a finding exposes missing rule-impact handling, independently confirm the affected repository

--- a/repo-governance/conventions/structure/plans.md
+++ b/repo-governance/conventions/structure/plans.md
@@ -69,6 +69,7 @@ Standards for organizing planning documents in `plans/` — temporary, distinct 
 - [PRs Open — Boundary Test](./plans/prs-open-at-delivery-boundaries-boundary-test.md) — qualification.
 - [PRs Open — PR Size](./plans/prs-open-at-delivery-boundaries-pr-size.md) — surface bounds.
 - [PRs Open — Addition Targets and Limits](./plans/prs-open-at-delivery-boundaries-pr-size-addition-limits.md) — strong C target, hard O/machine bounds, conditional file-budget exception, and plan-doc exemption.
+- [PRs Open — Single-Source Other/Document Exception](./plans/prs-open-at-delivery-boundaries-pr-size-single-source-other-document-exception.md) — narrow O=1,100 exception for one canonical source.
 - [PRs Open — Atomicity](./plans/prs-open-at-delivery-boundaries-pr-size-atomicity.md) — rule 5.
 - [PRs Open — PR Body](./plans/prs-open-at-delivery-boundaries-pr-body.md) — why, entry, skip.
 - [Delivery Boundaries](./plans/delivery-boundaries-and-applicability.md) — table.

--- a/repo-governance/conventions/structure/plans/README.md
+++ b/repo-governance/conventions/structure/plans/README.md
@@ -27,7 +27,7 @@ when_to_use: "Read this index to find the right Plans Organization Convention ch
   bootcamp-executable checkbox.
 - [Execution-Grade Clarity](./execution-grade-clarity.md) — Writing or reviewing a delivery.md checkbox for execution-grade clarity.
 - [Schema and Migration Contracts](./schema-and-migration-contracts.md) — Making schema changes, compatibility, migration, rollback, and no-loss proof executable.
-- [Delivery Reconciliation and Conditional Recovery](./delivery-reconciliation-and-recovery.md) — Places governance and architecture reconciliation with the change and gives conditional recovery work explicit terminal states. Use when delivery may change repository rules, documented C4 elements, or invoke rollback/recovery work.
+- [Delivery Reconciliation and Conditional Recovery](./delivery-reconciliation-and-recovery.md) — Reconciles governance/C4 changes and conditional recovery within delivery.
 - [[AI] vs [HUMAN]](./executor-tagging-tags-and-bias.md) — Deciding whether a delivery.md checkbox should be tagged [AI], [HUMAN], or [AI+HUMAN].
 - [Git-Mechanical Steps Are [AI]](./executor-tagging-git-mechanical-steps.md) — Tagging a worktree-provisioning, push, or worktree-removal step in delivery.md.
 - [Placement, Legend, and Execution Semantics](./executor-tagging-placement-legend-and-execution-semantics.md) — Adding the executor-tag legend to a delivery.md file or handling a [HUMAN] stop during execution.
@@ -40,7 +40,8 @@ when_to_use: "Read this index to find the right Plans Organization Convention ch
 - [Rules 5-7 and \*-to-pr Scope](./prs-open-at-delivery-boundaries-rules-continued.md) — Deciding whether work may share a PR or await another merge.
 - [Boundary Test](./prs-open-at-delivery-boundaries-boundary-test.md) — Testing a delivery boundary.
 - [Bounding PR Size](./prs-open-at-delivery-boundaries-pr-size.md) — Splitting an oversized sweep by surface, with a file backstop.
-- [Addition Limits, File-Budget Exception, and Plan-Document Exemption](./prs-open-at-delivery-boundaries-pr-size-addition-limits.md) — C=500, hard O/machine bounds, file-budget exception, and plan-document LOC exemption.
+- [Addition Limits, File-Budget Exception, and Plan-Document Exemption](./prs-open-at-delivery-boundaries-pr-size-addition-limits.md) — C=500; O/machine limits; file-budget and plan-document exceptions.
+- [Single-Source Other/Document Natural-Seam Exception](./prs-open-at-delivery-boundaries-pr-size-single-source-other-document-exception.md) — Narrow O=1,100 exception for one canonical source.
 - [The Atomicity Exception (PR-Size Rule 5)](./prs-open-at-delivery-boundaries-pr-size-atomicity.md) — A convention and its binding must merge together past the size bound.
 - [What Every PR Body Must Carry](./prs-open-at-delivery-boundaries-pr-body.md) — Writing or reviewing a PR description.
 - [Delivery Boundaries Declaration and Applicability](./delivery-boundaries-and-applicability.md) — Writing a Delivery Boundaries table, or checking whether a grandfathered plan must retrofit gates.

--- a/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-body.md
+++ b/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-body.md
@@ -34,8 +34,9 @@ academic paper. `.github/pull_request_template.md` prompts for each in compact f
    counts. When `C` exceeds the strong 500-line recommendation or the default 20 hand-authored-file
    budget is exceeded, name the natural cohesive seam, exact finite allocation, viable split points
    considered and rejected, and the review/proof approach. For a file-budget exception, also state the
-   build-validity constraint, recovery, and matching plan record. State any hard-bound exemption
-   separately.
+   build-validity constraint, recovery, and matching plan record. For the bounded single-source
+   other/document exception, state its source line count, exact source and canonical target, `O`
+   measurement, semantic constraint, and matching plan record. State any hard-bound exemption separately.
 
 **Why this binds prose PRs too.** [Code as
 Liability](../../../development/practice/code-as-liability/the-obligation.md) makes a PR adding

--- a/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size-addition-limits.md
+++ b/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size-addition-limits.md
@@ -21,7 +21,8 @@ Every PR is human-readable; there are no machine-only PRs. A person must review 
 Count handwritten **added** lines and hand-authored files:
 
 - Code/program-type additions (`C`) have a **strong recommended target of 500**, not a hard ceiling.
-- Other/document-type additions (`O`) must not exceed **1,000**.
+- Other/document-type additions (`O`) must not exceed **1,000**, except through the narrow
+  [Single-Source Other/Document Natural-Seam Exception](#single-source-otherdocument-natural-seam-exception).
 - `C` and `O` are measured independently; a mixed PR has no combined ceiling.
 - Deleted lines count as zero.
 - A PR should contain no more than **20 hand-authored files**. This is the default review budget;
@@ -60,9 +61,15 @@ total counts; exact allocation; cohesive seam/build constraint; every rejected v
 recovery; and matching PR declaration. Final delivery remeasures the whole diff and rejects a missing,
 stale, incomplete, or mismatched record. The PR body repeats counts, seam, splits, proof, and recovery.
 
-The exception never waives `O = 1,000`, the 300-file ceiling, surface/scope rules, verification, or
-recovery. It is invalid if a smaller build-valid seam exists, allocation is not finite before editing,
-or a split is rejected only to reduce PR count or effort.
+The exception never waives `O = 1,000` except through the separate
+[single-source exception](#single-source-otherdocument-natural-seam-exception), the 300-file ceiling,
+surface/scope rules, verification, or recovery. It is invalid if a smaller build-valid seam exists,
+allocation is not finite before editing, or a split is rejected only to reduce PR count or effort.
+
+## Single-Source Other/Document Natural-Seam Exception
+
+One named delivery may reach `O = 1,100` only under the
+[single-source exception conditions](./prs-open-at-delivery-boundaries-pr-size-single-source-other-document-exception.md).
 
 ## Narrow Plan-Document LOC Exemption
 

--- a/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size-atomicity.md
+++ b/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size-atomicity.md
@@ -19,7 +19,7 @@ delivery-boundary rule 5; qualify it when citing.
 
 [Bounding PR Size](./prs-open-at-delivery-boundaries-pr-size.md) rule 1 splits a sweep by surface.
 [Rule 4](./prs-open-at-delivery-boundaries-pr-size-addition-limits.md) sets the strong 500-code
-target, hard other/document and machine limits, and a default hand-authored-file budget. Its
+target, default-hard other/document and machine limits, and a default hand-authored-file budget. Its
 natural-seam records govern code diffs above 500 and narrowly justified file-budget exceptions, and
 its narrow plan-document exemption waives only the applicable hard LOC ceiling. Atomicity is broader:
 a remaining hard rule-4 bound may yield.
@@ -38,8 +38,8 @@ exact natural-seam record; atomicity does not erase that disclosure.
 It admits **only the paired surfaces, and only for rules this PR changes**. Nothing else rides
 along — an unrelated fix in a file the slice happens to touch is still scope creep, and rules 1-3
 still bound what enters. Outside atomicity and rule 4's narrow plan-document added-line exemption,
-the remaining hard rule-4 bounds stay binding. The 500 code target and the default file budget each
-separately permit only their documented natural-seam exception.
+the remaining hard rule-4 bounds stay binding. The 500 code target, default file budget, and default
+other/document ceiling each separately permit only their documented natural-seam exception.
 
 **A surface is a rule-1 category, not a directory.** Governance text is one surface however many
 subdirectories of `repo-governance/` a rule spans; agents plus their mirrors are one surface across

--- a/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size-single-source-other-document-exception.md
+++ b/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size-single-source-other-document-exception.md
@@ -1,0 +1,42 @@
+---
+title: "Single-Source Other/Document Natural-Seam Exception"
+description: "Defines the narrow O=1,100 exception for an indivisible, existing canonical source."
+category: explanation
+subcategory: conventions
+tags:
+  - conventions
+  - plans
+  - pr-review
+  - organization
+created: 2026-08-31
+when_to_use: "Use when one existing other/document source alone exceeds the default O=1,000 limit."
+---
+
+# Single-Source Other/Document Natural-Seam Exception
+
+`O = 1,000` is the hard default. One named delivery binding may instead reach `O = 1,100` only when
+one existing, non-generated other/document source alone exceeds 1,000 lines and must become exactly
+one canonical, non-generated behavior or contract target. The delivery contains only that
+source-to-target semantic change and required delivery-state artifacts; no neighbouring behavior,
+contract, or convenience change may ride along.
+
+Before implementation, the plan record and prospective size gate state the current source line count,
+exact source and target, finite allocation, semantic/build-validity constraint, every rejected viable
+split, review/proof approach, recovery, and matching PR declaration. Final delivery remeasures the
+whole diff and rejects `O > 1,100`, a source at or below 1,000, a missing record or allocation, an
+additional semantic change, or a stale/mismatched PR declaration. The PR body repeats the measurement,
+seam, rejected splits, proof, and recovery.
+
+This exception does not waive the 300-file ceiling, default file budget, surface/scope rules,
+verification, or recovery. A smaller canonical target, a generated source, a convenience grouping, or
+a split rejected only to reduce PR count or effort is not eligible.
+
+## Enforcement
+
+**Enforcement disposition — unenforced by decision.** A gate can measure source and `O` counts and
+require the record, but cannot determine semantic indivisibility. Authors and reviewers inspect it.
+
+## Related
+
+- [Addition Limits, File-Budget Exception, and Plan-Document Exemption](./prs-open-at-delivery-boundaries-pr-size-addition-limits.md)
+  — parent Rule-4 convention and the default limit.

--- a/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size.md
+++ b/repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size.md
@@ -41,7 +41,8 @@ repo's own posted reviews all ran against PRs of 15,000-56,000 lines and 160-3,5
    not a hard ceiling. A larger code diff is valid when it remains one natural, cohesive,
    independently reviewable, verifiable, and revertible seam; declare its measured size, seam,
    rejected split alternatives, and review proof. The independent **1,000** other/document-type
-   ceiling and **300** changed-file machine ceiling remain hard. **20** hand-authored files is the
+   ceiling remains hard except for the child rule's bounded single-source other/document exception;
+   the **300** changed-file machine ceiling remains hard. **20** hand-authored files is the
    default review budget; a named delivery may exceed it only through the child rule's exact,
    plan-and-PR-disclosed file-budget natural-seam exception. Deletions count as zero. The child
    defines file categories, generated-mirror exclusions, both natural-seam records, and the narrow

--- a/repo-governance/workflows/plan/plan-execution/per-phase-quality-gate-push-targets.md
+++ b/repo-governance/workflows/plan/plan-execution/per-phase-quality-gate-push-targets.md
@@ -27,7 +27,8 @@ when_to_use: Use when deciding where a phase's changes should push to under the 
      PR only at the unit's declared delivery boundary. Its body is the reader's entry point and
      applies [Bounding PR Size](../../../conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size.md):
      target 500 or fewer handwritten code/program-type additions as a strong recommendation, while
-     independently enforcing at most 1,000 handwritten other/document-type additions and at most 20
+     independently enforcing at most 1,000 handwritten other/document-type additions, except the
+     canonical bounded single-source other/document exception at most 1,100, and at most 20
      hand-authored files. A code diff above 500 remains valid only with its measured size, natural
      cohesive seam, rejected split alternatives, and review proof recorded. Claim the plan-document
      LOC exemption only for a qualifying initial establishment or backlog/in-progress pure move. At an


### PR DESCRIPTION
## Outcome

Adds one narrowly bounded `O <= 1,100` exception for an existing, non-generated other/document source that alone exceeds 1,000 lines and must stay one canonical behavior or contract target.

## Why

A current 1,010-line canonical feature source cannot be mechanically split without weakening its natural delivery seam. The default `O <= 1,000` and all other limits remain binding.

## Scope

- Canonical PR-size rule, its discoverable child, indexes, PR-body rule, template, and plan-quality consumers.
- Generated harness bindings regenerated from `.claude/`.
- No corpus migration or plan allocation changes; the plan will record the one eligible delivery separately.

## Reading Guide

- **Start here:** `repo-governance/conventions/structure/plans/prs-open-at-delivery-boundaries-pr-size-addition-limits.md`
- **Skip these paths:** generated bindings under `.agents/`, `.opencode/`, and `.codex/`.
- **Size:** C=0, O=81, 12 hand-authored files, 17 total files. No size exception is claimed by this PR.

## Verification

- `rtk npm run generate:bindings`
- `rtk npm run harness:bindings-validation` (195/195)
- `rtk npm run sync:dry-run`
- `rtk npm run validate:claude` (pass; three pre-existing metadata warnings)
- retained governance preflight, word-budget validation, README-index validation, `rtk git diff --check`, and pre-push gates

## Risk and rollback

The exception is constrained by source eligibility, exact allocation, plan/PR disclosure, and a 1,100 ceiling. Revert this PR to restore the former absolute default.

## Sibling obligation

A matching `ose-private` propagation PR is required before the active plan consumes the exception.