### PR TITLE
fix(ci): require explicit retention-days on every artifact upload

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -235,6 +235,11 @@ jobs:
         with:
           name: rhino-cli-gate-binary
           path: apps/rhino-cli/src/dist
+          # Intra-run scratch: every downstream gate job consumes this within
+          # the same run, so it is dead the moment the run ends. 1 is the
+          # shortest window GitHub accepts; the repository default (90 days)
+          # multiplied this by the PR rate into gigabytes of Actions storage.
+          retention-days: 1
 
   enumerate:
     name: Enumerate registry CI gate groups

--- a/repo-config.yml
+++ b/repo-config.yml
@@ -1800,6 +1800,19 @@ gates:
         glob: ".github/workflows/*.{yml,yaml}"
       ci: { scope: all-file-type }
 
+  - id: artifact-retention
+    type: check
+    # Self-discovers `.github/workflows/*` when invoked with no file arguments,
+    # matching actionlint's all-file-type CI shape above.
+    command: scripts/verify-artifact-retention.sh
+    kind: external
+    ci-group: shell-docker-actions
+    surfaces:
+      pre-commit:
+        scope: affected-file-type
+        glob: ".github/workflows/*.{yml,yaml}"
+      ci: { scope: all-file-type }
+
   - id: shellcheck
     type: check
     command: shellcheck --severity=warning

--- a/repo-governance/development/infra/ci-conventions.md
+++ b/repo-governance/development/infra/ci-conventions.md
@@ -27,6 +27,7 @@ GitHub Actions, and naming.
 - [Docker Conventions](./ci-conventions/docker-conventions.md) — The Dockerfile template, compose file roles, and .dockerignore pattern. Use when writing a Dockerfile, compose file, or .dockerignore.
 - [GitHub Actions Conventions — File Organisation and Composite Actions](./ci-conventions/github-actions-file-organisation-and-composite-actions.md) — The path pattern for workflow and action files. Use when creating or locating a workflow file or action.
 - [Expression Safety](./ci-conventions/github-actions-expression-safety.md) — Two GitHub Actions expression-injection and falsy-value antipatterns. Use when a run step references a `${{ ... }}` expression.
+- [Artifact Retention](./ci-conventions/github-actions-artifact-retention.md) — Why every upload-artifact step must declare retention-days. Use when a workflow step uploads a build artifact or test report.
 - [GitHub Actions Conventions — Reusable Workflows and CRON Scheduling](./ci-conventions/github-actions-reusable-workflows-and-cron-scheduling.md) — Reusable workflow structure and the staggered CRON tracks. Use when writing a reusable workflow or scheduling a CRON job.
 
 ## Naming and Onboarding

--- a/repo-governance/development/infra/ci-conventions/README.md
+++ b/repo-governance/development/infra/ci-conventions/README.md
@@ -15,6 +15,7 @@ when_to_use: "Read this index to find the right CI/CD Conventions child document
 - [Docker Conventions](./docker-conventions.md) — The Dockerfile template, compose file roles, and .dockerignore pattern. Use when writing a Dockerfile, compose file, or .dockerignore.
 - [GitHub Actions Conventions — File Organisation and Composite Actions](./github-actions-file-organisation-and-composite-actions.md) — The path pattern for workflow and action files. Use when creating or locating a workflow file or action.
 - [Expression Safety](./github-actions-expression-safety.md) — Two GitHub Actions expression-injection and falsy-value antipatterns. Use when a run step references a ${{ ... }} expression.
+- [Artifact Retention](./github-actions-artifact-retention.md) — Why every upload-artifact step must declare retention-days. Use when a workflow step uploads a build artifact or test report.
 - [GitHub Actions Conventions — Reusable Workflows and CRON Scheduling](./github-actions-reusable-workflows-and-cron-scheduling.md) — Reusable workflow structure and the staggered CRON tracks. Use when writing a reusable workflow or scheduling a CRON job.
 - [Naming Conventions and Adding a New App to CI](./naming-conventions-and-adding-a-new-app-to-ci.md) — App/workflow filename grammar and the new-app checklist. Use when naming or onboarding a new app.
 - [E2E Test Pairing Rule and Environment Variable Standard](./e2e-test-pairing-rule-and-environment-variable-standard.md) — E2E runner pairing and required env-variable rules. Use when wiring an E2E runner or env variable.

