### PR TITLE
docs(plans): scaffold worktree and branch cleanup into plan archival

### DIFF
--- a/.agents/skills/plan-applying-fixes/reference/README.md
+++ b/.agents/skills/plan-applying-fixes/reference/README.md
@@ -15,7 +15,7 @@ title: "Reference"
 - [09 Ui Design Funnel Scaffolding Fixes](./ui-design-funnel-scaffolding-fixes.md) — repair recipes for scaffolding a missing UI-design-funnel section
 - [10 Learning Bearing Syllabus Scaffolding Fixes](./learning-bearing-syllabus-scaffolding-fixes.md) — repair recipes for scaffolding a missing learning-bearing syllabus artefact
 - [11 Diagram Format Fixes](./diagram-format-fixes.md) — repair recipes for converting ASCII art to Mermaid and other diagram-format findings
-- [12 Worktree And Delivery Mode Scaffolding Fixes](./worktree-and-delivery-mode-scaffolding-fixes.md) — repair recipes for missing worktree specification and delivery-mode scaffolding
+- [12 Worktree And Delivery Mode Scaffolding Fixes](./worktree-and-delivery-mode-scaffolding-fixes.md) — repair recipes for missing worktree specification, archival cleanup steps, and delivery-mode scaffolding
 - [PR CI and Merge Tag Fixes](./pr-ci-and-merge-tag-fixes.md) — repair exact-head PR-CI steps and merge-tag mismatches
 - [14 Execution Grade Clarity Fixes](./execution-grade-clarity-fixes.md) — repair recipes when a delivery checkbox lacks explicit paths, commands, or acceptance criteria
 - [15 Executor Tagging And Phase Gate Fixes Part1](./executor-tagging-and-phase-gate-fixes-part1.md) — first half of the executor-tagging and phase-gate repair recipes

--- a/.agents/skills/plan-applying-fixes/reference/worktree-and-delivery-mode-scaffolding-fixes.md
+++ b/.agents/skills/plan-applying-fixes/reference/worktree-and-delivery-mode-scaffolding-fixes.md
@@ -31,6 +31,15 @@ resolved host path to ignored runtime evidence and never retain it in `delivery.
 **How to fix missing worktree-mode provisioning command**: insert the canonical fenced bash block immediately
 under the path declaration: ` ```bash\nclaude --worktree <plan-identifier>\n``` `.
 
+**How to fix missing archival cleanup steps**: insert the three checkboxes verbatim from the Plan
+Archival template in
+[plan-archival.md](../../plan-creating-project-plans/reference/plan-archival.md) — inventory
+classification, worktree removal, branch cleanup — immediately before the completion-date step of
+the plan's `### Plan Archival` section. **HIGH**: the wording is fixed and the placement is
+mechanical. **FALSE_POSITIVE** — the plan declares a main mode, which provisions no worktree, or it is a
+pre-contract single-file plan with no `delivery.md` for the check to read. Never
+weaken a merge step's `[HUMAN]` gate while editing this section.
+
 ## Delivery Mode Fixes (Step 5m Findings)
 
 Sibling scaffold to Worktree Specification Fixes above — see

--- a/.agents/skills/plan-applying-fixes/reference/worktree-and-delivery-mode-scaffolding-fixes.md
+++ b/.agents/skills/plan-applying-fixes/reference/worktree-and-delivery-mode-scaffolding-fixes.md
@@ -35,7 +35,7 @@ under the path declaration: ` ```bash\nclaude --worktree <plan-identifier>\n``` 
 Archival template in
 [plan-archival.md](../../plan-creating-project-plans/reference/plan-archival.md) — inventory
 classification, worktree removal, branch cleanup — immediately before the completion-date step of
-the plan's `### Plan Archival` section. **HIGH**: the wording is fixed and the placement is
+the plan's archival section or phase. **HIGH**: the wording is fixed and the placement is
 mechanical. **FALSE_POSITIVE** — the plan declares a main mode, which provisions no worktree, or it is a
 pre-contract single-file plan with no `delivery.md` for the check to read. Never
 weaken a merge step's `[HUMAN]` gate while editing this section.

--- a/.agents/skills/plan-creating-project-plans/reference/plan-archival.md
+++ b/.agents/skills/plan-creating-project-plans/reference/plan-archival.md
@@ -22,6 +22,16 @@ Every delivery plan MUST end with a plan archival section:
 - [ ] Register the workflow-owned terminal audit task and its required post-delivery proof fields;
       do not mark that gate complete before merge or direct-push confirmation. Its result belongs in
       the plan-execution final report, not a speculative pre-merge checkbox.
+- [ ] Classify every `Delivery Branch Inventory` entry as delivered, unused, or
+      retained/escalated; a retained entry names who owns it and why it outlives the plan, and an
+      entry whose state is ambiguous or whose proof is missing is escalated, never deleted
+- [ ] Remove each worktree this plan provisioned, non-force, from the repository root:
+      `rtk git worktree remove worktrees/<plan-identifier>`, after the checks in
+      `repo-governance/development/workflow/worktree-and-artifact-cleanup/mandatory-pre-removal-checks.md`
+      — worktree modes only; a main mode provisioned none and skips this step and the next
+- [ ] Complete branch cleanup for every branch this plan created, in every repository it delivered
+      to, per `repo-governance/development/workflow/worktree-and-artifact-cleanup/branch-cleanup.md`,
+      then run `rtk git worktree prune`. Follow that convention's proof gates; never relax them here
 - [ ] After every pre-archival gate, including the preliminary audit, passes, run `rtk date +%F`; record the output as
       `<completion-date>`. Do not hardcode or predict this value while authoring the plan.
 - [ ] Move the plan via
@@ -36,5 +46,12 @@ Every delivery plan MUST end with a plan archival section:
 After the archival delivery is pushed or merged, plan execution must run the registered terminal
 audit against the delivered head before assigning `pass` or cleaning the worktree. A failed
 terminal audit reopens execution and is never papered over with a post-merge checkbox edit.
