### PR TITLE
test(organiclever-be): migrate to the target test contract (Phase 15)

### DIFF
--- a/apps/organiclever-be/project.json
+++ b/apps/organiclever-be/project.json
@@ -86,7 +86,7 @@
     "test:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "dotnet test apps/organiclever-be/tests/unit/OrganicleverBe.UnitTests.fsproj --collect:\"XPlat Code Coverage\" /p:Threshold=80 /p:ThresholdType=line"
+        "command": "dotnet test apps/organiclever-be/tests/unit/OrganicleverBe.UnitTests.fsproj /p:CollectCoverage=true /p:Threshold=99 \"/p:Include=[OrganicleverBe]*\" /p:ThresholdType=line \"/p:ExcludeByFile=**/OrganicleverBe/Program.fs%2C**/Contexts/Db/Infrastructure/DbMigrations.fs%2C**/Contexts/Journal/Infrastructure/JournalInfrastructure.fs%2C**/Contexts/Messaging/Infrastructure/JetStreamDemo.fs%2C**/Infrastructure/NatsConnect.fs\""
       },
       "cache": true,
       "inputs": ["{projectRoot}/src/**/*.fs", "{projectRoot}/tests/unit/**/*.fs"]
@@ -99,7 +99,10 @@
           "npx nx run organiclever-be:lint",
           "npx nx run organiclever-be:test:unit",
           "npx nx run organiclever-be:test:coverage",
-          "npx nx run organiclever-be:test:specs"
+          "npx nx run organiclever-be:test:specs",
+          "npx nx run organiclever-be:test:layout:validation",
+          "npx nx run organiclever-be:coverage:policy:validation",
+          "npx nx run organiclever-be:package-manifest:policy:validation"
         ],
         "parallel": false
       },
@@ -162,6 +165,30 @@
       },
       "cache": true,
       "inputs": ["default", "specs"]
+    },
+    "test:layout:validation": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "apps/rhino-cli/scripts/rhino-bin.sh test-contract layout validate --project organiclever-be"
+      },
+      "cache": true,
+      "inputs": ["default", "{projectRoot}/project.json"]
+    },
+    "coverage:policy:validation": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "apps/rhino-cli/scripts/rhino-bin.sh test-contract coverage validate --project organiclever-be"
+      },
+      "cache": true,
+      "inputs": ["default", "{projectRoot}/project.json"]
+    },
+    "package-manifest:policy:validation": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "apps/rhino-cli/scripts/rhino-bin.sh test-contract manifest validate --project organiclever-be"
+      },
+      "cache": true,
+      "inputs": ["default", "{projectRoot}/project.json"]
     }
   },
   "namedInputs": {

--- a/apps/organiclever-be/src/OrganicleverBe/Contexts/Db/Infrastructure/DbMigrations.fs
+++ b/apps/organiclever-be/src/OrganicleverBe/Contexts/Db/Infrastructure/DbMigrations.fs
@@ -1,5 +1,6 @@
 namespace OrganicleverBe.Contexts.Db
 
+open System.Diagnostics.CodeAnalysis
 open System.Reflection
 open DbUp
 
@@ -12,6 +13,7 @@ module Infrastructure =
     /// Applies all pending embedded migrations to the given PostgreSQL connection
     /// string. The migration scripts live as embedded resources in the
     /// OrganicleverBe assembly. Fails fast if any script cannot be applied.
+    [<ExcludeFromCodeCoverage(Justification = "Integration-tested against real PostgreSQL — see tests/integration/DatabaseBootTests.fs")>]
     let runMigrations (connStr: string) : unit =
         let result =
             DeployChanges.To

--- a/apps/organiclever-be/src/OrganicleverBe/Contexts/Journal/Infrastructure/JournalInfrastructure.fs
+++ b/apps/organiclever-be/src/OrganicleverBe/Contexts/Journal/Infrastructure/JournalInfrastructure.fs
@@ -1,6 +1,7 @@
 namespace OrganicleverBe.Contexts.Journal
 
 open System
+open System.Diagnostics.CodeAnalysis
 open System.Linq
 open System.Threading.Tasks
 open Microsoft.EntityFrameworkCore
@@ -56,6 +57,7 @@ module Infrastructure =
           UpdatedAt = r.UpdatedAt }
 
     /// Builds the EF-backed journal repository over an AppDbContext.
