### PR TITLE
fix(rhino-cli): read the false-positive ledger from local-tmp

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -12,7 +12,7 @@ b915496d3ffd590f0d9c53357f7b67673beb1544ddf8b3e6db627391865f34a3  apps/rhino-cli
 bb3b9213394085b3de9869892a6a0566074a3991c3a65af62f811ada78b7d3a2  apps/rhino-cli/src/RhinoCli.Application/src/Md.fs
 84a842f1d53732f843913b678b92420f229cc74bc9a35c2944b0c5f9fd35ac53  apps/rhino-cli/src/RhinoCli.Application/src/Parity.fs
 6967fea6ffe4d3d5fc7aa58678c1634b2d63702af6d093b73de1062fc2cd2b42  apps/rhino-cli/src/RhinoCli.Application/src/RepoConfig.fs
-3b241ebc61a86ad78adc78441953e5429d21ce57f21c6a4200d12cfff19b9040  apps/rhino-cli/src/RhinoCli.Application/src/RepoGovernance.fs
+f60d52d3986ae2c980212d513dc2f75c7969df32daf8280b70e3ea88f465701c  apps/rhino-cli/src/RhinoCli.Application/src/RepoGovernance.fs
 578a2e0e39badfbdcdf1c3abbf39cd73d13c5e439a8d56f0726397ab1b62fd2f  apps/rhino-cli/src/RhinoCli.Application/src/Specs.fs
 bd65007f689a1c5ed30e1d6154b7f6b8b813994efe6b7b92d2d81c0f11de65a4  apps/rhino-cli/src/RhinoCli.Application/src/TestContract.fs
 841f0114881d11350d79ffd97065d11473bdf4c9e968867ffdb4bc447a52ad64  apps/rhino-cli/src/RhinoCli.Application/src/TestContractBdd.fs
@@ -92,7 +92,7 @@ b8ef29846f9b919f63cb0e1dcf57b07fe3f39e0575c2d25e09fa1fa70b302edd  specs/apps/rhi
 6e16c2c7953f6c4a4c3a63fbfd693d01af5425d2ab2af66e06c3c42c75124287  specs/apps/rhino/cli/behaviors/repo-config/README.md
 1f6ee13979f8e21fe00f01cb45781cea6db9a752d5d0c86c9b44bc97340c585f  specs/apps/rhino/cli/behaviors/repo-config/data-driven.feature
 41ec86ef8a6b8bc159eab13090c75cf37f2655e1ac2c74c9e80e6d35bc277911  specs/apps/rhino/cli/behaviors/repo-governance/README.md
-59d7af092efd26e6afa15c2519a2063f4085be66f3b4960a4130b0fea2a23504  specs/apps/rhino/cli/behaviors/repo-governance/repo-governance-audit.feature
+c4ee41cae3b2d4f918d669a3040ec03cd163051231d07cd8925dd3ce5bf24caf  specs/apps/rhino/cli/behaviors/repo-governance/repo-governance-audit.feature
 6f1f1529df19246ee75e526a7e6ea3ef5aa9580df6237e22b989b62432024995  specs/apps/rhino/cli/behaviors/repo-governance/repo-governance-layer-coherence.feature
 c68f3384431771e33b5a114156e5f02f9dece6db2287b648d684d83cb03ba27a  specs/apps/rhino/cli/behaviors/repo-governance/repo-governance-traceability-audit.feature
 9d3319010979ca1251f05f9ea54387ff755de22c7184b0530baf2a2ef19734a5  specs/apps/rhino/cli/behaviors/repo-governance/repo-governance-vendor-audit.feature

--- a/apps/rhino-cli/src/RhinoCli.Application/src/RepoGovernance.fs
+++ b/apps/rhino-cli/src/RhinoCli.Application/src/RepoGovernance.fs
@@ -741,7 +741,7 @@ type AuditOptions =
         /// Override for the `ran_at` timestamp; `None` uses the current UTC time.
         Now: string option
         /// Known-false-positives Markdown file; `None` defaults to
-        /// `generated-reports/.known-false-positives.md` under the repo root.
+        /// `local-tmp/.known-false-positives.md` under the repo root.
         KnownFalsePositivesPath: string option
         /// Findings whose `File` matches any of these globs are dropped.
         ExcludeGlobs: string list
@@ -887,7 +887,7 @@ let private knownFalsePositiveRe =
 let private loadKnownFalsePositives (opts: AuditOptions) : Set<string> =
     let path =
         opts.KnownFalsePositivesPath
