### PR TITLE
feat(rhino): add gate surface guards

### DIFF
--- a/apps/rhino-cli/parity-manifest.sha256
+++ b/apps/rhino-cli/parity-manifest.sha256
@@ -11,7 +11,7 @@ c9bcab647bfa6b7f7f07db8da416708ab87728a71e5dd24bb3d9d85b871367e0  apps/rhino-cli
 b915496d3ffd590f0d9c53357f7b67673beb1544ddf8b3e6db627391865f34a3  apps/rhino-cli/src/RhinoCli.Application/src/Harness.fs
 bb3b9213394085b3de9869892a6a0566074a3991c3a65af62f811ada78b7d3a2  apps/rhino-cli/src/RhinoCli.Application/src/Md.fs
 84a842f1d53732f843913b678b92420f229cc74bc9a35c2944b0c5f9fd35ac53  apps/rhino-cli/src/RhinoCli.Application/src/Parity.fs
-6967fea6ffe4d3d5fc7aa58678c1634b2d63702af6d093b73de1062fc2cd2b42  apps/rhino-cli/src/RhinoCli.Application/src/RepoConfig.fs
+6e9f2f203b170217fc548420606f1b73d70d7d72ad87675b274eea6a6f010b0f  apps/rhino-cli/src/RhinoCli.Application/src/RepoConfig.fs
 f60d52d3986ae2c980212d513dc2f75c7969df32daf8280b70e3ea88f465701c  apps/rhino-cli/src/RhinoCli.Application/src/RepoGovernance.fs
 578a2e0e39badfbdcdf1c3abbf39cd73d13c5e439a8d56f0726397ab1b62fd2f  apps/rhino-cli/src/RhinoCli.Application/src/Specs.fs
 bd65007f689a1c5ed30e1d6154b7f6b8b813994efe6b7b92d2d81c0f11de65a4  apps/rhino-cli/src/RhinoCli.Application/src/TestContract.fs
@@ -23,9 +23,9 @@ aea907ab80dca82acd86e5af31c8e4d10f304d7b20a09ae7bf276119a98455f5  apps/rhino-cli
 0a70fd4037fa3415bdf05b3523e7d6a1ffc62429970bc7e29a29ddceb7419fe7  apps/rhino-cli/src/RhinoCli.Application/src/TestContractProject.fs
 16bfb1fb1c2610c25f0cdc765dd65572bf5d4dfa40aa2c8249b25fd12cefa6d8  apps/rhino-cli/src/RhinoCli.Application/src/TestCoverage.fs
 bf6df2031e43d7352bd145de54960b18c4934b7a8ea160fd358d345fc5b3b58c  apps/rhino-cli/src/RhinoCli.Cli/RhinoCli.Cli.fsproj
-c7a2fedae172ab6d5b29682b4ba641e73d07a6a3950f4e999c0a6bf186510858  apps/rhino-cli/src/RhinoCli.Cli/src/Dispatch.fs
+1b505b9acab0fcee33d864576d078f2a9c3992041f4e101b3594b6b9a81766ed  apps/rhino-cli/src/RhinoCli.Cli/src/Dispatch.fs
 0f8cfd3dfcba6084b0a019d2c3fa58f12f453cb9fd7f4c76985e1c839cd23d66  apps/rhino-cli/src/RhinoCli.Cli/src/Formatters.fs
-6b02e63a5b4563a1ccd1cb56bcc40c61375ff3a4305aa686d4967eeb64a62fbc  apps/rhino-cli/src/RhinoCli.Cli/src/Gate.fs
+17937fe3b9ba8c890231393a1e7a5e98936a10b0a567b6a0f5f46c0cb1d308ae  apps/rhino-cli/src/RhinoCli.Cli/src/Gate.fs
 3fa334643831198a2e47fd6d6fb6a5cbcad0f4a3f27391934c71beb7a08d020e  apps/rhino-cli/src/RhinoCli.Cli/src/HelpText.fs
 d7ff185030ec8501b639875753a3bc9487e0f783c6efa593484b6199811ddff2  apps/rhino-cli/src/RhinoCli.Cli/src/RootArgs.fs
 52512b342d694832e500cc9a6d9711992211d31b5479f8e0fe2b6c1bbcc2b4d1  apps/rhino-cli/src/RhinoCli.Domain/RhinoCli.Domain.fsproj