+    [<ExcludeFromCodeCoverage(Justification = "Integration-tested against real PostgreSQL — see tests/integration/JournalRepositoryTests.fs")>]
     let efRepository (db: AppDbContext) : JournalRepository =
         { Create =
             fun row ->

--- a/apps/organiclever-be/src/OrganicleverBe/Contexts/Messaging/Infrastructure/JetStreamDemo.fs
+++ b/apps/organiclever-be/src/OrganicleverBe/Contexts/Messaging/Infrastructure/JetStreamDemo.fs
@@ -1,5 +1,6 @@
 namespace OrganicleverBe.Contexts.Messaging
 
+open System.Diagnostics.CodeAnalysis
 open System.Text
 open System.Threading.Tasks
 open NATS.Client.Core
@@ -26,6 +27,7 @@ module Infrastructure =
     /// Runs the JetStream durable demo against a connected NATS client: create or
     /// get the stream and durable consumer, publish one demo message, then fetch
     /// and acknowledge it. Returns the outcome.
+    [<ExcludeFromCodeCoverage(Justification = "Requires a live NATS JetStream broker; e2e-tested per the @e2e-tagged specs/apps/organiclever/be/behaviors/messaging/jetstream-demo.feature, owned by organiclever-be-e2e")>]
     let runDemo (conn: NatsConnection) : Task<JetStreamDemoOutcome> =
         task {
             try

--- a/apps/organiclever-be/src/OrganicleverBe/Handlers/HealthHandler.fs
+++ b/apps/organiclever-be/src/OrganicleverBe/Handlers/HealthHandler.fs
@@ -3,11 +3,6 @@ module OrganicleverBe.Handlers.HealthHandler
 open Giraffe
 open OpenAPI.OrganicleverBe.Contracts.HealthResponse
 
-/// GET /health → 200 with a JSON health payload.
+/// GET /health → 200 with a JSON health payload. Wired into the real
+/// composition root at `OrganicleverBe.WebApp.buildWebApp`.
 let healthHandler: HttpHandler = fun next ctx -> json { Status = "ok" } next ctx
-
-/// Composition of the health route. Bounded-context routes are added in later phases.
-let webApp: HttpHandler =
-    choose
-        [ GET >=> route "/health" >=> healthHandler
-          RequestErrors.NOT_FOUND "Not Found" ]

--- a/apps/organiclever-be/src/OrganicleverBe/Infrastructure/NatsClient.fs
+++ b/apps/organiclever-be/src/OrganicleverBe/Infrastructure/NatsClient.fs
@@ -1,8 +1,6 @@
 module OrganicleverBe.Infrastructure.NatsClient
 
 open System
-open System.Threading.Tasks
-open NATS.Client.Core
 
 /// Reads ORGANICLEVER_BE_NATS_URL or falls back to the default local NATS URL.
 let natsUrl () : string =
@@ -10,20 +8,3 @@ let natsUrl () : string =
     | null
     | "" -> "nats://localhost:4222"
     | value -> value
-
-/// Opens a best-effort NATS.Net connection on boot. Messaging is exercised at the
-/// e2e level (JetStream demo, later phases); a failed connect here logs and is
-/// non-fatal so the HTTP host still serves /health.
-let connectAsync (url: string) : Task<NatsConnection option> =
-    task {
-        let conn = new NatsConnection(NatsOpts(Url = url))
-
-        try
-            do! conn.ConnectAsync()
-            printfn "NATS connected: %s" url
-            return Some conn
-        with ex ->
-            eprintfn "NATS connect failed (%s): %s" url ex.Message
-            do! conn.DisposeAsync()
-            return None
-    }

--- a/apps/organiclever-be/src/OrganicleverBe/Infrastructure/NatsConnect.fs
+++ b/apps/organiclever-be/src/OrganicleverBe/Infrastructure/NatsConnect.fs
@@ -1,0 +1,31 @@
+module OrganicleverBe.Infrastructure.NatsConnect
+
+open System.Diagnostics.CodeAnalysis
+open System.Threading.Tasks
+open NATS.Client.Core
+
+/// Opens a best-effort NATS.Net connection on boot. Messaging is exercised at the
+/// e2e level (JetStream demo, later phases); a failed connect here logs and is
+/// non-fatal so the HTTP host still serves /health.
+///
+/// The success path requires a live NATS broker; e2e-tested per the
+/// @e2e-tagged specs/apps/organiclever/be/behaviors/messaging/nats-connect.feature,
+/// owned by organiclever-be-e2e. The graceful-failure path is unit-tested
+/// directly in Tests/NatsClientTests.fs. Kept in its own file (rather than
+/// alongside the pure, fully unit-tested `natsUrl` in NatsClient.fs) so the
+/// project-level coverage `/p:ExcludeByFile` can exclude exactly this
+/// live-broker-only surface.
+[<ExcludeFromCodeCoverage(Justification = "Requires a live NATS broker to connect — see module doc comment above")>]
+let connectAsync (url: string) : Task<NatsConnection option> =
+    task {
+        let conn = new NatsConnection(NatsOpts(Url = url))
+
+        try
+            do! conn.ConnectAsync()
+            printfn "NATS connected: %s" url
+            return Some conn
+        with ex ->
+            eprintfn "NATS connect failed (%s): %s" url ex.Message
+            do! conn.DisposeAsync()
+            return None
+    }

--- a/apps/organiclever-be/src/OrganicleverBe/OrganicleverBe.fsproj
+++ b/apps/organiclever-be/src/OrganicleverBe/OrganicleverBe.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="Infrastructure/AppDbContext.fs" />
     <Compile Include="Infrastructure/Database.fs" />
     <Compile Include="Infrastructure/NatsClient.fs" />
+    <Compile Include="Infrastructure/NatsConnect.fs" />
     <!-- env context (tiered .env.<APP_ENV> loader) -->
     <Compile Include="Contexts/Env/Infrastructure/EnvTier.fs" />
     <!-- db context (DbUp migration routine) -->

--- a/apps/organiclever-be/src/OrganicleverBe/Program.fs
+++ b/apps/organiclever-be/src/OrganicleverBe/Program.fs
@@ -9,6 +9,7 @@ open Giraffe
 open OrganicleverBe.Infrastructure.AppDbContext
 open OrganicleverBe.Infrastructure.Database
 open OrganicleverBe.Infrastructure.NatsClient
+open OrganicleverBe.Infrastructure.NatsConnect
 open OrganicleverBe.Contexts.Db.Infrastructure
 open OrganicleverBe.Contexts.Env.Infrastructure
 open OrganicleverBe.Contexts.Messaging.Application

--- a/apps/organiclever-be/src/OrganicleverBe/WebApp.fs
+++ b/apps/organiclever-be/src/OrganicleverBe/WebApp.fs
@@ -2,6 +2,7 @@ module OrganicleverBe.WebApp
 
 open Microsoft.Extensions.DependencyInjection
 open Giraffe
+open OrganicleverBe.Handlers.HealthHandler
 open OrganicleverBe.Infrastructure.AppDbContext
 open OrganicleverBe.Contexts.Journal.Infrastructure
 open OrganicleverBe.Contexts.Messaging.Application
@@ -21,7 +22,7 @@ let private journalRoutes: HttpHandler =
 /// existing liveness probe.
 let buildWebApp (status: SharedMessagingStatus) : HttpHandler =
     choose
-        [ GET >=> route "/health" >=> json {| status = "ok" |}
+        [ GET >=> route "/health" >=> healthHandler
           OrganicleverBe.Contexts.Health.Api.routes
           journalRoutes
           OrganicleverBe.Contexts.Messaging.Api.routes status

--- a/apps/organiclever-be/tests/unit/OrganicleverBe.UnitTests.fsproj
+++ b/apps/organiclever-be/tests/unit/OrganicleverBe.UnitTests.fsproj
@@ -23,6 +23,10 @@
     <Compile Include="Tests/JournalApiTests.fs" />
     <Compile Include="Tests/MessagingTests.fs" />
     <Compile Include="Tests/EnvTierLoaderTests.fs" />
+    <Compile Include="Tests/DatabaseTests.fs" />
+    <Compile Include="Tests/AppDbContextTests.fs" />
+    <Compile Include="Tests/NatsClientTests.fs" />
+    <Compile Include="Tests/WebAppTests.fs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -37,6 +41,14 @@
     <!-- Keep the test host's explicit FSharp.Core floor compatible with the
          shared loader project reference. -->
     <PackageReference Update="FSharp.Core" Version="10.1.400" />
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="8.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/organiclever-be/tests/unit/Tests/AppDbContextTests.fs
+++ b/apps/organiclever-be/tests/unit/Tests/AppDbContextTests.fs
@@ -1,0 +1,31 @@
+module OrganicleverBe.Tests.Unit.Tests.AppDbContextTests
+
+open Microsoft.EntityFrameworkCore
+open Xunit
+open OrganicleverBe.Infrastructure.AppDbContext
+
+/// A DbContextOptions pointed at an unreachable PostgreSQL host. Building the
+/// context and its model from these options never opens a connection — EF Core
+/// only connects when a query actually executes — so this exercises the
+/// context's own construction, model building, and DbSet accessors without any
+/// live database.
+let private unreachableOptions () : DbContextOptions<AppDbContext> =
+    DbContextOptionsBuilder<AppDbContext>()
+        .UseNpgsql("Host=127.0.0.1;Port=1;Database=organiclever_be_unit_test;Username=x;Password=x")
+        .UseSnakeCaseNamingConvention()
+        .Options
+
+[<Fact>]
+let ``AppDbContext builds its model on construction without connecting`` () =
+    use ctx = new AppDbContext(unreachableOptions ())
+    // Accessing .Model lazily triggers OnModelCreating; this is pure metadata
+    // construction and never opens a database connection.
+    Assert.NotNull(box ctx.Model)
+
+[<Fact>]
+let ``AppDbContext exposes a gettable and settable JournalEntries DbSet`` () =
+    use ctx = new AppDbContext(unreachableOptions ())
+    let originalSet = ctx.JournalEntries
+    Assert.NotNull(box originalSet)
+    ctx.JournalEntries <- originalSet
+    Assert.Same(originalSet, ctx.JournalEntries)

--- a/apps/organiclever-be/tests/unit/Tests/DatabaseTests.fs
+++ b/apps/organiclever-be/tests/unit/Tests/DatabaseTests.fs
@@ -1,0 +1,33 @@
+module OrganicleverBe.Tests.Unit.Tests.DatabaseTests
+
+open System
+open Xunit
+open OrganicleverBe.Infrastructure.Database
+
+/// Saves and restores DATABASE_URL around a test body so this module's
+/// mutations of process-wide environment state never leak into other tests.
+let private withDatabaseUrl (value: string option) (body: unit -> unit) =
+    let previous = Environment.GetEnvironmentVariable("DATABASE_URL")
+
+    try
+        Environment.SetEnvironmentVariable("DATABASE_URL", (defaultArg value null))
+        body ()
+    finally
+        Environment.SetEnvironmentVariable("DATABASE_URL", previous)
+
+[<Fact>]
+let ``requireDatabaseUrl returns the configured connection string`` () =
+    withDatabaseUrl (Some "Host=localhost;Database=organiclever_be;Username=x;Password=x") (fun () ->
+        Assert.Equal("Host=localhost;Database=organiclever_be;Username=x;Password=x", requireDatabaseUrl ()))
+
+[<Fact>]
+let ``requireDatabaseUrl fails fast when DATABASE_URL is unset`` () =
+    withDatabaseUrl None (fun () ->
+        let ex = Assert.Throws<Exception>(fun () -> requireDatabaseUrl () |> ignore)
+        Assert.Contains("DATABASE_URL", ex.Message))
+
+[<Fact>]
+let ``requireDatabaseUrl fails fast when DATABASE_URL is blank`` () =
+    withDatabaseUrl (Some "") (fun () ->
+        let ex = Assert.Throws<Exception>(fun () -> requireDatabaseUrl () |> ignore)
+        Assert.Contains("DATABASE_URL", ex.Message))

--- a/apps/organiclever-be/tests/unit/Tests/HealthContextTests.fs
+++ b/apps/organiclever-be/tests/unit/Tests/HealthContextTests.fs
@@ -7,6 +7,10 @@ open OrganicleverBe.Contexts.Health.Api
 open OrganicleverBe.Tests.Unit.Steps.BddState
 
 [<Fact>]
+let ``the health context declares it has no infrastructure dependencies`` () =
+    Assert.False(OrganicleverBe.Contexts.Health.Infrastructure.hasInfrastructureDependencies)
+
+[<Fact>]
 let ``getHealth reports healthy`` () =
     let status = getHealth ()
     Assert.Equal("ok", status.Status)

--- a/apps/organiclever-be/tests/unit/Tests/HealthHandlerTests.fs
+++ b/apps/organiclever-be/tests/unit/Tests/HealthHandlerTests.fs
@@ -2,7 +2,7 @@ module OrganicleverBe.Tests.Unit.Tests.HealthHandlerTests
 
 open System.Net
 open Xunit
-open OrganicleverBe.Handlers.HealthHandler
+open OrganicleverBe.WebApp
 open OrganicleverBe.Tests.Unit.Steps.BddState
 
 [<Fact>]

--- a/apps/organiclever-be/tests/unit/Tests/JournalApiTests.fs
+++ b/apps/organiclever-be/tests/unit/Tests/JournalApiTests.fs
@@ -1,9 +1,12 @@
 module OrganicleverBe.Tests.Unit.Tests.JournalApiTests
 
+open System
 open System.Net
 open System.Net.Http
 open System.Text
+open System.Threading.Tasks
 open Xunit
+open OrganicleverBe.Contexts.Journal.Infrastructure
 open OrganicleverBe.Contexts.Journal.Application
 open OrganicleverBe.Contexts.Journal.Api
 open OrganicleverBe.Tests.Unit.Steps.BddState
@@ -13,6 +16,28 @@ open OrganicleverBe.Tests.Unit.Steps.BddState
 let private journalClient () : HttpClient =
     let repo = inMemoryRepository ()
     buildClient (routes repo)
+
+/// A fixed row whose stored `Payload` is not valid JSON, letting a test drive
+/// the wire-serialisation fallback in `entryToWire` without needing a real
+/// storage layer to produce a corrupt row.
+let private rowWithInvalidPayload: JournalEntryRow =
+    { Id = "bad-payload-1"
+      Name = "reading"
+      Payload = "not valid json{"
+      StartedAt = DateTime.UtcNow
+      FinishedAt = DateTime.UtcNow
+      Labels = [||]
+      CreatedAt = DateTime.UtcNow
+      UpdatedAt = DateTime.UtcNow }
+
+/// A repository stub that always serves `rowWithInvalidPayload`, regardless of
+/// which id is requested.
+let private repoWithInvalidPayload () : JournalRepository =
+    { Create = fun _ -> Task.FromResult rowWithInvalidPayload
+      FindById = fun _ -> Task.FromResult(Some rowWithInvalidPayload)
+      List = fun () -> Task.FromResult [ rowWithInvalidPayload ]
+      Update = fun _ -> Task.FromResult(Some rowWithInvalidPayload)
+      Delete = fun _ -> Task.FromResult true }
 
 let private jsonContent (body: string) : StringContent =
     new StringContent(body, Encoding.UTF8, "application/json")
@@ -123,3 +148,78 @@ let ``DELETE a missing journal entry returns 404`` () =
     let client = journalClient ()
     let resp = client.DeleteAsync("/api/v1/journal/entries/does-not-exist").Result
     Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode)
+
+[<Fact>]
+let ``POST journal entries with only a name defaults every optional field`` () =
+    let client = journalClient ()
+    let minimal = "{\"name\":\"reading\"}"
+
+    let resp = client.PostAsync("/api/v1/journal/entries", jsonContent minimal).Result
+
+    Assert.Equal(HttpStatusCode.Created, resp.StatusCode)
+    let body = resp.Content.ReadAsStringAsync().Result
+    Assert.Contains("reading", body)
+
+[<Fact>]
+let ``POST journal entries with malformed JSON returns 400`` () =
+    let client = journalClient ()
+
+    let resp =
+        client.PostAsync("/api/v1/journal/entries", jsonContent "{not valid json").Result
+
+    Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode)
+
+[<Fact>]
+let ``PUT a journal entry with malformed JSON returns 400`` () =
+    let client = journalClient ()
+
+    let created =
+        client.PostAsync("/api/v1/journal/entries", jsonContent validEntryJson).Result
+
+    let id = extractId (created.Content.ReadAsStringAsync().Result)
+
+    let resp =
+        client.PutAsync(sprintf "/api/v1/journal/entries/%s" id, jsonContent "{not valid json").Result
+
+    Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode)
+
+[<Fact>]
+let ``PUT a journal entry without a name field updates only the supplied fields`` () =
+    let client = journalClient ()
+
+    let created =
+        client.PostAsync("/api/v1/journal/entries", jsonContent validEntryJson).Result
+
+    let id = extractId (created.Content.ReadAsStringAsync().Result)
+    let update = "{\"payload\":{\"title\":\"Refactoring\"}}"
+
+    let resp =
+        client.PutAsync(sprintf "/api/v1/journal/entries/%s" id, jsonContent update).Result
+
+    Assert.Equal(HttpStatusCode.OK, resp.StatusCode)
+    let body = resp.Content.ReadAsStringAsync().Result
+    Assert.Contains("reading", body)
+    Assert.Contains("Refactoring", body)
+
+[<Fact>]
+let ``PUT a journal entry with an invalid name format returns 400`` () =
+    let client = journalClient ()
+
+    let created =
+        client.PostAsync("/api/v1/journal/entries", jsonContent validEntryJson).Result
+
+    let id = extractId (created.Content.ReadAsStringAsync().Result)
+    let update = "{\"name\":\"Invalid Name\"}"
+
+    let resp =
+        client.PutAsync(sprintf "/api/v1/journal/entries/%s" id, jsonContent update).Result
+
+    Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode)
+
+[<Fact>]
+let ``GET a journal entry whose stored payload is not valid JSON still serialises`` () =
+    let client = buildClient (routes (repoWithInvalidPayload ()))
+    let resp = client.GetAsync("/api/v1/journal/entries/bad-payload-1").Result
+    Assert.Equal(HttpStatusCode.OK, resp.StatusCode)
+    let body = resp.Content.ReadAsStringAsync().Result
+    Assert.Contains("bad-payload-1", body)