-        |> Option.defaultValue (Path.Combine(opts.RepoRoot, "generated-reports", ".known-false-positives.md"))
+        |> Option.defaultValue (Path.Combine(opts.RepoRoot, "local-tmp", ".known-false-positives.md"))
 
     if not (File.Exists path) then
         Set.empty

--- a/apps/rhino-cli/tests/unit/Steps/RepoGovernanceSteps.fs
+++ b/apps/rhino-cli/tests/unit/Steps/RepoGovernanceSteps.fs
@@ -410,7 +410,7 @@ type RepoGovernanceSteps() =
             )
 
     [<Given>]
-    member _.``a repository where a finding key matches a known-false-positives entry``() =
+    member _.``a repository where a finding key matches a known-false-positives entry in local-tmp``() =
         auditSuppressedKey <- "vendor-audit|suppressed.md|00000005"
 
         auditRunner <-
@@ -419,7 +419,7 @@ type RepoGovernanceSteps() =
                     [ "vendor-audit", [ auditFindingWithKey auditSuppressedKey "suppressed.md" "known false positive" ] ]
             )
 
-        let dir = Path.Combine(root (), "generated-reports")
+        let dir = Path.Combine(root (), "local-tmp")
         Directory.CreateDirectory dir |> ignore
 
         File.WriteAllText(

--- a/plans/in-progress/update-tmp-folders/delivery.md
+++ b/plans/in-progress/update-tmp-folders/delivery.md
@@ -41,10 +41,11 @@ The plan-execution Step 0 gate enters this worktree by default: it auto-provisio
 
 ### Delivery Branch Inventory
 
-| Branch                        | Mode          | Lifecycle state | Proof                                                                                                                                        |
-| ----------------------------- | ------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `worktree/update-tmp-folders` | `provisioned` | `unused`        | `git worktree add` at `2026-09-04T06:38:11Z`; removed and branch deleted before any delivery, to honor the one-worktree-at-a-time constraint |
-| `worktree/update-tmp-folders` | `provisioned` | `active`        | `git worktree add` at `2026-09-04T10:20:32Z` from `origin/main` `e61a4877a`; upstream unset immediately                                      |
+| Branch                        | Mode             | Lifecycle state    | Proof                                                                                                                                                                                                                                                                  |
+| ----------------------------- | ---------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `worktree/update-tmp-folders` | `provisioned`    | `unused`           | `git worktree add` at `2026-09-04T06:38:11Z`; removed and branch deleted before any delivery, to honor the one-worktree-at-a-time constraint                                                                                                                           |
+| `worktree/update-tmp-folders` | `provisioned`    | `active`           | `git worktree add` at `2026-09-04T10:20:32Z` from `origin/main` `e61a4877a`; upstream unset immediately                                                                                                                                                                |
+| `worktree/update-tmp-folders` | `worktree-to-pr` | `delivered` (DU-1) | PR [#473](https://github.com/wahidyankf/ose-public/pull/473), squash-merged `2026-09-04T11:14:07Z`; reviewed head `ae04b3dfb6ee99cbf2a8ecdc08fecafb70f18288`, base `e61a4877a2c87490cea1a16f9a739ac9127f4a85`, merge commit `24a6d93a600e5ff6813571f7c0572e03d0a43f21` |
 
 The plan must not record an absolute, home, tool-prefix, drive, UNC, or other host-specific path.
 Resolve its declared route only at runtime against the selected repository root; retain any resolved
@@ -577,45 +578,45 @@ itself or for another agent` already covers the case, and the neighbouring scrat
 **Outcome**: The intent-based rule and its consumers are on `main`.
 **Proof**: PR merged with green exact-head/base CI.
 
-- [ ] [AI] **RP-8.3 Composed quality gate** — run
+- [x] [AI] **RP-8.3 Composed quality gate** — run
       [rules-quality-gate](../../../repo-governance/workflows/rules/rules-quality-gate.md) at
       `mode: strict`. This is where repository-wide duplication, contradiction, and traceability
       findings surface that Phase 1's subject-scoped sweep deliberately did not look for. Fix
       findings attributable to this run's edits and re-verify; report findings that predate the run
       rather than absorbing them. Route failures per the workflow's own table — budget exceeded
       returns to RP-5, contradiction to RP-3, duplication to RP-6, invalid gate declaration to RP-7
-- [ ] [AI] Run every check in [Local Quality Gates (Before Push)](#local-quality-gates-before-push)
-- [ ] [AI] Commit under the plan's standing authorization per
+- [x] [AI] Run every check in [Local Quality Gates (Before Push)](#local-quality-gates-before-push)
+- [x] [AI] Commit under the plan's standing authorization per
       [Commit Guidelines](#commit-guidelines) — suggested split:
       one commit for `repo-governance/` + `AGENTS.md` + glossary + docs, one for `.claude/` +
       regenerated mirrors + `.prettierignore`. Suggested type/scope:
       `docs(governance): re-found the temporary-directory split on artifact intent`
-- [ ] [AI] Push and open a draft PR against `main`:
+- [x] [AI] Push and open a draft PR against `main`:
       `rtk gh pr create --draft --base main --title "docs(governance): re-found the temporary-directory split on artifact intent"`.
       The PR body states the new-code cost/benefit (this unit adds no code) and links this plan
-- [ ] [AI] **RP-9 PR content** — the PR body states, for each of the four normalized statements: the
+- [x] [AI] **RP-9 PR content** — the PR body states, for each of the four normalized statements: the
       statement itself, its destination, its enforcement disposition, and any supersession or
       eviction it caused. Name the two supersessions explicitly — a reviewer who cannot see what was
       displaced cannot review the displacement. If RP-5 evicted an `AGENTS.md` entry, say so in its
       own sentence; that is the change most likely to surprise a reader
-- [ ] [AI] **RP-9 Sibling obligation** — record `sibling-obligation: ose-private` in the PR body and
+- [x] [AI] **RP-9 Sibling obligation** — record `sibling-obligation: ose-private` in the PR body and
       as a durable note, together with the parity objective slug `update-tmp-folders`, the shared
       worktree basename `update-tmp-folders`, and the branch `worktree/update-tmp-folders` fixed at
       RP-1. This plan discharges that obligation in Phase 5 rather than deferring it; the record
       exists so a reader of the merged PR alone can still see what was owed
-- [ ] [AI] Assert before delivery that the current worktree basename and branch match the recorded
+- [x] [AI] Assert before delivery that the current worktree basename and branch match the recorded
       identity: `rtk git rev-parse --abbrev-ref HEAD` prints `worktree/update-tmp-folders`
-- [ ] [AI] Keep the PR body free of bare `#NNN` issue references — a `#`-prefixed number in a body
+- [x] [AI] Keep the PR body free of bare `#NNN` issue references — a `#`-prefixed number in a body
       parses as a footer and trips the message gate
-- [ ] [AI] Run every check in [Post-Push Verification](#post-push-verification)
-- [ ] [AI] Confirm the `Quality gate` workflow from `.github/workflows/pr-quality-gate.yml` is green
+- [x] [AI] Run every check in [Post-Push Verification](#post-push-verification)
+- [x] [AI] Confirm the `Quality gate` workflow from `.github/workflows/pr-quality-gate.yml` is green
       for the PR's exact current head and base
-- [ ] [AI] Confirm one authenticated clean current-head `pr-leak-review` result
-- [ ] [AI] Mark the PR ready for review, then merge it — `[AI]` merges once the hardened
+- [x] [AI] Confirm one authenticated clean current-head `pr-leak-review` result
+- [x] [AI] Mark the PR ready for review, then merge it — `[AI]` merges once the hardened
       preconditions above hold
-- [ ] [AI] Record the merged PR number and its 40-character reviewed-head SHA in the
+- [x] [AI] Record the merged PR number and its 40-character reviewed-head SHA in the
       [Delivery Branch Inventory](#delivery-branch-inventory)
-- [ ] [AI] Fast-forward local `main` in the primary checkout after the merge:
+- [x] [AI] Fast-forward local `main` in the primary checkout after the merge:
       `rtk git -C <primary-checkout-root> fetch origin && rtk git -C <primary-checkout-root> merge --ff-only origin/main`
       — a side-worktree push advances `origin/main` but not local `main`, and the divergence is
       otherwise silent. Never `reset --hard`
@@ -624,14 +625,53 @@ itself or for another agent` already covers the case, and the neighbouring scrat
 
 > All checks below must pass before starting Phase 4.
 
-- [ ] [AI] `rtk gh pr view <pr-number> --json state` reports `MERGED`
-- [ ] [AI] All PR check runs are green — verified via `rtk gh pr checks <pr-number>`
-- [ ] [AI] Local `main` in the primary checkout is at the same SHA as `origin/main`
-- [ ] [AI] The Delivery Branch Inventory records the PR number and reviewed-head SHA
+- [x] [AI] `rtk gh pr view <pr-number> --json state` reports `MERGED`
+- [x] [AI] All PR check runs are green — verified via `rtk gh pr checks <pr-number>`
+- [x] [AI] Local `main` in the primary checkout is at the same SHA as `origin/main`
+- [x] [AI] The Delivery Branch Inventory records the PR number and reviewed-head SHA
 
 > **Pause Safety**: `main` carries a coherent rule with all its consumers aligned; every prior
 > artifact still resolves. Safe to stop. To resume: `rtk gh pr list --head worktree/update-tmp-folders`
 > to confirm nothing is open.
+>
+> **Phase 3 Result**: PR [#473](https://github.com/wahidyankf/ose-public/pull/473) merged
+> `2026-09-04T11:14:07Z`. Reviewed head `ae04b3dfb6ee99cbf2a8ecdc08fecafb70f18288`, base
+> `e61a4877a2c87490cea1a16f9a739ac9127f4a85` (equal to `origin/main` at review time — no drift),
+> merge commit `24a6d93a600e5ff6813571f7c0572e03d0a43f21`. 312 files, +1057 / -488. Two commits:
+> `34a34a67d` (governance rule, `AGENTS.md`, glossary, docs) and `ae04b3dfb` (agents, skills,
+> mirrors, `.prettierignore`, this plan). All 15 check runs green at that exact head/base — the
+> `Quality gate` workflow's `governance`, `harness`, `specs`, `markdown`, `formatting-verify`, and
+> `shell-docker-actions` groups plus `Build rhino-cli`, `Detect affected languages`,
+> `Specs structure validation`, and `Validate env-contract surfaces`. The three language quality
+> gates report `skipping` because this unit touches no code.
+>
+> `pr-review-security-maker` returned **CLEAN** in leak-only mode at head `ae04b3dfb`, read-only,
+> nothing posted. It examined every candidate rather than pattern-matching: the
+> `/home/user/repos/project/` string is a pre-existing generic placeholder inside a documented
+> anti-pattern whose only change was the trailing directory name; `wahidyankf@gmail.com` is the
+> commit author identity already public on every commit in this repository; `test@test.com` is the
+> stray-override anti-pattern this plan names on purpose; the `a1b2c3`/`d4e5f6` strings are
+> synthetic UUID-chain illustrations.
+>
+> **RP-8.3 composed quality gate**, run under the user's five-iteration cap: pass 1 found zero
+> findings attributable to this run. Rather than spend further iterations, propagation completeness
+> was proven directly, which is what the cap directs: the AC-6 sweep leaves zero `WRITE-TARGET`
+> occurrences (33 survivors, all `RULE` or `INFRA`, enumerated in `verdicts-bindings.md`); a
+> mechanical cross-check confirms **every** `local-tmp/<x>/` path inside each of the 43 agents
+> equals that agent's declared family, with zero mismatches; and a contradiction scan across the
+> four rule shards (`overview-and-the-rule.md`, `generated-reports-and-progressive-writing.md`,
+> `mandatory-report-generation.md`, `status-exceptions-and-related.md`) finds them mutually
+> consistent, each stating the intent test in compatible words. The governance audit
+> (`layer-coherence`, `traceability-audit`, `governance-word-budget`) reports 0 findings.
+>
+> **One deviation.** `git merge --ff-only origin/main` cannot succeed in the worktree after a squash
+> merge — the branch's two commits and `main`'s one squashed commit share no ancestry. Verified
+> `git diff HEAD origin/main` is **empty**, so the branch content is fully represented on `main`,
+> then re-pointed the branch with `git checkout -B worktree/update-tmp-folders origin/main`. The
+> working tree was clean beforehand and clean after; no `reset --hard` was used, and no untracked or
+> ignored file was touched. The primary checkout's `main` fast-forwarded normally and now equals
+> `origin/main` at `24a6d93a6`. `origin/worktree/update-tmp-folders` still holds the pre-squash
+> commits and will be realigned with `--force-with-lease` when DU-2 pushes.
 
 ## Phase 4: Relocate the Suppression Ledger (`ose-public` DU-2)
 

--- a/specs/apps/rhino/cli/behaviors/repo-governance/repo-governance-audit.feature
+++ b/specs/apps/rhino/cli/behaviors/repo-governance/repo-governance-audit.feature
@@ -29,7 +29,7 @@ Feature: Governance Audit Orchestrator
     Then every run produces byte-identical JSON output
 
   Scenario: Skip list honored: false-positive entries do not count toward total_findings
-    Given a repository where a finding key matches a known-false-positives entry
+    Given a repository where a finding key matches a known-false-positives entry in local-tmp
     When the developer runs repo-governance audit
     Then the matching finding appears under skipped_false_positives
     And the matching finding does not count toward total_findings


### PR DESCRIPTION
## What this does

Moves the false-positive suppression ledger from `generated-reports/.known-false-positives.md` to `local-tmp/.known-false-positives.md`, and makes `rhino-cli` read it there by default.

DU-1 ([#473](https://github.com/wahidyankf/ose-public/pull/473)) re-founded the temporary-directory split on artifact intent and pointed every document at the new path. This unit makes the tool agree. It is DU-2 of [`plans/in-progress/update-tmp-folders/`](https://github.com/wahidyankf/ose-public/blob/main/plans/in-progress/update-tmp-folders/delivery.md).

## Why the ledger belongs in `local-tmp/`

The ledger is written by fixers and read by checkers. No human asks for it by name, and it is a step toward the answer rather than the answer — it fails both questions of the intent test DU-1 established. It is also **shared across families**, so it sits at the `local-tmp/` root rather than under any one `local-tmp/<agent-family>/` directory; filing it under a family would break the cross-family lookup.

## The change

`RepoGovernance.fs`, `loadKnownFalsePositives`:

```diff
-        |> Option.defaultValue (Path.Combine(opts.RepoRoot, "generated-reports", ".known-false-positives.md"))
+        |> Option.defaultValue (Path.Combine(opts.RepoRoot, "local-tmp", ".known-false-positives.md"))
```

plus the `KnownFalsePositivesPath` doc-comment in `AuditOptions`, which named the old default.

## TDD

**RED** — the existing scenario `Skip list honored: false-positive entries do not count toward total_findings` now writes its ledger to `local-tmp/` and is renamed to say so. Against the old `generated-reports` default it fails:

```
Failed  Skip list honored: false-positive entries do not count toward total_findings [56 ms]
Failed!  - Failed: 1, Passed: 2467, Skipped: 0, Total: 2468
```

**GREEN** — after the source change:

```
Passed!  - Failed: 0, Passed: 2468, Skipped: 0, Total: 2468
```

The existing scenario was retargeted rather than duplicated: it already asserts end-to-end that a key in the ledger lands in `skipped_false_positives` and does not count toward `total_findings`. Pointing it at the new location makes it a regression test for the path itself, and a second near-identical scenario would have added no coverage.

**REFACTOR** — `grep -c "generated-reports" RepoGovernance.fs` → `0`. The skip-list occurrences in `Md.fs` and `Convention.fs` are deliberately untouched: `generated-reports/` still exists for human-requested artifacts and should still be skipped.

## Parity boundary

`RepoGovernance.fs` and `repo-governance-audit.feature` are both byte-identical across `ose-public` and `ose-private`. `apps/rhino-cli/parity-manifest.sha256` is regenerated (`parity manifest generate`, discovered from `repo-config.yml`'s `parity-manifest` gate and confirmed against `DispatchUnitTests.fs:1106`), and `parity manifest validate` exits 0. **The identical change is owed to `ose-private` and is discharged by this plan's Phase 5, not deferred.**

## One thing I verified rather than assumed

Report filenames use double underscores (`docs__a1b2c3__2026-09-04--12-00__audit.md`), which `md naming validate` would normally reject — they were exempt only because `generated-reports` is in `namingSkipDirs` and `local-tmp` is not. I wrote a real report-shaped file into `local-tmp/docs/` and ran the gate: it passes, because the naming walker does not descend into `local-tmp/` at all. No skip-list change is needed. Probe removed afterward.

## Verification

| Check | Result |
| --- | --- |
| `nx run rhino-cli:test:quick` | exit 0 — 2468/2468 |
| `nx affected -t typecheck,lint,test:quick,specs:coverage` | exit 0 |
| `parity manifest validate` | exit 0 — `parity-manifest.sha256 is current` |
| `npm run validate:sync` | exit 0, 94/94 |
| `md naming` / `md heading-hierarchy` / `md frontmatter` | exit 0 |
| `grep -c "generated-reports" RepoGovernance.fs` | 0 |
| Ledger byte count after move | 1665, matching the pre-move value |

The ledger file itself is gitignored, so the move is not in this diff; it was performed in the working checkout and its byte count verified against the value recorded before the move.
