### PR TITLE
test: cover Rhino glossary and DDD registry branches

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -33,7 +33,7 @@ ea9c28fc3b1c41add46abd4de607b27e0b3b985b0d9825ad6763e2341892f91a  apps/rhino-cli
 822f6ec8446562a4de9a3b1a2481af50fac01bbedc32e1963142709e5f48ec13  apps/rhino-cli/src/fsharplint.json
 aca5d109fdc277b6f4c6695a1265b163fac319b66d6201b32b85e5571a29d3ea  apps/rhino-cli/src/tests/integration/RhinoCli.IntegrationTests.fsproj
 51bbb1298cd542e36b0f98320c3ef762d37f78e5fca2a7889c66811a4110c277  apps/rhino-cli/src/tests/integration/Steps/PreCommitHookSteps.fs
-36bbb75e00a39648f3b3c9801fd6798252ae35b301f519b96515a086ea2b4091  apps/rhino-cli/src/tests/unit/RhinoCli.UnitTests.fsproj
+c10a61adff388617d4f05c33208fc8133704940375cdf5af61e33215d87d0b91  apps/rhino-cli/src/tests/unit/RhinoCli.UnitTests.fsproj
 a4129f2917299cb8ab288f84ce3822d9ddd01ab56e236cd70fcfee02a6fdeff0  apps/rhino-cli/src/tests/unit/Steps/ContractsSteps.fs
 85ba308ad0a88485db55b305120d99b9a4ec328d2379536110f73e51f4797fe2  apps/rhino-cli/src/tests/unit/Steps/ConventionSteps.fs
 a909884a9d8816e2b476cc8c00be03ac4085b849cbe83c4b18e0213ac9cad1d7  apps/rhino-cli/src/tests/unit/Steps/ConventionUnitTests.fs
@@ -66,6 +66,7 @@ df2d2403e3dbf9b7cde5eae9ff273fb26d62ee0841ba72bbbf81c91ed8c8527d  apps/rhino-cli
 9ff7adddaadd1cd8383f14ed09be08a88ec05808a2919e9ccf2df0a5fdabb1af  apps/rhino-cli/src/tests/unit/Steps/GateValidationSteps.fs
 413baab2577c13102e7eb36979cbea9d75735929a5c429591a05ca85cf69cbec  apps/rhino-cli/src/tests/unit/Steps/GitRootUnitTests.fs
 f8001cb2ebc6ae2184962f56d8224caacdc67d1ae6647b32960c092972b21eba  apps/rhino-cli/src/tests/unit/Steps/GitSteps.fs
+1984bbf0150dbc30ecdbc241af1afdbef265b3c7495d120ad684c6f5d8f35c22  apps/rhino-cli/src/tests/unit/Steps/GlossaryDddCoverageUnitTests.fs
 05565785d04524a6d5bd28d40889dafc8a25c41fe66a05d95663f073f6602795  apps/rhino-cli/src/tests/unit/Steps/GlossarySteps.fs
 88973990d3cb584c6da4769af25e9a202fc5d66a1fc04bfc82f1aeaecf6c48fb  apps/rhino-cli/src/tests/unit/Steps/GovernanceSteps.fs
 8f7fab6081cb2c8031ab0344d11633eac0090ce672ecdf5f3718511fc7c8f979  apps/rhino-cli/src/tests/unit/Steps/HarnessSteps.fs
@@ -86,7 +87,7 @@ f6ffc8353519a85166543c825a1558361f107bdc19383a9dcf3d28870d4c0154  apps/rhino-cli
 3a2a32b2c95722988c1cc6488f1f9c588b79eedfc5c7382dd4191e5e15ee5479  apps/rhino-cli/src/tests/unit/Steps/WaveDMermaidWarningUnitTests.fs
 102b81c9fdb265a1d681896dcb3b04cb9fb603aae4821bb250a4e28cbde38e52  apps/rhino-cli/src/tests/unit/Steps/WaveDParityRegressionUnitTests.fs
 2746e79c69ca753cba4d5800f286acd7e64a53bbc263da01fb8a18ac9a12d0ed  apps/rhino-cli/src/tests/unit/Steps/WaveEFApplicationUnitTests.fs
-2a1d237985477ad302e14f72dc53f2e5bc94944839bcdcc11b6c83af445c4ce8  apps/rhino-cli/src/tests/unit/Steps/WaveEFDispatchUnitTests.fs
+224a2bc83da11a56fa0a630783a35d8ec2f02c1fc7ff3c1cee07a3004e560450  apps/rhino-cli/src/tests/unit/Steps/WaveEFDispatchUnitTests.fs
 251246dd01ec3245ef29238e279095a107aa401b56211446accc9d6cc87cc859  apps/rhino-cli/src/tests/unit/Steps/WaveEFE2eCoverageUnitTests.fs
 9ee57d1e183149f11ffed9cbe9b7eb56d7a626c5ab58902b883a54bc54f96354  apps/rhino-cli/src/tests/unit/Steps/WaveEFFormattersUnitTests.fs
 67d9065a63071df2ffaadf09583338a58b184791f5a93f4ec6992dd8d4209e5d  apps/rhino-cli/src/tests/unit/Steps/WaveEFGateUnitTests.fs