--- a/apps/organiclever-be/tests/unit/Tests/JournalDomainTests.fs
+++ b/apps/organiclever-be/tests/unit/Tests/JournalDomainTests.fs
@@ -34,6 +34,14 @@ let ``validateName rejects an uppercase name`` () =
     | Error _ -> ()
 
 [<Fact>]
+let ``validateName rejects a name longer than 64 characters`` () =
+    let tooLong = String.replicate 65 "a"
+
+    match validateName tooLong with
+    | Ok _ -> Assert.Fail("expected Error for a name over the 64-character limit")
+    | Error msg -> Assert.Contains("64", msg)
+
+[<Fact>]
 let ``validateNewEntry rejects a blank name`` () =
     let input: NewEntryInput =
         { Name = ""

--- a/apps/organiclever-be/tests/unit/Tests/MessagingTests.fs
+++ b/apps/organiclever-be/tests/unit/Tests/MessagingTests.fs
@@ -17,6 +17,10 @@ let ``outcomeToString renders the delivered-and-acked outcome`` () =
     Assert.Equal("delivered_and_acked", outcomeToString DeliveredAndAcked)
 
 [<Fact>]
+let ``outcomeToString renders a failed outcome with its reason`` () =
+    Assert.Equal("failed: NATS unavailable at startup", outcomeToString (Failed "NATS unavailable at startup"))
+
+[<Fact>]
 let ``messaging status endpoint reports pending before the demo runs`` () =
     let status = newShared ()
     let client = buildClient (routes status)

--- a/apps/organiclever-be/tests/unit/Tests/NatsClientTests.fs
+++ b/apps/organiclever-be/tests/unit/Tests/NatsClientTests.fs
@@ -1,0 +1,35 @@
+module OrganicleverBe.Tests.Unit.Tests.NatsClientTests
+
+open System
+open Xunit
+open OrganicleverBe.Infrastructure.NatsClient
+open OrganicleverBe.Infrastructure.NatsConnect
+
+let private withNatsUrl (value: string option) (body: unit -> unit) =
+    let previous = Environment.GetEnvironmentVariable("ORGANICLEVER_BE_NATS_URL")
+
+    try
+        Environment.SetEnvironmentVariable("ORGANICLEVER_BE_NATS_URL", (defaultArg value null))
+        body ()
+    finally
+        Environment.SetEnvironmentVariable("ORGANICLEVER_BE_NATS_URL", previous)
+
+[<Fact>]
+let ``natsUrl defaults to the local NATS URL when unset`` () =
+    withNatsUrl None (fun () -> Assert.Equal("nats://localhost:4222", natsUrl ()))
+
+[<Fact>]
+let ``natsUrl returns the configured URL when set`` () =
+    withNatsUrl (Some "nats://example.internal:4222") (fun () ->
+        Assert.Equal("nats://example.internal:4222", natsUrl ()))
+
+// connectAsync's success path requires a live NATS broker and is excluded from
+// unit coverage (see NatsClient.fs); this test proves the documented
+// graceful-failure behavior on a connection that cannot succeed, with no
+// broker required.
+[<Fact>]
+let ``connectAsync returns None instead of throwing when the broker is unreachable`` () =
+    let result =
+        connectAsync "nats://127.0.0.1:1" |> Async.AwaitTask |> Async.RunSynchronously
+
+    Assert.True(result.IsNone)

--- a/apps/organiclever-be/tests/unit/Tests/WebAppTests.fs
+++ b/apps/organiclever-be/tests/unit/Tests/WebAppTests.fs
@@ -1,0 +1,42 @@
+module OrganicleverBe.Tests.Unit.Tests.WebAppTests
+
+open System.Net
+open Microsoft.AspNetCore.Hosting
+open Microsoft.AspNetCore.TestHost
+open Microsoft.EntityFrameworkCore
+open Microsoft.Extensions.DependencyInjection
+open Giraffe
+open Xunit
+open OrganicleverBe.Infrastructure.AppDbContext
+open OrganicleverBe.WebApp
+open OrganicleverBe.Contexts.Messaging.Application
+
+/// Builds a test client for the real `buildWebApp` composition root, with an
+/// `AppDbContext` registered against an unreachable connection string. The
+/// journal routing surface (`journalRoutes` in WebApp.fs) resolves and builds
+/// its repository from DI on every request it sees — including a request no
+/// journal route ultimately matches — so a request that falls through to the
+/// final 404 still exercises that composition-root wiring without needing a
+/// live PostgreSQL connection.
+let private buildFullClient () : System.Net.Http.HttpClient =
+    let builder =
+        WebHostBuilder()
+            .ConfigureServices(fun services ->
+                services.AddGiraffe() |> ignore
+
+                services.AddDbContext<AppDbContext>(fun opts ->
+                    opts
+                        .UseNpgsql("Host=127.0.0.1;Port=1;Database=organiclever_be_unit_test;Username=x;Password=x")
+                        .UseSnakeCaseNamingConvention()
+                    |> ignore)
+                |> ignore)
+            .Configure(fun app -> app.UseGiraffe(buildWebApp (newShared ())))
+
+    let server = new TestServer(builder)
+    server.CreateClient()
+
+[<Fact>]
+let ``an unmatched path resolves the journal repository from DI and falls through to 404`` () =
+    let client = buildFullClient ()
+    let resp = client.GetAsync("/totally-unmatched-path").Result
+    Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode)