--- a/repo-governance/development/infra/ci-conventions/github-actions-artifact-retention.md
+++ b/repo-governance/development/infra/ci-conventions/github-actions-artifact-retention.md
@@ -1,0 +1,48 @@
+---
+title: "Artifact Retention"
+description: Every upload-artifact step must declare retention-days, because the inherited default bills storage.
+category: explanation
+subcategory: development
+tags: [ci-cd, github-actions, cost]
+created: 2026-09-01
+when_to_use: Use when a workflow step uploads a build artifact or test report.
+---
+
+# Artifact Retention
+
+**Every `actions/upload-artifact` step must declare an explicit `retention-days`.**
+
+A step that omits it inherits the repository default. GitHub ships that default at **90 days**,
+and the value is invisible at the point of use — nothing in the workflow file reveals how long the
+upload will be billed. Retention is therefore a required, reviewable declaration, not an inherited
+default.
+
+The cost is multiplicative, not additive: retained bytes are `size x runs-per-day x
+retention-days`. A 38 MB scratch binary uploaded by a PR gate that runs 30 times a day holds
+**~100 GB** at 90-day retention. The account-wide Actions storage quota is measured in fractions of
+a gigabyte, so a single undeclared step can exhaust it on its own while every individual upload
+still looks harmless in review.
+
+Choose the window by what the artifact is _for_:
+
+| Artifact role                                 | Window               |
+| --------------------------------------------- | -------------------- |
+| Intra-run scratch consumed by a later job     | `1`                  |
+| Test report or trace read when triage happens | `7`                  |
+| Anything longer                               | Justify in a comment |
+
+Only **private** repositories consume the billed quota — public-repository Actions storage is
+free. Do not treat a public repository as an exemption: workflows are copied between repositories,
+and this repository's `pr-quality-gate.yml` is mirrored into a private sibling where the same step
+does bill.
+
+## Enforcement
+
+The `artifact-retention` gate (`scripts/verify-artifact-retention.sh`) fails any
+`upload-artifact` step with no `retention-days` in its step block. It runs on `pre-commit` for
+changed workflow files and across all workflows in CI. Attributing `retention-days` to the correct
+step matters: a value on a _later_ step does not satisfy an earlier one.
+
+The repository default is a backstop, not the control. Set it to a short window
+(`PUT /repos/{owner}/{repo}/actions/permissions/artifact-and-log-retention`), because it also caps
+**log** retention, which this gate cannot see and which bills at the same rate.

