### PR TITLE
test: isolate Rhino coverage from DDD delivery state

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -1,5 +1,5 @@
 51f04bc4a3f84b9b73386a760312757e62af4fa5ed4a6d357b6d9b0a266cf48e  apps/rhino-cli/LICENSE
-22e8799130718d869359a97a48c6caa932e1c1be3f058fd3e2f1180b2d8f13d9  apps/rhino-cli/project.json
+827e27845b484b84581f25017314f62936ec99234a43ab902b64b24dce04e0cf  apps/rhino-cli/project.json
 22b1d0652e8937a20c83841966e4f8b1c451d671d34dd27fb5fa13f11d340a4d  apps/rhino-cli/src/.gitignore
 ffa0c75a032cccbc893f9907fe70e980f1df7a1a6875d4b3cf1b727165b13f48  apps/rhino-cli/src/RhinoCli.Application/RhinoCli.Application.fsproj
 5e8d325763a66e9dd083cabdb01af9310178aebf7239c7b3d4f6d8bd0a575b80  apps/rhino-cli/src/RhinoCli.Application/src/Contracts.fs
@@ -86,7 +86,7 @@ f6ffc8353519a85166543c825a1558361f107bdc19383a9dcf3d28870d4c0154  apps/rhino-cli
 3a2a32b2c95722988c1cc6488f1f9c588b79eedfc5c7382dd4191e5e15ee5479  apps/rhino-cli/src/tests/unit/Steps/WaveDMermaidWarningUnitTests.fs
 102b81c9fdb265a1d681896dcb3b04cb9fb603aae4821bb250a4e28cbde38e52  apps/rhino-cli/src/tests/unit/Steps/WaveDParityRegressionUnitTests.fs
 2746e79c69ca753cba4d5800f286acd7e64a53bbc263da01fb8a18ac9a12d0ed  apps/rhino-cli/src/tests/unit/Steps/WaveEFApplicationUnitTests.fs
-40452413bce1a8c19eec83bb43a483231be0041e5192c9e23ce95cc95785c80a  apps/rhino-cli/src/tests/unit/Steps/WaveEFDispatchUnitTests.fs
+717ed475a7c1ae0df0f3c84f1667b298b02460ec5588fe9697135101c7bd7b20  apps/rhino-cli/src/tests/unit/Steps/WaveEFDispatchUnitTests.fs
 251246dd01ec3245ef29238e279095a107aa401b56211446accc9d6cc87cc859  apps/rhino-cli/src/tests/unit/Steps/WaveEFE2eCoverageUnitTests.fs
 9ee57d1e183149f11ffed9cbe9b7eb56d7a626c5ab58902b883a54bc54f96354  apps/rhino-cli/src/tests/unit/Steps/WaveEFFormattersUnitTests.fs
 67d9065a63071df2ffaadf09583338a58b184791f5a93f4ec6992dd8d4209e5d  apps/rhino-cli/src/tests/unit/Steps/WaveEFGateUnitTests.fs

--- a/apps/rhino-cli/project.json
+++ b/apps/rhino-cli/project.json
@@ -82,7 +82,7 @@
       "options": {
         "command": "env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR dotnet test apps/rhino-cli/src/tests/unit/RhinoCli.UnitTests.fsproj /p:CollectCoverage=true /p:Threshold=90 /p:ThresholdType=line \"/p:ExcludeByFile=**/RhinoCli.Program/src/Program.fs\""
       },
-      "cache": true,
+      "cache": false,
       "inputs": ["{projectRoot}/src/**/*.fs", "{projectRoot}/src/tests/unit/**/*.fs"],
       "outputs": ["{projectRoot}/src/tests/unit/coverage.json"]
     },

--- a/apps/rhino-cli/src/tests/unit/Steps/WaveEFDispatchUnitTests.fs
+++ b/apps/rhino-cli/src/tests/unit/Steps/WaveEFDispatchUnitTests.fs
@@ -10,12 +10,12 @@
 ///
 /// Read-only leaves are driven against this checkout's own real repository
 /// root (via `RhinoCli.Infrastructure.GitRoot.findRoot`), the same technique
-/// `GovernanceSteps.fs`'s `findRepoRoot` already uses — these validators are
-/// exactly the ones this repo's own CI keeps green, so a clean exit code is
-/// the correct assertion without hand-building a fixture. Leaves that write
-/// (`bindings generate`, `sync promote`, `scaffold dart`, `readme-index
-/// rewrite-paths`, `e2e-coverage validate`) always use a throwaway temp
-/// directory instead, never the real checkout.
+/// `GovernanceSteps.fs`'s `findRepoRoot` already uses. Routes whose coverage
+/// depends on mutable repository declarations use a throwaway fixture instead:
+/// a delivery must not make a coverage result depend on unrelated repository
+/// state. Leaves that write (`bindings generate`, `sync promote`, `scaffold
+/// dart`, `readme-index rewrite-paths`, `e2e-coverage validate`) always use a
+/// throwaway temp directory too, never the real checkout.
 module RhinoCli.Tests.Unit.Steps.WaveEFDispatchUnitTests
 
 open System
