### PR TITLE
fix(crane-cli): restore 36 Gherkin scenarios lost to a retired corpus path

### DIFF
--- a/apps/crane-cli/tests/integration/Suite.fs
+++ b/apps/crane-cli/tests/integration/Suite.fs
@@ -9,7 +9,7 @@ let private assembly = Assembly.GetExecutingAssembly()
 
 let private gherkinRoot =
     match System.Environment.GetEnvironmentVariable("GHERKIN_ROOT") with
-    | null -> Path.Combine(__SOURCE_DIRECTORY__, "../../../../specs/apps/crane/behavior/cli/gherkin")
+    | null -> Path.Combine(__SOURCE_DIRECTORY__, "../../../../specs/apps/crane/cli/behaviors")
     | root -> root
 
 /// Returns loaded Gherkin scenarios, or a single no-op placeholder when none can be loaded.

--- a/apps/crane-cli/tests/unit/Suite.fs
+++ b/apps/crane-cli/tests/unit/Suite.fs
@@ -9,36 +9,40 @@ let private assembly = Assembly.GetExecutingAssembly()
 
 let private gherkinRoot =
     match System.Environment.GetEnvironmentVariable("GHERKIN_ROOT") with
-    | null -> Path.Combine(__SOURCE_DIRECTORY__, "../../../../specs/apps/crane/behavior/cli/gherkin")
+    | null -> Path.Combine(__SOURCE_DIRECTORY__, "../../../../specs/apps/crane/cli/behaviors")
     | root -> root
 
-/// Returns loaded Gherkin scenarios, or a single no-op placeholder when none can be loaded.
-/// Prevents xUnit from failing with "No data found" when step definitions are not yet implemented.
+/// Every scenario in the owner corpus, one xUnit row each.
+///
+/// This function raises rather than degrading. A corpus that cannot be read is
+/// indistinguishable at the exit code from a corpus that passes, so an earlier
+/// version returned a single no-op row "so [Theory] does not fail with No data
+/// found" — which is exactly what let a retired `gherkinRoot` path hide 36
+/// scenarios behind a green target. A missing directory, an unreadable feature
+/// file, and an empty corpus are all failures here.
 let private buildScenarioData () : seq<obj[]> =
+    if not (Directory.Exists gherkinRoot) then
+        failwithf "the Gherkin corpus directory does not exist: %s" gherkinRoot
+
+    let files =
+        Directory.GetFiles(gherkinRoot, "*.feature", SearchOption.AllDirectories)
+
+    if Array.isEmpty files then
+        failwithf "no .feature file was found under %s" gherkinRoot
+
+    let defs = StepDefinitions(assembly)
+
     let loaded =
-        if Directory.Exists(gherkinRoot) then
-            let files =
-                Directory.GetFiles(gherkinRoot, "*.feature", SearchOption.AllDirectories)
-
-            let defs = StepDefinitions(assembly)
-
-            files
-            |> Seq.collect (fun path ->
-                try
-                    let feature = defs.GenerateFeature(path)
-                    feature.Scenarios |> Seq.map (fun scenario -> [| scenario :> obj |])
-                with _ ->
-                    Seq.empty)
-            |> Seq.toList
-        else
-            []
+        files
+        |> Seq.collect (fun path ->
+            let feature = defs.GenerateFeature(path)
+            feature.Scenarios |> Seq.map (fun scenario -> [| scenario :> obj |]))
+        |> Seq.toList
 
     if List.isEmpty loaded then
-        // Placeholder: step definitions not yet implemented.
-        // Returns a single no-op row so [Theory] does not fail with "No data found".
-        Seq.singleton [| box "no-op" |]
-    else
-        loaded :> seq<_>
+        failwithf "the %d feature file(s) under %s expanded to no scenarios" files.Length gherkinRoot
+
+    loaded :> seq<_>
 
 type CraneCliUnitSuite() =
     static member Scenarios() : seq<obj[]> =