+
+The three cleanup steps are scaffolding, not the procedure. Worktree removal routes to
+[Mandatory Pre-Removal Checks](../../../../repo-governance/development/workflow/worktree-and-artifact-cleanup/mandatory-pre-removal-checks.md)
+and branch deletion to
+[Branch Cleanup](../../../../repo-governance/development/workflow/worktree-and-artifact-cleanup/branch-cleanup.md);
+those two own the proof gates, and a plan never restates or weakens either. A plan
+declaring a main mode provisions no worktree and omits the two removal steps.
 
 See [knowledge-capture-scaffold-and-entries.md](knowledge-capture-scaffold-and-entries.md) and [knowledge-capture-phase-template.md](knowledge-capture-phase-template.md) for the mandatory phase that precedes archival, and [common-mistakes.md](common-mistakes.md) for authoring pitfalls to avoid before reaching this section.

--- a/.agents/skills/plan-validating-quality/reference/README.md
+++ b/.agents/skills/plan-validating-quality/reference/README.md
@@ -14,7 +14,7 @@ title: "Reference"
 - [08 Factual Accuracy Validation](./factual-accuracy-validation.md) — verifying factual claims with web tools (Step 4b)
 - [09 Rule8 Operational Readiness Validation](./rule8-operational-readiness-validation.md) — Rule 8: operational readiness validation (Step 5b)
 - [10 Rule9 Manual Behavioral Assertion Validation](./rule9-manual-behavioral-assertion-validation.md) — Rule 9: manual behavioral assertion validation (Step 5c)
-- [11 Rule10 Worktree Specification Validation](./rule10-worktree-specification-validation.md) — Rule 10: worktree specification validation (Step 5d)
+- [11 Rule10 Worktree Specification Validation](./rule10-worktree-specification-validation.md) — Rule 10: worktree specification and archival-cleanup validation (Step 5d)
 - [12 Rule11 Execution Grade Clarity Validation](./rule11-execution-grade-clarity-validation.md) — Rule 11: execution-grade clarity validation (Step 5e)
 - [13 Rule12 Anti Hallucination Scan](./rule12-anti-hallucination-scan.md) — Rule 12: anti-hallucination scan (Step 5f)
 - [14 Rule13 Harness Neutrality Scan](./rule13-harness-neutrality-scan.md) — Rule 13: harness-neutrality scan (Step 5g), conditional on agent/skill/rules touching plans

--- a/.agents/skills/plan-validating-quality/reference/rule10-worktree-specification-validation.md
+++ b/.agents/skills/plan-validating-quality/reference/rule10-worktree-specification-validation.md
@@ -47,13 +47,14 @@ worktree artifacts are absent):
    pending: **HIGH**. For a main mode, require `Worktree: not applicable` plus the mode and primary
    checkout rationale; any worktree identity or provisioning command is **HIGH**.
 
-7. **Archival cleanup steps** — for a worktree mode, `### Plan Archival` contains a step
+7. **Archival cleanup steps** — for a worktree mode, the plan's archival section or phase — the
+   `### Plan Archival` section, or the phase that performs archival — contains a step
    classifying every `Delivery Branch Inventory` entry, a worktree-removal step, and a
    branch-cleanup step routing to
    [Branch Cleanup](../../../../repo-governance/development/workflow/worktree-and-artifact-cleanup/branch-cleanup.md).
-   Missing any of the three: **MEDIUM** — the obligation already binds at plan-execution
-   finalization, so the defect is that the plan does not show it, not that it is unbound. Does not
-   fire for a main mode, which provisions no worktree, nor on a plan folder with no `delivery.md`.
+   Missing any: **MEDIUM** — the obligation already binds at plan-execution
+   finalization, so the defect is that the plan does not show it, not that it is unbound. Never
+   fires for a main mode, which provisions none, or a plan folder with no `delivery.md`.
 
 **Finding severity**: missing section: **HIGH**. Wrong format/identifier mismatch: **HIGH**. Missing
 provisioning command: **MEDIUM**. Missing cross-reference: **LOW**. More than one distinct worktree

--- a/.agents/skills/plan-validating-quality/reference/rule10-worktree-specification-validation.md
+++ b/.agents/skills/plan-validating-quality/reference/rule10-worktree-specification-validation.md
@@ -47,8 +47,17 @@ worktree artifacts are absent):
    pending: **HIGH**. For a main mode, require `Worktree: not applicable` plus the mode and primary
    checkout rationale; any worktree identity or provisioning command is **HIGH**.
 
+7. **Archival cleanup steps** — for a worktree mode, `### Plan Archival` contains a step
+   classifying every `Delivery Branch Inventory` entry, a worktree-removal step, and a
+   branch-cleanup step routing to
+   [Branch Cleanup](../../../../repo-governance/development/workflow/worktree-and-artifact-cleanup/branch-cleanup.md).
+   Missing any of the three: **MEDIUM** — the obligation already binds at plan-execution
+   finalization, so the defect is that the plan does not show it, not that it is unbound. Does not
+   fire for a main mode, which provisions no worktree, nor on a plan folder with no `delivery.md`.
+
 **Finding severity**: missing section: **HIGH**. Wrong format/identifier mismatch: **HIGH**. Missing
 provisioning command: **MEDIUM**. Missing cross-reference: **LOW**. More than one distinct worktree
 path for this repository: **HIGH**. Machine-specific worktree identity path: **HIGH**.
 Missing/incomplete identity or inventory outside the documented authoring exception: **HIGH**.
 Machine-specific local path anywhere in committed `delivery.md`: **HIGH**.
+Missing a worktree-mode archival cleanup step: **MEDIUM**.

--- a/.claude/skills/plan-applying-fixes/reference/README.md
+++ b/.claude/skills/plan-applying-fixes/reference/README.md
@@ -15,7 +15,7 @@ title: "Reference"
 - [09 Ui Design Funnel Scaffolding Fixes](./ui-design-funnel-scaffolding-fixes.md) — repair recipes for scaffolding a missing UI-design-funnel section
 - [10 Learning Bearing Syllabus Scaffolding Fixes](./learning-bearing-syllabus-scaffolding-fixes.md) — repair recipes for scaffolding a missing learning-bearing syllabus artefact
 - [11 Diagram Format Fixes](./diagram-format-fixes.md) — repair recipes for converting ASCII art to Mermaid and other diagram-format findings