--- a/scripts/verify-artifact-retention.sh
+++ b/scripts/verify-artifact-retention.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Verify every actions/upload-artifact step declares an explicit retention-days.
+#
+# An upload step with no retention-days inherits the repository default, which
+# GitHub ships at 90 days. A per-run scratch artifact retained for 90 days
+# multiplies by the run rate and silently consumes the account-wide Actions
+# storage quota, so the retention window is a required, reviewable declaration
+# rather than an inherited default.
+set -euo pipefail
+
+list="$(mktemp)"
+trap 'rm -f "$list"' EXIT
+
+if [ "$#" -eq 0 ]; then
+	find .github/workflows -maxdepth 1 -type f \
+		\( -name '*.yml' -o -name '*.yaml' \) | sort >"$list"
+else
+	printf '%s\n' "$@" >"$list"
+fi
+
+status=0
+while IFS= read -r file; do
+	[ -n "$file" ] || continue
+	[ -f "$file" ] || continue
+
+	if ! awk -v FILE="$file" '
+		{ line[NR] = $0 }
+		END {
+			nb = 0
+			for (i = 1; i <= NR; i++) {
+				s = line[i]
+				if (s ~ /^[ \t]*#/) continue
+				if (s !~ /^[ \t]*-([ \t]|$)/) continue
+				nb++
+				bullet[nb] = i
+				pos = index(s, "-")
+				indent[nb] = pos - 1
+			}
+
+			bad = 0
+			for (i = 1; i <= NR; i++) {
+				s = line[i]
+				if (s ~ /^[ \t]*#/) continue
+				if (s !~ /uses:[ \t]*[^ \t]*actions\/upload-artifact/) continue
+
+				owner = 0
+				for (b = 1; b <= nb; b++) {
+					if (bullet[b] <= i) owner = b; else break
+				}
+				if (owner == 0) { start = 1; stop = NR }
+				else {
+					start = bullet[owner]
+					stop = NR
+					for (c = owner + 1; c <= nb; c++) {
+						if (indent[c] <= indent[owner]) { stop = bullet[c] - 1; break }
+					}
+				}
+
+				found = 0
+				for (j = start; j <= stop; j++) {
+					t = line[j]
+					if (t ~ /^[ \t]*#/) continue
+					if (t ~ /retention-days[ \t]*:/) { found = 1; break }
+				}
+				if (!found) {
+					printf "%s:%d: upload-artifact step has no retention-days\n", FILE, i > "/dev/stderr"
+					bad = 1
+				}
+			}
+			exit bad
+		}
+	' "$file"; then
+		status=1
+	fi
+done <"$list"
+
+if [ "$status" -ne 0 ]; then
+	printf '%s\n' \
+		"Every actions/upload-artifact step must declare retention-days." \
+		"Without it the step inherits the repository default (90 days on a new repo)." >&2
+fi
+
+exit "$status"


### PR DESCRIPTION
## Problem

GitHub warned that the account's 0.5 GB monthly Actions storage allowance was 100% consumed.

Root cause: the `rhino-cli-gate-binary` upload in `pr-quality-gate.yml` declared no
`retention-days`, so it inherited the repository default of **90 days**. The artifact is ~38 MB of
intra-run scratch consumed by downstream gate jobs within the same run — dead the moment the run
ends, but billed for three months.

Measured before this change:

| Repo          | Artifact                   | Live copies | Size       |
| ------------- | -------------------------- | ----------- | ---------- |
| `ose-public`  | `rhino-cli-gate-binary`    | 946         | 7.31 GB    |
| `ose-public`  | `rhino-cli-fsharp-binary`  | 148         | 3.18 GB    |
| `ose-private` | both binaries              | 61          | 1.72 GB    |

Only `ose-private` bills (public-repository Actions storage is free), and its ~448 MB of 90-day
log retention alone was ~90% of the quota before artifacts were counted.

## Change

- `pr-quality-gate.yml`: pin the gate binary to `retention-days: 1`, the shortest window GitHub
  accepts, with a comment recording why.
- `scripts/verify-artifact-retention.sh`: new verifier failing any `upload-artifact` step with no
  `retention-days` in its step block.
- `repo-config.yml`: register the `artifact-retention` gate on `pre-commit` (changed workflow
  files) and the `shell-docker-actions` CI group (all workflows).
- New `ci-conventions` shard documenting the rule, the cost model, and how to pick a window.

## Verification

Falsifiable both directions through the real group dispatch, not just a direct script call:

```
# with the fix
gate run --surface=ci --group=shell-docker-actions  ->  exit 0, artifact-retention PASS
# retention-days removed
gate run --surface=ci --group=shell-docker-actions  ->  exit 1, artifact-retention FAIL
  .github/workflows/pr-quality-gate.yml:234: upload-artifact step has no retention-days
```

Adversarial fixture confirms a `retention-days` on a *later* step does not satisfy an earlier one,
and that commented-out steps are ignored. `shellcheck` and `shfmt -d` clean.

Out of band (API, not in this diff): all live artifacts in both repos were deleted (~12 GB freed,
now 0 bytes), and the artifact-and-log retention default was set to 7 days on `ose-public`,
`ose-private`, `beaver-nest`, and `grind-in-public`. The repository default is a backstop — it also
caps *log* retention, which this gate cannot see.

## Preexisting failures, not introduced here

Verified byte-identical on unmodified `origin/main`:

- `gate validate` exits 1: `Hand-wired CI gate "compat-min-version" ... is missing from pr-quality-gate.yml`
- `md links validate` exits 1: `found 536 broken links` (same count on baseline)

## Cost/benefit

New code is one 60-line POSIX shell verifier and one registry entry. It replaces an invisible
inherited default with a reviewable declaration at the point of use, and closes the class rather
than the single site that triggered the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014uVi8Ckz9QqRjHrAR8RArN