--- a/apps/rhino-cli/src/tests/unit/RhinoCli.UnitTests.fsproj
+++ b/apps/rhino-cli/src/tests/unit/RhinoCli.UnitTests.fsproj
@@ -52,6 +52,7 @@
     <Compile Include="Steps/WaveEFE2eCoverageUnitTests.fs" />
     <Compile Include="Steps/WaveEFFormattersUnitTests.fs" />
     <Compile Include="Steps/WaveEFApplicationUnitTests.fs" />
+    <Compile Include="Steps/GlossaryDddCoverageUnitTests.fs" />
     <Compile Include="Steps/HarnessSteps.fs" />
     <Compile Include="Steps/HarnessUnitTests.fs" />
     <Compile Include="Steps/SpecsSteps.fs" />

--- a/apps/rhino-cli/src/tests/unit/Steps/GlossaryDddCoverageUnitTests.fs
+++ b/apps/rhino-cli/src/tests/unit/Steps/GlossaryDddCoverageUnitTests.fs
@@ -1,0 +1,157 @@
+/// Plain xunit tests calling `RhinoCli.Application.Glossary`/`Ddd`'s public
+/// helper functions directly with synthetic content. These fixtures cover
+/// content-dependent parser branches without altering either repository's
+/// real glossary or bounded-context registry.
+module RhinoCli.Tests.Unit.Steps.GlossaryDddCoverageUnitTests
+
+open System
+open System.IO
+open Xunit
+open RhinoCli.Domain.Types
+open RhinoCli.Application
+
+let private newTempDir () =
+    let dir =
+        Path.Combine(Path.GetTempPath(), "rhino-cli-glossary-ddd-cov-" + Guid.NewGuid().ToString("N"))
+
+    Directory.CreateDirectory(dir) |> ignore
+    dir
+
+let private writeFile (root: string) (relativePath: string) (content: string) =
+    let full = Path.Combine(root, relativePath)
+    Directory.CreateDirectory(Path.GetDirectoryName full) |> ignore
+    File.WriteAllText(full, content)
+
+// ---------------------------------------------------------------------------
+// Glossary.parseContent — forbidden-synonyms bullet parsing (both separator
+// forms) and the generic "## " section close
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``parseContent parses forbidden synonyms with both em-dash and hyphen separators and closes the section on the next heading``
+    ()
+    =
+    let content =
+        "**Bounded context**: sample\n"
+        + "**Maintainer**: me\n"
+        + "**Last reviewed**: 2026-01-01\n"
+        + "\n"
+        + "## Term index\n"
+        + "\n"
+        + "| Term | Code identifier(s) | Used in features |\n"
+        + "| --- | --- | --- |\n"
+        + "| Widget | `Widget` | sub/dir/widget.feature |\n"
+        + "\n"
+        + "## Forbidden synonyms\n"
+        + "\n"
+        + "- \"Thingy\" — use Widget instead\n"
+        + "- \"Doohickey\" - use Gadget instead\n"
+        + "\n"
+        + "## Notes\n"
+        + "\n"
+        + "Some other content that must not be parsed as a bullet.\n"
+
+    let g = Glossary.parseContent "fixture.md" content
+
+    Assert.Equal(2, g.ForbiddenSynonyms.Length)
+
+    Assert.Contains(
+        g.ForbiddenSynonyms,
+        (fun (f: Glossary.Forbidden) -> f.Term = "Thingy" && f.Reason = "use Widget instead")
+    )
+
+    Assert.Contains(
+        g.ForbiddenSynonyms,
+        (fun (f: Glossary.Forbidden) -> f.Term = "Doohickey" && f.Reason = "use Gadget instead")
+    )
+
+// ---------------------------------------------------------------------------
+// Glossary.featureRefResolves — slash-qualified and glob-qualified branches
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``featureRefResolves resolves a slash-qualified reference against the gherkin path's parent directory`` () =
+    let root = newTempDir ()
+    let gherkinPath = Path.Combine(root, "specs", "apps", "foo", "gherkin")
+    Directory.CreateDirectory gherkinPath |> ignore
+    writeFile root "specs/apps/foo/sub/dir/thing.feature" "Feature: thing\n"
+
+    let resolved = Glossary.featureRefResolves "sub/dir/thing.feature" [ gherkinPath ]
+
+    Assert.True resolved
+
+[<Fact>]
+let ``featureRefResolves resolves a glob-qualified reference against files in the gherkin path`` () =
+    let root = newTempDir ()
+    let gherkinPath = Path.Combine(root, "gherkin")
+    writeFile root "gherkin/foo.feature" "Feature: foo\n"
+
+    let resolved = Glossary.featureRefResolves "*.feature" [ gherkinPath ]
+
+    Assert.True resolved
+
+// ---------------------------------------------------------------------------
+// Glossary.checkForbiddenSynonyms — the forbidden-synonym self-use loop
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``checkForbiddenSynonyms flags a forbidden term still used in the context's own code`` () =
+    let root = newTempDir ()
+    writeFile root "code/sample.fs" "let thingy = 1\n"
+
+    let glossary: Glossary.Glossary =
+        { Path = "fixture.md"
+          Frontmatter = Map.empty
+          Terms = []
+          ForbiddenSynonyms =
+            [ { Glossary.Forbidden.Term = "thingy"
+                Reason = "use Widget instead"
+                SourceLine = 1 } ]
+          ParseErrors = [] }
+
+    let findings =
+        Glossary.checkForbiddenSynonyms
+            "fixture.md"
+            glossary
+            [ Path.Combine(root, "code") ]
+            [ "*.fs" ]
+            []
+            Severity.Blocking
+
+    Assert.Single(findings) |> ignore
+    Assert.Contains("thingy", findings.[0].Message)
+
+// ---------------------------------------------------------------------------
+// Ddd.loadRegistry — default code_lang assignment and malformed-YAML branch
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``loadRegistry defaults an empty code_lang to ts and tsx`` () =
+    let root = newTempDir ()
+
+    writeFile
+        root
+        "specs/apps/fixture/ddd/bounded-contexts.yaml"
+        ("version: 2\n"
+         + "app: fixture\n"
+         + "contexts:\n"
+         + "  - name: sample\n"
+         + "    code: [apps/fixture]\n"
+         + "    gherkin: [specs/fixture]\n")
+
+    let result = Ddd.loadRegistry root "fixture"
+
+    match result with
+    | Ok registry -> Assert.Equal<string list>([ "ts"; "tsx" ], registry.Contexts.[0].CodeLang)
+    | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+
+[<Fact>]
+let ``loadRegistry reports an error for malformed YAML`` () =
+    let root = newTempDir ()
+    writeFile root "specs/apps/fixture/ddd/bounded-contexts.yaml" "version: [unterminated\n"
+
+    let result = Ddd.loadRegistry root "fixture"
+
+    match result with
+    | Error _ -> ()
+    | Ok _ -> Assert.Fail "expected Error for malformed YAML"