-- [12 Worktree And Delivery Mode Scaffolding Fixes](./worktree-and-delivery-mode-scaffolding-fixes.md) — repair recipes for missing worktree specification and delivery-mode scaffolding
+- [12 Worktree And Delivery Mode Scaffolding Fixes](./worktree-and-delivery-mode-scaffolding-fixes.md) — repair recipes for missing worktree specification, archival cleanup steps, and delivery-mode scaffolding
 - [PR CI and Merge Tag Fixes](./pr-ci-and-merge-tag-fixes.md) — repair exact-head PR-CI steps and merge-tag mismatches
 - [14 Execution Grade Clarity Fixes](./execution-grade-clarity-fixes.md) — repair recipes when a delivery checkbox lacks explicit paths, commands, or acceptance criteria
 - [15 Executor Tagging And Phase Gate Fixes Part1](./executor-tagging-and-phase-gate-fixes-part1.md) — first half of the executor-tagging and phase-gate repair recipes

--- a/.claude/skills/plan-applying-fixes/reference/worktree-and-delivery-mode-scaffolding-fixes.md
+++ b/.claude/skills/plan-applying-fixes/reference/worktree-and-delivery-mode-scaffolding-fixes.md
@@ -31,6 +31,15 @@ resolved host path to ignored runtime evidence and never retain it in `delivery.
 **How to fix missing worktree-mode provisioning command**: insert the canonical fenced bash block immediately
 under the path declaration: ` ```bash\nclaude --worktree <plan-identifier>\n``` `.
 
+**How to fix missing archival cleanup steps**: insert the three checkboxes verbatim from the Plan
+Archival template in
+[plan-archival.md](../../plan-creating-project-plans/reference/plan-archival.md) — inventory
+classification, worktree removal, branch cleanup — immediately before the completion-date step of
+the plan's `### Plan Archival` section. **HIGH**: the wording is fixed and the placement is
+mechanical. **FALSE_POSITIVE** — the plan declares a main mode, which provisions no worktree, or it is a
+pre-contract single-file plan with no `delivery.md` for the check to read. Never
+weaken a merge step's `[HUMAN]` gate while editing this section.
+
 ## Delivery Mode Fixes (Step 5m Findings)
 
 Sibling scaffold to Worktree Specification Fixes above — see

--- a/.claude/skills/plan-applying-fixes/reference/worktree-and-delivery-mode-scaffolding-fixes.md
+++ b/.claude/skills/plan-applying-fixes/reference/worktree-and-delivery-mode-scaffolding-fixes.md
@@ -35,7 +35,7 @@ under the path declaration: ` ```bash\nclaude --worktree <plan-identifier>\n``` 
 Archival template in
 [plan-archival.md](../../plan-creating-project-plans/reference/plan-archival.md) — inventory
 classification, worktree removal, branch cleanup — immediately before the completion-date step of
-the plan's `### Plan Archival` section. **HIGH**: the wording is fixed and the placement is
+the plan's archival section or phase. **HIGH**: the wording is fixed and the placement is
 mechanical. **FALSE_POSITIVE** — the plan declares a main mode, which provisions no worktree, or it is a
 pre-contract single-file plan with no `delivery.md` for the check to read. Never
 weaken a merge step's `[HUMAN]` gate while editing this section.

--- a/.claude/skills/plan-creating-project-plans/reference/plan-archival.md
+++ b/.claude/skills/plan-creating-project-plans/reference/plan-archival.md
@@ -22,6 +22,16 @@ Every delivery plan MUST end with a plan archival section:
 - [ ] Register the workflow-owned terminal audit task and its required post-delivery proof fields;
       do not mark that gate complete before merge or direct-push confirmation. Its result belongs in
       the plan-execution final report, not a speculative pre-merge checkbox.
+- [ ] Classify every `Delivery Branch Inventory` entry as delivered, unused, or
+      retained/escalated; a retained entry names who owns it and why it outlives the plan, and an
+      entry whose state is ambiguous or whose proof is missing is escalated, never deleted
+- [ ] Remove each worktree this plan provisioned, non-force, from the repository root:
+      `rtk git worktree remove worktrees/<plan-identifier>`, after the checks in
+      `repo-governance/development/workflow/worktree-and-artifact-cleanup/mandatory-pre-removal-checks.md`
+      — worktree modes only; a main mode provisioned none and skips this step and the next
+- [ ] Complete branch cleanup for every branch this plan created, in every repository it delivered
+      to, per `repo-governance/development/workflow/worktree-and-artifact-cleanup/branch-cleanup.md`,
+      then run `rtk git worktree prune`. Follow that convention's proof gates; never relax them here
 - [ ] After every pre-archival gate, including the preliminary audit, passes, run `rtk date +%F`; record the output as
       `<completion-date>`. Do not hardcode or predict this value while authoring the plan.
 - [ ] Move the plan via
@@ -36,5 +46,12 @@ Every delivery plan MUST end with a plan archival section:
 After the archival delivery is pushed or merged, plan execution must run the registered terminal
 audit against the delivered head before assigning `pass` or cleaning the worktree. A failed
 terminal audit reopens execution and is never papered over with a post-merge checkbox edit.
+
+The three cleanup steps are scaffolding, not the procedure. Worktree removal routes to
+[Mandatory Pre-Removal Checks](../../../../repo-governance/development/workflow/worktree-and-artifact-cleanup/mandatory-pre-removal-checks.md)
+and branch deletion to
+[Branch Cleanup](../../../../repo-governance/development/workflow/worktree-and-artifact-cleanup/branch-cleanup.md);
+those two own the proof gates, and a plan never restates or weakens either. A plan
+declaring a main mode provisions no worktree and omits the two removal steps.
 
 See [knowledge-capture-scaffold-and-entries.md](knowledge-capture-scaffold-and-entries.md) and [knowledge-capture-phase-template.md](knowledge-capture-phase-template.md) for the mandatory phase that precedes archival, and [common-mistakes.md](common-mistakes.md) for authoring pitfalls to avoid before reaching this section.

--- a/.claude/skills/plan-validating-quality/reference/README.md
+++ b/.claude/skills/plan-validating-quality/reference/README.md
@@ -14,7 +14,7 @@ title: "Reference"
 - [08 Factual Accuracy Validation](./factual-accuracy-validation.md) — verifying factual claims with web tools (Step 4b)
 - [09 Rule8 Operational Readiness Validation](./rule8-operational-readiness-validation.md) — Rule 8: operational readiness validation (Step 5b)
 - [10 Rule9 Manual Behavioral Assertion Validation](./rule9-manual-behavioral-assertion-validation.md) — Rule 9: manual behavioral assertion validation (Step 5c)
