### PR TITLE
feat(specs): add the islamic-be behaviour corpus and OpenAPI contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,11 @@ coverage.xml
 # Bundled OpenAPI spec + docs
 specs/apps/a-demo/contracts/generated/
 specs/apps/ose/lms-be/contracts/generated/
+# The islamic contract keeps a hand-written README in its generated/ folder, so the folder
+# itself is ignored by glob and the README negated back in. The two siblings above ignore
+# the whole directory instead; theirs hold nothing but build output.
+specs/apps/islamic/be/contracts/generated/*
+!specs/apps/islamic/be/contracts/generated/README.md
 
 # MemSearch vector index (local user-specific data)
 .memsearch/

--- a/plans/in-progress/islamic-be-init/delivery.md
+++ b/plans/in-progress/islamic-be-init/delivery.md
@@ -689,12 +689,54 @@ platform linux`. Root cause: the `gate` matrix job provisions the **union** of a
 
 > All checks below must pass before starting Phase 3. Phase 2 (DU2) may proceed in parallel.
 
-- [ ] [AI] `npm run test:validators` — exits zero with the new Go extractor cases present
-- [ ] [AI] `npm exec nx -- run rhino-cli:repo-config:validation` — exits zero
-- [ ] [AI] `npm exec nx -- run-many -t test:quick --projects=ose-be,ose-be-e2e` — exits zero, proving no regression to existing lanes
-- [ ] [AI] Confirm the merged `pr-quality-gate.yml` excludes `tag:lang:go` in the `typescript`, `dotnet`, `flutter`, **and** `java` jobs — acceptance: `rtk grep -c 'tag:lang:go' .github/workflows/pr-quality-gate.yml` reports 5
-- [ ] [AI] `rtk npm run doctor` — reports a `go` row with a real version
-- [ ] [AI] `rtk git log -1 --stat -- apps/rhino-cli/` — shows this delivery unit touched no `rhino-cli` file
+- [x] [AI] `npm run test:validators` — exits zero with the new Go extractor cases present
+
+  > **Verified (2026-09-08).** Exit 0, `fail 0`. Nine tests naming Godog are present and passing.
+  > Captured to `evidence/du1-gate-validators.txt` — the full run, not a `tail`; the first capture
+  > was piped through `tail -20` and silently held only the last file's summary, which would have
+  > made the Go cases look absent.
+
+- [x] [AI] `npm exec nx -- run rhino-cli:repo-config:validation` — exits zero
+
+  > **Verified (2026-09-08).** The target named in this checkbox does not exist. The real entrypoint
+  > is `apps/rhino-cli/scripts/rhino-bin.sh repo-config validate`, which exits 0 with
+  > `repo-config.yml matches the canonical schema (key set + enums OK)`. Captured to
+  > `evidence/du1-gate-repo-config.txt`.
+
+- [x] [AI] `npm exec nx -- run-many -t test:quick --projects=ose-be,ose-be-e2e` — exits zero, proving no regression to existing lanes
+
+  > **Verified (2026-09-08).** Exit 0. Re-run with `--skip-nx-cache` after the first attempt came
+  > back entirely from cache: `test:coverage:{unit,integration,e2e,behaviour}` all genuinely
+  > re-executed against the modified `behaviour-coverage.mjs`, so `ose-be`'s F# bindings are proven
+  > unbroken rather than assumed. (The cache hit was in fact legitimate —
+  > `{workspaceRoot}/scripts/behaviour-coverage.mjs` is a declared input to both targets — but that
+  > was confirmed after the fact, not before.) Captured to `evidence/du1-gate-ose-be.txt`.
+
+- [x] [AI] Confirm the merged `pr-quality-gate.yml` excludes `tag:lang:go` in the `typescript`, `dotnet`, `flutter`, **and** `java` jobs — acceptance: `rtk grep -c 'tag:lang:go' .github/workflows/pr-quality-gate.yml` reports 5
+
+  > **Verified (2026-09-08) against `origin/main` at `f9e40bc67`.** The count is 5 as stated, but
+  > the count alone is not the invariant — the real property is _which_ lists. `tag:lang:go` appears
+  > in the typescript (:331), dotnet (:360 and :363, two lines), flutter (:387), and java (:402)
+  > lists, and is absent from the go job's own (:417). Note the checkbox names four jobs while the
+  > count is 5, because the dotnet job carries two invocations.
+  >
+  > Two things this check surfaces that it was not looking for. There is no `tag:lang:dotnet` tag at
+  > all — .NET projects carry `lang:fsharp`/`lang:csharp`, so a naive `grep -c tag:lang:dotnet`
+  > returns 0 and proves nothing. And `tag:lang:rust` appears in only 4 lists: the dotnet job never
+  > excludes it, so a Rust project would be swept into the .NET job. That hole predates this plan
+  > and stays out of scope, recorded in `learnings.md`.
+
+- [x] [AI] `rtk npm run doctor` — reports a `go` row with a real version
+
+  > **Verified (2026-09-08).** `✓ go v1.26.1 (required: ≥1.26)` and, unasked,
+  > `✓ golangci-lint v2.11.3 (required: ≥2.11)`. Both resolve real detected versions rather than
+  > echoing the pin. Captured to `evidence/du1-gate-doctor.txt`.
+
+- [x] [AI] `rtk git log -1 --stat -- apps/rhino-cli/` — shows this delivery unit touched no `rhino-cli` file
+
+  > **Verified (2026-09-08).** `git diff --name-only 63ce3eea6..d534cadf3` filtered to
+  > `apps/rhino-cli/` returns nothing across all three commits — a stronger check than `log -1`,
+  > which would only have inspected the last commit of the three.
 
 > **Pause Safety**: the Go lane exists and every gate is registered, but no Go project does — the
 > `go` job is correct and dormant. Nothing else changed behaviour. Safe to stop. To resume:
@@ -704,14 +746,86 @@ platform linux`. Root cause: the `gate` matrix job provisions the **union** of a
 
 Delivery boundary. Independent of DU1; may run before, after, or concurrently.
 
-- [ ] [AI] Create `specs/apps/islamic/README.md` and `specs/apps/islamic/overview.md` following the shape of `specs/apps/ose/` — acceptance: `rhino-cli specs structure validate` accepts the new product folder
-- [ ] [AI] Create `specs/apps/islamic/be/README.md` describing the corpus, and `architecture.md` with C4 context, container, and component diagrams using the accessible palette — acceptance: both files exist and every Mermaid `classDef` uses palette hex codes
-- [ ] [AI] Create `specs/apps/islamic/be/behaviours/health/` with `README.md` and `health.feature` carrying the three US-1 scenarios from `prd.md` verbatim — acceptance: `npx gherkin` parses the feature and scenario names match `prd.md`
-- [ ] [AI] Create `specs/apps/islamic/be/behaviours/config/` with `README.md` and `port-resolution.feature` carrying the five US-3 scenarios — acceptance: the feature parses and all five scenarios are present
-- [ ] [AI] Create `specs/apps/islamic/be/contracts/openapi.yaml` (OpenAPI 3.1) with `paths/health.yaml`, `schemas/health.yaml`, and `schemas/error.yaml`, plus a README for each folder — acceptance: the root document references the fragments and every folder carries an annotated index
-- [ ] [AI] Copy `.spectral.yaml` from `specs/apps/ose/be/contracts/` unchanged — acceptance: the two ruleset files are byte-identical
-- [ ] [AI] Create `specs/apps/islamic/be/contracts/project.json` registering `islamic-contracts` with `lint`, `bundle`, `docs`, `typecheck`, `test:quick`, `deps:audit`, `compat:min-version`, and `specs:structure-validation` targets, plus `namedInputs.specs` — acceptance: `npx nx show project islamic-contracts` resolves
-- [ ] [AI] Create `specs/apps/islamic/be/contracts/generated/README.md` explaining that bundles are generated — acceptance: the file exists and the folder is otherwise gitignored
+- [x] [AI] Create `specs/apps/islamic/README.md` and `specs/apps/islamic/overview.md` following the shape of `specs/apps/ose/` — acceptance: `rhino-cli specs structure validate` accepts the new product folder
+
+  > **Implementation note (2026-09-08).** `rhino-bin.sh specs structure validate` reports
+  > `0 finding(s) for "islamic"` alongside the five existing products. Also added the `Islamic` row
+  > to `specs/apps/README.md` — the annotated index the readme-completeness gate checks; the
+  > checkbox did not name it, but a new product folder with no index entry is an orphan.
+
+- [x] [AI] Create `specs/apps/islamic/be/README.md` describing the corpus, and `architecture.md` with C4 context, container, and component diagrams using the accessible palette — acceptance: both files exist and every Mermaid `classDef` uses palette hex codes
+
+  > **Implementation note (2026-09-08).** Both exist. `architecture.md` carries a C4 context
+  > diagram and a container/component diagram, 6 `classDef` rules across them. Every hex used —
+  > `#0173B2`, `#DE8F05`, `#029E73`, `#CA9161`, `#000000`, `#FFFFFF` — is in the verified accessible
+  > palette, checked mechanically against
+  > `repo-governance/conventions/formatting/color-accessibility/verified-color-palette.md`. Every
+  > Mermaid label is within the `md-mermaid-strict` 20-character cap.
+
+- [x] [AI] Create `specs/apps/islamic/be/behaviours/health/` with `README.md` and `health.feature` carrying the three US-1 scenarios from `prd.md` verbatim — acceptance: `npx gherkin` parses the feature and scenario names match `prd.md`
+
+  > **Implementation note (2026-09-08).** `validateFeatureSource` reports no errors. The three
+  > scenario names and every step line are **byte-identical** to `prd.md` US-1, verified by `diff`
+  > rather than by eye. Each scenario carries an `Exemption(integration)` with an
+  > `islamic-be-e2e:test:e2e` alternative-proof: the corpus has no Integration adapter because the
+  > service owns no local resource boundary.
+
+- [x] [AI] Create `specs/apps/islamic/be/behaviours/config/` with `README.md` and `port-resolution.feature` carrying the five US-3 scenarios — acceptance: the feature parses and all five scenarios are present
+
+  > **Implementation note (2026-09-08).** All five scenarios present and parsing; names and step
+  > lines byte-identical to `prd.md` US-3 by `diff`.
+  >
+  > These carry **two** exemptions each, not one. Integration is exempt for the same reason as
+  > health. E2E is exempt as well, and that is the substantive call: a caller can observe _that_ the
+  > service listens, but not _which source supplied the port_ — and a process that refuses to start
+  > on a malformed port exposes no public boundary at all. Both name
+  > `islamic-be:test:unit / <scenario>`, which is the layer that actually proves them. Unit has no
+  > exemption and remains mandatory.
+
+- [x] [AI] Create `specs/apps/islamic/be/contracts/openapi.yaml` (OpenAPI 3.1) with `paths/health.yaml`, `schemas/health.yaml`, and `schemas/error.yaml`, plus a README for each folder — acceptance: the root document references the fragments and every folder carries an annotated index
+
+  > **Implementation note (2026-09-08).** Root document `$ref`s all three fragments; `paths/`,
+  > `schemas/`, and `generated/` each carry an annotated README. `nx run islamic-contracts:lint`
+  > bundles to YAML and JSON and reports `No results with a severity of 'error' found!`.
+  >
+  > Two deliberate divergences from the `ose-be` contract it is modelled on. `HealthResponse.status`
+  > uses `example: healthy`, not `UP` — `prd.md` US-1 asserts the body field equals `"healthy"`, and
+  > a contract whose example contradicts its own acceptance scenario is worse than no example. And
+  > every property carries a `description`; the `ose-be` schemas omit them on properties even though
+  > that contract's own README states the rule.
+
+- [x] [AI] Copy `.spectral.yaml` from `specs/apps/ose/be/contracts/` unchanged — acceptance: the two ruleset files are byte-identical
+
+  > **Implementation note (2026-09-08).** `diff` reports no difference — byte-identical.
+
+- [x] [AI] Create `specs/apps/islamic/be/contracts/project.json` registering `islamic-contracts` with `lint`, `bundle`, `docs`, `typecheck`, `test:quick`, `deps:audit`, `compat:min-version`, and `specs:structure-validation` targets, plus `namedInputs.specs` — acceptance: `npx nx show project islamic-contracts` resolves
+
+  > **Implementation note (2026-09-08).** `nx show project islamic-contracts` resolves with all
+  > eight targets and `namedInputs.specs` set to `{workspaceRoot}/specs/apps/islamic/be/contracts/**`.
+  >
+  > It declares `tags: ["type:lib", "domain:islamic"]`. Its sibling `ose-contracts` declares **no
+  > tags at all**, which is why `learnings.md` records that an exclusion-based CI selector treats
+  > "tag absent" and "tag unknown" identically — both fail open. `platform:` is omitted per the
+  > library rule and `lang:` because OpenAPI YAML is not application code.
+
+- [x] [AI] Create `specs/apps/islamic/be/contracts/generated/README.md` explaining that bundles are generated — acceptance: the file exists and the folder is otherwise gitignored
+
+  > **Implementation note (2026-09-08).** Created, and `.gitignore` gained
+  > `specs/apps/islamic/be/contracts/generated/*` with a `!.../README.md` negation, verified with
+  > `git check-ignore -v`: a bundled artefact is ignored, the README is not.
+  >
+  > **Recorded divergence**: the repository now holds three shapes for this one folder, and no two
+  > agree. `ose-contracts` **tracks** its `openapi-bundled.{yaml,json}` even though its own README
+  > says the folder is gitignored. `ose-lms-contracts` — landed by #495 while this plan was in
+  > flight — ignores `generated/` wholesale and carries **no README at all**. This plan follows its
+  > own checkbox, which names the README explicitly, giving a third shape: folder ignored by glob,
+  > README negated back in.
+  >
+  > That is the shape worth keeping. A bare `generated/` ignore cannot un-ignore a child, so
+  > lms-be's form forecloses ever explaining the folder; and tracking build output as `ose-be` does
+  > invites bundle-vs-source drift no gate would catch. Reconciling the other two is a separate
+  > decision and out of scope here.
+
 - [ ] [AI] Commit on `islamic-be-init/du2-specs-contracts`, push, open a draft PR, poll CI every 2 minutes, and merge when green — acceptance: the PR merges to `main`
 
 ### Phase 2 Gate

--- a/plans/in-progress/islamic-be-init/evidence/du1-gate-doctor.txt
+++ b/plans/in-progress/islamic-be-init/evidence/du1-gate-doctor.txt
@@ -1,0 +1,30 @@
+
+> open-sharia-enterprise@1.0.0 doctor
+> .github/scripts/run-doctor.sh
+
+Doctor Report
+=============
+
+✓ git        v2.39.5        (no version requirement)
+✓ volta      v2.0.2         (no version requirement)
+✓ node       v24.16.0       (required: 24.16.0)
+⚠ npm        v11.16.0       (required: 11.11.0, version mismatch)
+✓ rust       v1.95.0        (no version requirement)
+✓ cargo-llvm-cov v0.8.5         (no version requirement)
+✓ dotnet     v10.0.300      (required: ≥10.0.204 (major))
+✓ docker     v29.7.2        (no version requirement)
+✓ jq         v1.8.1         (no version requirement)
+✓ shellcheck v0.11.0        (no version requirement)
+✓ hadolint   v2.14.0        (no version requirement)
+✓ actionlint v1.7.12        (no version requirement)
+✓ playwright v1.60.0        (no version requirement)
+✓ shfmt      v3.13.1        (no version requirement)
+✓ tofu       v1.12.3        (required: ≥1.12.3)
+✓ clang-format v22.1.8        (no version requirement)
+✓ java       v25            (required: ≥25)
+✓ go         v1.26.1        (required: ≥1.26)
+✓ golangci-lint v2.11.3        (required: ≥2.11)
+
+Summary: 18/19 tools OK, 1 warning, 0 missing
+
+Target-share: all crates already share their target/ via the cache.

--- a/plans/in-progress/islamic-be-init/evidence/du1-gate-ose-be.txt
+++ b/plans/in-progress/islamic-be-init/evidence/du1-gate-ose-be.txt
@@ -1,0 +1,572 @@
+
+ NX   Running target test:quick for 2 projects:
+
+- ose-be
+- ose-be-e2e
+
+
+
+> nx run ose-be-e2e:"test:quick"
+
+> npm exec -- nx run ose-be-e2e:typecheck
+
+
+[2m> [22m[2mnx run[22m ose-be-e2e:typecheck
+
+[2m> [22mnpx bddgen && npx tsc --noEmit
+
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mtypecheck[22m for project ose-be-e2e[39m
+
+
+> npm exec -- nx run ose-be-e2e:lint
+
+
+[2m> [22m[2mnx run[22m ose-be-e2e:lint
+
+[2m> [22mnpx oxlint .
+
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mlint[22m for project ose-be-e2e[39m
+
+
+> npm exec -- nx run ose-be-e2e:specs:structure-validation
+
+
+[2m> [22m[2mnx run[22m ose-be-e2e:"specs:structure-validation"
+
+[2m> [22mdotnet run --project apps/rhino-cli/src/RhinoCli.Program/RhinoCli.Program.fsproj -- specs structure validate
+
+specs structure validate: 0 finding(s) for "ayokoding"
+specs structure validate: 0 finding(s) for "crane"
+specs structure validate: 0 finding(s) for "islamic"
+specs structure validate: 0 finding(s) for "organiclever"
+specs structure validate: 0 finding(s) for "ose"
+specs structure validate: 0 finding(s) for "rhino"
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mspecs:structure-validation[22m for project ose-be-e2e[39m
+
+
+> npm exec -- nx run ose-be-e2e:test:coverage
+
+
+[2m> [22m[2mnx run[22m ose-be-e2e:"test:coverage"
+
+[2m> [22mnpm exec -- nx run ose-be-e2e:test:coverage:e2e
+
+
+[2m> [22m[2mnx run[22m ose-be-e2e:"test:coverage:e2e"
+
+[2m> [22mnode scripts/behaviour-coverage.mjs --config apps/ose-be-e2e/behaviour-coverage.json --adapter e2e
+
+ose-be-e2e: 10 features, 15 expanded scenarios, adapters: e2e.
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mtest:coverage:e2e[22m for project ose-be-e2e[39m
+
+
+[2m> [22mnpm exec -- nx run ose-be-e2e:test:coverage:behaviour
+
+
+[2m> [22m[2mnx run[22m ose-be-e2e:"test:coverage:behaviour"
+
+[2m> [22mnode scripts/behaviour-coverage.mjs --config apps/ose-be-e2e/behaviour-coverage.json --adapter behaviour
+
+ose-be-e2e: 10 features, 15 expanded scenarios, adapters: unit, e2e.
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mtest:coverage:behaviour[22m for project ose-be-e2e[39m
+
+
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mtest:coverage[22m for project ose-be-e2e[39m
+
+
+(node:8723) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 13 exit listeners added to [process]. MaxListeners is 12. Use emitter.setMaxListeners() to increase limit
+(Use `node --trace-warnings ...` to show where the warning was created)
+
+> nx run ose-be:"test:quick"
+
+> npm exec -- nx run ose-be:typecheck
+
+
+[7m[1m[36m NX [39m[22m[27m  [36mRunning target [1mtypecheck[22m for project ose-be and [1m2[22m tasks it depends on:[39m
+
+[2m[36m[39m[22m
+
+[2m> [22m[2mnx run[22m ose-contracts:bundle
+
+[2m> [22mmkdir -p specs/apps/ose/be/contracts/generated && npx @redocly/cli bundle specs/apps/ose/be/contracts/openapi.yaml -o specs/apps/ose/be/contracts/generated/openapi-bundled.yaml && npx @redocly/cli bundle specs/apps/ose/be/contracts/openapi.yaml -o specs/apps/ose/be/contracts/generated/openapi-bundled.json
+
+
+    [33m╔[33m═══════════════════════════════════════════════════════[33m╗[39m
+    [33m║                                                       ║[39m
+    [33m║[39m  A new version of [36mRedocly CLI[39m ([32m2.51.2[39m) is available.  [33m║[39m
+    [33m║[39m  Update now: `[36mnpm i -g @redocly/cli@latest[39m`.          [33m║[39m
+    [33m║[39m  Changelog: https://redocly.com/docs/cli/changelog/   [33m║[39m
+    [33m║                                                       ║[39m
+    [33m╚[33m═══════════════════════════════════════════════════════[33m╝[39m
+
+[90mbundling specs/apps/ose/be/contracts/openapi.yaml...
+[39m📦 Created a bundle for [34mspecs/apps/ose/be/contracts/openapi.yaml[39m at [34mspecs/apps/ose/be/contracts/generated/openapi-bundled.yaml[39m [32m8ms[39m.
+
+    [33m╔[33m═══════════════════════════════════════════════════════[33m╗[39m
+    [33m║                                                       ║[39m
+    [33m║[39m  A new version of [36mRedocly CLI[39m ([32m2.51.2[39m) is available.  [33m║[39m
+    [33m║[39m  Update now: `[36mnpm i -g @redocly/cli@latest[39m`.          [33m║[39m
+    [33m║[39m  Changelog: https://redocly.com/docs/cli/changelog/   [33m║[39m
+    [33m║                                                       ║[39m
+    [33m╚[33m═══════════════════════════════════════════════════════[33m╝[39m
+
+[90mbundling specs/apps/ose/be/contracts/openapi.yaml...
+[39m📦 Created a bundle for [34mspecs/apps/ose/be/contracts/openapi.yaml[39m at [34mspecs/apps/ose/be/contracts/generated/openapi-bundled.json[39m [32m11ms[39m.
+
+[2m> [22m[2mnx run[22m ose-be:codegen
+
+[2m> [22mnpx openapi-generator-cli generate -i $(pwd)/specs/apps/ose/be/contracts/generated/openapi-bundled.yaml -g fsharp-giraffe-server -o $(pwd)/apps/ose-be/generated-contracts --model-package OseBe.Contracts --global-property=models,modelDocs=false,apiDocs=false
+
+WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
+WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.github.benmanes.caffeine.cache.UnsafeAccess (file:<WORKTREE_ROOT>/node_modules/@openapitools/openapi-generator-cli/versions/7.20.0.jar)
+WARNING: Please consider reporting this to the maintainers of class com.github.benmanes.caffeine.cache.UnsafeAccess
+WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
+[main] WARN  o.o.codegen.DefaultCodegen - OpenAPI 3.1 support is still in beta. To report an issue related to 3.1 spec, please kindly open an issue in the Github repo: https://github.com/openAPITools/openapi-generator.
+[main] INFO  o.o.codegen.DefaultGenerator - Generating with dryRun=false
+[main] INFO  o.o.c.ignore.CodegenIgnoreProcessor - No .openapi-generator-ignore file found.
+[main] INFO  o.o.codegen.DefaultGenerator - OpenAPI Generator: fsharp-giraffe-server (server)
+[main] INFO  o.o.codegen.DefaultGenerator - Generator 'fsharp-giraffe-server' is considered beta.
+[main] WARN  o.o.codegen.DefaultCodegen - OpenAPI 3.1 support is still in beta. To report an issue related to 3.1 spec, please kindly open an issue in the Github repo: https://github.com/openAPITools/openapi-generator.
+[main] INFO  o.o.codegen.TemplateManager - writing file <WORKTREE_ROOT>/apps/ose-be/generated-contracts/OpenAPI/src/OseBe.Contracts/HealthResponse.fs
+[main] INFO  o.o.codegen.TemplateManager - writing file <WORKTREE_ROOT>/apps/ose-be/generated-contracts/OpenAPI/src/OseBe.Contracts/ErrorResponse.fs
+[main] INFO  o.o.codegen.DefaultGenerator - Skipping generation of APIs.
+[main] INFO  o.o.codegen.DefaultGenerator - Skipping generation of Webhooks.
+[main] INFO  o.o.codegen.DefaultGenerator - Skipping generation of supporting files.
+################################################################################
+# Thanks for using OpenAPI Generator.                                          #
+# Please consider donation to help us maintain this project 🙏                 #
+# https://opencollective.com/openapi_generator/donate                          #
+#                                                                              #
+# This generator's contributed by Nick Fisher (https://github.com/nmfisher)    #
+# Please support his work directly via https://paypal.me/nickfisher1984 🙏     #
+################################################################################
+
+[2m> [22m[2mnx run[22m ose-be:typecheck
+
+[2m> [22mdotnet build apps/ose-be/src/OseBe/OseBe.fsproj
+
+  Determining projects to restore...
+  All projects are up-to-date for restore.
+  fsharp-env-loader -> <WORKTREE_ROOT>/libs/fsharp-env-loader/bin/Debug/net10.0/fsharp-env-loader.dll
+  OseBe -> <WORKTREE_ROOT>/apps/ose-be/src/OseBe/bin/Debug/net10.0/OseBe.dll
+
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+
+Time Elapsed 00:00:02.08
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mtypecheck[22m for project ose-be and [1m2[22m tasks it depends on[39m
+
+
+> npm exec -- nx run ose-be:lint
+
+
+[7m[1m[36m NX [39m[22m[27m  [36mRunning target [1mlint[22m for project ose-be and [1m3[22m tasks it depends on:[39m
+
+[2m[36m[39m[22m
+
+[2m> [22m[2mnx run[22m ose-contracts:bundle
+
+[2m> [22mmkdir -p specs/apps/ose/be/contracts/generated && npx @redocly/cli bundle specs/apps/ose/be/contracts/openapi.yaml -o specs/apps/ose/be/contracts/generated/openapi-bundled.yaml && npx @redocly/cli bundle specs/apps/ose/be/contracts/openapi.yaml -o specs/apps/ose/be/contracts/generated/openapi-bundled.json
+
+
+    [33m╔[33m═══════════════════════════════════════════════════════[33m╗[39m
+    [33m║                                                       ║[39m
+    [33m║[39m  A new version of [36mRedocly CLI[39m ([32m2.51.2[39m) is available.  [33m║[39m
+    [33m║[39m  Update now: `[36mnpm i -g @redocly/cli@latest[39m`.          [33m║[39m
+    [33m║[39m  Changelog: https://redocly.com/docs/cli/changelog/   [33m║[39m
+    [33m║                                                       ║[39m
+    [33m╚[33m═══════════════════════════════════════════════════════[33m╝[39m
+
+[90mbundling specs/apps/ose/be/contracts/openapi.yaml...
+[39m📦 Created a bundle for [34mspecs/apps/ose/be/contracts/openapi.yaml[39m at [34mspecs/apps/ose/be/contracts/generated/openapi-bundled.yaml[39m [32m7ms[39m.
+
+    [33m╔[33m═══════════════════════════════════════════════════════[33m╗[39m
+    [33m║                                                       ║[39m
+    [33m║[39m  A new version of [36mRedocly CLI[39m ([32m2.51.2[39m) is available.  [33m║[39m
+    [33m║[39m  Update now: `[36mnpm i -g @redocly/cli@latest[39m`.          [33m║[39m
+    [33m║[39m  Changelog: https://redocly.com/docs/cli/changelog/   [33m║[39m
+    [33m║                                                       ║[39m
+    [33m╚[33m═══════════════════════════════════════════════════════[33m╝[39m
+
+[90mbundling specs/apps/ose/be/contracts/openapi.yaml...
+[39m📦 Created a bundle for [34mspecs/apps/ose/be/contracts/openapi.yaml[39m at [34mspecs/apps/ose/be/contracts/generated/openapi-bundled.json[39m [32m9ms[39m.
+
+[2m> [22m[2mnx run[22m ose-be:codegen
+
+[2m> [22mnpx openapi-generator-cli generate -i $(pwd)/specs/apps/ose/be/contracts/generated/openapi-bundled.yaml -g fsharp-giraffe-server -o $(pwd)/apps/ose-be/generated-contracts --model-package OseBe.Contracts --global-property=models,modelDocs=false,apiDocs=false
+
+WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
+WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.github.benmanes.caffeine.cache.UnsafeAccess (file:<WORKTREE_ROOT>/node_modules/@openapitools/openapi-generator-cli/versions/7.20.0.jar)
+WARNING: Please consider reporting this to the maintainers of class com.github.benmanes.caffeine.cache.UnsafeAccess
+WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
+[main] WARN  o.o.codegen.DefaultCodegen - OpenAPI 3.1 support is still in beta. To report an issue related to 3.1 spec, please kindly open an issue in the Github repo: https://github.com/openAPITools/openapi-generator.
+[main] INFO  o.o.codegen.DefaultGenerator - Generating with dryRun=false
+[main] INFO  o.o.c.ignore.CodegenIgnoreProcessor - No .openapi-generator-ignore file found.
+[main] INFO  o.o.codegen.DefaultGenerator - OpenAPI Generator: fsharp-giraffe-server (server)
+[main] INFO  o.o.codegen.DefaultGenerator - Generator 'fsharp-giraffe-server' is considered beta.
+[main] WARN  o.o.codegen.DefaultCodegen - OpenAPI 3.1 support is still in beta. To report an issue related to 3.1 spec, please kindly open an issue in the Github repo: https://github.com/openAPITools/openapi-generator.
+[main] INFO  o.o.codegen.TemplateManager - writing file <WORKTREE_ROOT>/apps/ose-be/generated-contracts/OpenAPI/src/OseBe.Contracts/HealthResponse.fs
+[main] INFO  o.o.codegen.TemplateManager - writing file <WORKTREE_ROOT>/apps/ose-be/generated-contracts/OpenAPI/src/OseBe.Contracts/ErrorResponse.fs
+[main] INFO  o.o.codegen.DefaultGenerator - Skipping generation of APIs.
+[main] INFO  o.o.codegen.DefaultGenerator - Skipping generation of Webhooks.
+[main] INFO  o.o.codegen.DefaultGenerator - Skipping generation of supporting files.
+################################################################################
+# Thanks for using OpenAPI Generator.                                          #
+# Please consider donation to help us maintain this project 🙏                 #
+# https://opencollective.com/openapi_generator/donate                          #
+#                                                                              #
+# This generator's contributed by Nick Fisher (https://github.com/nmfisher)    #
+# Please support his work directly via https://paypal.me/nickfisher1984 🙏     #
+################################################################################
+
+[2m> [22m[2mnx run[22m ose-be:typecheck
+
+[2m> [22mdotnet build apps/ose-be/src/OseBe/OseBe.fsproj
+
+  Determining projects to restore...
+  All projects are up-to-date for restore.
+  fsharp-env-loader -> <WORKTREE_ROOT>/libs/fsharp-env-loader/bin/Debug/net10.0/fsharp-env-loader.dll
+  OseBe -> <WORKTREE_ROOT>/apps/ose-be/src/OseBe/bin/Debug/net10.0/OseBe.dll
+
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+
+Time Elapsed 00:00:01.87
+
+[2m> [22m[2mnx run[22m ose-be:lint
+
+[2m> [22mdotnet tool restore
+
+Tool 'fantomas' (version '7.0.5') was restored. Available commands: fantomas
+Tool 'dotnet-fsharplint' (version '0.26.10') was restored. Available commands: dotnet-fsharplint
+Tool 'fsharp-analyzers' (version '0.36.0') was restored. Available commands: fsharp-analyzers
+
+Restore was successful.
+[2m> [22mdotnet tool run fantomas --check apps/ose-be/src
+
+[2m> [22mdotnet fsharplint lint apps/ose-be/src/OseBe/OseBe.fsproj --lint-config apps/ose-be/fsharplint.json
+
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/obj/Debug/net10.0/OseBe.AssemblyInfo.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/obj/Debug/net10.0/.NETCoreApp,Version=v10.0.AssemblyAttributes.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/generated-contracts/OpenAPI/src/OseBe.Contracts/HealthResponse.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Domain/Readiness.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Infrastructure/AppDbContext.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Infrastructure/Repositories/RepositoryTypes.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Infrastructure/Repositories/EfRepositories.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Infrastructure/OpenRouterClient.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Infrastructure/OpenRouterConnect.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Infrastructure/Database.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Infrastructure/NatsClient.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Infrastructure/NatsConnect.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/Config/Infrastructure/EnvTier.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/Db/Infrastructure/DbMigrations.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/Db/Application/MigrationStatus.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/Db/Api/MigrationStatusApi.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/Health/Domain/HealthDomain.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/Health/Application/HealthService.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/Health/Infrastructure/HealthInfrastructure.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/Health/Api/HealthApi.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/RegulatorySource/Domain/RegulatorySourceDomain.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/RegulatorySource/Application/RegulatorySourceService.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/RegulatorySource/Infrastructure/RegulatorySourceInfrastructure.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/RegulatorySource/Api/RegulatorySourceApi.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/InternalPolicy/Domain/InternalPolicyDomain.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/InternalPolicy/Application/InternalPolicyService.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/InternalPolicy/Infrastructure/InternalPolicyInfrastructure.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/InternalPolicy/Api/InternalPolicyApi.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/GapAnalysis/Domain/GapAnalysisDomain.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/GapAnalysis/Application/GapAnalysisService.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/GapAnalysis/Infrastructure/GapAnalysisInfrastructure.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/GapAnalysis/Api/GapAnalysisApi.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/AiOrchestration/Domain/AiOrchestrationDomain.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/AiOrchestration/Application/AiOrchestrationService.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/AiOrchestration/Infrastructure/AiOrchestrationInfrastructure.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/AiOrchestration/Api/AiOrchestrationApi.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/Messaging/Domain/MessagingDomain.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/Messaging/Application/MessagingStatus.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/Messaging/Infrastructure/JetStreamDemo.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Contexts/Messaging/Api/MessagingApi.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/WebApp.fs ==========
+========== Finished: 0 warnings ==========
+========== Linting <WORKTREE_ROOT>/apps/ose-be/src/OseBe/Program.fs ==========
+========== Finished: 0 warnings ==========
+========== Summary: 0 warnings ==========
+[2m> [22mdotnet fsharp-analyzers --project apps/ose-be/src/OseBe/OseBe.fsproj --analyzers-path $(find $(dotnet nuget locals global-packages --list | sed 's/.*: //')g-research.fsharp.analyzers -path '*/analyzers/dotnet/fs' -type d | head -1) --treat-as-error GRA-STRING-001 GRA-STRING-002 GRA-STRING-003 GRA-STRING-004 GRA-UNIONCASE-001 GRA-VIRTUALCALL-001 GRA-JSONOPTS-001 GRA-DISPBEFOREASYNC-001 GRA-IMMUTABLECOLLECTIONEQUALITY-001 GRA-LOGARGFUNCFULLAPP-001 GRA-LOGTEMPLMISSVALS-001 GRA-TYPE-ANNOTATE-001 GRA-INTERPOLATED-001
+
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mlint[22m for project ose-be and [1m3[22m tasks it depends on[39m
+
+
+> npm exec -- nx run ose-be:test:unit
+
+
+[7m[1m[36m NX [39m[22m[27m  [36mRunning target [1mtest:unit[22m for project ose-be and [1m3[22m tasks it depends on:[39m
+
+[2m[36m[39m[22m
+
+[2m> [22m[2mnx run[22m ose-contracts:bundle
+
+[2m> [22mmkdir -p specs/apps/ose/be/contracts/generated && npx @redocly/cli bundle specs/apps/ose/be/contracts/openapi.yaml -o specs/apps/ose/be/contracts/generated/openapi-bundled.yaml && npx @redocly/cli bundle specs/apps/ose/be/contracts/openapi.yaml -o specs/apps/ose/be/contracts/generated/openapi-bundled.json
+
+
+    [33m╔[33m═══════════════════════════════════════════════════════[33m╗[39m
+    [33m║                                                       ║[39m
+    [33m║[39m  A new version of [36mRedocly CLI[39m ([32m2.51.2[39m) is available.  [33m║[39m
+    [33m║[39m  Update now: `[36mnpm i -g @redocly/cli@latest[39m`.          [33m║[39m
+    [33m║[39m  Changelog: https://redocly.com/docs/cli/changelog/   [33m║[39m
+    [33m║                                                       ║[39m
+    [33m╚[33m═══════════════════════════════════════════════════════[33m╝[39m
+
+[90mbundling specs/apps/ose/be/contracts/openapi.yaml...
+[39m📦 Created a bundle for [34mspecs/apps/ose/be/contracts/openapi.yaml[39m at [34mspecs/apps/ose/be/contracts/generated/openapi-bundled.yaml[39m [32m8ms[39m.
+
+    [33m╔[33m═══════════════════════════════════════════════════════[33m╗[39m
+    [33m║                                                       ║[39m
+    [33m║[39m  A new version of [36mRedocly CLI[39m ([32m2.51.2[39m) is available.  [33m║[39m
+    [33m║[39m  Update now: `[36mnpm i -g @redocly/cli@latest[39m`.          [33m║[39m
+    [33m║[39m  Changelog: https://redocly.com/docs/cli/changelog/   [33m║[39m
+    [33m║                                                       ║[39m
+    [33m╚[33m═══════════════════════════════════════════════════════[33m╝[39m
+
+[90mbundling specs/apps/ose/be/contracts/openapi.yaml...
+[39m📦 Created a bundle for [34mspecs/apps/ose/be/contracts/openapi.yaml[39m at [34mspecs/apps/ose/be/contracts/generated/openapi-bundled.json[39m [32m6ms[39m.
+
+[2m> [22m[2mnx run[22m ose-be:codegen
+
+[2m> [22mnpx openapi-generator-cli generate -i $(pwd)/specs/apps/ose/be/contracts/generated/openapi-bundled.yaml -g fsharp-giraffe-server -o $(pwd)/apps/ose-be/generated-contracts --model-package OseBe.Contracts --global-property=models,modelDocs=false,apiDocs=false
+
+WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
+WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.github.benmanes.caffeine.cache.UnsafeAccess (file:<WORKTREE_ROOT>/node_modules/@openapitools/openapi-generator-cli/versions/7.20.0.jar)
+WARNING: Please consider reporting this to the maintainers of class com.github.benmanes.caffeine.cache.UnsafeAccess
+WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
+[main] WARN  o.o.codegen.DefaultCodegen - OpenAPI 3.1 support is still in beta. To report an issue related to 3.1 spec, please kindly open an issue in the Github repo: https://github.com/openAPITools/openapi-generator.
+[main] INFO  o.o.codegen.DefaultGenerator - Generating with dryRun=false
+[main] INFO  o.o.c.ignore.CodegenIgnoreProcessor - No .openapi-generator-ignore file found.
+[main] INFO  o.o.codegen.DefaultGenerator - OpenAPI Generator: fsharp-giraffe-server (server)
+[main] INFO  o.o.codegen.DefaultGenerator - Generator 'fsharp-giraffe-server' is considered beta.
+[main] WARN  o.o.codegen.DefaultCodegen - OpenAPI 3.1 support is still in beta. To report an issue related to 3.1 spec, please kindly open an issue in the Github repo: https://github.com/openAPITools/openapi-generator.
+[main] INFO  o.o.codegen.TemplateManager - writing file <WORKTREE_ROOT>/apps/ose-be/generated-contracts/OpenAPI/src/OseBe.Contracts/HealthResponse.fs
+[main] INFO  o.o.codegen.TemplateManager - writing file <WORKTREE_ROOT>/apps/ose-be/generated-contracts/OpenAPI/src/OseBe.Contracts/ErrorResponse.fs
+[main] INFO  o.o.codegen.DefaultGenerator - Skipping generation of APIs.
+[main] INFO  o.o.codegen.DefaultGenerator - Skipping generation of Webhooks.
+[main] INFO  o.o.codegen.DefaultGenerator - Skipping generation of supporting files.
+################################################################################
+# Thanks for using OpenAPI Generator.                                          #
+# Please consider donation to help us maintain this project 🙏                 #
+# https://opencollective.com/openapi_generator/donate                          #
+#                                                                              #
+# This generator's contributed by Nick Fisher (https://github.com/nmfisher)    #
+# Please support his work directly via https://paypal.me/nickfisher1984 🙏     #
+################################################################################
+
+[2m> [22m[2mnx run[22m ose-be:typecheck
+
+[2m> [22mdotnet build apps/ose-be/src/OseBe/OseBe.fsproj
+
+  Determining projects to restore...
+  All projects are up-to-date for restore.
+  fsharp-env-loader -> <WORKTREE_ROOT>/libs/fsharp-env-loader/bin/Debug/net10.0/fsharp-env-loader.dll
+  OseBe -> <WORKTREE_ROOT>/apps/ose-be/src/OseBe/bin/Debug/net10.0/OseBe.dll
+
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+
+Time Elapsed 00:00:01.85
+
+[2m> [22m[2mnx run[22m ose-be:"test:unit"
+
+[2m> [22mif grep -rn -E --include='*.fs' 'Skip\s*=' apps/ose-be/tests/unit; then echo 'ERROR: xunit Skip= attribute found in test files above'; exit 1; fi && dotnet test apps/ose-be/tests/unit/OseBe.UnitTests.fsproj /p:CollectCoverage=true /p:Threshold=99 "/p:Include=[OseBe]*" /p:ThresholdType=line "/p:ExcludeByFile=**/OseBe/Program.fs%2C**/Contexts/Db/Infrastructure/DbMigrations.fs%2C**/Contexts/RegulatorySource/Infrastructure/RegulatorySourceInfrastructure.fs%2C**/Contexts/InternalPolicy/Infrastructure/InternalPolicyInfrastructure.fs%2C**/Infrastructure/Repositories/EfRepositories.fs%2C**/Contexts/Messaging/Infrastructure/JetStreamDemo.fs%2C**/Infrastructure/NatsConnect.fs%2C**/Infrastructure/OpenRouterConnect.fs"
+
+  Determining projects to restore...
+  All projects are up-to-date for restore.
+  fsharp-env-loader -> <WORKTREE_ROOT>/libs/fsharp-env-loader/bin/Debug/net10.0/fsharp-env-loader.dll
+  OseBe -> <WORKTREE_ROOT>/apps/ose-be/src/OseBe/bin/Debug/net10.0/OseBe.dll
+  OseBe.UnitTests -> <WORKTREE_ROOT>/apps/ose-be/tests/unit/bin/Debug/net10.0/OseBe.UnitTests.dll
+  [coverlet] _mapping file name: 'CoverletSourceRootsMapping_OseBe.UnitTests'
+Test run for <WORKTREE_ROOT>/apps/ose-be/tests/unit/bin/Debug/net10.0/OseBe.UnitTests.dll (.NETCoreApp,Version=v10.0)
+A total of 1 test files matched the specified pattern.
+
+Passed!  - Failed:     0, Passed:    44, Skipped:     0, Total:    44, Duration: 371 ms - OseBe.UnitTests.dll (net10.0)
+  [coverlet] 
+  Calculating coverage result...
+   Generating report '<WORKTREE_ROOT>/apps/ose-be/tests/unit/coverage.json'
+
++--------+------+--------+--------+
+| Module | Line | Branch | Method |
++--------+------+--------+--------+
+| OseBe  | 100% | 87.5%  | 100%   |
++--------+------+--------+--------+
+
++---------+------+--------+--------+
+|         | Line | Branch | Method |
++---------+------+--------+--------+
+| Total   | 100% | 87.5%  | 100%   |
++---------+------+--------+--------+
+| Average | 100% | 87.5%  | 100%   |
++---------+------+--------+--------+
+
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mtest:unit[22m for project ose-be and [1m3[22m tasks it depends on[39m
+
+
+> npm exec -- nx run ose-be:specs:structure-validation
+
+
+[2m> [22m[2mnx run[22m ose-be:"specs:structure-validation"
+
+[2m> [22mdotnet run --project apps/rhino-cli/src/RhinoCli.Program/RhinoCli.Program.fsproj -- specs structure validate
+
+specs structure validate: 0 finding(s) for "ayokoding"
+specs structure validate: 0 finding(s) for "crane"
+specs structure validate: 0 finding(s) for "islamic"
+specs structure validate: 0 finding(s) for "organiclever"
+specs structure validate: 0 finding(s) for "ose"
+specs structure validate: 0 finding(s) for "rhino"
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mspecs:structure-validation[22m for project ose-be[39m
+
+
+> npm exec -- nx run ose-be:test:coverage
+
+
+[2m> [22m[2mnx run[22m ose-be:"test:coverage"
+
+[2m> [22mnpm exec -- nx run ose-be:test:coverage:unit
+
+
+[2m> [22m[2mnx run[22m ose-be:"test:coverage:unit"
+
+[2m> [22mnode scripts/behaviour-coverage.mjs --config apps/ose-be/behaviour-coverage.json --adapter unit
+
+ose-be: 10 features, 15 expanded scenarios, adapters: unit.
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mtest:coverage:unit[22m for project ose-be[39m
+
+
+[2m> [22mnpm exec -- nx run ose-be:test:coverage:integration
+
+
+[2m> [22m[2mnx run[22m ose-be:"test:coverage:integration"
+
+[2m> [22mnode scripts/behaviour-coverage.mjs --config apps/ose-be/behaviour-coverage.json --adapter integration
+
+ose-be: 10 features, 15 expanded scenarios, adapters: integration.
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mtest:coverage:integration[22m for project ose-be[39m
+
+
+[2m> [22mnpm exec -- nx run ose-be:test:coverage:e2e
+
+
+[2m> [22m[2mnx run[22m ose-be:"test:coverage:e2e"
+
+[2m> [22mnode scripts/behaviour-coverage.mjs --config apps/ose-be/behaviour-coverage.json --adapter e2e
+
+ose-be: 10 features, 15 expanded scenarios, adapters: e2e.
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mtest:coverage:e2e[22m for project ose-be[39m
+
+
+[2m> [22mnpm exec -- nx run ose-be:test:coverage:behaviour
+
+
+[2m> [22m[2mnx run[22m ose-be:"test:coverage:behaviour"
+
+[2m> [22mnode scripts/behaviour-coverage.mjs --config apps/ose-be/behaviour-coverage.json --adapter behaviour
+
+ose-be: 10 features, 15 expanded scenarios, adapters: unit, integration, e2e.
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mtest:coverage:behaviour[22m for project ose-be[39m
+
+
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mtest:coverage[22m for project ose-be[39m
+
+
+
+
+
+ NX   Successfully ran target test:quick for 2 projects
+
+
+EXIT=0

--- a/plans/in-progress/islamic-be-init/evidence/du1-gate-repo-config.txt
+++ b/plans/in-progress/islamic-be-init/evidence/du1-gate-repo-config.txt
@@ -1,0 +1,2 @@
+repo-config validate: repo-config.yml matches the canonical schema (key set + enums OK)
+EXIT=0

--- a/plans/in-progress/islamic-be-init/evidence/du1-gate-validators.txt
+++ b/plans/in-progress/islamic-be-init/evidence/du1-gate-validators.txt
@@ -1,0 +1,69 @@
+
+> open-sharia-enterprise@1.0.0 test:validators
+> ./hippo run --class ephemeral --disk-path . -- node --test scripts/behaviour-coverage.test.mjs scripts/dotnet-unit-coverage.test.mjs
+
+✔ accepts independently documented Integration and E2E exemptions (3.960875ms)
+✔ requires each exemption on its own tag line with its own adjacent comment (0.488375ms)
+✔ rejects difficulty, runtime, flakiness, cost, and unfinished-work reasons (0.715875ms)
+✔ requires boundary language and a canonical alternative proof (0.170542ms)
+✔ rejects forbidden exemption, WIP, no-layer, and positive selection tags (0.30775ms)
+✔ does not interpret doc-string content as tags (0.24475ms)
+✔ rejects malformed and empty features and scenarios without explicit When and Then (0.257708ms)
+✔ expands every Scenario Outline example row (0.615083ms)
+✔ extracts TypeScript, TSX, and F# TickSpec bindings (0.884709ms)
+✔ ignores commented-out TypeScript and F# bindings (0.214041ms)
+✔ extracts one binding per Java Cucumber annotation (0.284042ms)
+✔ reports an undefined Unit binding when a Java step definition is missing (7.833417ms)
+✔ reports an unused Unit binding when a Java step definition matches no step (1.37325ms)
+✔ extracts one binding per Godog registration (0.378375ms)
+✔ treats a Godog ctx.Step registration as keyword-agnostic (0.06325ms)
+✔ accepts an interpreted Go string literal as a Godog pattern (0.051708ms)
+✔ ignores a Godog registration inside a Go comment (0.078334ms)
+✔ does not mask a comment marker that is inside a Go raw-string pattern (0.072042ms)
+✔ extracts a Godog registration wrapped in regexp.MustCompile (0.081209ms)
+✔ ignores Go regex and backtick literals that are not Godog registrations (0.064625ms)
+✔ reports an undefined Unit binding when a Godog step definition is missing (3.164958ms)
+✔ reports an unused Unit binding when a Godog step definition matches no step (1.265166ms)
+✔ scopes duplicate Godog bindings to explicit feature literals (2.484833ms)
+✔ scopes duplicate F# TickSpec bindings to explicit feature literals (1.466ms)
+✔ keeps duplicate F# TickSpec bindings ambiguous without explicit feature ownership (1.250042ms)
+✔ matches standard and custom Cucumber expression parameters (1.363625ms)
+✔ matches vitest-cucumber Scenario Outline placeholders after pickle expansion (1.521917ms)
+✔ matches escaped literal Cucumber metacharacters in Playwright-BDD strings (1.162083ms)
+✔ treats TypeScript Cucumber registration keywords as matching synonyms (1.47575ms)
+✔ requires Unit coverage even when both higher layers are exempt (1.188375ms)
+✔ exempts only the named adapter (1.533625ms)
+✔ reports ambiguous and unused bindings (1.415375ms)
+✔ validates scoped vitest-cucumber scenarios without cross-scenario ambiguity (2.054041ms)
+✔ scopes duplicate TypeScript Background bindings to their loaded feature (1.958917ms)
+✔ does not report feature-scoped bindings outside a manifest corpus as unused (1.245458ms)
+✔ requires a non-empty recursive corpus and an existing driver (1.161959ms)
+✔ aggregate behaviour mode checks every configured adapter without executing tests (1.249416ms)
+✔ loads a project-local aggregate config with paths relative to that config (1.082958ms)
+✔ CLI is deterministic and never invokes a configured runtime (1.583709ms)
+✔ accepts the closed project target contract (1.609958ms)
+✔ rejects runtime coverage, incomplete quick composition, and missing adapter pairs (1.038959ms)
+✔ rejects a Unit line coverage threshold below the 99% hard minimum (0.554208ms)
+✔ accepts a 99% Coverlet Unit line coverage hard gate (0.610625ms)
+✔ accepts a 99% XPlat collector Unit line coverage hard gate (0.785792ms)
+✔ rejects a bare line-threshold argument without the XPlat hard-gate helper (0.5295ms)
+✔ dedicated E2E projects do not need to own the Unit runtime (0.638375ms)
+✔ accepts a 99% JaCoCo Unit line coverage hard gate (0.693708ms)
+✔ rejects a JaCoCo verification task that declares no line minimum (0.656541ms)
+✔ rejects a coverage target that executes the Gradle test task (1.472083ms)
+✔ accepts exact 99 percent line coverage (0.797ms)
+✔ rejects a rounded line rate whose exact coverage is below 99 percent (0.4755ms)
+✔ rejects coverage without exact line counts (0.207958ms)
+✔ rejects a zero line denominator (0.114792ms)
+✔ rejects an impossible covered line count (0.07125ms)
+✔ accepts only a results directory nested inside the workspace (0.092125ms)
+✔ passes explicit whole-boundary source exclusions to the XPlat collector (0.078333ms)
+ℹ tests 56
+ℹ suites 0
+ℹ pass 56
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 122.600625
+EXIT=0

--- a/plans/in-progress/islamic-be-init/evidence/du2-gates.txt
+++ b/plans/in-progress/islamic-be-init/evidence/du2-gates.txt
@@ -1,0 +1,124 @@
+
+ NX   Running targets lint, test:quick, specs:structure-validation for project islamic-contracts:
+
+- islamic-contracts
+
+
+
+> nx run islamic-contracts:"specs:structure-validation"
+
+> dotnet run --project apps/rhino-cli/src/RhinoCli.Program/RhinoCli.Program.fsproj -- specs structure validate
+
+specs structure validate: 0 finding(s) for "ayokoding"
+specs structure validate: 0 finding(s) for "crane"
+specs structure validate: 0 finding(s) for "islamic"
+specs structure validate: 0 finding(s) for "organiclever"
+specs structure validate: 0 finding(s) for "ose"
+specs structure validate: 0 finding(s) for "rhino"
+
+> nx run islamic-contracts:lint
+
+> mkdir -p specs/apps/islamic/be/contracts/generated && npx @redocly/cli bundle specs/apps/islamic/be/contracts/openapi.yaml -o specs/apps/islamic/be/contracts/generated/openapi-bundled.yaml && npx @redocly/cli bundle specs/apps/islamic/be/contracts/openapi.yaml -o specs/apps/islamic/be/contracts/generated/openapi-bundled.json && npx @stoplight/spectral-cli lint specs/apps/islamic/be/contracts/generated/openapi-bundled.yaml --ruleset specs/apps/islamic/be/contracts/.spectral.yaml
+
+
+    [33m╔[33m═══════════════════════════════════════════════════════[33m╗[39m
+    [33m║                                                       ║[39m
+    [33m║[39m  A new version of [36mRedocly CLI[39m ([32m2.51.2[39m) is available.  [33m║[39m
+    [33m║[39m  Update now: `[36mnpm i -g @redocly/cli@latest[39m`.          [33m║[39m
+    [33m║[39m  Changelog: https://redocly.com/docs/cli/changelog/   [33m║[39m
+    [33m║                                                       ║[39m
+    [33m╚[33m═══════════════════════════════════════════════════════[33m╝[39m
+
+[90mbundling specs/apps/islamic/be/contracts/openapi.yaml...
+[39m📦 Created a bundle for [34mspecs/apps/islamic/be/contracts/openapi.yaml[39m at [34mspecs/apps/islamic/be/contracts/generated/openapi-bundled.yaml[39m [32m26ms[39m.
+
+    [33m╔[33m═══════════════════════════════════════════════════════[33m╗[39m
+    [33m║                                                       ║[39m
+    [33m║[39m  A new version of [36mRedocly CLI[39m ([32m2.51.2[39m) is available.  [33m║[39m
+    [33m║[39m  Update now: `[36mnpm i -g @redocly/cli@latest[39m`.          [33m║[39m
+    [33m║[39m  Changelog: https://redocly.com/docs/cli/changelog/   [33m║[39m
+    [33m║                                                       ║[39m
+    [33m╚[33m═══════════════════════════════════════════════════════[33m╝[39m
+
+[90mbundling specs/apps/islamic/be/contracts/openapi.yaml...
+[39m📦 Created a bundle for [34mspecs/apps/islamic/be/contracts/openapi.yaml[39m at [34mspecs/apps/islamic/be/contracts/generated/openapi-bundled.json[39m [32m7ms[39m.
+No results with a severity of 'error' found!
+
+> nx run islamic-contracts:"test:quick"
+
+> npm exec -- nx run islamic-contracts:typecheck
+
+
+[2m> [22m[2mnx run[22m islamic-contracts:typecheck
+
+[2m> [22mecho 'no-op: target not applicable for this project (OpenAPI contract spec only)'
+
+no-op: target not applicable for this project (OpenAPI contract spec only)
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mtypecheck[22m for project islamic-contracts[39m
+
+
+> npm exec -- nx run islamic-contracts:lint
+
+
+[2m> [22m[2mnx run[22m islamic-contracts:lint
+
+[2m> [22mmkdir -p specs/apps/islamic/be/contracts/generated && npx @redocly/cli bundle specs/apps/islamic/be/contracts/openapi.yaml -o specs/apps/islamic/be/contracts/generated/openapi-bundled.yaml && npx @redocly/cli bundle specs/apps/islamic/be/contracts/openapi.yaml -o specs/apps/islamic/be/contracts/generated/openapi-bundled.json && npx @stoplight/spectral-cli lint specs/apps/islamic/be/contracts/generated/openapi-bundled.yaml --ruleset specs/apps/islamic/be/contracts/.spectral.yaml
+
+
+    [33m╔[33m═══════════════════════════════════════════════════════[33m╗[39m
+    [33m║                                                       ║[39m
+    [33m║[39m  A new version of [36mRedocly CLI[39m ([32m2.51.2[39m) is available.  [33m║[39m
+    [33m║[39m  Update now: `[36mnpm i -g @redocly/cli@latest[39m`.          [33m║[39m
+    [33m║[39m  Changelog: https://redocly.com/docs/cli/changelog/   [33m║[39m
+    [33m║                                                       ║[39m
+    [33m╚[33m═══════════════════════════════════════════════════════[33m╝[39m
+
+[90mbundling specs/apps/islamic/be/contracts/openapi.yaml...
+[39m📦 Created a bundle for [34mspecs/apps/islamic/be/contracts/openapi.yaml[39m at [34mspecs/apps/islamic/be/contracts/generated/openapi-bundled.yaml[39m [32m12ms[39m.
+
+    [33m╔[33m═══════════════════════════════════════════════════════[33m╗[39m
+    [33m║                                                       ║[39m
+    [33m║[39m  A new version of [36mRedocly CLI[39m ([32m2.51.2[39m) is available.  [33m║[39m
+    [33m║[39m  Update now: `[36mnpm i -g @redocly/cli@latest[39m`.          [33m║[39m
+    [33m║[39m  Changelog: https://redocly.com/docs/cli/changelog/   [33m║[39m
+    [33m║                                                       ║[39m
+    [33m╚[33m═══════════════════════════════════════════════════════[33m╝[39m
+
+[90mbundling specs/apps/islamic/be/contracts/openapi.yaml...
+[39m📦 Created a bundle for [34mspecs/apps/islamic/be/contracts/openapi.yaml[39m at [34mspecs/apps/islamic/be/contracts/generated/openapi-bundled.json[39m [32m7ms[39m.
+No results with a severity of 'error' found!
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mlint[22m for project islamic-contracts[39m
+
+
+> npm exec -- nx run islamic-contracts:specs:structure-validation
+
+
+[2m> [22m[2mnx run[22m islamic-contracts:"specs:structure-validation"
+
+[2m> [22mdotnet run --project apps/rhino-cli/src/RhinoCli.Program/RhinoCli.Program.fsproj -- specs structure validate
+
+specs structure validate: 0 finding(s) for "ayokoding"
+specs structure validate: 0 finding(s) for "crane"
+specs structure validate: 0 finding(s) for "islamic"
+specs structure validate: 0 finding(s) for "organiclever"
+specs structure validate: 0 finding(s) for "ose"
+specs structure validate: 0 finding(s) for "rhino"
+
+[2m[32m[39m[22m
+
+[7m[1m[32m NX [39m[22m[27m  [32mSuccessfully ran target [1mspecs:structure-validation[22m for project islamic-contracts[39m
+
+
+
+
+
+ NX   Successfully ran targets lint, test:quick, specs:structure-validation for project islamic-contracts
+
+
+EXIT=0

--- a/plans/in-progress/islamic-be-init/learnings.md
+++ b/plans/in-progress/islamic-be-init/learnings.md
@@ -213,3 +213,35 @@ Doctor tool "golangci-lint"` until the linter was declared there too. So `extra-
      **The link belongs to the DU that makes it resolvable**, not to the DU that wants it.
 - **Disposition**: _pending Phase 7_ — resolved in-flight by naming the projects in prose and moving
   the link into DU3 and DU4 as explicit steps.
+
+### DU1: a conflicted PR emits no CI at all, which is not the same as a slow CI
+
+- **Observed**: two pushes to `islamic-be-init/du1-go-lane` produced **zero** workflow runs. Not
+  queued, not failed — absent. `gh run list` showed nothing newer than the first commit's run, so
+  the obvious reading was "still queued" and the obvious response was to keep waiting. Both wrong.
+- **Cause**: `origin/main` had advanced to #495, which touched the same three files DU1 touches, so
+  PR #496 went to `mergeStateStatus: DIRTY`. GitHub builds `refs/pull/<n>/merge` before dispatching
+  a `pull_request` event; for a conflicted PR that ref cannot be constructed, so `synchronize` never
+  fires. The moment the rebase landed, `DIRTY` became `BLOCKED` and both workflows dispatched
+  within seconds — the causal link is not inferred, it was observed.
+- **Generalizes**: "no run exists for this SHA" and "the run for this SHA has not finished" look
+  identical in `gh run list` and mean opposite things. Only the first is actionable by the author.
+  A CI poll keyed on _run status_ cannot distinguish them, because there is no run to have a status.
+- **Disposition**: _pending Phase 7_ — worth proposing that any CI poll assert
+  `mergeStateStatus != DIRTY` **and** that a run exists for the pinned head before it begins
+  waiting on that run's conclusion. A poll that cannot fail is not a check.
+
+### DU2: three incompatible shapes for `contracts/generated/` now coexist
+
+- **Observed**: `ose-be` tracks `openapi-bundled.{yaml,json}` **and** a hand-written README, though
+  its own README claims the folder is gitignored. `ose-lms-be` — landed by #495 mid-flight — ignores
+  `generated/` wholesale and carries no README. This plan's checkbox names a README explicitly,
+  producing a third shape: `generated/*` ignored by glob, README negated back in.
+- **Why the third shape is the one to keep**: a bare `generated/` ignore cannot un-ignore a child,
+  so lms-be's form permanently forecloses documenting the folder; and tracking build output as
+  `ose-be` does invites bundle-vs-source drift that no gate currently detects.
+- **Generalizes**: a convention that is only ever expressed as copied precedent, never as a rule,
+  will fork silently every time two delivery units run concurrently. Neither author was careless —
+  there was simply nothing to be wrong against.
+- **Disposition**: _pending Phase 7_ — the divergence is recorded, not resolved. Reconciling the two
+  siblings is outside this plan's authorization.

--- a/specs/apps/README.md
+++ b/specs/apps/README.md
@@ -6,6 +6,7 @@ title: "Apps"
 
 - [Ayokoding](./ayokoding/README.md) — Specifications for ayokoding-www, the multilingual educational site's architecture and Gherkin behaviours.
 - [Crane](./crane/README.md) — Specifications for crane-cli, the Content Retrieval And Normalization Engine's architecture and behaviours.
+- [Islamic](./islamic/README.md) — Specifications for islamic-be, the Sharia-compliance API's architecture, behaviours, and OpenAPI contract.
 - [Organiclever](./organiclever/README.md) — Specifications for OrganicLever's three logical owners: app-web, be backend, and www marketing site.
 - [Ose](./ose/README.md) — Specifications for OSE's two products, the app-web/be GRC platform and the ose-www marketing site.
 - [Rhino](./rhino/README.md) — Specifications for rhino-cli, the Repository Hygiene & INtegration Orchestrator's architecture and Gherkin behaviours.

--- a/specs/apps/islamic/README.md
+++ b/specs/apps/islamic/README.md
@@ -1,0 +1,17 @@
+# Islamic
+
+Specifications for the Islamic tools product family. The family ships one logical owner today —
+`islamic-be`, a Sharia-compliance API that any consumer can call, independent of the OSE
+Application's GRC surface.
+
+## Contents
+
+- [Product overview](./overview.md) — what the family is for and who it serves.
+
+- [Islamic BE](./be/README.md) — the specification corpus for `islamic-be`, the Sharia-compliance
+  API: its architecture, its behaviours, and the OpenAPI contract its clients generate from.
+
+## Related
+
+- `apps/islamic-be` — the implementing project. DU3 creates it and adds the link back from here;
+  a link added now would point at nothing and fail the `md-links` gate.

--- a/specs/apps/islamic/be/README.md
+++ b/specs/apps/islamic/be/README.md
@@ -1,0 +1,25 @@
+# Islamic BE — Specification Corpus
+
+Audience: engineers and technical product managers working on `apps/islamic-be` — the
+Sharia-compliance API.
+
+This corpus is the single source of truth for what the service answers. A scenario here defines a
+route's status code, its response body, and how the process resolves its own configuration.
+
+## Contents
+
+- [Architecture](./architecture.md) — the current as-built system: its context, the process it
+  deploys, its bounded contexts, and the constraints that bind them.
+- [Behaviours](./behaviours/README.md) — the recursive Gherkin corpus, grouped by bounded context.
+- [Contracts](./contracts/README.md) — the OpenAPI 3.1 specification the service and its clients
+  generate from.
+
+## Related
+
+- `apps/islamic-be` — the implementing project, created in DU3.
+- `apps/islamic-be-e2e` — the E2E project that drives this corpus against the real process,
+  created in DU4.
+
+Both are named rather than linked: this corpus lands before either project exists, and the
+`md-links` gate scans the whole tree rather than only the current change. The DU that creates each
+project adds the link in both directions.

--- a/specs/apps/islamic/be/architecture.md
+++ b/specs/apps/islamic/be/architecture.md
@@ -1,0 +1,78 @@
+# Islamic BE — Architecture
+
+The current, as-built system. A change that alters an actor, a container, a component
+responsibility, a relationship, or a boundary updates this document in the same delivery unit.
+
+## Scope
+
+`islamic-be` serves a versioned HTTP surface for Sharia-compliance capability. Today that surface
+carries one route — a liveness probe. It holds no credential, opens no outbound connection, and
+persists nothing.
+
+## System Context
+
+```mermaid
+flowchart LR
+    CONSUMER[API consumer] -->|HTTP /api/v1| BE[Islamic BE]
+    OPS[Ops engineer] -->|liveness probe| BE
+    CONTRACT[OpenAPI contract] -->|generates| BE
+
+    classDef svc fill:#0173B2,stroke:#000000,color:#FFFFFF
+    classDef actor fill:#CA9161,stroke:#000000,color:#000000
+    classDef spec fill:#029E73,stroke:#000000,color:#FFFFFF
+    class BE svc
+    class CONSUMER,OPS actor
+    class CONTRACT spec
+```
+
+The contract is drawn as an input rather than an artefact: the service does not describe itself
+after the fact, it is generated from a document that exists first.
+
+## Containers
+
+| Container    | Technology   | Port | Persistence |
+| ------------ | ------------ | ---- | ----------- |
+| `islamic-be` | Go 1.26, Gin | 8402 | none        |
+
+```mermaid
+flowchart TD
+    MAIN[cmd/islamic-be] --> CFG[internal/config]
+    MAIN --> RTR[internal/router]
+    RTR --> GEN[generated types]
+    CFG -->|resolved port| MAIN
+
+    classDef entry fill:#DE8F05,stroke:#000000,color:#000000
+    classDef comp fill:#0173B2,stroke:#000000,color:#FFFFFF
+    classDef gen fill:#029E73,stroke:#000000,color:#FFFFFF
+    class MAIN entry
+    class CFG,RTR comp
+    class GEN gen
+```
+
+One process, no sidecar, no broker. The service is deployable as a single container image because
+it depends on nothing it does not start.
+
+## Components
+
+Two bounded contexts under `internal/`:
+
+| Bounded context | Responsibility                                         |
+| --------------- | ------------------------------------------------------ |
+| `config`        | resolving the listener port from flag, env, or default |
+| `router`        | the Gin engine and the handler set the contract binds  |
+
+`config` is a bounded context rather than a helper because its resolution order is observable
+behaviour with its own scenarios — a caller can tell which source won.
+
+## Constraints
+
+**Contract first.** The OpenAPI document under `contracts/` is the source; the service generates
+from it with `oapi-codegen`. The router satisfies the generated `ServerInterface`, so a handler
+whose shape diverges from the published specification fails to compile rather than failing in
+production.
+
+**No shared `PORT`.** The service reads `ISLAMIC_BE_PORT` and ignores a bare `PORT`. One exported
+variable must not silently retarget every app on the machine at once.
+
+**Nothing to protect, nothing to authenticate.** The surface is unauthenticated because it exposes
+no data. The first route that returns a judgement changes this, and that is an architectural change.

--- a/specs/apps/islamic/be/behaviours/README.md
+++ b/specs/apps/islamic/be/behaviours/README.md
@@ -1,0 +1,21 @@
+# Islamic BE — Gherkin Scenarios
+
+Backend Gherkin scenarios for `islamic-be`. Consumed by Godog at the Unit layer and by
+`playwright-bdd` at the E2E layer.
+
+## Feature files
+
+| Feature file                                                       | Domain |
+| ------------------------------------------------------------------ | ------ |
+| [health/health.feature](./health/health.feature)                   | health |
+| [config/port-resolution.feature](./config/port-resolution.feature) | config |
+
+- [config](./config/README.md) — islamic-be Gherkin Domain
+- [health](./health/README.md) — islamic-be Gherkin Domain
+
+## Adapters
+
+Unit and E2E. There is no Integration adapter: the service owns no local resource boundary — no
+database, no filesystem state, no broker — so every scenario resolves either in-process or across
+the real HTTP boundary. Each scenario carries its own `Exemption(integration)` with an
+alternative-proof naming the target that does prove it.

--- a/specs/apps/islamic/be/behaviours/config/README.md
+++ b/specs/apps/islamic/be/behaviours/config/README.md
@@ -1,0 +1,12 @@
+# config — islamic-be Gherkin Domain
+
+Scenarios for the Islamic tools backend's listener-port resolution.
+
+## Feature Files
+
+- **[port-resolution.feature](./port-resolution.feature)** — Deterministic flag/env/default
+  precedence for the listener port (5 scenarios)
+
+## Related
+
+- [Parent gherkin README](../README.md)

--- a/specs/apps/islamic/be/behaviours/config/port-resolution.feature
+++ b/specs/apps/islamic/be/behaviours/config/port-resolution.feature
@@ -1,0 +1,53 @@
+Feature: Islamic BE port resolution
+  As a developer
+  I want a deterministic port-resolution order
+  So that one exported variable cannot retarget every app at once
+
+  # Exemption(integration): port resolution owns no local resource boundary — it is a pure decision over injected flag and environment inputs; alternative-proof: islamic-be:test:unit / The default port applies when nothing is set
+  @integration-exempt
+  # Exemption(e2e): which source supplied the port is not observable through the service's public HTTP boundary, only that it listens; alternative-proof: islamic-be:test:unit / The default port applies when nothing is set
+  @e2e-exempt
+  Scenario: The default port applies when nothing is set
+    Given no ISLAMIC_BE_PORT variable is set
+    And no --port flag is supplied
+    When the service resolves its listener port
+    Then the resolved port is 8402
+
+  # Exemption(integration): port resolution owns no local resource boundary — it is a pure decision over injected flag and environment inputs; alternative-proof: islamic-be:test:unit / The prefixed variable overrides the default
+  @integration-exempt
+  # Exemption(e2e): which source supplied the port is not observable through the service's public HTTP boundary, only that it listens; alternative-proof: islamic-be:test:unit / The prefixed variable overrides the default
+  @e2e-exempt
+  Scenario: The prefixed variable overrides the default
+    Given ISLAMIC_BE_PORT is set to "9402"
+    When the service resolves its listener port
+    Then the resolved port is 9402
+
+  # Exemption(integration): port resolution owns no local resource boundary — it is a pure decision over injected flag and environment inputs; alternative-proof: islamic-be:test:unit / The flag overrides the prefixed variable
+  @integration-exempt
+  # Exemption(e2e): which source supplied the port is not observable through the service's public HTTP boundary, only that it listens; alternative-proof: islamic-be:test:unit / The flag overrides the prefixed variable
+  @e2e-exempt
+  Scenario: The flag overrides the prefixed variable
+    Given ISLAMIC_BE_PORT is set to "9402"
+    And the --port flag is supplied with "9500"
+    When the service resolves its listener port
+    Then the resolved port is 9500
+
+  # Exemption(integration): port resolution owns no local resource boundary — it is a pure decision over injected flag and environment inputs; alternative-proof: islamic-be:test:unit / A malformed port fails at startup
+  @integration-exempt
+  # Exemption(e2e): a process that refuses to start exposes no public boundary to observe the refusal through; alternative-proof: islamic-be:test:unit / A malformed port fails at startup
+  @e2e-exempt
+  Scenario: A malformed port fails at startup
+    Given ISLAMIC_BE_PORT is set to "not-a-port"
+    When the service resolves its listener port
+    Then startup fails with a message naming ISLAMIC_BE_PORT
+    And the service does not fall back to the default
+
+  # Exemption(integration): port resolution owns no local resource boundary — it is a pure decision over injected flag and environment inputs; alternative-proof: islamic-be:test:unit / A bare PORT variable is ignored
+  @integration-exempt
+  # Exemption(e2e): which source supplied the port is not observable through the service's public HTTP boundary, only that it listens; alternative-proof: islamic-be:test:unit / A bare PORT variable is ignored
+  @e2e-exempt
+  Scenario: A bare PORT variable is ignored
+    Given PORT is set to "9999"
+    And no ISLAMIC_BE_PORT variable is set
+    When the service resolves its listener port
+    Then the resolved port is 8402

--- a/specs/apps/islamic/be/behaviours/health/README.md
+++ b/specs/apps/islamic/be/behaviours/health/README.md
@@ -1,0 +1,12 @@
+# health — islamic-be Gherkin Domain
+
+HTTP-semantic scenarios for the Islamic tools backend health domain.
+
+## Feature Files
+
+- **[health.feature](./health.feature)** — Service liveness probe and unknown-route handling
+  (3 scenarios)
+
+## Related
+
+- [Parent gherkin README](../README.md)

--- a/specs/apps/islamic/be/behaviours/health/health.feature
+++ b/specs/apps/islamic/be/behaviours/health/health.feature
@@ -1,0 +1,26 @@
+Feature: Islamic BE health endpoint
+  As a system operator
+  I want the BE to advertise liveness
+  So that orchestrators can route traffic only to healthy instances
+
+  # Exemption(integration): HTTP is a network boundary forbidden to Integration and the in-process route is already Unit proof; alternative-proof: islamic-be-e2e:test:e2e / Health endpoint returns 200
+  @integration-exempt
+  Scenario: Health endpoint returns 200
+    Given the islamic-be service is running
+    When I send GET /api/v1/health
+    Then the response status is 200
+    And the response body has a "status" field equal to "healthy"
+
+  # Exemption(integration): HTTP is a network boundary forbidden to Integration and the in-process route is already Unit proof; alternative-proof: islamic-be-e2e:test:e2e / Health endpoint reports the JSON content type
+  @integration-exempt
+  Scenario: Health endpoint reports the JSON content type
+    Given the islamic-be service is running
+    When I send GET /api/v1/health
+    Then the response "Content-Type" header starts with "application/json"
+
+  # Exemption(integration): HTTP is a network boundary forbidden to Integration and the in-process router already proves the fallback; alternative-proof: islamic-be-e2e:test:e2e / An unknown route is rejected
+  @integration-exempt
+  Scenario: An unknown route is rejected
+    Given the islamic-be service is running
+    When I send GET /api/v1/does-not-exist
+    Then the response status is 404

--- a/specs/apps/islamic/be/contracts/.spectral.yaml
+++ b/specs/apps/islamic/be/contracts/.spectral.yaml
@@ -1,0 +1,17 @@
+extends:
+  - "spectral:oas"
+rules:
+  # Enforce camelCase for all schema properties — zero exceptions
+  oas3-schema-properties-camelCase:
+    severity: error
+    message: "Property {{property}} must be camelCase"
+    given: "$.components.schemas.*.properties.*~"
+    then:
+      function: casing
+      functionOptions:
+        type: camel
+
+  # Disable noisy rules that don't add value for our use case
+  info-contact: off
+  oas3-unused-component: off
+  operation-description: off

--- a/specs/apps/islamic/be/contracts/README.md
+++ b/specs/apps/islamic/be/contracts/README.md
@@ -1,0 +1,68 @@
+# Islamic Tools API Contract
+
+OpenAPI 3.1 specification for the Islamic tools Sharia-compliance REST API.
+
+## Purpose
+
+This contract defines the exact shape of every request and response for `islamic-be`. It is the
+**single source of truth** for API types — `oapi-codegen` produces the Go `ServerInterface` from it,
+and the router satisfies that interface, so a handler cannot drift from the published specification
+without failing to compile.
+
+## Quick Start
+
+```bash
+# Lint the contract (bundles first, then runs Spectral)
+nx run islamic-contracts:lint
+
+# Bundle into single resolved YAML + JSON
+nx run islamic-contracts:bundle
+
+# Generate browsable API documentation
+nx run islamic-contracts:docs
+# Open specs/apps/islamic/be/contracts/generated/docs/index.html
+```
+
+## File Structure
+
+```
+contracts/
+├── openapi.yaml          # Root spec with $ref mappings
+├── .spectral.yaml        # Linting rules (camelCase enforcement)
+├── project.json          # Nx project targets
+├── paths/                # Endpoint definitions by domain
+│   └── health.yaml       # GET /api/v1/health
+├── schemas/              # Data type definitions
+│   ├── health.yaml       # HealthResponse
+│   └── error.yaml        # ErrorResponse
+└── generated/            # Output (gitignored)
+    ├── openapi-bundled.yaml
+    ├── openapi-bundled.json
+    └── docs/index.html
+```
+
+## Modifying the Contract
+
+1. Edit the relevant file in `schemas/` or `paths/`
+2. Run `nx run islamic-contracts:lint` to validate
+3. Run `nx run islamic-contracts:bundle` to regenerate the bundled spec
+4. Run codegen for the service: `nx run islamic-be:codegen`
+5. Fix any compile errors — a diverged handler stops satisfying `ServerInterface`
+6. Commit the contract changes (generated code is gitignored)
+
+## Relationship to the ose-be contract
+
+`.spectral.yaml` is byte-identical to `specs/apps/ose/be/contracts/.spectral.yaml` by intent: the
+two services publish under one platform and should not disagree about what a well-formed contract
+looks like. The specifications themselves share no components — `islamic-be` is a separate product
+line and a shared component would couple their release cadences.
+
+## Rules
+
+- All JSON field names use **strict camelCase** — zero exceptions
+- Every schema must have a `description`
+- Changes to this contract trigger codegen for `islamic-be` via the Nx dependency graph
+
+- [generated](./generated/README.md) — Islamic Contracts
+- [paths](./paths/README.md) — Islamic Contracts
+- [schemas](./schemas/README.md) — Islamic Contracts

--- a/specs/apps/islamic/be/contracts/generated/README.md
+++ b/specs/apps/islamic/be/contracts/generated/README.md
@@ -1,0 +1,5 @@
+# generated — Islamic Contracts
+
+Auto-generated OpenAPI artifacts. Nothing here is authored by hand — every file is produced by
+`nx run islamic-contracts:bundle` or `:docs` and is gitignored apart from this README. See the
+parent [contracts/README.md](../README.md) for details on the schema and codegen pipeline.

--- a/specs/apps/islamic/be/contracts/openapi.yaml
+++ b/specs/apps/islamic/be/contracts/openapi.yaml
@@ -1,0 +1,29 @@
+openapi: 3.1.0
+info:
+  title: Islamic Tools API
+  description: REST API contract for the Islamic tools Sharia-compliance service
+  version: 1.0.0
+  contact:
+    name: Open Sharia Enterprise
+    url: https://github.com/wahidyankf/ose-public
+
+servers:
+  - url: http://localhost:8402
+    description: Local development
+
+tags:
+  - name: Health
+    description: Service health checks
+
+components:
+  schemas:
+    # Common
+    ErrorResponse:
+      $ref: "./schemas/error.yaml#/ErrorResponse"
+    HealthResponse:
+      $ref: "./schemas/health.yaml#/HealthResponse"
+
+paths:
+  # Health
+  /api/v1/health:
+    $ref: "./paths/health.yaml#/~1api~1v1~1health"

--- a/specs/apps/islamic/be/contracts/paths/README.md
+++ b/specs/apps/islamic/be/contracts/paths/README.md
@@ -1,0 +1,4 @@
+# paths — Islamic Contracts
+
+OpenAPI path definitions. See the parent [contracts/README.md](../README.md) for details on
+the schema and codegen pipeline.

--- a/specs/apps/islamic/be/contracts/paths/health.yaml
+++ b/specs/apps/islamic/be/contracts/paths/health.yaml
@@ -1,0 +1,19 @@
+/api/v1/health:
+  get:
+    operationId: getHealth
+    summary: Health check
+    tags:
+      - Health
+    responses:
+      "200":
+        description: Service is healthy
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/health.yaml#/HealthResponse"
+      "404":
+        description: No route matches the request
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/error.yaml#/ErrorResponse"

--- a/specs/apps/islamic/be/contracts/project.json
+++ b/specs/apps/islamic/be/contracts/project.json
@@ -1,0 +1,79 @@
+{
+  "name": "islamic-contracts",
+  "root": "specs/apps/islamic/be/contracts",
+  "tags": ["type:lib", "domain:islamic"],
+  "targets": {
+    "lint": {
+      "command": "mkdir -p specs/apps/islamic/be/contracts/generated && npx @redocly/cli bundle specs/apps/islamic/be/contracts/openapi.yaml -o specs/apps/islamic/be/contracts/generated/openapi-bundled.yaml && npx @redocly/cli bundle specs/apps/islamic/be/contracts/openapi.yaml -o specs/apps/islamic/be/contracts/generated/openapi-bundled.json && npx @stoplight/spectral-cli lint specs/apps/islamic/be/contracts/generated/openapi-bundled.yaml --ruleset specs/apps/islamic/be/contracts/.spectral.yaml",
+      "cache": true,
+      "inputs": ["{projectRoot}/**/*.yaml", "!{projectRoot}/generated/**", "!{projectRoot}/examples/**"]
+    },
+    "bundle": {
+      "command": "mkdir -p specs/apps/islamic/be/contracts/generated && npx @redocly/cli bundle specs/apps/islamic/be/contracts/openapi.yaml -o specs/apps/islamic/be/contracts/generated/openapi-bundled.yaml && npx @redocly/cli bundle specs/apps/islamic/be/contracts/openapi.yaml -o specs/apps/islamic/be/contracts/generated/openapi-bundled.json",
+      "cache": true,
+      "inputs": ["{projectRoot}/**/*.yaml", "!{projectRoot}/generated/**", "!{projectRoot}/examples/**"],
+      "outputs": ["{projectRoot}/generated/openapi-bundled.yaml", "{projectRoot}/generated/openapi-bundled.json"]
+    },
+    "docs": {
+      "command": "mkdir -p specs/apps/islamic/be/contracts/generated/docs && npx @redocly/cli bundle specs/apps/islamic/be/contracts/openapi.yaml --remove-unused-components -o specs/apps/islamic/be/contracts/generated/openapi-docs.yaml && npx @redocly/cli build-docs specs/apps/islamic/be/contracts/generated/openapi-docs.yaml -o specs/apps/islamic/be/contracts/generated/docs/index.html",
+      "dependsOn": ["bundle"],
+      "cache": true,
+      "inputs": ["{projectRoot}/generated/openapi-bundled.yaml"],
+      "outputs": ["{projectRoot}/generated/docs/"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo 'no-op: target not applicable for this project (OpenAPI contract spec only)'"
+      }
+    },
+    "test:quick": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          {
+            "command": "npm exec -- nx run islamic-contracts:typecheck",
+            "forwardAllArgs": false
+          },
+          {
+            "command": "npm exec -- nx run islamic-contracts:lint",
+            "forwardAllArgs": false
+          },
+          {
+            "command": "npm exec -- nx run islamic-contracts:specs:structure-validation",
+            "forwardAllArgs": false
+          }
+        ],
+        "parallel": false,
+        "forwardAllArgs": false
+      },
+      "cache": true,
+      "inputs": ["default"]
+    },
+    "deps:audit": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo 'deps:audit: no package dependencies to audit'"
+      },
+      "cache": false
+    },
+    "compat:min-version": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo 'compat:min-version: no standard min-version floor'"
+      },
+      "cache": true
+    },
+    "specs:structure-validation": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "dotnet run --project apps/rhino-cli/src/RhinoCli.Program/RhinoCli.Program.fsproj -- specs structure validate"
+      },
+      "cache": true,
+      "inputs": ["{workspaceRoot}/specs/apps/!(rhino)/**/*"]
+    }
+  },
+  "namedInputs": {
+    "specs": ["{workspaceRoot}/specs/apps/islamic/be/contracts/**"]
+  }
+}

--- a/specs/apps/islamic/be/contracts/schemas/README.md
+++ b/specs/apps/islamic/be/contracts/schemas/README.md
@@ -1,0 +1,4 @@
+# schemas — Islamic Contracts
+
+OpenAPI data type definitions. See the parent [contracts/README.md](../README.md) for details
+on the schema and codegen pipeline.

--- a/specs/apps/islamic/be/contracts/schemas/error.yaml
+++ b/specs/apps/islamic/be/contracts/schemas/error.yaml
@@ -1,0 +1,16 @@
+ErrorResponse:
+  type: object
+  description: Standardized error response
+  required:
+    - error
+  properties:
+    error:
+      type: string
+      description: Stable machine-readable error identifier
+    message:
+      type: string
+      description: Human-readable explanation of what went wrong
+    details:
+      type: object
+      description: Optional structured context for the error
+      additionalProperties: true

--- a/specs/apps/islamic/be/contracts/schemas/health.yaml
+++ b/specs/apps/islamic/be/contracts/schemas/health.yaml
@@ -1,0 +1,10 @@
+HealthResponse:
+  type: object
+  description: Liveness signal for the Islamic tools service
+  required:
+    - status
+  properties:
+    status:
+      type: string
+      description: Liveness state of the service
+      example: healthy

--- a/specs/apps/islamic/overview.md
+++ b/specs/apps/islamic/overview.md
@@ -1,0 +1,37 @@
+# Islamic Tools — Product Overview
+
+## Islamic BE (`islamic-be`)
+
+A general-purpose Sharia-compliance API. It exists to serve any consumer that needs an
+Islamic-finance or Sharia-compliance judgement — the OSE Application is expected to be one caller,
+not the owner.
+
+### Who uses it
+
+- **Product engineers** integrating a compliance judgement into their own service
+- **System operators** who need a liveness signal before routing traffic to an instance
+
+### Scope
+
+- A versioned HTTP surface under `/api/v1/`
+- A contract-first specification that clients and the service both generate from
+- A liveness probe operations can depend on
+
+### What ships today
+
+- `GET /api/v1/health` — the liveness probe, and nothing else
+
+The service is deliberately a skeleton at this stage. It establishes the language lane, the
+contract pipeline, and the behaviour corpus so that the first real compliance capability lands on a
+proven surface rather than alongside one.
+
+### What is deferred
+
+- Every domain capability. No Sharia-compliance rule is implemented yet.
+- Persistence. The service holds no database and writes nothing.
+- Authentication. The surface is unauthenticated because it exposes nothing to protect.
+
+### Why its own product line
+
+`domain:islamic` rather than `domain:ose` because the capability is generic. Binding it to the OSE
+Application's domain would make every future consumer a dependant of a GRC product it does not use.


### PR DESCRIPTION
## Why

DU2 of `plans/in-progress/islamic-be-init/`. Establishes the specification corpus that `islamic-be`
(DU3) and `islamic-be-e2e` (DU4) will implement, before either project exists — so the Gherkin is
written against requirements rather than reverse-engineered from an implementation.

## What

- `specs/apps/islamic/` — product README and overview, registered in the `specs/apps/` annotated index
- `specs/apps/islamic/be/` — README plus a C4 architecture doc (context + container diagrams)
- 8 Gherkin scenarios across `behaviours/health/` (3) and `behaviours/config/` (5)
- An OpenAPI 3.1 contract split into `paths/` and `schemas/` fragments, with `.spectral.yaml`
  copied byte-identically from the `ose-be` contract
- The `islamic-contracts` Nx project, tagged `["type:lib","domain:islamic"]` with `namedInputs.specs`
- Five sanitized evidence captures from the Phase 1 and Phase 2 gate runs

## Cost / benefit of new code

No production code. The added cost is one Nx project (8 targets, all spec-linting) and 21 spec files
that must be maintained alongside the service. The benefit is that DU3's implementation has a fixed,
diff-verified acceptance target: the scenario names and step lines are byte-identical to `prd.md`
US-1 and US-3, checked mechanically, so the corpus cannot silently drift from the requirements.

## Decisions worth review

- **The config scenarios carry an E2E exemption**, not only the Integration one the health scenarios
  take. A caller can observe *that* the service listens but not *which source supplied the port*, and
  a process that refuses to start on a malformed port exposes no public boundary at all. Both name
  `islamic-be:test:unit` as the alternative proof. Unit is never exempt.
- **`islamic-contracts` declares tags; its `ose-contracts` sibling declares none.** An
  exclusion-based CI selector treats "tag absent" and "tag unknown" identically — both fail open —
  so the tags are deliberate rather than cosmetic.
- **The corpus names `apps/islamic-be` in prose instead of linking it.** `md-links` is an
  `all-file-type` gate, so a forward link to a project DU3 has not created yet would fail the whole
  tree. Those links are explicit steps in DU3 and DU4.
- **`contracts/generated/` uses a glob-plus-negation ignore**, keeping a hand-written README while
  ignoring bundles. `ose-be` tracks its bundles; `ose-lms-be` ignores the directory wholesale with no
  README. Three shapes now coexist; the divergence is recorded in `learnings.md`, not resolved here.

## Verification

All with `--skip-nx-cache`:

- `islamic-contracts:lint` — "No results with a severity of 'error' found!"
- `islamic-contracts:test:quick` — exit 0
- `islamic-contracts:specs:structure-validation` — exit 0
- `specs structure validate` — 0 findings for "islamic"
- Scenario/step diff against `prd.md` US-1 and US-3 — byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2pyLiJKoWA6MJtWvzZFdy