--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -20,7 +20,7 @@ bd65007f689a1c5ed30e1d6154b7f6b8b813994efe6b7b92d2d81c0f11de65a4  apps/rhino-cli
 625feeb23d8111c4ede63e62b386d8f5674424d7e5499ce1cf8091a8d4075649  apps/rhino-cli/src/RhinoCli.Application/src/TestContractJson.fs
 aea907ab80dca82acd86e5af31c8e4d10f304d7b20a09ae7bf276119a98455f5  apps/rhino-cli/src/RhinoCli.Application/src/TestContractLayout.fs
 954a4ae657a38fe903e6694aef748fe65d153c5b74e3a7fbfe2c9bcf867a87ba  apps/rhino-cli/src/RhinoCli.Application/src/TestContractManifest.fs
-5e8652d09ea701b9a11040fa0ab594a5579cb338cc10385835eb0b7e92101bd5  apps/rhino-cli/src/RhinoCli.Application/src/TestContractProject.fs
+e614fb87e3b58b5b7a00b25055cbf868c2bcde5bced2bd20f0665634c7d953c9  apps/rhino-cli/src/RhinoCli.Application/src/TestContractProject.fs
 16bfb1fb1c2610c25f0cdc765dd65572bf5d4dfa40aa2c8249b25fd12cefa6d8  apps/rhino-cli/src/RhinoCli.Application/src/TestCoverage.fs
 bf6df2031e43d7352bd145de54960b18c4934b7a8ea160fd358d345fc5b3b58c  apps/rhino-cli/src/RhinoCli.Cli/RhinoCli.Cli.fsproj
 abc917372177ea12ec695222c0889b1d502c70f00407a5c613306f2ed8c28676  apps/rhino-cli/src/RhinoCli.Cli/src/Dispatch.fs