--- a/apps/rhino-cli/src/tests/unit/Steps/WaveEFDispatchUnitTests.fs
+++ b/apps/rhino-cli/src/tests/unit/Steps/WaveEFDispatchUnitTests.fs
@@ -22,6 +22,8 @@ open System
 open System.IO
 open Xunit
 open RhinoCli.Cli.Dispatch
+open RhinoCli.Application.Ddd
+open RhinoCli.Domain.Types
 
 let private newTempDir () =
     let dir =
@@ -98,6 +100,23 @@ let private newDddAreaFixture () : string =
         "version: 2\napp: fixture-app\ncontexts:\n  - name: journal\n    summary: Fixture bounded context\n    layers: [domain, application]\n    code: [apps/fixture-app/src/contexts/journal]\n    glossary: specs/apps/fixture-app/ddd/ubiquitous-language/journal.md\n    gherkin: [specs/apps/fixture-app/behavior/surface/gherkin/domain]\n"
 
     root
+
+// ---------------------------------------------------------------------------
+// DDD application contracts — direct unit coverage for parser branches that
+// dispatch-only fixtures cannot observe independently.
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``DDD severity treats unknown text as blocking`` () =
+    let severity = parseSeverity "fatal"
+
+    Assert.Equal(Severity.Blocking, severity)
+
+[<Fact>]
+let ``DDD marks open-host-service as a unidirectional relationship`` () =
+    match relationshipKindIsAsymmetric "open-host-service" with
+    | Some isAsymmetric -> Assert.False(isAsymmetric)
+    | None -> Assert.Fail("open-host-service must be a supported relationship kind")
 
 // ---------------------------------------------------------------------------
 // repo-governance * — read-only, safe against the real checkout


### PR DESCRIPTION
## What

Adds unit coverage for `RhinoCli.Application.Glossary` and `RhinoCli.Application.Ddd` parser
branches using synthetic fixtures, and refreshes `apps/rhino-cli/parity-manifest.sha256`.

## Why

`ose-public`'s real `specs/apps/ose/ddd/**` content is what currently exercises the
forbidden-synonyms bullet parser, the slash- and glob-qualified `featureRefResolves` branches, and
`Ddd.loadRegistry`'s default-`code_lang` and malformed-YAML branches. Retiring that registry
(plan `adopt-beavernest-test-automation`, Phase 2 / PR #408) drops `rhino-cli` line coverage below
the 90% gate. These fixtures close the gap without altering either repository's real glossary or
bounded-context registry, per the parity-boundary-drift guidance.

The manifest refresh also picks up the `WaveEFDispatchUnitTests.fs` additions from the preceding
commit on this branch, which landed without regenerating the manifest.

## Cost/benefit

Test-only change; the new-code cost statement does not apply. No production source is touched.

## Verification

`dotnet test apps/rhino-cli/src/tests/unit/RhinoCli.UnitTests.fsproj /p:CollectCoverage=true
/p:Threshold=90 /p:ThresholdType=line` — 1404 passed locally on this branch, and 1402 passed with
`RhinoCli.Application` at 90.13% / `RhinoCli.Cli` at 90.32% when applied on top of PR #408's tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsN3MrWCJ1sGjWuDbJtBRt