@@ -49,4 +53,4 @@ type CraneCliUnitSuite() =
     member _.``Crane unit scenarios``(item: obj) =
         match item with
         | :? Scenario as scenario -> scenario.Action.Invoke()
-        | _ -> () // no-op placeholder — step definitions not yet implemented
+        | other -> failwithf "expected a TickSpec Scenario row, got %O" (other.GetType())

--- a/plans/in-progress/adopt-beavernest-test-automation/learnings.md
+++ b/plans/in-progress/adopt-beavernest-test-automation/learnings.md
@@ -185,3 +185,39 @@ that globs for sources disagree silently and the runner reports the build tool's
 `**/.next/**` in the affected project restored `build` and `test:quick` to being composable in one
 workspace.
 Route:
+
+## L-10: A no-data placeholder turned an unreadable corpus into a passing suite
+
+Repository relevance: public
+Observation: `apps/crane-cli/tests/unit/Suite.fs` resolved its Gherkin corpus from `GHERKIN_ROOT`
+and fell back to `specs/apps/crane/behavior/cli/gherkin`, the path Phase 5 retired. `GHERKIN_ROOT`
+is set nowhere, so the fallback ran, `Directory.Exists` returned false, and `buildScenarioData`
+answered with a single no-op row — added deliberately "so `[Theory]` does not fail with No data
+found". `nx run crane-cli:test:unit` reported 99 passing tests; with the path corrected it reports 135. Thirty-six scenarios had been dark, and all thirty-six passed the moment they were loaded, so
+the twelve step-definition files were never wrong. `specs:behavior:coverage` also passed throughout,
+because it scans step sources statically and never asks whether the runtime found the corpus.
+Durable prevention: a suite that loads no scenarios must fail, not degrade. Treat a missing corpus
+directory, an unreadable feature file, and an empty expansion as three distinct errors that each
+name the offending path, and never wrap per-file parsing in a `with _ -> Seq.empty` that turns a
+binding defect into an empty set. Verify such a guard by pointing it at a path that does not exist
+and asserting a non-zero exit — the same path had been exiting 0.
+Route:
+
+## L-11: The Phase 4 enforcement foundation is built but almost entirely unwired
+
+Repository relevance: public
+Observation: grepping every `gates:` entry in `repo-config.yml`, every `apps/*/project.json` and
+`libs/*/project.json` target, and every `.github/workflows/*.yml` for the six `test-contract`
+validators returns zero call sites for all six. Only `parity manifest validate` (1) and
+`specs structure validate` (19) are wired. Four of the six — `bdd`, `coverage`, `layout`,
+`manifest` — require `--fixture <NAME>.json` and read only the fixture corpus, so their being
+ungated is the known L-8 gap rather than a defect. But `test-contract registry validate` and
+`registry validate-mapping` both read the real `repo-config.yml` and run against the repository
+today, and neither is invoked by anything. `registry validate` had been exiting 1 on `main` with
+seven findings, five of them naming `wahidyankf-www` and `wahidyankf-www-fe-e2e`, projects deleted
+in #423 — the orphans survived precisely because no gate asked.
+Durable prevention: a validator that reads real repository state is finished only when something
+runs it. Register the gate in the same delivery unit that builds the validator, and prove the wiring
+by making the repository violate the rule and watching the gate fail — an unwired validator and a
+passing one are indistinguishable from the exit code of any gate run.
+Route:

--- a/repo-config.yml
+++ b/repo-config.yml
@@ -216,7 +216,7 @@ coverage:
     # crane domain
     - name: crane-cli
       levels: [unit, integration]
-      specs: "specs/apps/crane/behavior/cli/**"
+      specs: "specs/apps/crane/cli/behaviors/**"
 
     # libs
     - name: web-ui
@@ -295,11 +295,11 @@ testing:
         state: identity
         legacy:
           present: true