--- a/apps/rhino-cli/src/RhinoCli.Application/src/TestContractProject.fs
+++ b/apps/rhino-cli/src/RhinoCli.Application/src/TestContractProject.fs
@@ -391,6 +391,35 @@ let private compileList (repoRoot: string) (projectFile: string) : string list =
     |> Seq.map (fun m -> joinRelative directory (forwardSlashes m.Groups.["value"].Value))
     |> Seq.toList
 
+/// The `.fsproj`/`.csproj` tokens one `dotnet test` command line names,
+/// resolved against `cwd`. Shared by the direct `dotnet test` command shape
+/// and the wrapper-script shape below, which apply this to different text
+/// (the command itself, versus a script the command invokes).
+let private dotnetProjectTokens (repoRoot: string) (cwd: string) (tokens: string list) : string list =
+    tokens
+    |> List.filter (fun token ->
+        token.EndsWith(".fsproj", StringComparison.Ordinal)
+        || token.EndsWith(".csproj", StringComparison.Ordinal))
+    |> List.map (fun token ->
+        if File.Exists(absoluteOf repoRoot token) then
+            token
+        else
+            joinRelative cwd token)
+
+/// Strips this repository's own `${ROOT}/` (or `$ROOT/`) prefix convention —
+/// every `scripts/run-integration.sh` wrapper computes `ROOT` as the absolute
+/// repository root via `$(dirname "${BASH_SOURCE[0]}")/../../..` and then
+/// addresses every path from it, so a `.fsproj` token carrying that prefix is
+/// already repository-root-relative once the prefix itself is removed.
+let private stripRepoRootPrefix (token: string) : string =
+    [ "${ROOT}/"; "$ROOT/" ]
+    |> List.tryPick (fun prefix ->
+        if token.StartsWith(prefix, StringComparison.Ordinal) then
+            Some(token.Substring(prefix.Length))
+        else
+            None)
+    |> Option.defaultValue token
+
 /// Every repository-relative file one command selects.
 let private selectionOfCommand (repoRoot: string) (projectRoot: string) (cwd: string) (command: string) : string list =
     let tokens = tokenize command
