### PR TITLE
docs(social): add Week 41 LinkedIn update

### DIFF
--- a/social-media-posts/linkedin/2026/2026-09-02__linkedin__ose-update-week-0041.md
+++ b/social-media-posts/linkedin/2026/2026-09-02__linkedin__ose-update-week-0041.md
@@ -1,0 +1,46 @@
+Posted: Wednesday, September 2, 2026
+Platform: LinkedIn
+Window: 2026-08-26 07:33:08 +0700 → 2026-09-02 18:41:48 +0700. ~344 commits across three repos (ose-public 151, ose-private 68, beaver-nest 125).
+
+---
+
+OPEN SHARIA ENTERPRISE
+Week 41
+
+Highlights: BeaverNest became an always-available family service: accounts protect centralized SQLite state, resilient releases preserve live sessions, and verified backups protect the result. Meanwhile, Rhino's reviewed Rust-to-F# rewrite shipped across both OSE repositories.
+
+🌐 Cross-repo
+
+The F# Rhino remains behavior-equivalent across 13 namespaces and all 519 retained scenarios, with a much smaller code surface. That should lower context and token demand for agent-assisted changes. Edit–rebuild is slower; the ~93 MB self-contained artifact is a real distribution cost. The ~64 ms startup penalty is small for this internal CLI; one controlled pre-commit run improved from 14.24s to 4.19s.
+
+Specifications now sit with the product, app, library, or tool they describe. New gates verify project mappings, BDD evidence, and coverage policy. Independent BeaverNest's testing and coding-harness lessons now feed the OSE siblings.
+
+🌳 ose-public
+
+The logical-owner model now covers CLI, AyoKoding, libraries, OrganicLever, and OSE; the old five-folder spec tree is rejected. Initial test-contract migrations exposed cache-serialization and environment-test concurrency defects, now covered by regressions.
+
+wahidyankf-www now lives in grind-in-public rather than OSE. CI uploads must also declare retention explicitly.
+
+🏗️ ose-private
+
+Private reached the same F# Rhino endpoint and owner-centric specification model, preserving parity without keeping two implementations alive. Delivery rules now retain portable worktree identity, explicit tester outputs, and recovery evidence.
+
+🦦 BeaverNest
+
+One-time family setup, persistent login, and role-aware access now protect centralized chat, learning, and theme records. A checksum-verified, recoverable cutover moved them into private SQLite; old sources remain until the routed generation is proven.
+
+The always-on route promotes immutable Phoenix releases behind Caddy without dropping the healthy slot. LiveView and Codex progress survive compatible reconnects. Parents and children stay read-only; only an eligible admin may temporarily enable repository writes.
+
+A durable scheduler runs independently verified backups and records receipts, with controls restricted to admins. A Go resource guard admits heavy work only when capacity is safe, serializes competing runs, and protects the serving app from development pressure.
+
+🔜 Next 2–4 weeks
+
+Continue rolling the test contract across remaining public/private owners while preserving Rhino parity. BeaverNest's next planned step is a reusable family learning engine with authored subjects, mastery, review, parent verification, and a generic mission runner—still backlog, not shipped.
+
+Insha Allah.
+
+- ose-public: https://github.com/wahidyankf/ose-public
+- BeaverNest: https://github.com/wahidyankf/beaver-nest
+- OrganicLever: https://www.organiclever.com/
+- Updates: https://www.oseplatform.com/updates/
+- Learning: https://www.ayokoding.com


### PR DESCRIPTION
## Summary

- add the Week 41 LinkedIn update covering completed origin/main work in ose-public, ose-private, and BeaverNest
- record the Rhino Rust-to-F# outcome and measured trade-offs without overstating inferred token savings
- distinguish shipped BeaverNest reliability work from the learning-engine backlog

## Verification

- pre-push repository gates passed
- markdownlint: 0 errors
- LinkedIn body: 2,984 of 3,000 characters
- current-head content audit: no secret, protected environment value, or machine-specific path found

## Surface gates

EXEMPT — Markdown-only LinkedIn post; no reachable UI, API, or runtime behavior changed. Markdown validation remains covered by the Quality gate.

## Cost and benefit

Cost: one maintained social-post artifact. Benefit: a concise, evidence-backed weekly update across all three repositories.