### PR TITLE
feat(governance): gate mermaid labels at the binding 20-character rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
       "node_modules/.bin/prettier --write",
       "node_modules/.bin/markdownlint-cli2",
       "apps/rhino-cli/scripts/rhino-bin.sh md mermaid validate --exclude \"apps/rhino-cli/tests/fixtures\" --exclude \"plans/done\" --exclude \"apps/ayokoding-www/content\"",
+      "apps/rhino-cli/scripts/rhino-bin.sh md mermaid validate --exclude \"apps/rhino-cli/tests/fixtures\" --exclude \"plans/done\" --exclude \"apps/ayokoding-www/content\" --max-label-len \"20\"",
       "apps/rhino-cli/scripts/rhino-bin.sh md heading-hierarchy validate",
       "apps/rhino-cli/scripts/rhino-bin.sh md naming validate --exempt \"*__linkedin__*.md\" --exempt \"CONTRIBUTING.md\" --exempt \"pull_request_template.md\" --exempt \"RTK.md\"",
       "apps/rhino-cli/scripts/rhino-bin.sh md frontmatter validate"

--- a/repo-config.yml
+++ b/repo-config.yml
@@ -747,6 +747,37 @@ gates:
       pre-commit: { scope: affected-file-type, glob: "*.md" }
       ci: { scope: all-file-type }
 
+  # Rule 3 (common-syntax-errors-label-constraints-rule-3-line-length.md) binds
+  # Mermaid labels at 20 characters per `<br/>` segment, because renderers clip
+  # past roughly 20-22 with no error. The `md-mermaid` entry above runs at the
+  # validator's 30-character default -- Mermaid's `wrappingWidth` baseline, a
+  # backstop, not the rule -- so a green run there proves only that a diagram is
+  # under the backstop. This entry closes that 10-character gap.
+  #
+  # Deliberately scoped `affected-file-type` on BOTH surfaces, never
+  # `all-file-type`: the legacy corpus carries 413 violations across 155 files at
+  # the 20 threshold (measured 2026-09-08 by running the command below with
+  # `--max-label-len 20` over the same excludes). A repo-wide failing gate would
+  # turn `main` red on 155 files nobody touched, which is exactly the corpus-size
+  # objection mermaid-render-fidelity-caveat.md raises. Scoping to changed files
+  # ratchets instead: new and edited diagrams meet Rule 3, untouched ones stay on
+  # the 30 backstop until someone edits them. Widen to `all-file-type` only after
+  # a sweep clears the 413.
+  - id: md-mermaid-strict
+    type: check
+    command: md mermaid validate
+    kind: rhino-cli
+    ci-group: markdown
+    args:
+      max-label-len: ["20"]
+      exclude:
+        - apps/rhino-cli/tests/fixtures
+        - plans/done
+        - apps/ayokoding-www/content
+    surfaces:
+      pre-commit: { scope: affected-file-type, glob: "*.md" }
+      ci: { scope: affected-file-type, glob: "*.md" }
+
   - id: md-heading-hierarchy
     type: check
     command: md heading-hierarchy validate

--- a/repo-governance/conventions/formatting/diagrams/common-syntax-errors-label-constraints-quick-reference.md
+++ b/repo-governance/conventions/formatting/diagrams/common-syntax-errors-label-constraints-quick-reference.md
@@ -11,9 +11,10 @@ when_to_use: "Use when you want the full label-constraint rules summarized in on
 | Edge label `\|"text"\|`                | No                 | 20 chars   | No (`.` breaks parser)        |
 
 **Automated enforcement**: Run `rhino-cli md mermaid validate` to check these rules
-mechanically instead of counting characters manually. Use `--max-label-len 20` to enforce
-the 20-character limit (the default is 30, matching Mermaid's `wrappingWidth`
-baseline). The tool also checks parallel rank width (Rule 2 above) and single-diagram-per-block.
+mechanically instead of counting characters manually. Pass `--max-label-len 20` to check the
+20-character limit above; the bare default is 30, matching Mermaid's `wrappingWidth` baseline. The
+`md-mermaid-strict` gate applies the 20 automatically to every changed `.md` file. The tool also
+checks parallel rank width (Rule 2 above) and single-diagram-per-block.
 
 **Real-World Context**: All five rules were verified when fixing C4 architecture diagrams in the monorepo. Failures observed:
 