@@ -54,7 +54,7 @@ cdff5c19b5b7ea3949c4a305daaedba632e4b1b5446c6fa0e1e2b816bbd9b151  specs/apps/rhi
 147b55728155da0dfc2e7e10df064bcf879bb0df7ed77d2c2bdd6153330c3169  specs/apps/rhino/cli/behaviors/gate/gate-declaration.feature
 70dbf099375e02ba0a19e23f7145308417e43711f3eb7435bd7848395deefd8c  specs/apps/rhino/cli/behaviors/gate/gate-emission.feature
 991b36ae431b50e18141880d487ed4cd9380628fb387ccbcbb4dba4dfd052408  specs/apps/rhino/cli/behaviors/gate/gate-enumeration.feature
-503c931690b7f6e0de8a54dd28efb4ab1170541530e4f604ae58d2a4348ca182  specs/apps/rhino/cli/behaviors/gate/gate-execution.feature
+df3adb4b7b4eb22a232d482059d8c9947e0f7c98482ad69295a3cf08b401f0ed  specs/apps/rhino/cli/behaviors/gate/gate-execution.feature
 720632fc23373b94f9fec7612d15d84593ed2e9c696fe0f2cdc6a8a1e9550ef4  specs/apps/rhino/cli/behaviors/gate/gate-validation.feature
 653fc2342734a060c759478cae63d1f14c2471c89389b41ced03164cea8bbbe2  specs/apps/rhino/cli/behaviors/gate/parity-manifest.feature
 828e3130905b6427eb293a859ceeddd8641afc464da5d4a0b42343d9b05a74e5  specs/apps/rhino/cli/behaviors/git/README.md

--- a/apps/rhino-cli/src/RhinoCli.Application/src/RepoConfig.fs
+++ b/apps/rhino-cli/src/RhinoCli.Application/src/RepoConfig.fs
@@ -114,6 +114,15 @@ type GateSurface =
     | PrePush
     | Ci
 
+/// Optional tool-neutral process wrapper for a complete gate surface run.
+/// The configured command receives `Args`, followed by the current Rhino CLI
+/// executable and its exact `gate run` argument vector. `ActiveEnv` is set by
+/// the wrapper for its child and prevents recursive re-entry.
+type GateSurfaceGuard =
+    { Command: string
+      Args: string list
+      ActiveEnv: string }
+
 /// The scope that determines a gate's inputs on a surface
 /// [Repo-grounded — `repo_config/mod.rs::ScopeKind`].
 type ScopeKind =
@@ -201,6 +210,7 @@ type HarnessCatalog = { Document: string; Verified: string }
 type RepoConfig =
     { Harness: HarnessEntry list
       Gates: GateEntry list
+      GateSurfaceGuards: Map<GateSurface, GateSurfaceGuard>
       Doctor: DoctorConfig
       HarnessCatalog: HarnessCatalog option }
 
@@ -210,6 +220,7 @@ type RepoConfig =
 let empty: RepoConfig =
     { Harness = []
       Gates = []
+      GateSurfaceGuards = Map.empty
       Doctor =
         { DotnetGlobalJson = None
           SkipTools = [] }
@@ -286,6 +297,12 @@ type GateEntryDto =
       CiGroup: string | null }
 
 [<CLIMutable>]
+type GateSurfaceGuardDto =
+    { Command: string | null
+      Args: ResizeArray<string>
+      ActiveEnv: string | null }
+
+[<CLIMutable>]
 type DoctorConfigDto =
     { DotnetGlobalJson: string | null
       SkipTools: ResizeArray<string> }
@@ -297,6 +314,7 @@ type HarnessCatalogDto = { Document: string; Verified: string }
 type RepoConfigDto =
     { Harness: ResizeArray<HarnessEntryDto>
       Gates: ResizeArray<GateEntryDto>
+      GateSurfaceGuards: Dictionary<string, GateSurfaceGuardDto>
       Doctor: DoctorConfigDto
       HarnessCatalog: HarnessCatalogDto }
 
