### PR TITLE
test: await Ayo household URL state

### DIFF
--- a/apps/ayokoding-www-fe-e2e/src/steps/cost-of-living-calculator.steps.ts
+++ b/apps/ayokoding-www-fe-e2e/src/steps/cost-of-living-calculator.steps.ts
@@ -80,9 +80,11 @@ Given(
   async ({ page }, tabName: string, _role: string, _household: string) => {
     await page.goto("/en/tools/cost-of-living-calculator");
     await page.getByRole("tab", { name: tabName }).click();
+    await page.waitForURL(/tab=min-role/);
     await page.locator("#target-amount-input").fill("1000");
     await page.keyboard.press("Tab");
-    await page.waitForLoadState("networkidle");
+    await page.waitForURL(/target=1000/);
+    await expect(page.getByTestId("qualifying-divider")).toBeVisible();
   },
 );
 
@@ -988,8 +990,10 @@ When(
     await page.waitForURL(/schoolkids=2/);
     const areaLabel = area === "center" ? "City center" : "Rural";
     // Area is a SegmentedControl (radiogroup), not a <select>
-    await page.getByRole("radio", { name: areaLabel }).click();
-    await page.waitForLoadState("networkidle");
+    const areaRadio = page.getByRole("radio", { name: areaLabel });
+    await areaRadio.click();
+    await expect(areaRadio).toHaveAttribute("aria-checked", "true");
+    if (area === "rural") await page.waitForURL(/area=rural/);
   },
 );
 
@@ -998,10 +1002,8 @@ Then(
   async ({ page }, _role: string) => {
     const divider = page.locator("[data-testid='qualifying-divider']");
     const noQual = page.locator("[data-testid='no-qualifier-message']");
-    // `waitForLoadState("networkidle")` in the preceding step settles network requests, but the
-    // React re-render this triggers can still lag behind under full-suite parallel load — a bare
-    // `.isVisible()` sampled the DOM once and flaked. `expect.poll` retries the predicate until
-    // one of the two elements actually renders, matching Playwright's normal auto-wait behavior.
+    // The preceding step verifies each URL-state mutation. This additional poll tolerates the
+    // resulting React re-render under full-suite parallel load rather than sampling the DOM once.
     await expect
       .poll(async () => (await divider.isVisible()) || (await noQual.isVisible()), {
         timeout: 60000,


### PR DESCRIPTION
## Summary

Stabilizes the Ayo household-composition scenario by waiting for the URL state that drives its reactive calculation, rather than treating network idle as proof that client state committed.

## Validation

- Targeted household scenario in Chromium, Firefox, and WebKit
- Related Ayo reference-role scenario in Chromium, Firefox, and WebKit
- `npx nx run ayokoding-www-fe-e2e:typecheck`
- `npx nx run ayokoding-www-fe-e2e:lint`
- Required pre-push gate