-          corpus: "specs/apps/crane/behavior/cli/**"
+          corpus: "specs/apps/crane/cli/behaviors/**"
           levels: [unit, integration]
         canonical:
           owner: crane-cli
-          corpus: "specs/apps/crane/behavior/cli/**"
+          corpus: "specs/apps/crane/cli/behaviors/**"
           runtimes:
             - level: integration
               project: crane-cli
@@ -583,34 +583,6 @@ testing:
           runtimes:
             - level: unit
               project: ts-env-loader
-      - project: wahidyankf-www
-        behavior-id: wahidyankf-www:default
-        state: identity
-        legacy:
-          present: true
-          corpus: "specs/apps/wahidyankf/behavior/www/**"
-          levels: [unit]
-        canonical:
-          owner: wahidyankf-www
-          corpus: "specs/apps/wahidyankf/behavior/www/**"
-          runtimes:
-            - level: e2e
-              project: wahidyankf-www-fe-e2e
-            - level: unit
-              project: wahidyankf-www
-      - project: wahidyankf-www-fe-e2e
-        behavior-id: wahidyankf-www:default
-        state: identity
-        legacy:
-          present: true
-          corpus: "specs/apps/wahidyankf/behavior/www/**"
-          levels: [e2e]
-        canonical:
-          owner: wahidyankf-www
-          corpus: null
-          runtimes:
-            - level: e2e
-              project: wahidyankf-www-fe-e2e
       - project: web-ui
         behavior-id: web-ui:default
         state: identity
@@ -706,7 +678,7 @@ testing:
         lifecycle-state: active
         owner: crane-cli
         corpus:
-          - "specs/apps/crane/behavior/cli/**"
+          - "specs/apps/crane/cli/behaviors/**"
         adapters:
           unit:
             disposition: required
@@ -1116,46 +1088,6 @@ testing:
           e2e:
             disposition: inapplicable
             reason: no user-facing surface
-    - project: wahidyankf-www
-      profile: application
-      migration-state: verified
-      behavior:
-        id: wahidyankf-www:default
-        lifecycle-state: active
-        owner: wahidyankf-www
-        corpus:
-          - "specs/apps/wahidyankf/behavior/www/**"
-        adapters:
-          unit:
-            disposition: required
-            project: wahidyankf-www
-            driver: apps/wahidyankf-www/tests/unit/bdd/unit-driver.ts
-          integration:
-            disposition: inapplicable
-            reason: no isolated local-resource boundary
-          e2e:
-            disposition: delegated
-            project: wahidyankf-www-fe-e2e
-            driver: apps/wahidyankf-www-fe-e2e/tests/e2e/bdd/e2e-driver.ts
-    - project: wahidyankf-www-fe-e2e
-      profile: e2e
-      migration-state: verified
-      behavior:
-        id: wahidyankf-www:default
-        lifecycle-state: active
-        owner: wahidyankf-www
-        corpus: []
-        adapters:
-          unit:
-            disposition: inapplicable
-            reason: the owning project hosts the unit adapter
-          integration:
-            disposition: inapplicable
-            reason: no isolated local-resource boundary
-          e2e:
-            disposition: required
-            project: wahidyankf-www-fe-e2e
-            driver: apps/wahidyankf-www-fe-e2e/tests/e2e/bdd/e2e-driver.ts
     - project: web-ui
       profile: library
       migration-state: verified


### PR DESCRIPTION
## What

`crane-cli`'s unit suite has been running 36 fewer tests than it looked like it was running. This restores them.

`apps/crane-cli/tests/unit/Suite.fs` resolved its corpus from `GHERKIN_ROOT`, falling back to `specs/apps/crane/behavior/cli/gherkin` — the path Phase 5 retired. `GHERKIN_ROOT` is set nowhere in `apps/crane-cli/project.json` or the test tree, so the fallback is what ran. `Directory.Exists` returned false, and `buildScenarioData` answered with a single no-op row:

```fsharp
if List.isEmpty loaded then
    // Placeholder: step definitions not yet implemented.
    // Returns a single no-op row so [Theory] does not fail with "No data found".
    Seq.singleton [| box "no-op" |]
```

That guard is what converted a corpus that could not be read into a green target.

**Measured, not inferred:**

| | `nx run crane-cli:test:unit --skip-nx-cache` |
| --- | --- |
| before | `Passed! - Failed: 0, Passed: 99, Total: 99` |
| after | `Passed! - Failed: 0, Passed: 135, Total: 135` |

The 36 scenarios were never broken. The 12 step-definition files under `tests/unit/Steps/` bind them correctly and always did — only the root path was wrong, so all 36 pass the moment they are loaded.

## The placeholder is removed, not repaired

A missing directory, an unreadable feature file, and an empty corpus now each raise with the offending path named. Falsified in both directions:

- corpus present → `Passed! ... Total: 135`, exit 0
- `GHERKIN_ROOT` pointed back at the retired path → exit 1, `System.Exception : the Gherkin corpus directory does not exist: .../specs/apps/crane/behavior/cli/gherkin`

That second run is the point: **the same path that now exits 1 previously exited 0.** An exit code that cannot distinguish "passed" from "read nothing" is not a test result.

## Registry corrections

`repo-config.yml` carried the retired crane glob in four places (219, 298, 302, 709) while `apps/crane-cli/project.json` had already been updated to `specs/apps/crane/cli/behaviors`. The registry and the project disagreed, and neither failed. All four now agree.

It also still declared `wahidyankf-www` and `wahidyankf-www-fe-e2e` across four blocks, against a corpus glob matching no file. Both projects were deleted in #423 and neither appears in `nx show projects`. `rhino-cli test-contract registry validate` went from **seven findings to one**; the survivor is `fsharp-env-loader`'s `bootstrap` lifecycle-state, which is by design until Phase 8B.

## What this PR deliberately does not do

The integration tier still reports a single no-op row. `tests/integration/Steps/{PdfSteps,OcrSteps}.fs` are one line each — a module declaration and no bindings at all — and every one of the 37 scenarios in the corpus is tagged `@unit`, so no scenario declares an integration-level obligation. Whether that adapter gets built or governed as `inapplicable` under AC-TEST-06 is a Phase 6 design decision, not a bug fix, and it does not belong in the same commit as a measured regression fix. Its corpus path is corrected here so the follow-up starts from one fewer confound.

## Cost / benefit

Net −64 lines. The suite gains three failure paths it did not have, each naming the path it could not read; it loses the branch that swallowed all three. The benefit is 36 scenarios of `crane-cli` behaviour that are now actually executed on every `test:quick`, plus a registry that no longer claims two deleted projects.

## Verification

- `nx run-many -t typecheck,lint,test:quick,test:integration -p crane-cli --skip-nx-cache` — exit 0.
- `rhino-cli gate run --surface=pre-push` — exit 0.
- `rhino-cli test-contract registry validate` — 7 findings → 1 (expected bootstrap).
- `fantomas` applied; no parity-boundary path touched, so no cross-repo propagation is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second commit: plan learnings

`8c94de1e6` appends two entries to the plan's `learnings.md`:

- **L-10** — the no-op placeholder row, added so `[Theory]` would not fail with "No data found", is what turned an unreadable corpus into a passing suite. `specs:behavior:coverage` passed throughout, because it scans step sources statically and never asks whether the runtime found the corpus — so neither signal available at the time could have caught this.
- **L-11** — all six `test-contract` validators built in Phase 4 have **zero call sites** across `gates:`, every `project.json`, and every workflow. Four of them read only fixtures, which is the known L-8 gap and not a defect. But `registry validate` and `registry validate-mapping` read the real `repo-config.yml` and are gated nowhere — which is exactly why the `wahidyankf` orphans this PR removes survived from #423 until now. Wiring those two is filed as follow-up work, not done here.