--- a/repo-governance/conventions/formatting/diagrams/common-syntax-errors-label-constraints-rule-3-line-length.md
+++ b/repo-governance/conventions/formatting/diagrams/common-syntax-errors-label-constraints-rule-3-line-length.md
@@ -9,7 +9,7 @@ Both node label lines (each segment between `<br/>` tags) and edge label strings
 
 Count every character including spaces, colons, slashes, and Unicode.
 
-**Note**: `rhino-cli md mermaid validate` enforces ≤ **30** raw characters per `<br/>`-split line (Mermaid's `wrappingWidth` baseline). Use `--max-label-len 20` for stricter validation to guard against rendering clipping in some environments.
+**Enforcement**: two registry gates cover this rule. `md-mermaid` runs repo-wide at the validator's `--max-label-len` default of **30** — Mermaid's `wrappingWidth` baseline, a backstop rather than this rule. `md-mermaid-strict` runs at **20** over changed `.md` files only, so every new or edited diagram meets Rule 3 while the legacy corpus ratchets in as it is touched. A green `md-mermaid` run alone does not prove Rule 3 compliance.
 
 **Safe examples (≤20 chars):**
 

--- a/repo-governance/conventions/formatting/diagrams/mermaid-flowchart-width-constraints.md
+++ b/repo-governance/conventions/formatting/diagrams/mermaid-flowchart-width-constraints.md
@@ -12,7 +12,14 @@ The `rhino-cli md mermaid validate` command enforces a maximum horizontal width 
 
 **Parser notes**: Pipe-labeled edges (`A -->|text| B`) parse correctly as edges. Cyclic diagrams are ranked via DFS back-edge removal before longest-path ranking — a cycle ranks as its underlying chain rather than collapsing every node to rank 0.
 
-**Label length**: the validator enforces **≤ 30 raw characters per line** (each `<br/>`-separated segment measured individually). Note: most renderers visually clip at approximately 20 characters — keep displayed text shorter when possible.
+**Label length**: the binding limit is **20 characters per line** (each `<br/>`-separated segment measured individually) — see [Rule 3](./common-syntax-errors-label-constraints-rule-3-line-length.md). Two registry gates enforce it together, because the validator's own default is looser than the rule:
+
+| Gate                | Threshold | Scope                                              |
+| ------------------- | --------- | -------------------------------------------------- |
+| `md-mermaid`        | 30        | every `.md` file in CI — the repo-wide backstop    |
+| `md-mermaid-strict` | 20        | changed `.md` files only — the binding Rule-3 gate |
+
+The strict gate is scoped to changed files on purpose: the legacy corpus carries violations at 20 that a repo-wide failing gate would surface all at once. New and edited diagrams meet Rule 3; untouched ones ratchet in when someone next edits them.
 
 **Automated enforcement**:
 
@@ -23,6 +30,5 @@ The `rhino-cli md mermaid validate` command enforces a maximum horizontal width 
 
 Run without flags to perform a repo-wide scan (the Nx target runs with `--exclude apps/rhino-cli/tests/fixtures --exclude plans/done --exclude apps/ayokoding-www/content` plus the standardized noise-skip set) using defaults (MaxWidth=4, unlimited depth). Pass additional `--exclude <prefix>` flags to suppress noise in project-specific runs.
 
-**Gate location**: Runs at **pre-commit (staged `.md` files only)** via the `rhino-cli` pre-commit
-hook (lint-staged) via `npx nx run rhino-cli:mermaid:validation`. Does NOT run at pre-push or in a
-standalone CI workflow — mermaid validation is folded into lint-staged and `pr-quality-gate.yml`.
+**Gate location**: Both gates run at **pre-commit (staged `.md` files only)** via lint-staged, and in
+CI via `pr-quality-gate.yml`. Neither runs at pre-push, and neither has a standalone CI workflow.

--- a/repo-governance/conventions/formatting/diagrams/mermaid-render-fidelity-caveat.md
+++ b/repo-governance/conventions/formatting/diagrams/mermaid-render-fidelity-caveat.md
@@ -18,10 +18,16 @@ Two consequences bind any author or checker working on state diagrams:
    **30** and **33** characters while a **40**-character label rendered fine. Clipping depends on
    glyph widths and diagram layout, not raw length. Any future validator rule MUST therefore derive
    its threshold **empirically** from rendered output, never assume a simple character count.
-3. **Any such rule must WARN, never FAIL.** Measured blast radius across this repo's
-   `stateDiagram` edge labels: **31** labels over 40 chars, **202** in the 31–40 band, **983** in
-   the 26–30 band, and roughly **11,800** at or under 25. A failing gate on a heuristic threshold
-   would block on a defect it cannot actually detect, across a corpus this large.
+3. **A repo-wide rule on state-diagram edge labels must WARN, never FAIL.** Measured blast radius
+   across this repo's `stateDiagram` edge labels: **31** labels over 40 chars, **202** in the
+   31–40 band, **983** in the 26–30 band, and roughly **11,800** at or under 25. A repo-wide
+   failing gate on a heuristic threshold would block on a defect it cannot actually detect, across
+   a corpus this large.
+
+   This does not exempt flowchart labels, where the 20-character limit is
+   [Rule 3](./common-syntax-errors-label-constraints-rule-3-line-length.md), not a heuristic. The
+   `md-mermaid-strict` gate fails at 20 but is scoped to **changed `.md` files**, so it never
+   blocks on the untouched corpus — the same objection, answered by scope instead of severity.
 
 A candidate `rhino-cli` WARN-level rule is tracked as a two-pager idea brief at
 [`plans/ideas/mermaid-state-label-render-clipping-warn.md`](../../../../plans/ideas/q2-not-urgent-important/mermaid-state-label-render-clipping-warn.md).

--- a/repo-governance/development/quality/repository-validation/markdown-quality-gates.md
+++ b/repo-governance/development/quality/repository-validation/markdown-quality-gates.md
@@ -5,8 +5,9 @@ when_to_use: "Use when locating a markdown quality gate's command or exclusions.
 
 # Markdown Quality Gates
 
-Seven gates carry `ci-group: markdown` in `repo-config.yml`: `markdownlint`, `md-mermaid`,
-`md-heading-hierarchy`, `md-naming`, `md-frontmatter`, `md-links`, and `governance-readme-index`.
+Eight gates carry `ci-group: markdown` in `repo-config.yml`: `markdownlint`, `md-mermaid`,
+`md-mermaid-strict`, `md-heading-hierarchy`, `md-naming`, `md-frontmatter`, `md-links`, and
+`governance-readme-index`.
 The registry is the source of truth for every command, argument, and surface below — read
 `repo-config.yml` when this page and the registry disagree.
 
@@ -17,16 +18,27 @@ CI matrix derived from `ci-group` execute them; the commands below are what thos
 
 **Command**: `md mermaid validate`
 
-Checks maximum horizontal width (4 nodes per rank), label line length (≤ 30 chars), single diagram
-per fenced block, and valid syntax. Diagram types covered: `flowchart`/`graph` (all directions) and
+Checks maximum horizontal width (4 nodes per rank), label line length, single diagram per fenced
+block, and valid syntax. Diagram types covered: `flowchart`/`graph` (all directions) and
 `stateDiagram-v2`/`stateDiagram` (v1) — state node count contributes to width; state display names
-and transition edge labels are subject to the ≤ 30-char limit.
+and transition edge labels are subject to the label-length limit.
 
 **Registry exclusions**: `apps/rhino-cli/tests/fixtures`, `plans/done`,
 `apps/ayokoding-www/content`. The `--exclude` flag is repeatable; pass extra prefixes to suppress
 noise in project-specific runs.
 
 **Surfaces**: pre-commit (staged `.md` files) and CI (all `.md` files).
+
+## 1a. Mermaid Label Length, Strict
+
+**Command**: `md mermaid validate --max-label-len 20` (gate `md-mermaid-strict`)
+
+`md-mermaid` above runs at the validator's default of 30 — Mermaid's `wrappingWidth` baseline, a
+backstop. The binding limit is 20 (see
+[Rule 3](../../../conventions/formatting/diagrams/common-syntax-errors-label-constraints-rule-3-line-length.md));
+this gate closes that gap. Same command, same exclusions, same surfaces — but scoped to **changed**
+`.md` files on both, so it ratchets new and edited diagrams to 20 without failing on the untouched
+legacy corpus.
 
 ## 2. Markdown Link Validation
 


### PR DESCRIPTION
## Problem

Rule 3 ([`common-syntax-errors-label-constraints-rule-3-line-length.md`](https://github.com/wahidyankf/ose-public/blob/main/repo-governance/conventions/formatting/diagrams/common-syntax-errors-label-constraints-rule-3-line-length.md)) binds Mermaid labels at **20 characters** per `<br/>` segment, because renderers clip past roughly 20–22 with no error.

The `md-mermaid` gate ran at the validator's **30**-character default — Mermaid's `wrappingWidth` baseline, a backstop rather than the rule. Nothing checked the 10-character gap between them. A diagram authored to the gate's own error message rendered clipped in GitHub while every gate stayed green. That is how it happened here: labels in a plan's diagrams were sized to 30, passed pre-commit and CI, and rendered cut off.

Nothing was bypassed. The gate simply measured something looser than the rule it was believed to enforce.

## Change

New `md-mermaid-strict` registry gate — the same `md mermaid validate` command at `--max-label-len 20`.

Scoped `affected-file-type` on **both** pre-commit and CI, never `all-file-type`. The legacy corpus carries **413 violations across 155 files** at the 20 threshold. A repo-wide failing gate would turn `main` red on 155 files nobody touched — exactly the corpus-size objection [`mermaid-render-fidelity-caveat.md`](https://github.com/wahidyankf/ose-public/blob/main/repo-governance/conventions/formatting/diagrams/mermaid-render-fidelity-caveat.md) raises against heuristic thresholds. Changed-file scoping ratchets instead: new and edited diagrams meet Rule 3, untouched ones stay on the 30 backstop until someone edits them. Widening to `all-file-type` is a follow-up after a sweep clears the 413.

`AffectedFileType` resolves to `ChangedPaths`, and on the CI surface `changedPaths` derives those from the merge-base diff (`Gate.fs:684-698`) — so the CI declaration is a real PR-diff check, not a vacuous one. Thirteen existing gates already use that CI scope.

## Enforcement disposition: gated

Verified in both directions with asserted exit codes:

| Input | Result |
| --- | --- |
| node label `"this label is 25 chars"` (22 chars) | exit **1** — `[label_too_long] node "A" label ... is 22 chars (max 20)` |
| same diagram, label `"short label"` (11 chars) | exit **0** |

`md-mermaid` at its default passes the first case. That is the gap this closes.

## Rules propagation

Every other surface stating the threshold was tidied so none still tells the old story:

- **Rule 3** — replaced the "enforces ≤ 30 … use `--max-label-len 20` for stricter validation" note with the two-gate enforcement statement, and states plainly that a green `md-mermaid` run alone does not prove Rule 3 compliance
- **Label-constraint quick reference** — the 20 is now applied automatically to changed files, not a flag you must remember
- **Flowchart width constraints** — corrected "the validator enforces ≤ 30" to the binding 20 with a gate/threshold/scope table; corrected the gate-location paragraph, which described a stale `npx nx run rhino-cli:mermaid:validation` invocation
- **Render-fidelity caveat** — its "any such rule must WARN, never FAIL" guidance now scopes explicitly to *repo-wide* rules on `stateDiagram` edge labels (where clipping is genuinely unpredictable by character count), and notes that a changed-files-scoped FAIL on flowchart labels answers the same blast-radius objection by scope instead of severity
- **Markdown quality gates** — seven gates → eight, with the strict gate's command, threshold, and scope

## Parity

None required. The registry's `args` map renders generically through `RepoConfig.fs::fixedArguments`, so no F# change was needed and no parity-manifest file is touched. `repo-config validate` and `gate validate` both exit 0.

## Cost/benefit

New code: one 12-line registry entry plus its rationale comment, and one generated lint-staged line. No new validator, abstraction, or dependency — the threshold flag already existed and was simply never wired to a gate. The benefit is that the repository's stated diagram rule is now the rule that gets checked, on the narrowest surface that binds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015a9spDQ3PoMFNAoNLMT1VX