@@ -437,16 +466,40 @@ let private selectionOfCommand (repoRoot: string) (projectRoot: string) (cwd: st
 
             fromTestDir @ fromStepsGlob |> List.distinct
     elif command.Contains "dotnet test" then
+        dotnetProjectTokens repoRoot cwd tokens |> List.collect (compileList repoRoot)
+    elif
         tokens
-        |> List.filter (fun token ->
-            token.EndsWith(".fsproj", StringComparison.Ordinal)
-            || token.EndsWith(".csproj", StringComparison.Ordinal))
-        |> List.map (fun token ->
-            if File.Exists(absoluteOf repoRoot token) then
-                token
+        |> List.exists (fun token -> token.EndsWith(".sh", StringComparison.Ordinal))
+    then
+        // A docker-compose-orchestrated integration suite (bring up
+        // dependencies, export env, run, tear down even on failure) commonly
+        // lives behind a wrapper script rather than a direct `dotnet test`
+        // command — `apps/organiclever-be/scripts/run-integration.sh` and
+        // `apps/ose-be/scripts/run-integration.sh` both do this. The command
+        // string itself then names no `.fsproj`, so without reading into the
+        // script every file the suite it runs owns is reported unselected.
+        // Read the script the same way a `.fsproj`/`.csproj` compile list is
+        // read, and apply the identical `dotnet test` token scan to its
+        // content — the same rule, just against different text.
+        match
+            tokens
+            |> List.tryFind (fun token -> token.EndsWith(".sh", StringComparison.Ordinal))
+        with
+        | None -> []
+        | Some scriptToken ->
+            let scriptPath =
+                if File.Exists(absoluteOf repoRoot scriptToken) then
+                    scriptToken
+                else
+                    joinRelative cwd scriptToken
+
+            let scriptText = readTextOrEmpty (absoluteOf repoRoot scriptPath)
+
+            if scriptText.Contains "dotnet test" then
+                dotnetProjectTokens repoRoot cwd (tokenize scriptText |> List.map stripRepoRootPrefix)
+                |> List.collect (compileList repoRoot)
             else
-                joinRelative cwd token)
-        |> List.collect (compileList repoRoot)
+                []
     else
         []
 

--- a/apps/rhino-cli/tests/unit/Steps/TestContractProjectUnitTests.fs
+++ b/apps/rhino-cli/tests/unit/Steps/TestContractProjectUnitTests.fs
@@ -162,6 +162,90 @@ let ``the dotnet-shaped project satisfies the layout rule`` () =
     | Error(TestContract.Misuse message) -> failwith ("the shape must pass, found misuse: " + message)
 
 // ---------------------------------------------------------------------------
+// Runner discovery: .NET wrapper scripts
+//
+// A docker-compose-orchestrated integration suite commonly lives behind a
+// wrapper script (bring dependencies up, export env, run `dotnet test`, tear
+// down even on failure via a trap) rather than a direct `dotnet test`
+// command in project.json — `apps/organiclever-be/scripts/run-integration.sh`
+// and `apps/ose-be/scripts/run-integration.sh` both do this. Without reading
+// into the script, its command string names no `.fsproj`, so every file the
+// suite it runs owns is wrongly reported unselected.
+// ---------------------------------------------------------------------------
+
+let private wrapperScriptProjectJson =
+    """{
+  "name": "widget-wrapped",
+  "targets": {
+    "test:integration": {
+      "executor": "nx:run-commands",
+      "options": { "command": "libs/widget-wrapped/scripts/run-integration.sh" }
+    }
+  }
+}
+"""
+
+/// Mirrors the real repository's own `scripts/run-integration.sh` convention:
+/// a `ROOT` variable computed from the script's own location, then every path
+/// addressed from it with a `${ROOT}/` prefix.
+let private wrapperScriptBody (fsprojRelativePath: string) : string =
+    "#!/usr/bin/env bash\n"
+    + "set -euo pipefail\n"
+    + "ROOT=\"$(cd \"$(dirname \"${BASH_SOURCE[0]}\")/../../..\" && pwd)\"\n"
+    + "docker compose -f \"${ROOT}/libs/widget-wrapped/docker-compose.integration.yml\" up -d --wait\n"
+    + "dotnet test \"${ROOT}/"
+    + fsprojRelativePath
+    + "\" --logger \"console;verbosity=normal\"\n"
+
+[<Fact>]
+let ``a wrapper-script test:integration command selects the files its inner dotnet test compile list names`` () =
+    let root = newTempRepo ()
+    write root "libs/widget-wrapped/project.json" wrapperScriptProjectJson
+
+    write
+        root
+        "libs/widget-wrapped/scripts/run-integration.sh"
+        (wrapperScriptBody "libs/widget-wrapped/tests/integration/widget-wrapped-integration-tests.fsproj")
+
+    write
+        root
+        "libs/widget-wrapped/tests/integration/widget-wrapped-integration-tests.fsproj"
+        """<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="IntegrationCoreTests.fs" />
+  </ItemGroup>
+</Project>
+"""
+
+    write root "libs/widget-wrapped/tests/integration/IntegrationCoreTests.fs" "module IntegrationCoreTests\n"
+
+    let document =
+        materialized root "widget-wrapped" [ TestContractLayout.LayerIntegration ]
+
+    Assert.Equal<string list>(
+        [ "test:integration" ],
+        selectorsFor document "libs/widget-wrapped/tests/integration/IntegrationCoreTests.fs"
+    )
+
+[<Fact>]
+let ``a wrapper script that never calls dotnet test still leaves its files genuinely unselected`` () =
+    let root = newTempRepo ()
+    write root "libs/widget-wrapped/project.json" wrapperScriptProjectJson
+
+    write
+        root
+        "libs/widget-wrapped/scripts/run-integration.sh"
+        "#!/usr/bin/env bash\nset -euo pipefail\necho 'nothing to run yet'\n"
+
+    write root "libs/widget-wrapped/tests/integration/StrayIntegrationTests.fs" "module StrayIntegrationTests\n"
+
+    let message =
+        rejection (materialized root "widget-wrapped" [ TestContractLayout.LayerIntegration ])
+
+    Assert.Contains("layout-file-unselected", message)
+    Assert.Contains("libs/widget-wrapped/tests/integration/StrayIntegrationTests.fs", message)
+
+// ---------------------------------------------------------------------------
 // Runner discovery: vitest
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Phase 15 of `plans/in-progress/adopt-beavernest-test-automation/delivery.md`: migrate `organiclever-be` (F#/.NET Giraffe backend) to the target test contract.

- Raise `test:coverage` threshold from 80% to 99% (achieved **99.46%**, 45/45 unit tests passing). Fixed a silently-broken coverage-collection mechanism (`--collect:"XPlat Code Coverage"` was a no-op without a `coverlet.collector` package reference — tests passed regardless of actual coverage) and added 18 genuine unit tests closing real gaps across `Database`, `AppDbContext`, `WebApp`, `NatsClient`, `HealthInfrastructure`, `JournalApi`, `JournalDomain`, and `MessagingDomain`. The only exclusions (`/p:ExcludeByFile` + `[<ExcludeFromCodeCoverage>]`) are the composition-root entry point (`Program.fs`, matching existing repo precedent) and infra-bound code already covered by real integration tests (`DbMigrations.fs`, `JournalInfrastructure.fs`) or delegated to `organiclever-be-e2e` per `@e2e`-tagged Gherkin scenarios (`NatsConnect.connectAsync`, `JetStreamDemo.runDemo`).
- Wired up the 3 policy-validation Nx targets (`test:layout:validation`, `coverage:policy:validation`, `package-manifest:policy:validation`) into `test:quick`, modeled on Phase 14's `organiclever-app-web` precedent.
- Fixed a dead-code bug: `Handlers/HealthHandler.fs` carried an unused `webApp` composition duplicating the real one in `WebApp.fs` — the "tested" health handler wasn't the one actually running in production. `WebApp.fs` now delegates to `healthHandler` directly.
- **4th rhino-cli `TestContractProject.fs` bug found and fixed** (same class as Phase 12's 3): the layout scanner's `selectionOfCommand` only recognized `vitest`/`playwright`/direct-`dotnet test` command shapes, so it couldn't see into `organiclever-be`'s docker-compose-orchestrated `scripts/run-integration.sh` wrapper script, falsely flagging every integration test file as unselected (`layout-file-unselected`) even though the suite genuinely passes 5/5. Extended the scanner to read into `.sh` wrapper scripts and apply the same `dotnet test` compile-list scan to their content, with TDD coverage including a non-vacuousness negative case (a wrapper script that never calls `dotnet test` still correctly reports its files as unselected). `ose-private` parity propagation for this fix is tracked separately, not part of this PR.

## Before / After

| | Unit tests | Unit coverage | Integration |
|---|---|---|---|
| Before | 27 passing | ~47% (mechanism silently broken) | 5/5 real passes |
| After | 45 passing | 99.46% | 5/5 real passes (re-verified against live Postgres/NATS after refactors) |

rhino-cli itself: full unit suite 2436/2436 (was 2434, +2 new tests), lint clean, coverage 99.17% (floor 99%) — all unaffected/green.

## Files touched

**`organiclever-be`** (test-contract migration):
- `project.json` — coverage threshold 80→99, coverage mechanism fix, 3 new policy-validation targets wired into `test:quick`
- `tests/unit/OrganicleverBe.UnitTests.fsproj` — added `coverlet.collector`/`coverlet.msbuild` package refs, 4 new `<Compile>` entries
- `src/OrganicleverBe/Handlers/HealthHandler.fs` — removed dead `webApp` duplicate
- `src/OrganicleverBe/WebApp.fs` — `/health` route now delegates to `healthHandler`
- `src/OrganicleverBe/Infrastructure/NatsClient.fs` — reduced to `natsUrl` only
- `src/OrganicleverBe/Infrastructure/NatsConnect.fs` (new) — `connectAsync` relocated for reliable file-level coverage exclusion
- `src/OrganicleverBe/Program.fs`, `OrganicleverBe.fsproj` — wire in `NatsConnect`
- `src/OrganicleverBe/Contexts/Db/Infrastructure/DbMigrations.fs`, `Contexts/Journal/Infrastructure/JournalInfrastructure.fs`, `Contexts/Messaging/Infrastructure/JetStreamDemo.fs` — `[<ExcludeFromCodeCoverage>]` with justification, backed by real integration/e2e coverage
- `tests/unit/Tests/*.fs` — `HealthHandlerTests`, `HealthContextTests`, `JournalDomainTests`, `MessagingTests`, `JournalApiTests` extended; `DatabaseTests`, `AppDbContextTests`, `NatsClientTests`, `WebAppTests` new

**`rhino-cli`** (shared-tool fix):
- `src/RhinoCli.Application/src/TestContractProject.fs` — wrapper-script-aware layout scanning
- `tests/unit/Steps/TestContractProjectUnitTests.fs` — 2 new TDD tests (positive + non-vacuousness negative)
- `parity-manifest.sha256` — regenerated hash for the changed file

## Flagged, not fixed (out of scope)

`specs/apps/organiclever/be/behaviors/messaging/nats-config.feature`'s `@unit`-tagged scenario describes a "fail fast" / clear-error behavior when `ORGANICLEVER_BE_NATS_URL` is unset, but `NatsClient.natsUrl()` actually silently defaults to `nats://localhost:4222`. This is a product-behavior question outside this test-migration task's scope; left as-is rather than unilaterally changing behavior or leaving a TODO.

`repo-config.yml`'s driver-path registration for `organiclever-be` (unit + integration) was checked against `TestContract.fs`'s `pathFinding` (shape-only validation, no filesystem check) and against the identical accepted pattern in `crane-cli`/`fsharp-crane-core` — confirmed as established, tool-accepted convention, left untouched.

## Test plan

- [x] `npx nx run organiclever-be:test:quick --skip-nx-cache` — fully green (unit 45/45, coverage 99.46%, specs coverage, all 3 policy-validation targets)
- [x] `apps/organiclever-be/scripts/run-integration.sh` run against live Docker (Postgres + NATS) — 5/5 real passes
- [x] `grep -rn -E --include='*.fs' 'Skip\s*=' apps/organiclever-be/tests` — clean, no matches
- [x] `npx nx run rhino-cli:test:unit --skip-nx-cache` — 2436/2436, no regressions
- [x] `npx nx run rhino-cli:lint --skip-nx-cache` — clean
- [x] `npx nx run rhino-cli:test:coverage --skip-nx-cache` — 99.17%, floor holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAVoSfk5AochhrgQU2s343