### PR TITLE
fix(hippo): stop supervised dotnet work leaving detached build daemons

### DIFF
--- a/.github/scripts/test-hippo-consumer.sh
+++ b/.github/scripts/test-hippo-consumer.sh
@@ -18,6 +18,14 @@ if grep -q -- '--concurrency-env GOMAXPROCS' hippo; then
 	exit 1
 fi
 
+# A supervised command must leave no detached build daemon behind in the process
+# group HIPPO waits on; a daemon that outlives the command turns a finished run
+# into an unbounded hang. .NET has two such daemon sources and both are defaulted
+# off on the `run` branch, each still deferring to an explicit caller value.
+[ "$(grep -c -- 'MSBUILDDISABLENODEREUSE=${MSBUILDDISABLENODEREUSE:-1}' hippo)" -eq 1 ]
+[ "$(grep -c -- 'DOTNET_CLI_USE_MSBUILD_SERVER=${DOTNET_CLI_USE_MSBUILD_SERVER:-0}' hippo)" -eq 1 ]
+[ "$(grep -c -- 'export MSBUILDDISABLENODEREUSE DOTNET_CLI_USE_MSBUILD_SERVER' hippo)" -eq 1 ]
+
 # The committed file is a safe example; each machine's active policy remains
 # ignored and the test never creates it in the real checkout.
 git check-ignore --quiet hippo.local.json

--- a/hippo
+++ b/hippo
@@ -535,6 +535,16 @@ export HIPPO_DEFAULT_CONFIG
 case "${1:-}" in
 run)
 	shift
+	# HIPPO supervises a process group, so a daemon that outlives the command keeps
+	# the run alive after the command has already finished and printed its result.
+	# .NET's MSBuild node-reuse workers and MSBuild server are exactly that: they
+	# detach, reparent to init, stay in the group, and `hippo run` then never
+	# returns. It reads as contention rather than as a hang because the daemons are
+	# reused between builds, so only a cold first invocation reproduces it.
+	# Explicit caller configuration still wins, as it does above.
+	MSBUILDDISABLENODEREUSE=${MSBUILDDISABLENODEREUSE:-1}
+	DOTNET_CLI_USE_MSBUILD_SERVER=${DOTNET_CLI_USE_MSBUILD_SERVER:-0}
+	export MSBUILDDISABLENODEREUSE DOTNET_CLI_USE_MSBUILD_SERVER
 	exec "$binary" run \
 		--concurrency-env NX_PARALLEL \
 		--concurrency-env DOTNET_PROCESSOR_COUNT \

--- a/repo-governance/development/practice/resource-aware-development/workload-classes-and-supervision.md
+++ b/repo-governance/development/practice/resource-aware-development/workload-classes-and-supervision.md
@@ -15,5 +15,8 @@ group before release. Interactive children temporarily own the foreground termin
 non-controlling input remain unchanged.
 
 A guarded command returns only once its whole process group has retired, so a payload that leaves
-a persistent daemon behind — MSBuild node reuse is the one observed here — keeps the guard waiting
-long after the work itself finished. Disable the reuse or stop the daemon; never kill the guard.
+a persistent daemon behind keeps the guard waiting long after the work itself finished. The `run`
+branch of the consumer therefore defaults .NET's two daemon sources off —
+`MSBUILDDISABLENODEREUSE=1` and `DOTNET_CLI_USE_MSBUILD_SERVER=0` — while an explicit caller value
+still wins, and the consumer contract test asserts both defaults. Any other toolchain that detaches
+a daemon takes the same treatment at the wrapper; never kill the guard.


### PR DESCRIPTION
## Rule propagated

**Normalized statement.** A command invoked through the guarded consumer must not leave a background daemon alive in its supervised process group after the command itself exits. HIPPO waits on the group, so a surviving daemon turns a finished command into an unbounded hang. Concretely for .NET, the consumer's `run` branch defaults `MSBUILDDISABLENODEREUSE=1` and `DOTNET_CLI_USE_MSBUILD_SERVER=0`, and an explicit caller value still wins.

**Destination.** `repo-governance/development/practice/resource-aware-development/workload-classes-and-supervision.md`, the document that already owns the subject. The instruction-surface admission test fails on necessity: a contributor is led here by the guarded-compute activity the rule governs, so a governance layer reaches them just as well at no budget cost. No eviction, no threshold touched — the file moved from 178 to 208 words against a 650-word target.

**Supersession.** None. The existing paragraph already bound the general obligation; this is an **amend**, same layer and compatible obligation. What was new is that its remedy was a manual instruction ("disable the reuse or stop the daemon") with no consumer default and no enforcement. The obligation "never kill the guard" is preserved verbatim in force.

**Enforcement disposition: covered**, by `.github/scripts/test-hippo-consumer.sh` — the same wrapper-mapping contract block that already gates the two `--concurrency-env` mappings and rejects a leaked `GOMAXPROCS` mapping. Verified in both directions with asserted exit codes, in both repositories:

| State | Result |
| --- | --- |
| Violating (assertions only, no defaults) | `TERMINAL_EXIT=1`, success line absent |
| Conforming (defaults added) | `TERMINAL_EXIT=0`, `hippo consumer contract tests passed` |

## Why this was hard to see

`npm run validate:claude` printed its complete report — 1669 checks, 0 failures — and then `./hippo run` never returned. Every scheduler signal said healthy: `hippo status` reported `state=normal reason=normal profile=balanced concurrency=11`, the heavy-work lease named the hung run's own pid as its holder, and the telemetry journal kept sampling once a second. The process tree was the only place the truth showed — the lifetime launcher had no `dotnet` child (the command had finished), while three `MSBuild.dll /nodemode:1 /nodeReuse:true` processes had reparented to init without leaving the supervised group.

It is intermittent in a way that mimics load: warm node-reuse daemons are reused by the next build and nothing new lands in the group, so only a cold first invocation of a session reproduces it.

## Cost and benefit

Three added lines in the consumer and three assertions in a test that already runs, against a failure mode that cost two abandoned ten-minute waits and three misdiagnoses in one plan. No new dependency, no new gate, no new file.

## Sibling obligation

Named, not none: `hippo`, the consumer contract test, and the governance document are byte-identical across `ose-public` and `ose-private`. The parity PR is linked below and carries the same three edits.

Parity sibling: https://github.com/wahidyankf/ose-private/pull/168