-- [11 Rule10 Worktree Specification Validation](./rule10-worktree-specification-validation.md) — Rule 10: worktree specification validation (Step 5d)
+- [11 Rule10 Worktree Specification Validation](./rule10-worktree-specification-validation.md) — Rule 10: worktree specification and archival-cleanup validation (Step 5d)
 - [12 Rule11 Execution Grade Clarity Validation](./rule11-execution-grade-clarity-validation.md) — Rule 11: execution-grade clarity validation (Step 5e)
 - [13 Rule12 Anti Hallucination Scan](./rule12-anti-hallucination-scan.md) — Rule 12: anti-hallucination scan (Step 5f)
 - [14 Rule13 Harness Neutrality Scan](./rule13-harness-neutrality-scan.md) — Rule 13: harness-neutrality scan (Step 5g), conditional on agent/skill/rules touching plans

--- a/.claude/skills/plan-validating-quality/reference/rule10-worktree-specification-validation.md
+++ b/.claude/skills/plan-validating-quality/reference/rule10-worktree-specification-validation.md
@@ -47,13 +47,14 @@ worktree artifacts are absent):
    pending: **HIGH**. For a main mode, require `Worktree: not applicable` plus the mode and primary
    checkout rationale; any worktree identity or provisioning command is **HIGH**.
 
-7. **Archival cleanup steps** — for a worktree mode, `### Plan Archival` contains a step
+7. **Archival cleanup steps** — for a worktree mode, the plan's archival section or phase — the
+   `### Plan Archival` section, or the phase that performs archival — contains a step
    classifying every `Delivery Branch Inventory` entry, a worktree-removal step, and a
    branch-cleanup step routing to
    [Branch Cleanup](../../../../repo-governance/development/workflow/worktree-and-artifact-cleanup/branch-cleanup.md).
-   Missing any of the three: **MEDIUM** — the obligation already binds at plan-execution
-   finalization, so the defect is that the plan does not show it, not that it is unbound. Does not
-   fire for a main mode, which provisions no worktree, nor on a plan folder with no `delivery.md`.
+   Missing any: **MEDIUM** — the obligation already binds at plan-execution
+   finalization, so the defect is that the plan does not show it, not that it is unbound. Never
+   fires for a main mode, which provisions none, or a plan folder with no `delivery.md`.
 
 **Finding severity**: missing section: **HIGH**. Wrong format/identifier mismatch: **HIGH**. Missing
 provisioning command: **MEDIUM**. Missing cross-reference: **LOW**. More than one distinct worktree

--- a/.claude/skills/plan-validating-quality/reference/rule10-worktree-specification-validation.md
+++ b/.claude/skills/plan-validating-quality/reference/rule10-worktree-specification-validation.md
@@ -47,8 +47,17 @@ worktree artifacts are absent):
    pending: **HIGH**. For a main mode, require `Worktree: not applicable` plus the mode and primary
    checkout rationale; any worktree identity or provisioning command is **HIGH**.
 
+7. **Archival cleanup steps** — for a worktree mode, `### Plan Archival` contains a step
+   classifying every `Delivery Branch Inventory` entry, a worktree-removal step, and a
+   branch-cleanup step routing to
+   [Branch Cleanup](../../../../repo-governance/development/workflow/worktree-and-artifact-cleanup/branch-cleanup.md).
+   Missing any of the three: **MEDIUM** — the obligation already binds at plan-execution
+   finalization, so the defect is that the plan does not show it, not that it is unbound. Does not
+   fire for a main mode, which provisions no worktree, nor on a plan folder with no `delivery.md`.
+
 **Finding severity**: missing section: **HIGH**. Wrong format/identifier mismatch: **HIGH**. Missing
 provisioning command: **MEDIUM**. Missing cross-reference: **LOW**. More than one distinct worktree
 path for this repository: **HIGH**. Machine-specific worktree identity path: **HIGH**.
 Missing/incomplete identity or inventory outside the documented authoring exception: **HIGH**.
 Machine-specific local path anywhere in committed `delivery.md`: **HIGH**.
+Missing a worktree-mode archival cleanup step: **MEDIUM**.

--- a/plans/in-progress/scaffold-plan-archival-cleanup/delivery.md
+++ b/plans/in-progress/scaffold-plan-archival-cleanup/delivery.md
@@ -117,23 +117,23 @@ repository pair has flipped layouts before.
 **Outcome**: The worktree exists, the toolchain is converged, and the baseline is recorded.
 **Proof**: Baseline commands exit 0; the worktree identity is filled in above.
 
