### PR TITLE
test: await Ayo reference role controls

### DIFF
--- a/apps/ayokoding-www-fe-e2e/src/steps/cost-of-living-calculator.steps.ts
+++ b/apps/ayokoding-www-fe-e2e/src/steps/cost-of-living-calculator.steps.ts
@@ -722,11 +722,17 @@ When("I set the baseline source to {string}", async ({ page }, source: string) =
   const radioLabels: Record<string, string> = {
     "savings target": "Monthly savings target",
     "reference role": "Reference role",
+    "Match a role": "Match a role",
     "my salary": "My salary",
   };
   const radioLabel = radioLabels[source] ?? source;
-  await page.getByRole("radio", { name: radioLabel }).click();
-  await page.waitForLoadState("networkidle");
+  const radio = page.getByRole("radio", { name: radioLabel });
+  await radio.click();
+  await expect(radio).toHaveAttribute("aria-checked", "true");
+
+  if (radioLabel === "Match a role") {
+    await expect(page.getByLabel("Reference city")).toBeVisible();
+  }
 });
 
 When("I enter a monthly savings target of {string} USD", async ({ page }, amount: string) => {


### PR DESCRIPTION
## Benefit
Makes the reference-role browser scenario wait for the selected baseline and its dependent control before interacting.

## Cost
One E2E step-definition file; no production behavior changes.

## Recovery
Revert this squash merge.

## Evidence
Targeted Chromium, Firefox, and WebKit scenario; typecheck; lint; pre-push gate.