@@ -422,6 +440,59 @@ let private scopeKindNames =
 
 let private lookupVariant (table: (string * 'a) list) (raw: string) : 'a option =
     table |> List.tryFind (fst >> (=) raw) |> Option.map snd
+
+let private isPortableEnvironmentVariableName (value: string) : bool =
+    let isInitial character =
+        Char.IsAsciiLetter character || character = '_'
+
+    let isRemaining character =
+        Char.IsAsciiLetterOrDigit character || character = '_'
+
+    not (String.IsNullOrEmpty value)
+    && isInitial value.[0]
+    && (value |> Seq.skip 1 |> Seq.forall isRemaining)
+
+let private toGateSurfaceGuard
+    (surfaceName: string)
+    (dto: GateSurfaceGuardDto)
+    : Result<GateSurface * GateSurfaceGuard, string> =
+    match lookupVariant gateSurfaceNames surfaceName with
+    | None -> Error(sprintf "gate-surface-guards.%s: unknown gate surface" surfaceName)
+    | Some surface ->
+        let command = Option.ofObj dto.Command |> Option.defaultValue ""
+        let activeEnv = Option.ofObj dto.ActiveEnv |> Option.defaultValue ""
+        let args = toOptionList dto.Args
+
+        if String.IsNullOrWhiteSpace command then
+            Error(sprintf "gate-surface-guards.%s.command: must not be blank" surfaceName)
+        elif command <> command.Trim() then
+            Error(sprintf "gate-surface-guards.%s.command: must not carry leading or trailing whitespace" surfaceName)
+        elif String.IsNullOrWhiteSpace activeEnv then
+            Error(sprintf "gate-surface-guards.%s.active-env: must not be blank" surfaceName)
+        elif not (isPortableEnvironmentVariableName activeEnv) then
+            Error(sprintf "gate-surface-guards.%s.active-env: must be a valid environment variable name" surfaceName)
+        else
+            match args |> List.tryFindIndex isNull with
+            | Some index -> Error(sprintf "gate-surface-guards.%s.args[%d]: must be a string" surfaceName index)
+            | None ->
+                Ok(
+                    surface,
+                    { Command = command
+                      Args = args
+                      ActiveEnv = activeEnv }
+                )
+
+let private toGateSurfaceGuards
+    (dtos: Dictionary<string, GateSurfaceGuardDto>)
+    : Result<Map<GateSurface, GateSurfaceGuard>, string> =
+    match dtos with
+    | null -> Ok Map.empty
+    | entries ->
+        entries
+        |> Seq.map (fun kv -> toGateSurfaceGuard kv.Key kv.Value)
+        |> List.ofSeq
+        |> sequenceResults
+        |> Result.map Map.ofList
 
 let private toSurfaceScope (dto: SurfaceScopeDto) : SurfaceScope =
     { Scope = lookupVariant scopeKindNames dto.Scope |> Option.defaultValue Other
@@ -750,17 +821,20 @@ let private parseRepoConfig (data: string) : Result<RepoConfig, string> =
                 toOptionList dto.Harness
                 |> List.mapi toHarnessEntry
                 |> sequenceResults
-                |> Result.map (fun harness ->
-                    { Harness = harness
-                      Gates = toOptionList dto.Gates |> List.map toGateEntry
-                      Doctor = toDoctorConfig dto.Doctor
-                      HarnessCatalog =
-                        match box dto.HarnessCatalog with
-                        | null -> None
-                        | _ ->
-                            Some
-                                { Document = dto.HarnessCatalog.Document
-                                  Verified = dto.HarnessCatalog.Verified } })
+                |> Result.bind (fun harness ->
+                    toGateSurfaceGuards dto.GateSurfaceGuards
+                    |> Result.map (fun gateSurfaceGuards ->
+                        { Harness = harness
+                          Gates = toOptionList dto.Gates |> List.map toGateEntry
+                          GateSurfaceGuards = gateSurfaceGuards
+                          Doctor = toDoctorConfig dto.Doctor
+                          HarnessCatalog =
+                            match box dto.HarnessCatalog with
+                            | null -> None
+                            | _ ->
+                                Some
+                                    { Document = dto.HarnessCatalog.Document
+                                      Verified = dto.HarnessCatalog.Verified } }))
         with ex ->
             Error ex.Message
 

--- a/apps/rhino-cli/src/RhinoCli.Cli/src/Dispatch.fs
+++ b/apps/rhino-cli/src/RhinoCli.Cli/src/Dispatch.fs
@@ -1520,24 +1520,31 @@ let private runGateRunLeaf (repoRoot: string) (args: string list) : int =
 
         2
     | Some surface ->
-        let only = longOptionValue "only" args
-        let group = longOptionValue "group" args
-
-        let commitMessageFile =
-            args
-            |> List.tryFindIndex (fun a -> a = "--")
-            |> Option.bind (fun index -> args |> List.skip (index + 1) |> List.tryHead)
-
-        let result =
-            match commitMessageFile with
-            | Some file -> Gate.runAtRootWithOnlyAndMessageFile repoRoot surface only group (Some file) (printf "%s")
-            | None -> Gate.runAtRootWithOnlyAndMessageFile repoRoot surface only group None (printf "%s")
-
-        match result with
-        | Ok() -> 0
+        match Gate.runSurfaceGuardAtRoot repoRoot surface args with
         | Error message ->
             eprintfn "Error: %s" message
             1
+        | Ok(Gate.SurfaceGuardExited exitCode) -> exitCode
+        | Ok Gate.ContinueWithoutSurfaceGuard ->
+            let only = longOptionValue "only" args
+            let group = longOptionValue "group" args
+
+            let commitMessageFile =
+                args
+                |> List.tryFindIndex (fun a -> a = "--")
+                |> Option.bind (fun index -> args |> List.skip (index + 1) |> List.tryHead)
+
+            let result =
+                match commitMessageFile with
+                | Some file ->
+                    Gate.runAtRootWithOnlyAndMessageFile repoRoot surface only group (Some file) (printf "%s")
+                | None -> Gate.runAtRootWithOnlyAndMessageFile repoRoot surface only group None (printf "%s")
+
+            match result with
+            | Ok() -> 0
+            | Error message ->
+                eprintfn "Error: %s" message
+                1
 
 /// `gate emit` [Repo-grounded — `commands/gate/emit.rs::run`]. `--surface`
 /// is required — see `runGateListLeaf`'s doc comment for why the check comes

--- a/apps/rhino-cli/src/RhinoCli.Cli/src/Gate.fs
+++ b/apps/rhino-cli/src/RhinoCli.Cli/src/Gate.fs
@@ -909,6 +909,52 @@ let private parseRunSurface (surface: string) : Result<GateSurface, string> =
     | "ci" -> Ok Ci
     | other -> Error(sprintf "unknown gate surface \"%s\"" other)
 
+/// Result of checking the optional whole-surface execution guard. An active
+/// marker or absent declaration continues in this process; otherwise the
+/// complete invocation has already run as the configured guard's child and
+/// its exact exit code must become this process's exit code.
+type SurfaceGuardRun =
+    | ContinueWithoutSurfaceGuard
+    | SurfaceGuardExited of exitCode: int
+
+/// Re-executes an entire `gate run` invocation through the configured
+/// tool-neutral surface guard. The guard receives its configured arguments,
+/// the current Rhino executable, then `gate run` and `gateRunArgs` unchanged.
+/// Its `active-env` marker is expected to be present in the re-executed child,
+/// which prevents recursive wrapping.
+let runSurfaceGuardAtRoot
+    (repoRoot: string)
+    (surface: string)
+    (gateRunArgs: string list)
+    : Result<SurfaceGuardRun, string> =
+    match parseRunSurface surface with
+    | Error message -> Error message
+    | Ok parsedSurface ->
+        match load repoRoot with
+        | Error message -> Error message
+        | Ok config ->
+            match Map.tryFind parsedSurface config.GateSurfaceGuards with
+            | None -> Ok ContinueWithoutSurfaceGuard
+            | Some guard ->
+                let activeValue = Environment.GetEnvironmentVariable guard.ActiveEnv
+
+                if not (String.IsNullOrEmpty activeValue) then
+                    Ok ContinueWithoutSurfaceGuard
+                else
+                    try
+                        let currentExe = Diagnostics.Process.GetCurrentProcess().MainModule.FileName
+
+                        let exitCode =
+                            runInherited
+                                guard.Command
+                                (guard.Args @ [ currentExe; "gate"; "run" ] @ gateRunArgs)
+                                repoRoot
+                                []
+
+                        Ok(SurfaceGuardExited exitCode)
+                    with ex ->
+                        Error(sprintf "gate surface guard for \"%s\" failed to start: %s" surface ex.Message)
+
 /// Resolves the gates selected by a declared CI group, excluding hand-wired
 /// members: they are dispatched by their own dedicated CI workflow job, not
 /// by `--group` [Repo-grounded — `gate/run.rs::resolve_group_gates`].

--- a/apps/rhino-cli/tests/unit/Steps/GateExecutionSteps.fs
+++ b/apps/rhino-cli/tests/unit/Steps/GateExecutionSteps.fs
@@ -1,4 +1,4 @@
-/// TickSpec step definitions binding `gate-execution.feature`'s 30 scenarios
+/// TickSpec step definitions binding `gate-execution.feature`'s 35 scenarios
 /// [Repo-grounded —
 /// `specs/apps/rhino/cli/behaviors/gate/gate-execution.feature`,
 /// `apps/rhino-cli/tests/gate_specs.rs`].
@@ -126,6 +126,7 @@ type GateExecutionSteps() =
         dir
 
     let mutable succeeded: bool option = None
+    let mutable lastExitCode: int option = None
     let mutable output: string = ""
     let mutable pathOverride: string option = None
     let mutable ciChangedBase: string option = None
@@ -201,6 +202,7 @@ type GateExecutionSteps() =
         @ extra
 
     let recordRun (result: RunResult) =
+        lastExitCode <- Some result.ExitCode
         succeeded <- Some(result.ExitCode = 0)
         output <- result.Stdout + result.Stderr
 
@@ -218,6 +220,15 @@ type GateExecutionSteps() =
             [ "gate"; "run"; sprintf "--surface=%s" surface; sprintf "--group=%s" group ]
 
         recordRun (run prebuiltFsharpCli.Value args root (fixtureEnv []))
+
+    let runGateWithEnvironment (surface: string) (only: string option) (extra: (string * string) list) =
+        let args =
+            [ "gate"; "run"; sprintf "--surface=%s" surface ]
+            @ (only
+               |> Option.map (fun id -> [ sprintf "--only=%s" id ])
+               |> Option.defaultValue [])
+
+        recordRun (run prebuiltFsharpCli.Value args root (fixtureEnv extra))
 
     let appendRun (surface: string) (only: string) =
         runGate surface (Some only)
@@ -370,6 +381,122 @@ type GateExecutionSteps() =
 
                 (trimmed.StartsWith "name:" || trimmed.StartsWith "- name:")
                 && l.Contains stepNameFragment))
+
+    let recordingGateConfig (guard: string) : string =
+        guard
+        + config (gate "recording" "check" "sh record-leaf.sh" "external" "      pre-push: { scope: other }\n")
+
+    let prepareRecordingGate (guard: string) =
+        initGit ()
+        write "record-leaf.sh" "#!/bin/sh\nprintf 'leaf-ran\\n' > leaf.txt\n"
+        write "repo-config.yml" (recordingGateConfig guard)
+
+    // --- Optional whole-surface execution guard ---------------------------
+
+    [<Given>]
+    member _.``pre-push has a configured execution guard and a recording gate``() =
+        prepareRecordingGate (
+            String.concat
+                "\n"
+                [ "gate-surface-guards:"
+                  "  pre-push:"
+                  "    command: sh"
+                  "    args: [guard.sh]"
+                  "    active-env: RHINO_TEST_GUARD_ACTIVE"
+                  "" ]
+        )
+
+        write
+            "guard.sh"
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > guard-arguments.txt\ncount=0\nif [ -f guard-count.txt ]; then count=$(cat guard-count.txt); fi\ncount=$((count + 1))\nprintf '%s\\n' \"$count\" > guard-count.txt\nexport RHINO_TEST_GUARD_ACTIVE=1\nexec \"$@\"\n"
+
+    [<When>]
+    member _.``the guarded gate runs with an only selector``() = runGate "pre-push" (Some "recording")
+
+    [<Then>]
+    member _.``the guard receives the complete gate run arguments``() =
+        Assert.True(isSuccess (), sprintf "guarded gate failed: %s" output)
+
+        let arguments =
+            File.ReadAllLines(Path.Combine(root, "guard-arguments.txt")) |> Array.toList
+
+        Assert.True(arguments.Head.EndsWith("rhino-cli-fsharp", StringComparison.Ordinal))
+        Assert.Equal<string list>([ "gate"; "run"; "--surface=pre-push"; "--only=recording" ], arguments.Tail)
+
+    [<Then>]
+    member _.``the guard runs exactly once``() =
+        Assert.Equal("1\n", File.ReadAllText(Path.Combine(root, "guard-count.txt")))
+
+    [<Then>]
+    member _.``the selected gate still runs``() =
+        Assert.Equal("leaf-ran\n", File.ReadAllText(Path.Combine(root, "leaf.txt")))
+
+    [<When>]
+    member _.``the gate runs with the configured guard marker active``() =
+        runGateWithEnvironment "pre-push" (Some "recording") [ "RHINO_TEST_GUARD_ACTIVE", "already-active" ]
+
+    [<Then>]
+    member _.``the guard is bypassed``() =
+        Assert.True(isSuccess (), sprintf "active-marker gate failed: %s" output)
+        Assert.False(File.Exists(Path.Combine(root, "guard-arguments.txt")))
+        Assert.False(File.Exists(Path.Combine(root, "guard-count.txt")))
+
+    [<Given>]
+    member _.``pre-push has a configured execution guard that exits with code 23``() =
+        initGit ()
+        write "exit-23.sh" "#!/bin/sh\nexit 23\n"
+
+        write
+            "repo-config.yml"
+            (String.concat
+                "\n"
+                [ "gate-surface-guards:"
+                  "  pre-push:"
+                  "    command: sh"
+                  "    args: [exit-23.sh]"
+                  "    active-env: RHINO_TEST_GUARD_ACTIVE"
+                  "gates: []"
+                  "" ])
+
+    [<Given>]
+    member _.``pre-push has a missing configured execution guard and a recording gate``() =
+        prepareRecordingGate (
+            String.concat
+                "\n"
+                [ "gate-surface-guards:"
+                  "  pre-push:"
+                  "    command: ./missing-guard"
+                  "    active-env: RHINO_TEST_GUARD_ACTIVE"
+                  "" ]
+        )
+
+    [<Given>]
+    member _.``pre-push has no execution guard and has a recording gate``() = prepareRecordingGate ""
+
+    [<When>]
+    member _.``the guarded pre-push surface runs``() =
+        runGate
+            "pre-push"
+            (if File.Exists(Path.Combine(root, "record-leaf.sh")) then
+                 Some "recording"
+             else
+                 None)
+
+    [<Then>]
+    member _.``gate run exits with code 23``() =
+        Assert.Equal<int option>(Some 23, lastExitCode)
+
+    [<Then>]
+    member _.``gate run fails without running the selected gate``() =
+        Assert.False(isSuccess ())
+        Assert.Contains("surface guard", output)
+        Assert.False(File.Exists(Path.Combine(root, "leaf.txt")))
+
+    [<Then>]
+    member _.``the selected gate runs without a guard invocation``() =
+        Assert.True(isSuccess (), sprintf "unguarded gate failed: %s" output)
+        Assert.Equal("leaf-ran\n", File.ReadAllText(Path.Combine(root, "leaf.txt")))
+        Assert.False(File.Exists(Path.Combine(root, "guard-arguments.txt")))
 
     // --- Rhino CLI kind receives derived files -----------------------------
 
@@ -1434,6 +1561,26 @@ module private FeatureRunner =
 
     let gateDeclarationFeaturePath: string =
         Path.Combine(repoRoot, "specs", "apps", "rhino", "cli", "behaviors", "gate", "gate-declaration.feature")
+
+[<Fact>]
+let ``A configured surface guard re-executes the complete gate run exactly once`` () =
+    FeatureRunner.run "A configured surface guard re-executes the complete gate run exactly once"
+
+[<Fact>]
+let ``An active surface guard marker prevents recursive re-execution`` () =
+    FeatureRunner.run "An active surface guard marker prevents recursive re-execution"
+
+[<Fact>]
+let ``A surface guard child exit code is preserved`` () =
+    FeatureRunner.run "A surface guard child exit code is preserved"
+
+[<Fact>]
+let ``A configured surface guard fails closed when it cannot start`` () =
+    FeatureRunner.run "A configured surface guard fails closed when it cannot start"
+
+[<Fact>]
+let ``An unconfigured surface executes gates directly`` () =
+    FeatureRunner.run "An unconfigured surface executes gates directly"
 
 [<Fact>]
 let ``Rhino CLI kind receives derived files`` () =

--- a/apps/rhino-cli/tests/unit/Steps/RepoConfigUnitTests.fs
+++ b/apps/rhino-cli/tests/unit/Steps/RepoConfigUnitTests.fs
@@ -152,9 +152,111 @@ let ``load defaults every section to empty when repo-config.yml declares none of
         | Ok config ->
             Assert.Empty(config.Harness)
             Assert.Empty(config.Gates)
+            Assert.Empty(config.GateSurfaceGuards)
             Assert.Empty(config.Doctor.SkipTools)
             Assert.Equal<string option>(None, config.Doctor.DotnetGlobalJson)
         | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+    finally
+        Directory.Delete(root, true)
+
+// ---- load: optional gate surface execution guards ----
+
+[<Fact>]
+let ``load parses a tool-neutral gate surface execution guard`` () =
+    let root = newTempDir ()
+
+    try
+        writeFile
+            root
+            "repo-config.yml"
+            (String.concat
+                "\n"
+                [ "gate-surface-guards:"
+                  "  pre-push:"
+                  "    command: ./hippo"
+                  "    args:"
+                  "      - run"
+                  "      - --class=ephemeral"
+                  "      - --"
+                  "    active-env: HIPPO_SESSION"
+                  "" ])
+
+        match load root with
+        | Ok config ->
+            match Map.tryFind PrePush config.GateSurfaceGuards with
+            | Some guard ->
+                Assert.Equal("./hippo", guard.Command)
+                Assert.Equal<string list>([ "run"; "--class=ephemeral"; "--" ], guard.Args)
+                Assert.Equal("HIPPO_SESSION", guard.ActiveEnv)
+            | None -> Assert.Fail("expected a pre-push surface guard")
+        | Error message -> Assert.Fail(sprintf "expected Ok, got Error %s" message)
+    finally
+        Directory.Delete(root, true)
+
+[<Fact>]
+let ``load rejects an execution guard for an unknown gate surface`` () =
+    let root = newTempDir ()
+
+    try
+        writeFile
+            root
+            "repo-config.yml"
+            "gate-surface-guards:\n  release: { command: ./guard, active-env: GUARD_ACTIVE }\n"
+
+        match load root with
+        | Error message -> Assert.Contains("unknown gate surface", message)
+        | Ok _ -> Assert.Fail("expected the unknown guard surface to be rejected")
+    finally
+        Directory.Delete(root, true)
+
+[<Theory>]
+[<InlineData("", "GUARD_ACTIVE", "command")>]
+[<InlineData("./guard", "", "active-env")>]
+[<InlineData("./guard", "BAD=NAME", "active-env")>]
+[<InlineData("./guard", "BAD NAME", "active-env")>]
+[<InlineData("./guard", "BAD-NAME", "active-env")>]
+[<InlineData("./guard", "1BAD_NAME", "active-env")>]
+let ``load rejects a malformed gate surface execution guard`` command activeEnv expectedField =
+    let root = newTempDir ()
+
+    try
+        writeFile
+            root
+            "repo-config.yml"
+            (String.concat
+                "\n"
+                [ "gate-surface-guards:"
+                  "  pre-push:"
+                  sprintf "    command: '%s'" command
+                  sprintf "    active-env: '%s'" activeEnv
+                  "" ])
+
+        match load root with
+        | Error message -> Assert.Contains(expectedField, message)
+        | Ok _ -> Assert.Fail("expected the malformed guard to be rejected")
+    finally
+        Directory.Delete(root, true)
+
+[<Fact>]
+let ``load rejects a null gate surface execution guard argument`` () =
+    let root = newTempDir ()
+
+    try
+        writeFile
+            root
+            "repo-config.yml"
+            (String.concat
+                "\n"
+                [ "gate-surface-guards:"
+                  "  pre-push:"
+                  "    command: ./guard"
+                  "    args: [run, null, --]"
+                  "    active-env: HIPPO_SESSION"
+                  "" ])
+
+        match load root with
+        | Error message -> Assert.Contains("args[1]", message)
+        | Ok _ -> Assert.Fail("expected a null guard argument to be rejected")
     finally
         Directory.Delete(root, true)
 

--- a/apps/rhino-cli/tests/unit/Steps/WaveEFGateUnitTests.fs
+++ b/apps/rhino-cli/tests/unit/Steps/WaveEFGateUnitTests.fs
@@ -1,6 +1,6 @@
 /// Plain xunit tests for `RhinoCli.Cli.Dispatch.route`'s `gate run`/`gate
 /// list` leaves, driven **in-process** against a disposable Git fixture.
-/// `GateExecutionSteps.fs`'s 30 scenarios spawn the real, prebuilt CLI as a
+/// `GateExecutionSteps.fs`'s 35 scenarios spawn the real, prebuilt CLI as a
 /// subprocess (`gate run`'s `rhino-cli`-kind leaf spawns the current
 /// executable, so an in-process call would resolve to the test host) — that
 /// makes them invisible to coverlet's line-coverage instrumentation, which is
@@ -182,9 +182,63 @@ let private withPathPrepended (dir: string) (f: unit -> 'a) : 'a =
     finally
         Environment.SetEnvironmentVariable("PATH", original)
 
+let private withEnvironmentVariable (name: string) (value: string) (f: unit -> 'a) : 'a =
+    let original = Environment.GetEnvironmentVariable name
+
+    try
+        Environment.SetEnvironmentVariable(name, value)
+        f ()
+    finally
+        Environment.SetEnvironmentVariable(name, original)
+
 /// An always-runs `external`-kind gate declared on `pre-push`.
 let private alwaysRunsConfig =
     config (gate "always-runs" "check" "sh -c 'exit 0'" "external" "      pre-push: { scope: other }\n")
+
+let private guardedConfig (command: string) (args: string list) =
+    String.concat
+        "\n"
+        ([ "gate-surface-guards:"; "  pre-push:"; sprintf "    command: %s" command ]
+         @ (if List.isEmpty args then
+                []
+            else
+                "    args:" :: (args |> List.map (sprintf "      - '%s'")))
+         @ [ "    active-env: RHINO_TEST_GUARD_ACTIVE"; "gates: []"; "" ])
+
+[<Fact>]
+let ``route preserves the configured surface guard process exit code`` () =
+    let fx = GitFixture()
+    fx.Init()
+    fx.Write("repo-config.yml", guardedConfig "sh" [ "-c"; "exit 23" ])
+
+    let code, _, _ =
+        runCaptured (okRoot fx.Root) [| "gate"; "run"; "--surface=pre-push" |]
+
+    Assert.Equal(23, code)
+
+[<Fact>]
+let ``route fails closed when the configured surface guard cannot start`` () =
+    let fx = GitFixture()
+    fx.Init()
+    fx.Write("repo-config.yml", guardedConfig "./missing-guard" [])
+
+    let code, _, err =
+        runCaptured (okRoot fx.Root) [| "gate"; "run"; "--surface=pre-push" |]
+
+    Assert.Equal(1, code)
+    Assert.Contains("gate surface guard", err)
+
+[<Fact>]
+let ``route bypasses the configured surface guard when its marker is active`` () =
+    let fx = GitFixture()
+    fx.Init()
+    fx.Write("repo-config.yml", guardedConfig "./missing-guard" [])
+
+    let code, _, _ =
+        withEnvironmentVariable "RHINO_TEST_GUARD_ACTIVE" "active" (fun () ->
+            runCaptured (okRoot fx.Root) [| "gate"; "run"; "--surface=pre-push" |])
+
+    Assert.Equal(0, code)
 
 [<Fact>]
 let ``route runs an unconditional gate on pre-push`` () =

--- a/specs/apps/rhino/cli/behaviors/gate/gate-execution.feature
+++ b/specs/apps/rhino/cli/behaviors/gate/gate-execution.feature
@@ -1,6 +1,34 @@
 @gate @unit
 Feature: Gate execution
 
+  Scenario: A configured surface guard re-executes the complete gate run exactly once
+    Given pre-push has a configured execution guard and a recording gate
+    When the guarded gate runs with an only selector
+    Then the guard receives the complete gate run arguments
+    And the guard runs exactly once
+    And the selected gate still runs
+
+  Scenario: An active surface guard marker prevents recursive re-execution
+    Given pre-push has a configured execution guard and a recording gate
+    When the gate runs with the configured guard marker active
+    Then the guard is bypassed
+    And the selected gate still runs
+
+  Scenario: A surface guard child exit code is preserved
+    Given pre-push has a configured execution guard that exits with code 23
+    When the guarded pre-push surface runs
+    Then gate run exits with code 23
+
+  Scenario: A configured surface guard fails closed when it cannot start
+    Given pre-push has a missing configured execution guard and a recording gate
+    When the guarded pre-push surface runs
+    Then gate run fails without running the selected gate
+
+  Scenario: An unconfigured surface executes gates directly
+    Given pre-push has no execution guard and has a recording gate
+    When the guarded pre-push surface runs
+    Then the selected gate runs without a guard invocation
+
   Scenario: Rhino CLI kind receives derived files
     Given a rhino-cli gate matches staged files "a.md" and "b.md"
     When "rhino-cli gate run --surface=pre-commit --only=md-naming" runs


### PR DESCRIPTION
## Summary

- add optional tool-neutral guards for complete gate surfaces
- re-execute the exact Rhino gate invocation once and prevent recursion through an active environment marker
- fail closed on invalid configuration or startup failure while preserving child exit codes
- add canonical Gherkin and focused parser/process coverage

## Verification

- `nx run rhino-cli:test:quick`
- 509 Gherkin scenarios fully bound
- aggregate coverage: 99.14%
- staged `parity manifest validate`

## New-code cost / benefit

The foundation adds one optional configuration map and a small dispatch boundary. It lets repository-local compute guards wrap generated gate surfaces without hard-coding HIPPO or another scheduler into Rhino, while unchanged repositories retain direct execution.