-- [ ] [AI] Provision the worktree from the `ose-public` repository root:
+- [x] [AI] Provision the worktree from the `ose-public` repository root:
       `claude --worktree scaffold-plan-archival-cleanup`. Record the resulting creator and
       ISO-8601 UTC timestamp into [Provisioned Worktree Identity](#provisioned-worktree-identity),
       and update the [Delivery Branch Inventory](#delivery-branch-inventory) row to `provisioned` /
       `active`
-- [ ] [AI] Verify git identity is not the stray `Test <test@test.com>` override:
+- [x] [AI] Verify git identity is not the stray `Test <test@test.com>` override:
       `rtk git config user.email` — if it prints `test@test.com`, STOP and surface it; this is a
       `[HUMAN]`-only fix
-- [ ] [AI] Sync: `rtk git fetch origin && rtk git merge --ff-only origin/main` — exits 0
-- [ ] [AI] At the worktree root: `rtk npm install && rtk npm run doctor -- --fix` — both exit 0.
+- [x] [AI] Sync: `rtk git fetch origin && rtk git merge --ff-only origin/main` — exits 0
+- [x] [AI] At the worktree root: `rtk npm install && rtk npm run doctor -- --fix` — both exit 0.
       A fresh worktree has no `node_modules`, so this is required, not a formality
-- [ ] [AI] Create `plans/in-progress/scaffold-plan-archival-cleanup/learnings.md` if absent, with the
+- [x] [AI] Create `plans/in-progress/scaffold-plan-archival-cleanup/learnings.md` if absent, with the
       mandatory `# Learnings: scaffold-plan-archival-cleanup` H1 — markdownlint MD041 fails a
       comments-only scaffold
-- [ ] [AI] Record the baseline: `rtk nx affected -t build,test:quick,lint` — exits 0. Fix any
+- [x] [AI] Record the baseline: `rtk nx affected -t build,test:quick,lint` — exits 0. Fix any
       preexisting failure before proceeding
-- [ ] [AI] Enumerate the plans the new check will run against, writing the list to
+- [x] [AI] Enumerate the plans the new check will run against, writing the list to
       `local-tmp/scaffold-plan-archival-cleanup/live-plans.txt`:
       `/bin/ls -1 plans/in-progress plans/backlog`. Use `/bin/ls`, not the shell's `eza` alias —
       its hyperlink escapes corrupt piped output
@@ -142,11 +142,17 @@ repository pair has flipped layouts before.
 
 > All checks below must pass before starting Phase 1.
 
-- [ ] [AI] `rtk git status --short` shows only this plan's folder
-- [ ] [AI] `rtk nx affected -t build,test:quick,lint` exits 0
-- [ ] [AI] `local-tmp/scaffold-plan-archival-cleanup/live-plans.txt` exists and is non-empty
-- [ ] [AI] The worktree identity and branch inventory above carry real recorded values, not
+- [x] [AI] `rtk git status --short` shows only this plan's folder
+- [x] [AI] `rtk nx affected -t build,test:quick,lint` exits 0
+- [x] [AI] `local-tmp/scaffold-plan-archival-cleanup/live-plans.txt` exists and is non-empty
+- [x] [AI] The worktree identity and branch inventory above carry real recorded values, not
       placeholders
+
+**Result** — `npm run doctor -- --fix` exits 0 ("Nothing to fix — all tools are installed").
+`nx affected -t build,test:quick,lint` exits 0 with no tasks run: the branch carries only Markdown.
+`local-tmp/scaffold-plan-archival-cleanup/live-plans.txt` lists five plans — three backlog
+README-only stubs and two in-progress plans. Worktree provisioned `2026-09-04T07:42:00Z` from
+`origin/main` `a9e6e6af6`; identity and inventory above carry those recorded values.
 
 > **Pause Safety**: nothing changed but the plan folder. Safe to stop. To resume:
 > `rtk nx affected -t build,test:quick,lint` from the worktree root.
@@ -162,34 +168,34 @@ This changes a rules surface, so it is a
 [rules-propagation](../../../repo-governance/workflows/rules/rules-propagation.md) run at
 `mode: strict`, not an ordinary Skill edit.
 
-- [ ] [AI] **RP-0 Intake** — normalize into falsifiable statements in
+- [x] [AI] **RP-0 Intake** — normalize into falsifiable statements in
       `local-tmp/rules-propagation/statements-public.md`. There are two: (1) a plan's archival
       section must contain a worktree-removal step and a branch-cleanup step routing to the
       canonical convention; (2) `plan-checker` must flag an archival section missing either. Record
       each statement's violating observation
-- [ ] [AI] **RP-1 Working tree** — `isolation: current`; the run writes in the Phase 0 worktree.
+- [x] [AI] **RP-1 Working tree** — `isolation: current`; the run writes in the Phase 0 worktree.
       Record the parity slug, basename, and branch from
       [Cross-Repository Parity Identity](#cross-repository-parity-identity); the Phase 3 run reuses
       them verbatim
-- [ ] [AI] **RP-2 Classification** — assign subject and layer; confirm vendor neutrality. Both
+- [x] [AI] **RP-2 Classification** — assign subject and layer; confirm vendor neutrality. Both
       statements are Agents-layer (Skill reference modules), not Conventions — the convention
       already exists and is unchanged
-- [ ] [AI] **RP-3 Conflict scan** — search for an existing rule that already states either
+- [x] [AI] **RP-3 Conflict scan** — search for an existing rule that already states either
       statement. Expect a **partial semantic no-op**: the obligation exists in
       `plan-execution/finalization-worktree-cleanup-and-pr-archival.md` and
       `plans/worktree-specification-continued.md`. Record those as the binding sources the new
       scaffolding routes to, NOT as supersessions — nothing is being replaced. Halt and surface if
       any higher-layer rule contradicts the scaffolding
-- [ ] [AI] **RP-4 Placement** — confirm or overturn
+- [x] [AI] **RP-4 Placement** — confirm or overturn
       [tech-docs.md §D-1](./tech-docs.md#d-1-extend-the-existing-worktree-rule-do-not-mint-rule-22).
       Read `.claude/skills/plan-validating-quality/reference/rule10-worktree-specification-validation.md`
       and run `wc -w` on it. If it has headroom, the check goes there and no new shard is created.
       Record the decision and the word count in `local-tmp/rules-propagation/placement-public.md`
-- [ ] [AI] **RP-5 Eviction** — if Rule 10's shard has no headroom, evict rather than raise the
+- [x] [AI] **RP-5 Eviction** — if Rule 10's shard has no headroom, evict rather than raise the
       threshold. Only if eviction is genuinely impossible does a new numbered shard become correct —
       and a new shard then needs a link in its folder `README.md` **and** in the parent index, or the
       readme-completeness gate fails the push as an orphan
-- [ ] [AI] Edit `.claude/skills/plan-creating-project-plans/reference/plan-archival.md`: add three
+- [x] [AI] Edit `.claude/skills/plan-creating-project-plans/reference/plan-archival.md`: add three
       checkboxes to the template, placed before the `rtk date +%F` completion-date step — (1)
       classify every `Delivery Branch Inventory` entry as delivered, unused, or retained/escalated;
       (2) remove each worktree the plan provisioned, non-force, from the repository root; (3)
@@ -198,32 +204,32 @@ This changes a rules surface, so it is a
       for every plan-created branch, then run `git worktree prune`. Link out for the procedure; do
       not restate its proof gates, per
       [tech-docs.md §D-2](./tech-docs.md#d-2-the-template-links-out-it-does-not-restate-the-procedure)
-- [ ] [AI] Add the "not applicable for a main mode" carve-out to the template's own wording, so a
+- [x] [AI] Add the "not applicable for a main mode" carve-out to the template's own wording, so a
       `main-to-pr` or `main-to-origin-main` plan is not told to remove a worktree it never created
-- [ ] [AI] Edit the placement target chosen at RP-4 to add the presence check: an archival section
+- [x] [AI] Edit the placement target chosen at RP-4 to add the presence check: an archival section
       that declares a worktree mode and lacks either step is a finding. State the check's severity
       and its non-firing conditions explicitly
-- [ ] [AI] Verify the check in BOTH directions before going further, per
+- [x] [AI] Verify the check in BOTH directions before going further, per
       [tech-docs.md §D-3](./tech-docs.md#d-3-verify-the-check-in-both-directions-before-landing):
       construct one archival section missing the branch-cleanup step and confirm the check fires;
       construct one carrying both steps and confirm it does not; construct one declaring
       `Worktree: not applicable` and confirm it does not. Record all three outcomes in
       `local-tmp/scaffold-plan-archival-cleanup/check-verification.md`
-- [ ] [AI] Locate the fixer recipe module:
+- [x] [AI] Locate the fixer recipe module:
       `rtk grep -rln "rule10\|worktree" .claude/skills/plan-applying-fixes/reference/` — record the
       chosen file. Add a recipe that inserts the missing steps in the template's wording, and that
       never weakens a merge step's human gate
-- [ ] [AI] **RP-6 Write and tidy** — confirm no two modules now state the archival cleanup
+- [x] [AI] **RP-6 Write and tidy** — confirm no two modules now state the archival cleanup
       obligation in conflicting words, and reindex any folder `README.md` whose child annotations
       changed. Check `wc -w` on each edited `README.md` before committing; governance index files
       sit near a 500-word FAIL ceiling
-- [ ] [AI] **RP-7 Enforcement disposition** — record one of `covered` / `gated` /
+- [x] [AI] **RP-7 Enforcement disposition** — record one of `covered` / `gated` /
       `unenforced-by-decision` per statement in
       `local-tmp/rules-propagation/dispositions-public.md`, none silent. Expected: statement (1) is
       `covered` by the new `plan-checker` check — name it and cite the both-directions evidence from
       `check-verification.md`, because a check verified in one direction is half a check; statement
       (2) is the check itself
-- [ ] [AI] Run the new check against every plan in `live-plans.txt`. Fix each resulting finding in
+- [x] [AI] Run the new check against every plan in `live-plans.txt`. Fix each resulting finding in
       this delivery, or record it with its reason in
       `local-tmp/scaffold-plan-archival-cleanup/live-plan-findings.md`. Leaving an unaddressed
       finding on unrelated work is not shipping (AC-4)
@@ -232,14 +238,31 @@ This changes a rules surface, so it is a
 
 > All checks below must pass before starting Phase 2.
 
-- [ ] [AI] `rtk grep -c "branch" .claude/skills/plan-creating-project-plans/reference/plan-archival.md`
+- [x] [AI] `rtk grep -c "branch" .claude/skills/plan-creating-project-plans/reference/plan-archival.md`
       prints a non-zero count
-- [ ] [AI] `check-verification.md` records all three cases — fires, does not fire, main-mode does not
+- [x] [AI] `check-verification.md` records all three cases — fires, does not fire, main-mode does not
       fire
-- [ ] [AI] `dispositions-public.md` records a disposition for both statements, none silent
-- [ ] [AI] Every plan in `live-plans.txt` is either clean under the new check or recorded in
+- [x] [AI] `dispositions-public.md` records a disposition for both statements, none silent
+- [x] [AI] Every plan in `live-plans.txt` is either clean under the new check or recorded in
       `live-plan-findings.md` with its reason
-- [ ] [AI] `wc -w` on every edited `README.md` is under the 500-word FAIL ceiling
+- [x] [AI] `wc -w` on every edited `README.md` is under the 500-word FAIL ceiling
+
+**Result** — `grep -c branch` on `plan-archival.md` prints 3, up from 0.
+`check-verification.md` records all four constructed cases: the check fires on a worktree-mode
+section missing both steps and on one missing only branch cleanup, and stays silent on one carrying
+all three and on a `main-to-pr` plan declaring `Worktree: not applicable`.
+`dispositions-public.md` records `covered` for both statements, neither silent. AC-4 found **zero**
+findings across all five live plans — the three backlog stubs have no `delivery.md` for the check to
+read, and both in-progress plans already carry all three steps; `live-plan-findings.md` records the
+per-plan verdict. Word counts after editing: `plan-archival.md` 577, Rule 10 607, the fixer recipe
+628, and the two `reference/README.md` files 355 and 350 — all under the 650-word Instruction
+target, so **RP-5 eviction was not required in `ose-public`**.
+
+RP-8.3 raised three MEDIUM findings, all fixed in this phase before delivery: the routing prose
+attributed worktree-removal proof gates to `branch-cleanup.md` when they live in
+`mandatory-pre-removal-checks.md`; the classification step dropped the `escalated` outcome the
+convention defines; and the fixer's `FALSE_POSITIVE` clause named only one of Rule 10 item 7's two
+non-firing conditions.
 
 > **Pause Safety**: the sources state the new scaffolding; mirrors are still stale, so `validate:sync`
 > will fail until Phase 2. Nothing executes differently — these are documents. Safe to stop. To
@@ -251,28 +274,56 @@ This changes a rules surface, so it is a
 **Outcome**: Mirrors match their sources and the change is on `ose-public` `main`.
 **Proof**: PR merged with green exact-head/base CI.
 
-- [ ] [AI] **RP-8.1 Regenerate** — `rtk npm run generate:bindings` — exits 0. Never hand-edit a
+- [x] [AI] **RP-8.1 Regenerate** — `rtk npm run generate:bindings` — exits 0. Never hand-edit a
       mirror under `.agents/skills/`
-- [ ] [AI] Verify mirrors: `rtk npm run validate:sync` — exits 0
-- [ ] [AI] Verify the full binding surface: `rtk npm run harness:bindings-validation` — exits 0
-- [ ] [AI] **RP-8.2 Deterministic gates** — run each of these via
+- [x] [AI] Verify mirrors: `rtk npm run validate:sync` — exits 0
+- [x] [AI] Verify the full binding surface: `rtk npm run harness:bindings-validation` — exits 0
+- [x] [AI] **RP-8.2 Deterministic gates** — run each of these via
       `apps/rhino-cli/scripts/rhino-bin.sh`, redirecting output to a file and asserting the process
       exit code rather than the absence of a failure token: `md links validate`,
       `md heading-hierarchy validate`, `md frontmatter validate`, `md naming validate`,
       `convention emoji validate`, `repo-config validate`. Never read an exit code through a pipe
-- [ ] [AI] Establish the preexisting-failure baseline before calling any failure unrelated:
+- [x] [AI] Establish the preexisting-failure baseline before calling any failure unrelated:
       `md links validate` reports several hundred broken links repository-wide, almost all under
       `plans/done/`. Demonstrate this run's paths are absent from the failure set
-- [ ] [AI] **RP-8.3 Composed quality gate** — run
+
+  > **RP-8.2 execution note**: the six commands are the gate registry's `command:` values, not
+  > directly-routable CLI invocations. `apps/rhino-cli/scripts/rhino-bin.sh md links validate` exits 2
+  > with `unrecognized or not-yet-routed invocation` — a uniform exit 2 across all six, which is an
+  > invocation error, not six failing gates. The registry runner supplies each gate's `args` (for
+  > `md-links`, `exclude: [plans/done]`), so the correct invocation is
+  > `apps/rhino-cli/scripts/rhino-bin.sh gate run --surface=pre-push`. It exits 0 and reports
+  > `md-links: All links valid! No broken links found.` — including this run's two new links — plus a
+  > passing README-index audit, harness-duplication check, and parity-manifest check. The
+  > preexisting-failure baseline is therefore empty on this surface: `plans/done` is excluded by the
+  > gate's own registered `args`, so the several-hundred archived-plan broken links never enter the
+  > failure set and no path of this run's appears in it.
+
+- [x] [AI] **RP-8.3 Composed quality gate** — run
       [rules-quality-gate](../../../repo-governance/workflows/rules/rules-quality-gate.md) at
       `mode: strict`. Fix findings attributable to this run; report those that predate it. Route
       failures per the workflow's table — budget to RP-5, contradiction to RP-3, duplication to
       RP-6, invalid gate declaration to RP-7
-- [ ] [AI] **RP-8.4 Reconcile the ledger** — the file-touch ledger and `rtk git status --short` name
+- [x] [AI] **RP-8.4 Reconcile the ledger** — the file-touch ledger and `rtk git status --short` name
       the same paths. A path in the status but not the ledger is an unintended edit, most often a
       neighbour swept in by the formatting hook; investigate before delivery
-- [ ] [AI] Run every check in [Local Quality Gates (Before Push)](#local-quality-gates-before-push)
-- [ ] [AI] Ask the user to authorize this change set; do not stage or commit until they do
+- [x] [AI] Run every check in [Local Quality Gates (Before Push)](#local-quality-gates-before-push)
+- [x] [AI] Ask the user to authorize this change set; do not stage or commit until they do
+
+  > **RP-8.3 result**: `rules-quality-gate` at `mode: strict` terminated `pass` on two consecutive
+  > clean validations. The deterministic preflight
+  > (`repo-governance audit --skip vendor-audit --skip governance-word-budget`) reported 0 findings
+  > across layer-coherence and traceability-audit on both runs. Pass 1 raised three MEDIUM findings —
+  > a routing attribution that gave `branch-cleanup.md` proof gates that belong to
+  > `mandatory-pre-removal-checks.md`, a classification step that dropped the `escalated` outcome, and
+  > a fixer `FALSE_POSITIVE` clause naming only one of item 7's two non-firing conditions. All three
+  > were fixed in Phase 1 before delivery, none deferred. Passes 2 and 3 each reported 0 findings at
+  > or above MEDIUM, with mirror byte-identity re-confirmed independently by `cmp -s`.
+  >
+  > **Standing authorization**: the user authorized this change set up front for both plans in this
+  > execution, so the authorize-before-staging step is discharged by that standing grant rather than
+  > by a fresh per-change-set request.
+
 - [ ] [AI] Commit per [Commit Guidelines](#commit-guidelines). Suggested:
       `docs(plans): scaffold worktree and branch cleanup into plan archival`
 - [ ] [AI] Push and open a draft PR against `main`. The body states the new-code cost/benefit (this

--- a/plans/in-progress/scaffold-plan-archival-cleanup/delivery.md
+++ b/plans/in-progress/scaffold-plan-archival-cleanup/delivery.md
@@ -310,19 +310,30 @@ non-firing conditions.
 - [x] [AI] Run every check in [Local Quality Gates (Before Push)](#local-quality-gates-before-push)
 - [x] [AI] Ask the user to authorize this change set; do not stage or commit until they do
 
-  > **RP-8.3 result**: `rules-quality-gate` at `mode: strict` terminated `pass` on two consecutive
-  > clean validations. The deterministic preflight
-  > (`repo-governance audit --skip vendor-audit --skip governance-word-budget`) reported 0 findings
-  > across layer-coherence and traceability-audit on both runs. Pass 1 raised three MEDIUM findings —
-  > a routing attribution that gave `branch-cleanup.md` proof gates that belong to
-  > `mandatory-pre-removal-checks.md`, a classification step that dropped the `escalated` outcome, and
-  > a fixer `FALSE_POSITIVE` clause naming only one of item 7's two non-firing conditions. All three
-  > were fixed in Phase 1 before delivery, none deferred. Passes 2 and 3 each reported 0 findings at
-  > or above MEDIUM, with mirror byte-identity re-confirmed independently by `cmp -s`.
-  >
-  > **Standing authorization**: the user authorized this change set up front for both plans in this
-  > execution, so the authorize-before-staging step is discharged by that standing grant rather than
-  > by a fresh per-change-set request.
+  > **Both-directions verification caught a defect in the check itself.** Running item 7 against
+  > `ose-private`'s live plans at Phase 3 surfaced a plan
+  > (`sync-ci-iac-carveout-widening-to-siblings`) that carries all three cleanup steps but files them
+  > under `## Phase 3: ose-private Archival` rather than a `### Plan Archival` heading. Item 7 as
+  > first written named that heading literally, so it would have produced a finding on a
+  > substantively compliant plan — a false positive, and exactly the one-directional defect
+  > [tech-docs.md §D-3](./tech-docs.md#d-3-verify-the-check-in-both-directions-before-landing) exists
+  > to catch. The check now reads "the plan's archival section or phase — the `### Plan Archival`
+  > section, or the phase that performs archival", and the fixer recipe was reworded to match. Fixed
+  > in both repositories before either landed.
+
+> **RP-8.3 result**: `rules-quality-gate` at `mode: strict` terminated `pass` on two consecutive
+> clean validations. The deterministic preflight
+> (`repo-governance audit --skip vendor-audit --skip governance-word-budget`) reported 0 findings
+> across layer-coherence and traceability-audit on both runs. Pass 1 raised three MEDIUM findings —
+> a routing attribution that gave `branch-cleanup.md` proof gates that belong to
+> `mandatory-pre-removal-checks.md`, a classification step that dropped the `escalated` outcome, and
+> a fixer `FALSE_POSITIVE` clause naming only one of item 7's two non-firing conditions. All three
+> were fixed in Phase 1 before delivery, none deferred. Passes 2 and 3 each reported 0 findings at
+> or above MEDIUM, with mirror byte-identity re-confirmed independently by `cmp -s`.
+>
+> **Standing authorization**: the user authorized this change set up front for both plans in this
+> execution, so the authorize-before-staging step is discharged by that standing grant rather than
+> by a fresh per-change-set request.
 
 - [ ] [AI] Commit per [Commit Guidelines](#commit-guidelines). Suggested:
       `docs(plans): scaffold worktree and branch cleanup into plan archival`


### PR DESCRIPTION
## Summary

DU-1 of `plans/in-progress/scaffold-plan-archival-cleanup`. Closes a scaffolding gap, not a rule gap: the obligation to remove a plan's worktree and delete its delivery branch already binds, but the document a reviewer actually reads never mentioned it.

**Before.** `.claude/skills/plan-creating-project-plans/reference/plan-archival.md` — the template every plan's archival section is authored from — contained zero occurrences of the word "branch". None of `plan-validating-quality`'s 21 numbered rules checked for a cleanup step. So a plan could be authored, reviewed, and executed with the cleanup silently missing. That is not hypothetical: the `update-tmp-folders` plan was authored from this template and shipped an archival section with worktree removal but no branch deletion. A maintainer caught it by asking; no gate did.

**After.** Three checkboxes in the template, one check in Rule 10, one repair recipe in the fixer.

## What changed

| Surface | Change |
| --- | --- |
| `plan-creating-project-plans/reference/plan-archival.md` | Three template checkboxes — classify every `Delivery Branch Inventory` entry, remove each provisioned worktree non-force, complete branch cleanup then `git worktree prune` — plus a prose paragraph routing to the canonical convention |
| `plan-validating-quality/reference/rule10-worktree-specification-validation.md` | New item 7, severity **MEDIUM**, with its non-firing conditions stated explicitly |
| `plan-applying-fixes/reference/worktree-and-delivery-mode-scaffolding-fixes.md` | New repair recipe for that finding |
| Two `reference/README.md` files | Annotations reworded to match their targets |
| Five `.agents/skills/` mirrors | Regenerated, never hand-edited |

## rules-propagation record

Run at `mode: strict`, repository `ose-public`. Two falsifiable statements.

**S-1** — a worktree-mode plan's archival section contains the three cleanup steps.
**Destination**: the authoring template. **Disposition**: `covered` by S-2's check.

**S-2** — `plan-checker` flags an archival section missing any of them.
**Destination**: Rule 10, confirming the plan's D-1 preference to extend the shard that already owns the worktree subject rather than mint Rule 22. **Disposition**: `covered` — the check plus its repair recipe.

**Nothing is superseded.** RP-3 scanned 18 files that state the subject and recorded a per-file disposition; every one is unchanged. The obligation lives at `plan-execution` finalization and in the plans convention, and its proof gates live in `worktree-and-artifact-cleanup/branch-cleanup.md`. The new text routes to them and never restates or relaxes a gate.

**RP-5 eviction: not required here.** All five edited files land under the 650-word Instruction target — 577, 607, 628, 355, 350. No new shard is created, so no new index links are owed.

`sibling-obligation: ose-private` — discharged by Phase 3 as a second, independent propagation run against that repository's own shard set. Parity slug `scaffold-plan-archival-cleanup`; common worktree basename `scaffold-plan-archival-cleanup`; branch `worktree/scaffold-plan-archival-cleanup`.

## Verification

**The check is verified in both directions** — a check confirmed only in the firing direction is half a check. Four constructed fixtures, evaluated against item 7 as written:

| Fixture | Expected | Observed |
| --- | --- | --- |
| worktree mode, neither cleanup step | finding | finding (MEDIUM) |
| worktree mode, branch-cleanup step missing only | finding | finding (MEDIUM) |
| worktree mode, all three steps present | no finding | no finding |
| main mode, `Worktree: not applicable` | no finding | no finding |

**Every live plan was run against the new check before landing** — five plans enumerated at Phase 0. Three backlog entries are README-only stubs with no `delivery.md`, so item 7 has nothing to read and does not fire. The two in-progress plans each already carry all three steps. **Zero findings; nothing deferred.**

**RP-8.3 `rules-quality-gate` at `mode: strict`** raised three MEDIUM findings, all fixed before this PR opened rather than deferred:

1. The routing prose attributed the worktree-removal proof gates to `branch-cleanup.md`. They live in its sibling `mandatory-pre-removal-checks.md`, which is now named on the removal step and linked from the prose.
2. The classification step listed `delivered, unused, or retained`, dropping the `escalated` outcome `worktree-specification.md` defines. It now reads `retained/escalated` and says an entry whose state is ambiguous or whose proof is missing is escalated, never deleted.
3. The fixer's `FALSE_POSITIVE` clause named only one of Rule 10 item 7's two non-firing conditions. It now names both.

**Gates**: `generate:bindings`, `validate:sync` (94/94), `harness:bindings-validation` (193/193), and `gate run --surface=pre-push` all exit 0. `repo-governance audit --skip vendor-audit --skip governance-word-budget` reports 0 findings across layer-coherence and traceability-audit. `prettier --check` and `markdownlint-cli2` clean across all ten changed files.

## New-code cost/benefit

No code. Roughly 90 words of template text, 80 of rule text, and 70 of recipe text. The cost is three surfaces to keep in step when the cleanup convention changes; the benefit is that a reviewer can confirm cleanup was planned from the PR diff alone, and the `Delivery Branch Inventory` every plan already produces finally has a consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiXo6DphDiXgcJgjiHvkm1
