### PR TITLE
fix(hippo): read cache timestamps through the platform branch

### DIFF
--- a/.github/scripts/test-hippo-bootstrap.sh
+++ b/.github/scripts/test-hippo-bootstrap.sh
@@ -10,6 +10,18 @@ trap 'rm -rf -- "$temporary_root"' EXIT HUP INT TERM
 subject="$temporary_root/consumer/hippo"
 mkdir -p "$temporary_root/consumer" "$temporary_root/fake-bin" "$temporary_root/payload"
 cp "$repository_root/hippo" "$subject"
+
+# Timestamp reads must go through the platform-branching helper. The BSD form
+# `stat -f` means "filesystem status" to GNU coreutils, which writes a block of
+# filesystem detail to stdout before failing, so a `stat -f ... || stat -c ...`
+# fallback chain captures that detail alongside the real value and yields a
+# non-numeric result. Retention then silently treats every release as undatable
+# and reclaims nothing. That failure is invisible on macOS, so assert the shape
+# here rather than waiting for a Linux-only run to catch it.
+if grep -qE "stat -[fc] .*\|\| *stat -[fc] " "$repository_root/hippo"; then
+	echo "hippo must read timestamps through file_modified_epoch, not a stat fallback chain" >&2
+	exit 1
+fi
 chmod 755 "$subject"
 
 # The suite runs on both Linux and macOS runners. Pinning the fake uname to one

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,14 +11,15 @@ development path.
 
 ## Start with the workflow family
 
-| Family                          | What it does                                                                      | Where to look                                                                                                       |
-| ------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| Pull-request and main checks    | Validates affected workspace quality and environment contracts                    | `pr-quality-gate.yml`, `validate-env.yml`                                                                           |
-| Dependency and parity audits    | Looks for dependency risk and cross-repository Rhino CLI drift                    | `dependency-vulnerability-audit.yml`, `rhino-cli-parity-audit.yml`                                                  |
-| Non-product full quality        | Runs complete library and executable-tool test layers twice daily or on demand    | `non-product-full-quality.yml`                                                                                      |
-| Website delivery                | Tests each public website before its managed delivery step                        | `*-www-test-local-deploy-prod.yml` and `_reusable-www-test-local-deploy.yml`                                        |
-| Application delivery            | Tests a paired web/backend application before its managed staging path            | `*-app-test-local-deploy-stag.yml`, `*-app-test-stag.yml`, and reusable counterparts                                |
-| Backend images and UI artifacts | Builds publishable backend images or the web UI artifact when their inputs change | `_reusable-be-build-deploy.yml`, `*-be-build-deploy-stag.yml`, `publish-images.yml`, `web-ui-build-deploy-prod.yml` |
+| Family                          | What it does                                                                              | Where to look                                                                                                       |
+| ------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Pull-request and main checks    | Validates affected workspace quality and environment contracts                            | `pr-quality-gate.yml`, `validate-env.yml`                                                                           |
+| Dependency and parity audits    | Looks for dependency risk and cross-repository Rhino CLI drift                            | `dependency-vulnerability-audit.yml`, `rhino-cli-parity-audit.yml`                                                  |
+| Non-product full quality        | Runs complete library and executable-tool test layers twice daily or on demand            | `non-product-full-quality.yml`                                                                                      |
+| Website delivery                | Tests each public website before its managed delivery step                                | `*-www-test-local-deploy-prod.yml` and `_reusable-www-test-local-deploy.yml`                                        |
+| Application delivery            | Tests a paired web/backend application before its managed staging path                    | `*-app-test-local-deploy-stag.yml`, `*-app-test-stag.yml`, and reusable counterparts                                |
+| Backend images and UI artifacts | Builds publishable backend images or the web UI artifact when their inputs change         | `_reusable-be-build-deploy.yml`, `*-be-build-deploy-stag.yml`, `publish-images.yml`, `web-ui-build-deploy-prod.yml` |
+| Local compute boundary          | Proves the pinned HIPPO consumer contract on Linux and macOS before merge and twice daily | `hippo-consumer-smoke.yml`                                                                                          |
 
 The workflow filenames are the authoritative inventory. This map names stable
 families rather than maintaining a fragile duplicate list.

--- a/.github/workflows/hippo-consumer-smoke.yml
+++ b/.github/workflows/hippo-consumer-smoke.yml
@@ -64,13 +64,23 @@ jobs:
           ./hippo status --json --disk-path . > "${RUNNER_TEMP}/hippo-status.json"
           node -e '
           const value = JSON.parse(require("fs").readFileSync(process.env.RUNNER_TEMP + "/hippo-status.json", "utf8"));
