### PR TITLE
fix(repo): ignore generated-reports contents at every depth, not just the root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,8 +90,14 @@ local-tmp/*
 !local-tmp/.gitkeep
 
 # Generated reports
-generated-reports/*
-!generated-reports/.gitkeep
+# `**/` is load-bearing: a pattern containing a non-trailing slash is anchored
+# to this file's directory, so `generated-reports/*` alone would leave a nested
+# apps/<x>/generated-reports/ entirely untracked-and-visible. Matching contents
+# rather than the directory itself (`/*`, not `/`) is also load-bearing: git
+# cannot re-include a file whose parent directory is excluded, so `!.gitkeep`
+# below only works while the directory stays un-excluded.
+**/generated-reports/*
+!**/generated-reports/.gitkeep
 
 # Cache
 .eslintcache


### PR DESCRIPTION
## The defect

`.gitignore` carried `generated-reports/*`. A pattern containing a non-trailing slash is anchored to the directory holding the `.gitignore`, so that rule only covered the **root** `generated-reports/`. The rule it replaced — `generated-reports/` — had no anchor and matched at any depth.

The narrowing was silent: the repository's only tracked `generated-reports` directory is the root one, so every gate stayed green. Meanwhile `apps/crane-cli/generated-reports/` — 310 audit `.md` files from an unrelated development session in May — sat untracked and visible, one `git add -A` away from being committed. Those files have since been deleted; this PR closes the hole that exposed them.

## The fix

```diff
-generated-reports/*
-!generated-reports/.gitkeep
+**/generated-reports/*
+!**/generated-reports/.gitkeep
```

Two things are load-bearing and neither is visible from the pattern alone, so both are now stated in the file:

- **`**/`** removes the anchor, restoring all-depth coverage.
- **`/*` rather than `/`** — matching directory *contents* rather than the directory itself. Git cannot re-include a file whose parent directory is excluded, so the `!.gitkeep` negation only works while the directory stays un-excluded. This is why the original author wrote `/*`; the mistake was dropping the depth, not adding the `/*`.

## Cost and benefit of the new code

No new code — a two-line pattern change plus a rationale comment. It removes a footgun that had already produced 310 stray untracked files, and it costs nothing at runtime. The comment exists because this exact mistake is easy to repeat: both properties of the pattern are non-obvious and the failure mode is silent.

## Verification

Probes at two different depths, asserted **before and after** the change:

| probe | before | after |
| --- | --- | --- |
| `apps/crane-cli/generated-reports/probe__audit.md` | not ignored | ignored |
| `libs/probe/generated-reports/probe__audit.md` | not ignored | ignored |
| `generated-reports/probe__audit.md` (root) | ignored | ignored |
| `generated-reports/.gitkeep` (root, tracked) | addable | addable, still tracked |
| `libs/probe/generated-reports/.gitkeep` (nested) | addable | addable |

Also asserted: piping `git ls-files` through `git check-ignore --stdin` returns nothing, so no currently-tracked file becomes ignored.

The sibling ignore files (`.markdownlintignore`, `.prettierignore`, `.dockerignore`) already use the unanchored `generated-reports/` form, so this restores consistency rather than introducing a new divergence.

## Scope

ose-public only. `.gitignore` is outside the `apps/rhino-cli` parity boundary, and ose-private still carries the original unanchored `generated-reports/` rule with no nested directories — it never had this defect, so there is nothing to propagate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDqR73bw7aVDXaQPXQh4Wq