@@ -60,6 +60,35 @@ let private realRepoRoot () : string =
     match RhinoCli.Infrastructure.GitRoot.findRoot () with
     | Error message -> failwith message
     | Ok root -> root
+
+/// A minimal, internally consistent DDD-area spec tree. It keeps dispatch
+/// coverage for config-driven DDD branches independent of the live delivery
+/// state of this repository.
+let private newDddAreaFixture () : string =
+    let root = newTempDir ()
+    let app = "fixture-app"
+
+    writeFile
+        root
+        "repo-config.yml"
+        "specs:\n  ddd-areas:\n    - fixture-app\n  domain-areas: []\ngates: []\nharness: []\n"
+
+    for folder in [ "product"; "system-context"; "containers"; "components"; "behavior" ] do
+        let path = sprintf "specs/apps/%s/%s" app folder
+        writeFile root (path + "/README.md") "# Fixture\n"
+        writeFile root (path + "/fixture.md") "# Fixture\n"
+
+    writeFile
+        root
+        (sprintf "specs/apps/%s/behavior/surface/gherkin/domain/fixture.feature" app)
+        "Feature: Fixture\n\n  Scenario: Works\n    Given a fixture\n    When it runs\n    Then it passes\n"
+
+    writeFile
+        root
+        (sprintf "specs/apps/%s/ddd/bounded-contexts.yaml" app)
+        "version: 2\napp: fixture-app\ncontexts: []\n"
+
+    root
 
 // ---------------------------------------------------------------------------
 // repo-governance * — read-only, safe against the real checkout
@@ -585,17 +614,19 @@ let ``route rewrite-paths help wins when --map is present`` () =
     Assert.NotEmpty out
 
 // ---------------------------------------------------------------------------
-// DDD-area branches — real repo has real ddd-areas/domain-areas in
-// repo-config.yml (organiclever, ose / organiclever-be, ose-be)
+// DDD-area branches — use a fixture so phase deliveries can freely retire a
+// live DDD area without changing this dispatch test's coverage.
 // ---------------------------------------------------------------------------
 
 [<Fact>]
-let ``route runs specs structure validate for a real ddd-area app`` () =
-    let code, _, _ =
-        runCaptured (okRoot (realRepoRoot ())) [| "specs"; "structure"; "validate"; "organiclever" |]
-    // Only asserting the leaf executes its DDD (bc/ul) branch without
-    // crashing — organiclever's own spec health is out of scope here.
-    Assert.True(code = 0 || code = 1)
+let ``route runs specs structure validate for a configured fixture ddd-area app`` () =
+    let root = newDddAreaFixture ()
+
+    let code, out, _ =
+        runCaptured (okRoot root) [| "specs"; "structure"; "validate"; "fixture-app" |]
+
+    Assert.Equal(0, code)
+    Assert.Contains("0 finding(s)", out)
 
 [<Fact>]
 let ``route runs specs domain-coverage validate for a real eligible domain area`` () =
@@ -848,11 +879,13 @@ let ``route scaffolds a Dart contracts package`` () =
 // ---------------------------------------------------------------------------
 
 [<Fact>]
-let ``route runs specs counts validate with no folder using the repo-config ddd-areas default`` () =
-    let code, _, _ =
-        runCaptured (okRoot (realRepoRoot ())) [| "specs"; "counts"; "validate" |]
+let ``route runs specs counts validate with no folder using the fixture ddd-areas default`` () =
+    let root = newDddAreaFixture ()
 
-    Assert.True(code = 0 || code = 1)
+    let code, out, _ = runCaptured (okRoot root) [| "specs"; "counts"; "validate" |]
+
+    Assert.Equal(0, code)
+    Assert.Contains("specs/apps/fixture-app", out)
 
 [<Fact>]
 let ``route runs specs counts validate against a comma-separated --apps flag`` () =


### PR DESCRIPTION
## Summary

- replace live-repository DDD dispatch tests with a complete synthetic DDD-area fixture
- disable caching for rhino-cli:test:coverage because its suite reads repository configuration beyond its declared inputs
- refresh the Rhino parity manifest; the identical source change is prepared in ose-private for its downstream paired delivery

## Root cause

Phase 2 retires OSE from specs.ddd-areas. Rhino coverage tests read that live declaration, so the default specs counts validate route stopped exercising the DDD-area loop and raw line coverage fell below the 90% gate despite all tests passing.

## Cost / benefit

Cost: coverage runs no longer use Nx caching until every repository-reading test is isolated. Benefit: the 90% gate measures stable test coverage rather than whichever delivery state happens to be checked out.

## Verification

- rtk nx run rhino-cli:test:coverage --skip-nx-cache: 1,395 passed; 90.16% total line coverage
- rtk nx run rhino-cli:test:quick --skip-nx-cache
- repository pre-push gate: affected quick tests and parity manifest