-          if (value.schemaVersion !== 4 || value.profile?.resolvedProfile !== "local-constrained" || !value.configHash) process.exit(1);
-          const coordination = value.coordination;
-          if (coordination?.mode !== "reservation" || coordination.schemaVersion !== 4) process.exit(1);
+          const problems = [];
+          if (value.schemaVersion !== 4) problems.push("status schemaVersion " + value.schemaVersion);
+          if (!value.configHash) problems.push("missing configHash");
+          const profile = value.profile ?? {};
+          // resolvedProfile is pressure-dependent by design: the config declares a fallback and
+          // strict false, so a busy runner legitimately resolves to the fallback instead. Pin the
+          // config-derived request, and require only that the outcome stays on its declared chain.
+          if (profile.requestedProfile !== "local-constrained") problems.push("requestedProfile " + profile.requestedProfile);
+          if (!Array.isArray(profile.fallbackChain) || !profile.fallbackChain.includes(profile.resolvedProfile)) problems.push("resolvedProfile " + profile.resolvedProfile + " is outside its declared chain " + JSON.stringify(profile.fallbackChain));
+          const coordination = value.coordination ?? {};
+          if (coordination.mode !== "reservation") problems.push("coordination mode " + coordination.mode);
+          if (coordination.schemaVersion !== 4) problems.push("coordination schemaVersion " + coordination.schemaVersion);
           for (const field of ["capacity", "allocated", "waiting"]) {
             const vector = coordination[field];
-            if (typeof vector?.cpu !== "number" || typeof vector?.memoryBytes !== "number") process.exit(1);
+            if (typeof vector?.cpu !== "number" || typeof vector?.memoryBytes !== "number") problems.push(field + " vector " + JSON.stringify(vector));
           }
+          if (problems.length) { console.error("hippo status contract violated: " + problems.join("; ")); process.exit(1); }
           '
 
       - name: Verify shared root and OSE worker mappings

--- a/.github/workflows/hippo-consumer-smoke.yml
+++ b/.github/workflows/hippo-consumer-smoke.yml
@@ -1,6 +1,18 @@
 name: HIPPO Consumer Smoke
 
 on:
+  # A Linux-only retention defect once reached main through a green pull request
+  # because this suite ran on no pull-request surface at all. The path filter
+  # keeps unrelated pull requests free of the job while every change to the
+  # consumer boundary is proved on both operating systems before it merges.
+  pull_request:
+    paths:
+      - hippo
+      - hippo.lock
+      - hippo.local.json.example
+      - .github/scripts/test-hippo-bootstrap.sh
+      - .github/scripts/test-hippo-consumer.sh
+      - .github/workflows/hippo-consumer-smoke.yml
   schedule:
     - cron: "0 6,18 * * *"
   workflow_dispatch:

--- a/hippo
+++ b/hippo
@@ -442,7 +442,7 @@ prune_cache() {
 		if release_is_claimed "$candidate_path"; then
 			continue
 		fi
-		modified=$(stat -f '%m' "$candidate_path" 2>/dev/null || stat -c '%Y' "$candidate_path")
+		modified=$(file_modified_epoch "$candidate_path")
 		# Never date a release whose timestamp is unreadable, and never reclaim
 		# one used inside the idle window: it is still in service for some other
 		# repository even though no consumer happens to be running right now.


### PR DESCRIPTION
## What

`prune_cache` read release-directory timestamps through
`stat -f '%m' "$path" 2>/dev/null || stat -c '%Y' "$path"`. GNU coreutils reads `-f` as
`--file-system`, so on Linux `stat` wrote a block of filesystem detail to **stdout** before failing
on the format operand, and the fallback then appended the correct epoch. `2>/dev/null` suppresses
only stderr, so the command substitution captured the report concatenated with the value. The
numeric guard `case "$modified" in '' | *[!0-9]*) continue ;; esac` therefore skipped **every**
candidate and cache retention reclaimed nothing at all on Linux.

It fails safe — it never deletes — so the only symptom is a consumer cache that grows without
bound. macOS is unaffected, which is why no local run ever caught it.

## Evidence

- First-ever execution of `hippo-consumer-smoke.yml` failed on `ubuntu-24.04` and passed on
  `macos-15` (runs `33994712170`, `33994713323`).
- Reproduced in a Linux container and traced with `sh -x` to the retention assertion `[ 3 -eq 2 ]`.
  The container needs `procps` installed, or release-claim identity fails first and masks the fault.
- After the fix the Linux bootstrap suite exits 0 and the macOS consumer contract exits 0.
- Both guard controls run: reintroducing the fallback chain exits 1 with the message, the fixed tree
  exits 0.

## Why the surface changed too

The defect reached `main` through a green pull request because the consumer suite ran on **no**
pull-request surface — only on a schedule that had never fired. The workflow now carries a
path-filtered `pull_request` trigger, so this very PR proves the boundary on both operating systems
before it merges.

## Cost and benefit of the new code

Twelve lines of new non-test code: a static guard in the bootstrap suite and a trigger block.

- **Cost** — one extra CI job pair on pull requests that touch the consumer boundary, roughly
  21 seconds of suite time each plus runner setup. The path filter keeps every other pull request
  untouched. The guard asserts code shape rather than behaviour, which is a weaker kind of test.
- **Benefit** — the shape assertion is the only check that runs on the platform where this class of
  defect is *invisible*, so it stops a macOS-only workstation reintroducing a Linux-only fault. The
  trigger converts a twice-daily scheduled signal that had never fired into a pre-merge one.
- **Rejected alternative** — asserting retention behaviour on macOS only. That is what already
  existed, and it is exactly what missed this.
