### PR TITLE
test: align Wahidyankf navigation e2e label

### DIFF
--- a/apps/wahidyankf-www-fe-e2e/steps/accessibility.steps.ts
+++ b/apps/wahidyankf-www-fe-e2e/steps/accessibility.steps.ts
@@ -33,7 +33,7 @@ Then("the theme toggle button exposes an aria-label", async ({ page }) => {
 
 // @covers specs/apps/wahidyankf/behavior/wahidyankf-www/gherkin/app-shell/accessibility.feature:Interactive controls expose accessible names
 Then("every navigation link exposes link text or an aria-label", async ({ page }) => {
-  const linkNames = ["Home", "CV", "Personal Projects"];
+  const linkNames = ["Home", "CV", "Independent Projects"];
   for (const name of linkNames) {
     await expect(page.getByRole("link", { name: new RegExp(`^${name}$`) }).first()).toBeVisible();
   }


### PR DESCRIPTION
## Summary

Aligns the browser accessibility assertion with the existing “Independent Projects” navigation label.

## Cost / benefit

One test-only label correction removes a stale expectation from the prior UI rename and restores the full Docker E2E suite without changing product behavior.

## Verification

- `rtk nx run wahidyankf-www-fe-e2e:test:e2e` — 36 passed, 6 intentional skips
- pre-push gate