### PR TITLE
feat(islamic-be-e2e): drive the health scenarios through real HTTP

### DIFF
--- a/apps/islamic-be-e2e/.gitignore
+++ b/apps/islamic-be-e2e/.gitignore
@@ -1,0 +1,5 @@
+test-results/
+playwright-report/
+.features-gen/
+node_modules/
+dist/

--- a/apps/islamic-be-e2e/README.md
+++ b/apps/islamic-be-e2e/README.md
@@ -1,0 +1,69 @@
+# islamic-be-e2e
+
+End-to-end tests for [`islamic-be`](../islamic-be/README.md), driven through its public HTTP
+boundary. Playwright-BDD executes the same behaviour examples that describe the service — no
+browser involved. 🧪
+
+## Run locally
+
+```bash
+# Install test dependencies once on this machine
+./hippo run --class transactional --disk-path . -- npm exec nx -- run islamic-be-e2e:install
+
+# Build the service and run the scenarios against a real process
+./hippo run --class service --disk-path . -- npm exec nx -- run islamic-be-e2e:test:e2e
+```
+
+`test:e2e` runs [`apps/islamic-be/scripts/run-e2e.sh`](../islamic-be/scripts/run-e2e.sh), which
+builds the binary through Nx — so `codegen` runs first and the binary matches the current contract —
+and then hands process lifecycle to the harness. There is no `docker-compose` stack: the service
+owns no database, broker, or disk, so there is nothing to stand up.
+
+Use `islamic-be-e2e:test:e2e:ui` for Playwright's UI and `islamic-be-e2e:test:e2e:report` for the
+most recent report.
+
+## The suite starts the process it observes
+
+`steps/backend-process.ts` spawns the compiled binary on port 8402 and stops it afterwards. It
+reuses a process **only** if this harness started it and it is still alive; anything else already
+listening on 8402 is a hard error rather than a silent reuse.
+
+That rule is not defensive styling. While this suite was being written, a stale binary left over
+from an earlier `nx run islamic-be:dev` held the port, and a deliberately broken health handler
+still reported three green scenarios — the suite never executed the code under test. Reusing
+whatever answers on a port makes a green run meaningless, so this project refuses to do it. See
+[`plans/in-progress/islamic-be-init/evidence/phase-4-e2e.txt`](../../plans/in-progress/islamic-be-init/evidence/phase-4-e2e.txt)
+for both runs.
+
+Set `API_BASE_URL` to point Playwright's `request` fixture at a different environment. Never commit
+credentials or real access values.
+
+## Retries are off
+
+`retries: 0`, in CI and out. A scenario that only passes on a second attempt is a defect to fix at
+its root cause, and a retry would hide it. This diverges deliberately from `apps/ose-be-e2e`, which
+retries twice in CI.
+
+## Scope
+
+| Layer       | Owner        | Status                                                         |
+| ----------- | ------------ | -------------------------------------------------------------- |
+| Unit        | `islamic-be` | **Omitted here.** In-process proof belongs to the service      |
+| Integration | —            | **Omitted here.** `islamic-be` owns no local-resource boundary |
+| E2E         | `steps/`     | The three health scenarios, over real HTTP                     |
+
+This project owns no independent corpus. The behaviour source of truth is
+[the islamic-be Gherkin suite](../../specs/apps/islamic/be/behaviours/README.md).
+
+The five `config/` scenarios carry `@e2e-exempt` with a written reason: which source supplied the
+port is not observable through the public HTTP boundary, only that the service listens. That one tag
+is read by both `playwright.config.ts`'s filter and `scripts/behaviour-coverage.mjs`, so the
+exemption is declared once. There is no `e2e-coverage-baseline.json` — no exemption needs one, and
+deleting a single tag makes `test:coverage:e2e` fail with `undefined E2E binding`.
+
+## Checks
+
+```bash
+npm exec nx -- run islamic-be-e2e:test:quick    # typecheck, lint, specs, coverage validators
+npm exec nx -- run islamic-be-e2e:test:coverage # static binding coverage for both adapters
+```

--- a/apps/islamic-be-e2e/behaviour-coverage.json
+++ b/apps/islamic-be-e2e/behaviour-coverage.json
@@ -1,0 +1,14 @@
+{
+  "project": "islamic-be-e2e",
+  "corpus": ["../../specs/apps/islamic/be/behaviours"],
+  "adapters": {
+    "unit": {
+      "bindings": ["../islamic-be/internal/bdd"],
+      "driver": "../islamic-be/go.mod"
+    },
+    "e2e": {
+      "bindings": ["steps"],
+      "driver": "playwright.config.ts"
+    }
+  }
+}

--- a/apps/islamic-be-e2e/package.json
+++ b/apps/islamic-be-e2e/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "islamic-be-e2e",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:ui": "playwright test --ui",
+    "test:report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.60.0",
+    "playwright-bdd": "8.5.1"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/apps/islamic-be-e2e/playwright.config.ts
+++ b/apps/islamic-be-e2e/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from "@playwright/test";
+import { defineBddConfig } from "playwright-bdd";
+
+// Pin the tier deterministically. Leaving APP_ENV unset falls back to "local" per the loader
+// contract, which would read a developer's real .env.local instead of test fixtures.
+process.env.APP_ENV ??= "test";
+
+const testDir = defineBddConfig({
+  featuresRoot: "../../specs/apps/islamic/be/behaviours",
+  features: "../../specs/apps/islamic/be/behaviours/**/*.feature",
+  steps: ["./steps/**/*.ts"],
+  // The config scenarios each carry an @e2e-exempt tag with a written reason and a named
+  // alternative proof: which source supplied the port is not observable through the service's
+  // public HTTP boundary, only that it listens. The same tag is what
+  // scripts/behaviour-coverage.mjs honours, so the filter here and the static coverage validator
+  // read one declaration rather than two.
+  tags: "not @e2e-exempt",
+});
+
+export default defineConfig({
+  testDir,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  // No retries, in CI or out. A test that only passes on the second attempt is a defect to fix at
+  // its root cause, and a retry would hide it. This deliberately diverges from apps/ose-be-e2e.
+  retries: 0,
+  workers: 1,
+  reporter: [["list"], ["html"], ["junit", { outputFile: "test-results/junit.xml" }]],
+  use: {
+    baseURL: process.env.API_BASE_URL || "http://localhost:8402",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+});

--- a/apps/islamic-be-e2e/project.json
+++ b/apps/islamic-be-e2e/project.json
@@ -1,0 +1,137 @@
+{
+  "name": "islamic-be-e2e",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "apps/islamic-be-e2e/steps",
+  "namedInputs": {
+    "specs": ["{workspaceRoot}/specs/apps/islamic/be/behaviours/**/*.feature"]
+  },
+  "tags": ["type:e2e", "platform:playwright", "lang:ts", "domain:islamic"],
+  "implicitDependencies": ["islamic-be"],
+  "targets": {
+    "install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm install",
+        "cwd": "apps/islamic-be-e2e"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx oxlint .",
+        "cwd": "apps/islamic-be-e2e"
+      }
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx bddgen && npx tsc --noEmit",
+        "cwd": "apps/islamic-be-e2e"
+      },
+      "inputs": ["default", "{workspaceRoot}/specs/apps/islamic/be/behaviours/**/*.feature"]
+    },
+    "test:e2e": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "apps/islamic-be/scripts/run-e2e.sh"
+      }
+    },
+    "test:e2e:ui": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx bddgen && npx playwright test --ui",
+        "cwd": "apps/islamic-be-e2e"
+      }
+    },
+    "test:e2e:report": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx playwright show-report",
+        "cwd": "apps/islamic-be-e2e"
+      }
+    },
+    "test:coverage:e2e": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node scripts/behaviour-coverage.mjs --config apps/islamic-be-e2e/behaviour-coverage.json --adapter e2e"
+      },
+      "cache": true,
+      "inputs": [
+        "{workspaceRoot}/scripts/behaviour-coverage.mjs",
+        "{workspaceRoot}/apps/islamic-be-e2e/behaviour-coverage.json",
+        "{workspaceRoot}/package-lock.json",
+        "{workspaceRoot}/specs/apps/islamic/be/behaviours/**/*.feature",
+        "{workspaceRoot}/apps/islamic-be/internal/bdd/**/*.go",
+        "{workspaceRoot}/apps/islamic-be/go.mod",
+        "{workspaceRoot}/apps/islamic-be-e2e/steps/**/*.ts",
+        "{workspaceRoot}/apps/islamic-be-e2e/playwright.config.ts"
+      ]
+    },
+    "test:coverage:behaviour": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node scripts/behaviour-coverage.mjs --config apps/islamic-be-e2e/behaviour-coverage.json --adapter behaviour"
+      },
+      "cache": true,
+      "inputs": [
+        "{workspaceRoot}/scripts/behaviour-coverage.mjs",
+        "{workspaceRoot}/apps/islamic-be-e2e/behaviour-coverage.json",
+        "{workspaceRoot}/package-lock.json",
+        "{workspaceRoot}/specs/apps/islamic/be/behaviours/**/*.feature",
+        "{workspaceRoot}/apps/islamic-be/internal/bdd/**/*.go",
+        "{workspaceRoot}/apps/islamic-be/go.mod",
+        "{workspaceRoot}/apps/islamic-be-e2e/steps/**/*.ts",
+        "{workspaceRoot}/apps/islamic-be-e2e/playwright.config.ts"
+      ]
+    },
+    "test:coverage": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          { "command": "npm exec -- nx run islamic-be-e2e:test:coverage:e2e", "forwardAllArgs": false },
+          { "command": "npm exec -- nx run islamic-be-e2e:test:coverage:behaviour", "forwardAllArgs": false }
+        ],
+        "parallel": false,
+        "forwardAllArgs": false
+      },
+      "cache": true
+    },
+    "test:quick": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          { "command": "npm exec -- nx run islamic-be-e2e:typecheck", "forwardAllArgs": false },
+          { "command": "npm exec -- nx run islamic-be-e2e:lint", "forwardAllArgs": false },
+          { "command": "npm exec -- nx run islamic-be-e2e:specs:structure-validation", "forwardAllArgs": false },
+          { "command": "npm exec -- nx run islamic-be-e2e:test:coverage", "forwardAllArgs": false }
+        ],
+        "parallel": false,
+        "forwardAllArgs": false
+      },
+      "cache": true
+    },
+    "specs:structure-validation": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "dotnet run --project apps/rhino-cli/src/RhinoCli.Program/RhinoCli.Program.fsproj -- specs structure validate"
+      },
+      "cache": true,
+      "inputs": ["{workspaceRoot}/specs/apps/!(rhino)/**/*"]
+    },
+    "deps:audit": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm audit"
+      },
+      "cache": false
+    },
+    "compat:min-version": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo 'compat:min-version: no standard min-version floor for TypeScript'"
+      },
+      "cache": true
+    }
+  }
+}

--- a/apps/islamic-be-e2e/steps/backend-process.ts
+++ b/apps/islamic-be-e2e/steps/backend-process.ts
@@ -1,0 +1,92 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createBdd } from "playwright-bdd";
+
+const { AfterAll } = createBdd();
+
+const port = "8402";
+const baseUrl = `http://127.0.0.1:${port}`;
+const binary = "../islamic-be/dist/islamic-be";
+let backend: ChildProcessWithoutNullStreams | undefined;
+let output = "";
+
+const wait = (milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+async function endpointResponds(path = "/api/v1/health") {
+  try {
+    const response = await fetch(`${baseUrl}${path}`);
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function stopBackend() {
+  if (!backend) return;
+
+  const processToStop = backend;
+  backend = undefined;
+
+  if (processToStop.exitCode === null) {
+    processToStop.kill("SIGTERM");
+    await Promise.race([
+      new Promise<void>((resolve) => processToStop.once("exit", () => resolve())),
+      wait(5_000).then(() => {
+        if (processToStop.exitCode === null) processToStop.kill("SIGKILL");
+      }),
+    ]);
+  }
+
+  for (let attempt = 0; attempt < 20 && (await endpointResponds()); attempt += 1) {
+    await wait(100);
+  }
+}
+
+export async function startBackend() {
+  await stopBackend();
+  output = "";
+
+  // The compiled binary, not `go run`: `go run` forks a child and reports the wrapper's exit code,
+  // so a service that dies on startup would look alive to the harness. run-e2e.sh builds it first.
+  backend = spawn(binary, [], {
+    cwd: process.cwd(),
+    env: { ...process.env, ISLAMIC_BE_PORT: port },
+    stdio: "pipe",
+  });
+  backend.stdout.on("data", (chunk: Buffer) => (output += chunk.toString()));
+  backend.stderr.on("data", (chunk: Buffer) => (output += chunk.toString()));
+
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    if (await endpointResponds()) return;
+    if (backend.exitCode !== null) throw new Error(`islamic-be exited during startup:\n${output}`);
+    await wait(250);
+  }
+
+  throw new Error(`islamic-be did not become ready:\n${output}`);
+}
+
+export async function ensureBackendStarted() {
+  // Reuse only a process this harness started and is still running. Reusing *whatever* answers on
+  // the port -- the shape apps/ose-be-e2e uses -- means a stale binary left over from an earlier
+  // `nx run islamic-be:dev` silently satisfies every scenario, and the suite passes without ever
+  // executing the code under test. That is not a hypothetical: it happened while this suite was
+  // being written, and a deliberately broken health handler still reported three green scenarios.
+  if (backend && backend.exitCode === null) return;
+
+  if (await endpointResponds()) {
+    throw new Error(
+      `something is already listening on ${baseUrl} that this suite did not start. ` +
+        `E2E must observe the process it launched, so refusing to run against it. ` +
+        `Stop the stray process and re-run.`,
+    );
+  }
+
+  await startBackend();
+}
+
+AfterAll(async () => {
+  await stopBackend();
+});
+
+process.once("exit", () => {
+  if (backend?.exitCode === null) backend.kill("SIGKILL");
+});

--- a/apps/islamic-be-e2e/steps/health.steps.ts
+++ b/apps/islamic-be-e2e/steps/health.steps.ts
@@ -1,0 +1,56 @@
+/**
+ * Step definitions for the islamic-be health endpoint feature.
+ *
+ * Covers: specs/apps/islamic/be/behaviours/health/health.feature
+ */
+import { expect } from "@playwright/test";
+import { createBdd } from "playwright-bdd";
+import { setResponse, getResponse, clearResponse } from "../utils/response-store";
+import { ensureBackendStarted } from "./backend-process";
+
+const { Given, When, Then, Before } = createBdd();
+
+Before(() => {
+  clearResponse();
+});
+
+Given("the islamic-be service is running", async ({ request }) => {
+  await ensureBackendStarted();
+  const readinessResponse = await request.get("/api/v1/health");
+  expect(readinessResponse.status()).toBe(200);
+});
+
+// One binding for both request paths the feature exercises. Splitting it per path would leave the
+// unknown-route scenario with a step nothing else could reuse, and playwright-bdd requires exactly
+// one binding per step anyway.
+When(/^I send GET (\/api\/v1\/[a-z0-9-]+)$/, async ({ request }, path: string) => {
+  setResponse(await request.get(path));
+});
+
+// oxlint-disable-next-line no-empty-pattern
+Then("the response status is {int}", async ({}, expectedStatus: number) => {
+  expect(getResponse().status()).toBe(expectedStatus);
+});
+
+Then(
+  "the response body has a {string} field equal to {string}",
+  // oxlint-disable-next-line no-empty-pattern
+  async ({}, field: string, value: string) => {
+    const body = (await getResponse().json()) as Record<string, unknown>;
+    expect(body[field]).toBe(value);
+  },
+);
+
+Then(
+  "the response {string} header starts with {string}",
+  // oxlint-disable-next-line no-empty-pattern
+  async ({}, header: string, prefix: string) => {
+    const headers = getResponse().headers();
+    // Playwright lowercases header names; the feature names them as an operator would write them.
+    // Absence collapses to "" so the missing-header case fails on its own assertion with a clear
+    // message rather than on an undefined dereference inside the prefix check.
+    const actual = headers[header.toLowerCase()] ?? "";
+    expect(actual, `the response carries no ${header} header`).not.toBe("");
+    expect(actual.startsWith(prefix), `${header} was "${actual}"`).toBe(true);
+  },
+);

--- a/apps/islamic-be-e2e/tsconfig.json
+++ b/apps/islamic-be-e2e/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "CommonJS",
+    "moduleResolution": "node"
+  },
+  "include": ["steps/**/*.ts", "utils/**/*.ts", "playwright.config.ts", ".features-gen/**/*.ts"],
+  "exclude": ["node_modules", "dist", "test-results", "playwright-report"]
+}

--- a/apps/islamic-be-e2e/utils/response-store.ts
+++ b/apps/islamic-be-e2e/utils/response-store.ts
@@ -1,0 +1,18 @@
+import type { APIResponse } from "@playwright/test";
+
+let response: APIResponse | null = null;
+
+export function setResponse(r: APIResponse): void {
+  response = r;
+}
+
+export function getResponse(): APIResponse {
+  if (!response) {
+    throw new Error("No response stored. A When step must run before Then steps.");
+  }
+  return response;
+}
+
+export function clearResponse(): void {
+  response = null;
+}

--- a/apps/islamic-be/README.md
+++ b/apps/islamic-be/README.md
@@ -88,5 +88,5 @@ because the service makes no outbound TLS calls; add them the moment it does.
 ## See also
 
 - [Specification corpus](../../specs/apps/islamic/be/README.md) — behaviours, contract, architecture
-- `apps/islamic-be-e2e` — the E2E suite for this service. Named rather than linked until DU4
-  creates it; `md-links` scans the whole tree, so a forward link would fail every push.
+- [`apps/islamic-be-e2e`](../islamic-be-e2e/README.md) — the E2E suite for this service, driving
+  the three health scenarios through the real HTTP boundary

--- a/apps/islamic-be/behaviour-coverage.json
+++ b/apps/islamic-be/behaviour-coverage.json
@@ -5,6 +5,10 @@
     "unit": {
       "bindings": ["internal/bdd"],
       "driver": "go.mod"
+    },
+    "e2e": {
+      "bindings": ["../islamic-be-e2e/steps"],
+      "driver": "../islamic-be-e2e/playwright.config.ts"
     }
   }
 }

--- a/apps/islamic-be/project.json
+++ b/apps/islamic-be/project.json
@@ -100,7 +100,9 @@
         "{workspaceRoot}/apps/islamic-be/behaviour-coverage.json",
         "{workspaceRoot}/package-lock.json",
         "specs",
-        "{projectRoot}/internal/bdd/**/*.go"
+        "{projectRoot}/internal/bdd/**/*.go",
+        "{workspaceRoot}/apps/islamic-be-e2e/steps/**/*.ts",
+        "{workspaceRoot}/apps/islamic-be-e2e/playwright.config.ts"
       ]
     },
     "test:coverage:behaviour": {
@@ -113,7 +115,26 @@
         "{workspaceRoot}/scripts/behaviour-coverage.mjs",
         "{workspaceRoot}/apps/islamic-be/behaviour-coverage.json",
         "{workspaceRoot}/package-lock.json",
-        "specs"
+        "specs",
+        "{projectRoot}/internal/bdd/**/*.go",
+        "{workspaceRoot}/apps/islamic-be-e2e/steps/**/*.ts",
+        "{workspaceRoot}/apps/islamic-be-e2e/playwright.config.ts"
+      ]
+    },
+    "test:coverage:e2e": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node scripts/behaviour-coverage.mjs --config apps/islamic-be/behaviour-coverage.json --adapter e2e"
+      },
+      "cache": true,
+      "inputs": [
+        "{workspaceRoot}/scripts/behaviour-coverage.mjs",
+        "{workspaceRoot}/apps/islamic-be/behaviour-coverage.json",
+        "{workspaceRoot}/package-lock.json",
+        "specs",
+        "{projectRoot}/internal/bdd/**/*.go",
+        "{workspaceRoot}/apps/islamic-be-e2e/steps/**/*.ts",
+        "{workspaceRoot}/apps/islamic-be-e2e/playwright.config.ts"
       ]
     },
     "test:coverage": {
@@ -121,7 +142,7 @@
       "options": {
         "commands": ["echo 'islamic-be coverage validators complete'"]
       },
-      "dependsOn": ["test:coverage:unit", "test:coverage:behaviour"],
+      "dependsOn": ["test:coverage:unit", "test:coverage:e2e", "test:coverage:behaviour"],
       "cache": true
     },
     "test:quick": {

--- a/apps/islamic-be/scripts/run-e2e.sh
+++ b/apps/islamic-be/scripts/run-e2e.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# E2E test runner for islamic-be.
+#
+# The service owns no local-resource boundary -- no database, no message broker, no disk -- so
+# unlike apps/ose-be/scripts/run-e2e.sh there is no docker-compose stack to bring up. This script
+# builds the binary and hands process lifecycle to the Playwright harness, which starts and stops
+# it inside scenario steps so startup behaviour stays observable.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+# Fail fast, before paying for a build, on any unconditional test.skip() left in the suite.
+# test.skip(condition, reason) -- the documented Playwright environment-guard form -- is
+# intentionally allowed through.
+if grep -rn -E --include='*.ts' --exclude-dir=node_modules --exclude-dir=.features-gen \
+	--exclude-dir=test-results --exclude-dir=playwright-report \
+	'\$?test\.skip\([^,)]*\)' "${ROOT}/apps/islamic-be-e2e"; then
+	echo "ERROR: unconditional test.skip() found in the files above - use test.skip(condition, reason) for a legitimate environment guard, or remove it" >&2
+	exit 1
+fi
+
+# Build through Nx so codegen runs first and the binary matches the current contract.
+npm exec -- nx run islamic-be:build
+
+cd "${ROOT}/apps/islamic-be-e2e"
+npx bddgen && npx playwright test

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,6 +136,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "apps/islamic-be-e2e": {
+      "devDependencies": {
+        "@playwright/test": "1.60.0",
+        "playwright-bdd": "8.5.1"
+      }
+    },
     "apps/organiclever-app-web": {
       "version": "0.1.0",
       "dependencies": {
@@ -16033,6 +16039,10 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/islamic-be-e2e": {
+      "resolved": "apps/islamic-be-e2e",
+      "link": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",

--- a/plans/in-progress/islamic-be-init/delivery.md
+++ b/plans/in-progress/islamic-be-init/delivery.md
@@ -75,17 +75,17 @@ authenticated clean current-head `pr-leak-review`, and the applicable surface ga
 
 ### Delivery Branch Inventory
 
-| Branch                                | Repository    | Mode      | Lifecycle state | Proof                                                                                             |
-| ------------------------------------- | ------------- | --------- | --------------- | ------------------------------------------------------------------------------------------------- |
-| `worktree/ose-islamic`                | `ose-public`  | `to-pr`   | `active`        | carries the plan-authoring PR #488 and every Phase 0 record; removed by the terminal cleanup gate |
-| `worktree/islamic-be-init`            | `ose-private` | `pending` | `pending`       | `git worktree add` at Phase 5                                                                     |
-| `islamic-be-init/du1-go-lane`         | `ose-public`  | `to-pr`   | `pending`       | record merged PR number and 40-character head SHA at DU1                                          |
-| `islamic-be-init/du2-specs-contracts` | `ose-public`  | `to-pr`   | `pending`       | record merged PR number and 40-character head SHA at DU2                                          |
-| `islamic-be-init/du3-service`         | `ose-public`  | `to-pr`   | `pending`       | record merged PR number and 40-character head SHA at DU3                                          |
-| `islamic-be-init/du4-e2e`             | `ose-public`  | `to-pr`   | `pending`       | record merged PR number and 40-character head SHA at DU4                                          |
-| `islamic-be-init/du5-rhino-go-env`    | `ose-public`  | `to-pr`   | `pending`       | record merged PR number and 40-character head SHA at DU5                                          |
-| `islamic-be-init/du5-rhino-go-env`    | `ose-private` | `to-pr`   | `pending`       | record merged PR number and 40-character head SHA at DU5                                          |
-| `islamic-be-init/du6-registry`        | `ose-public`  | `to-pr`   | `pending`       | record merged PR number and 40-character head SHA at DU6                                          |
+| Branch                                | Repository    | Mode      | Lifecycle state | Proof                                                                                                                                                      |
+| ------------------------------------- | ------------- | --------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `worktree/ose-islamic`                | `ose-public`  | `to-pr`   | `active`        | carries the plan-authoring PR #488 and every Phase 0 record; removed by the terminal cleanup gate                                                          |
+| `worktree/islamic-be-init`            | `ose-private` | `pending` | `pending`       | `git worktree add` at Phase 5                                                                                                                              |
+| `islamic-be-init/du1-go-lane`         | `ose-public`  | `to-pr`   | `delivered`     | PR #496, reviewed head `d534cadf3e6c5a3d93ee980c1f1c3b041ca48612`, squashed to `f9e40bc675824719b13fa8d32e48b297dc7c75c7`; branch deleted local and remote |
+| `islamic-be-init/du2-specs-contracts` | `ose-public`  | `to-pr`   | `delivered`     | PR #497, reviewed head `bbf0d709e964968cd6fb0a226f9c24354a9c2dc8`, squashed to `fbb459cad0a567dcace99ec6f555c493a17f58c9`; branch deleted local and remote |
+| `islamic-be-init/du3-service`         | `ose-public`  | `to-pr`   | `delivered`     | PR #498, reviewed head `5554cd6f7e205ffa7b2b35270af5b2da6c964683`, squashed to `1ee0672909de1acf1f339a1b31c00cf78c5a7387`; branch deleted local and remote |
+| `islamic-be-init/du4-e2e`             | `ose-public`  | `to-pr`   | `active`        | branched from `1ee0672909de1acf1f339a1b31c00cf78c5a7387`; record merged PR number and 40-character head SHA at DU4                                         |
+| `islamic-be-init/du5-rhino-go-env`    | `ose-public`  | `to-pr`   | `pending`       | record merged PR number and 40-character head SHA at DU5                                                                                                   |
+| `islamic-be-init/du5-rhino-go-env`    | `ose-private` | `to-pr`   | `pending`       | record merged PR number and 40-character head SHA at DU5                                                                                                   |
+| `islamic-be-init/du6-registry`        | `ose-public`  | `to-pr`   | `pending`       | record merged PR number and 40-character head SHA at DU6                                                                                                   |
 
 Append every plan-created delivery branch before use. Before removal, classify every entry as
 delivered, unused, or retained/escalated; an active or unrecorded branch blocks cleanup.
@@ -1057,7 +1057,7 @@ must enforce at least 99% line coverage`. DU1 taught the extractor to read Go _b
   > **Implementation note (2026-09-09).** States why `test:integration` is absent, in its own
   > section, and passes the word-budget gate with no finding.
 
-- [ ] [AI] Commit on `islamic-be-init/du3-service`, push, open a draft PR, poll CI every 2 minutes, and merge when green — acceptance: the PR merges to `main`
+- [x] [AI] Commit on `islamic-be-init/du3-service`, push, open a draft PR, poll CI every 2 minutes, and merge when green — acceptance: the PR merges to `main`
 
   > **Implementation note (2026-09-09).** CI's `lint` gate group failed twice on this head, each
   > time for a reason that could not reproduce locally, because `nx run islamic-be:lint` and the
@@ -1120,7 +1120,18 @@ must enforce at least 99% line coverage`. DU1 taught the extractor to read Go _b
   > **Implementation note (2026-09-09).** The binary is produced and runs. Captured to
   > `evidence/du3-lint-build.txt`.
 
-- [ ] [AI] Confirm the merged PR's CI run shows the `go` job green **and** the `typescript`, `dotnet`, `flutter`, and `java` jobs not selecting any Go target — acceptance: the `go` job log lists `islamic-be` and none of the other four does; save to `evidence/du3-ci-routing.txt`
+- [x] [AI] Confirm the merged PR's CI run shows the `go` job green **and** the `typescript`, `dotnet`, `flutter`, and `java` jobs not selecting any Go target — acceptance: the `go` job log lists `islamic-be` and none of the other four does; save to `evidence/du3-ci-routing.txt`
+
+  > **Implementation note (2026-09-09).** Captured from run `34263277920` on head `5554cd6f7`.
+  > The `go` job ran targets for exactly one project — `islamic-be` — and passed. The `typescript`,
+  > `dotnet`, and `java` jobs each mention `islamic-be` on exactly one line, and in all three cases
+  > it is `git fetch` advertising the PR branch, not a target selection; their project lists are
+  > reproduced in the evidence file. `Flutter quality gate` was skipped outright. Every one of the
+  > 17 non-skipped checks passed.
+  >
+  > The file lands in DU4's commit rather than DU3's: the acceptance criterion is about the _merged_
+  > PR's run, which does not exist until after DU3's own head is final.
+
 - [x] [AI] `curl -s localhost:8402/api/v1/health` against a locally running instance — returns 200 with `{"status":"healthy"}`, captured to `evidence/phase-3-health.txt`
 
   > **Implementation note (2026-09-09).** 200 with `{"status":"healthy"}` from a real process on 8402.
@@ -1134,28 +1145,119 @@ must enforce at least 99% line coverage`. DU1 taught the extractor to read Go _b
 
 Delivery boundary. Requires DU3 merged.
 
-- [ ] [AI] Create `apps/islamic-be-e2e/package.json`, `tsconfig.json`, and `playwright.config.ts` mirroring `apps/ose-be-e2e/` with `bddgen` pointed at the islamic corpus — acceptance: `npx bddgen` generates test files from the health feature
-- [ ] [AI] Implement `steps/backend-process.ts` starting and stopping the real `islamic-be` process on a controlled port — acceptance: the suite starts the service itself and shuts it down deterministically
-- [ ] [AI] Implement `steps/health.steps.ts` and `utils/response-store.ts` binding the health scenarios over real HTTP — acceptance: all three US-1 scenarios pass against the running process
-- [ ] [AI] Create `behaviour-coverage.json` with the corpus and an `e2e` adapter — acceptance: the file mirrors the `ose-be-e2e` shape
-- [ ] [AI] Create `project.json` with the E2E target surface, tags `["type:e2e","platform:playwright","lang:ts","domain:islamic"]`, `implicitDependencies: ["islamic-be"]`, and `namedInputs.specs` — acceptance: the project declares no Unit or Integration target
-- [ ] [AI] Decide and record whether the config scenarios need an `e2e-coverage-baseline.json` `allowedUnbound` entry, with a written reason for each — acceptance: every unbound scenario carries a stated reason or is bound
-- [ ] [AI] Write `apps/islamic-be-e2e/README.md` — acceptance: it explains what the suite covers and how to run it
+- [x] [AI] Create `apps/islamic-be-e2e/package.json`, `tsconfig.json`, and `playwright.config.ts` mirroring `apps/ose-be-e2e/` with `bddgen` pointed at the islamic corpus — acceptance: `npx bddgen` generates test files from the health feature
+
+  > **Implementation note (2026-09-09).** Same pins as every other E2E project — `@playwright/test`
+  > 1.60.0, `playwright-bdd` 8.5.1. `bddgen` generates `.features-gen/health/health.feature.spec.js`
+  > and `typecheck` exits zero.
+  >
+  > **Deviation.** `retries: 0`, not `ose-be-e2e`'s `process.env.CI ? 2 : 0`. AGENTS.md requires
+  > fixing a flaky test at its root cause and forbids retrying; copying the sibling's value would
+  > have imported a rule violation into a new project. Recorded in the project README so the
+  > divergence is visible where a reader would otherwise "fix" it back.
+  >
+  > `ose-be-e2e`'s stray `dependencies: { "@vitejs/plugin-react" }` was not copied — a React plugin
+  > has no business in a headless API suite.
+
+- [x] [AI] Implement `steps/backend-process.ts` starting and stopping the real `islamic-be` process on a controlled port — acceptance: the suite starts the service itself and shuts it down deterministically
+
+  > **Implementation note (2026-09-09).** Spawns the compiled binary rather than `go run`: `go run`
+  > forks a child and reports the wrapper's exit status, so a service that dies during startup would
+  > look alive to the harness. `run-e2e.sh` builds through Nx first, so `codegen` runs and the
+  > binary matches the current contract.
+  >
+  > **Deviation, and the reason for it.** `ose-be-e2e`'s `ensureBackendStarted` reuses whatever
+  > answers on the port. Copied verbatim, that made this suite pass against a service it never
+  > started: a stale `islamic-be` left over from the DU3 manual health check still held 8402, and a
+  > deliberately broken health handler reported three green scenarios. This version reuses only a
+  > process this harness started and still owns, and treats any foreign listener as a hard error.
+  > Both runs are in `evidence/phase-4-e2e.txt`.
+
+- [x] [AI] Implement `steps/health.steps.ts` and `utils/response-store.ts` binding the health scenarios over real HTTP — acceptance: all three US-1 scenarios pass against the running process
+
+  > **Implementation note (2026-09-09).** All three pass. The `When` step is one regex covering both
+  > request paths the feature exercises, because playwright-bdd requires exactly one binding per
+  > step and a path-specific pair would leave the unknown-route step with a binding nothing reuses.
+  > A new `Then the response {string} header starts with {string}` binding serves the content-type
+  > scenario; a missing header collapses to `""` so it fails on its own assertion rather than on an
+  > undefined dereference.
+
+- [x] [AI] Create `behaviour-coverage.json` with the corpus and an `e2e` adapter — acceptance: the file mirrors the `ose-be-e2e` shape
+
+  > **Implementation note (2026-09-09).** Mirrors it exactly: `unit` pointing back at
+  > `../islamic-be/internal/bdd` and `e2e` at `steps`. `apps/islamic-be/behaviour-coverage.json`
+  > gains the matching `e2e` adapter and a `test:coverage:e2e` target, which is the deferral DU3
+  > recorded — the adapter belongs to the delivery unit that makes it resolvable, and this is it.
+
+- [x] [AI] Create `project.json` with the E2E target surface, tags `["type:e2e","platform:playwright","lang:ts","domain:islamic"]`, `implicitDependencies: ["islamic-be"]`, and `namedInputs.specs` — acceptance: the project declares no Unit or Integration target
+
+  > **Implementation note (2026-09-09).** No `test:unit`, no `test:integration`, no stub for either
+  > — both belong to `islamic-be`, and the anti-echo convention forbids a naming-symmetry target.
+
+- [x] [AI] Decide and record whether the config scenarios need an `e2e-coverage-baseline.json` `allowedUnbound` entry, with a written reason for each — acceptance: every unbound scenario carries a stated reason or is bound
+
+  > **Decision (2026-09-09): no baseline file.** Two independent reasons.
+  >
+  > First, the mechanism is already in place and is the live one. All five `config/` scenarios carry
+  > `@e2e-exempt` with a written reason and a named alternative proof. `scripts/behaviour-coverage.mjs`
+  > honours that tag (`EXEMPTION_TAGS`), and `playwright.config.ts` filters on the same tag, so the
+  > exemption is declared once and read by both. Adding `allowedUnbound` would restate it in a
+  > second place that could drift.
+  >
+  > Second, `allowedUnbound` is read by nothing. A repository-wide search outside `node_modules`,
+  > `.nx`, and `plans/` finds it only inside the nine existing `e2e-coverage-baseline.json` files
+  > themselves — not in `scripts/`, not in `apps/rhino-cli/src/`, not in `.github/`. They are
+  > residue from `plans/done/2026-07-18__e2e-scenario-coverage-gap-detector/`. Writing a tenth dead
+  > file to satisfy a checkbox would be decoration, not a gate.
+  >
+  > **Proven, not asserted.** Deleting one `@e2e-exempt` tag makes
+  > `nx run islamic-be:test:coverage:e2e` fail with `The default port applies when nothing is set /
+the service resolves its listener port: undefined E2E binding`. The tag restored, it passes. The
+  > exemptions are load-bearing.
+
+- [x] [AI] Write `apps/islamic-be-e2e/README.md` — acceptance: it explains what the suite covers and how to run it
+
+  > **Implementation note (2026-09-09).** 488 words, markdownlint clean. Documents the
+  > start-what-you-observe rule and the `retries: 0` divergence at the point a reader would question
+  > them.
+
 - [ ] [AI] Commit on `islamic-be-init/du4-e2e`, push, open a draft PR, poll CI every 2 minutes, and merge when green — acceptance: the PR merges to `main`
 
-- [ ] [AI] Add the reciprocal links for the E2E project: link `specs/apps/islamic/be/README.md` to `apps/islamic-be-e2e/README.md`, and link back — acceptance: `rhino-bin.sh md links validate --exclude plans/done` reports no broken links
+- [x] [AI] Add the reciprocal links for the E2E project: link `specs/apps/islamic/be/README.md` to `apps/islamic-be-e2e/README.md`, and link back — acceptance: `rhino-bin.sh md links validate --exclude plans/done` reports no broken links
 
   > **Added during execution (2026-09-08).** Same reason as the DU3 step: DU2's corpus could not
   > link a project that DU4 creates.
+  >
+  > **Implementation note (2026-09-09).** `All links valid!` Three placeholders left by DU2 and DU3
+  > became real links, and the paragraphs explaining why they were placeholders were removed rather
+  > than left to read as current fact.
 
 ### Phase 4 Gate
 
 > All checks below must pass before starting Phase 6. Phase 5 (DU5) may proceed in parallel.
 
-- [ ] [AI] `npm exec nx -- run islamic-be-e2e:test:e2e` — all scenarios pass against a real process
-- [ ] [AI] `npm exec nx -- run islamic-be-e2e:test:quick` — exits zero
-- [ ] [AI] `npm exec nx -- run islamic-be:test:coverage` — every adapter reports its scenarios bound or explicitly allowed
-- [ ] [AI] Capture the passing E2E run output to `evidence/phase-4-e2e.txt` — acceptance: the file records the scenario count and result
+- [x] [AI] `npm exec nx -- run islamic-be-e2e:test:e2e` — all scenarios pass against a real process
+
+  > **Implementation note (2026-09-09).** 3 passed. Verified to be capable of failing: with
+  > `StatusHealthy` mutated to `"ok"`, scenario 1 fails with `Expected: "healthy" / Received: "ok"`.
+  > The mutation was reverted and the captured run is the restored source.
+
+- [x] [AI] `npm exec nx -- run islamic-be-e2e:test:quick` — exits zero
+
+  > **Implementation note (2026-09-09).** Exits zero under `--skip-nx-cache`: typecheck, oxlint,
+  > specs structure, and both coverage validators.
+
+- [x] [AI] `npm exec nx -- run islamic-be:test:coverage` — every adapter reports its scenarios bound or explicitly allowed
+
+  > **Implementation note (2026-09-09).** `2 features, 8 expanded scenarios, adapters: unit, e2e.`
+  > across all three validators. `run-many test:quick` over `islamic-be`, `islamic-be-e2e`, and
+  > `islamic-contracts` exits zero with the Go coverage floor still at 100.0%.
+
+- [x] [AI] Capture the passing E2E run output to `evidence/phase-4-e2e.txt` — acceptance: the file records the scenario count and result
+
+  > **Implementation note (2026-09-09).** Records the passing run, the mutation that proves it can
+  > fail, and the earlier run that passed against a stale process — the last one kept deliberately,
+  > because the near-miss is the more useful half of the record.
 
 > **Pause Safety**: the full test pyramid is green — Unit bindings, E2E bindings, and static coverage
 > across both. The service is complete and gated; only registry documentation and env drift-checking

--- a/plans/in-progress/islamic-be-init/evidence/du3-ci-routing.txt
+++ b/plans/in-progress/islamic-be-init/evidence/du3-ci-routing.txt
@@ -1,0 +1,86 @@
+DU3 CI routing evidence
+=======================
+PR:       https://github.com/wahidyankf/ose-public/pull/498
+Run:      https://github.com/wahidyankf/ose-public/actions/runs/34263277920
+Head SHA: 5554cd6f7e205ffa7b2b35270af5b2da6c964683
+Base:     main @ fbb459cad0a567dcace99ec6f555c493a17f58c9
+
+Claim: the go job is green and selects islamic-be; the typescript, dotnet,
+flutter and java jobs select no Go target.
+
+--- check conclusions (gh pr checks 498) ---
+pass	.NET quality gate
+pass	Auto-format affected (lint-staged)
+pass	Build rhino-cli (gate profile)
+pass	Detect affected languages
+pass	Enumerate registry CI gate groups
+pass	formatting-verify
+pass	Go quality gate
+pass	governance
+pass	harness
+pass	Java quality gate
+pass	lint
+pass	markdown
+pass	Quality gate
+pass	shell-docker-actions
+pass	Specs structure validation (all affected)
+pass	TypeScript quality gate
+pass	Validate env-contract surfaces (no drift)
+skipping	Flutter quality gate
+
+--- go job (102187317083): selects islamic-be and passes ---
+##[group]Run npx nx affected -t typecheck lint test:quick compat:min-version --exclude='tag:lang:ts,tag:lang:fsharp,tag:lang:csharp,tag:lang:rust,tag:lang:dart,tag:lang:java' --parallel=1
+npx nx affected -t typecheck lint test:quick compat:min-version --exclude='tag:lang:ts,tag:lang:fsharp,tag:lang:csharp,tag:lang:rust,tag:lang:dart,tag:lang:java' --parallel=1
+ NX   Running targets typecheck, lint, test:quick, compat:min-version for project islamic-be and 7 tasks it depends on:
+ NX   Successfully ran targets typecheck, lint, test:quick, compat:min-version for project islamic-be and 7 tasks it depends on
+
+--- go job: every distinct project it ran a target for ---
+for project islamic-be
+
+--- typescript / dotnet / java jobs: projects they ran targets for ---
+[typescript]
+  for project ayokoding-www
+  for project ayokoding-www-be-e2e
+  for project ayokoding-www-fe-e2e
+  for project organiclever-app-web
+  for project organiclever-app-web-e2e
+  for project organiclever-be-e2e
+  for project organiclever-www
+  for project organiclever-www-fe-e2e
+  for project ose-app-web
+  for project ose-app-web-e2e
+  for project ose-be-e2e
+  for project ose-www
+  for project ose-www-be-e2e
+  for project ose-www-fe-e2e
+  for project ts-env-loader
+  for project web-ui
+  for project web-ui-token
+[dotnet]
+  for project crane-cli
+  for project fsharp-crane-core
+  for project fsharp-env-loader
+  for project organiclever-be
+  for project ose-be
+  for project rhino-cli
+[java]
+  for project ose-lms-be
+
+--- typescript / dotnet / java jobs: every line naming islamic-be ---
+(each is the git fetch advertising the PR branch, not a target selection)
+[typescript]
+   * [new branch]          islamic-be-init/du3-service              -> origin/islamic-be-init/du3-service
+[dotnet]
+   * [new branch]          islamic-be-init/du3-service              -> origin/islamic-be-init/du3-service
+[java]
+   * [new branch]          islamic-be-init/du3-service              -> origin/islamic-be-init/du3-service
+
+--- flutter job (102187318990) ---
+  conclusion: skipped  (job did not run; has-dart false)
+
+--- lint gate group (102187653307): the new provisioning steps ---
+##[group]Run npx nx affected -t codegen --exclude='tag:lang:ts,tag:lang:fsharp,tag:lang:csharp,tag:lang:rust,tag:lang:dart,tag:lang:java' --parallel=1
+npx nx affected -t codegen --exclude='tag:lang:ts,tag:lang:fsharp,tag:lang:csharp,tag:lang:rust,tag:lang:dart,tag:lang:java' --parallel=1
+Running gate lint-golangci
+0 issues.
+lint-golangci	PASS

--- a/plans/in-progress/islamic-be-init/evidence/phase-4-e2e.txt
+++ b/plans/in-progress/islamic-be-init/evidence/phase-4-e2e.txt
@@ -1,0 +1,101 @@
+
+> nx run islamic-be-e2e:"test:e2e"
+
+> apps/islamic-be/scripts/run-e2e.sh
+
+
+ NX   Running target build for project islamic-be and 2 tasks it depends on:
+
+
+
+> nx run islamic-contracts:bundle
+
+> mkdir -p specs/apps/islamic/be/contracts/generated && npx @redocly/cli bundle specs/apps/islamic/be/contracts/openapi.yaml -o specs/apps/islamic/be/contracts/generated/openapi-bundled.yaml && npx @redocly/cli bundle specs/apps/islamic/be/contracts/openapi.yaml -o specs/apps/islamic/be/contracts/generated/openapi-bundled.json
+
+
+    ╔═══════════════════════════════════════════════════════╗
+    ║                                                       ║
+    ║  A new version of Redocly CLI (2.51.2) is available.  ║
+    ║  Update now: `npm i -g @redocly/cli@latest`.          ║
+    ║  Changelog: https://redocly.com/docs/cli/changelog/   ║
+    ║                                                       ║
+    ╚═══════════════════════════════════════════════════════╝
+
+bundling specs/apps/islamic/be/contracts/openapi.yaml...
+📦 Created a bundle for specs/apps/islamic/be/contracts/openapi.yaml at specs/apps/islamic/be/contracts/generated/openapi-bundled.yaml 8ms.
+
+    ╔═══════════════════════════════════════════════════════╗
+    ║                                                       ║
+    ║  A new version of Redocly CLI (2.51.2) is available.  ║
+    ║  Update now: `npm i -g @redocly/cli@latest`.          ║
+    ║  Changelog: https://redocly.com/docs/cli/changelog/   ║
+    ║                                                       ║
+    ╚═══════════════════════════════════════════════════════╝
+
+bundling specs/apps/islamic/be/contracts/openapi.yaml...
+📦 Created a bundle for specs/apps/islamic/be/contracts/openapi.yaml at specs/apps/islamic/be/contracts/generated/openapi-bundled.json 8ms.
+
+> nx run islamic-be:codegen
+
+> go tool oapi-codegen -config oapi-codegen.yaml ../../specs/apps/islamic/be/contracts/generated/openapi-bundled.yaml
+
+
+> nx run islamic-be:build
+
+> go build -o dist/islamic-be ./cmd/islamic-be
+
+
+
+
+ NX   Successfully ran target build for project islamic-be and 2 tasks it depends on
+
+
+
+Running 3 tests using 1 worker
+
+  ✓  1 .features-gen/health/health.feature.spec.js:6:7 › Islamic BE health endpoint › Health endpoint returns 200 @integration-exempt (571ms)
+  ✓  2 .features-gen/health/health.feature.spec.js:13:7 › Islamic BE health endpoint › Health endpoint reports the JSON content type @integration-exempt (6ms)
+  ✓  3 .features-gen/health/health.feature.spec.js:19:7 › Islamic BE health endpoint › An unknown route is rejected @integration-exempt (8ms)
+
+  3 passed (984ms)
+
+
+
+ NX   Successfully ran target test:e2e for project islamic-be-e2e
+
+
+
+================================================================
+Mutation proof: the suite fails when the service is wrong
+================================================================
+
+A green suite is not evidence unless it can go red. With
+internal/health/health.go's StatusHealthy changed from "healthy" to "ok":
+
+  ✘  1 .features-gen/health/health.feature.spec.js:6:7 › Islamic BE health endpoint › Health endpoint returns 200 @integration-exempt (573ms)
+  ✓  2 .features-gen/health/health.feature.spec.js:13:7 › Islamic BE health endpoint › Health endpoint reports the JSON content type @integration-exempt (319ms)
+  ✓  3 .features-gen/health/health.feature.spec.js:19:7 › Islamic BE health endpoint › An unknown route is rejected @integration-exempt (6ms)
+    Expected: "healthy"
+    Received: "ok"
+  1 failed
+  2 passed (1.6s)
+ NX   Running target test:e2e for project islamic-be-e2e failed
+
+The mutation was reverted and the run above is the restored source.
+
+----------------------------------------------------------------
+First attempt at this proof, recorded because it nearly passed silently
+----------------------------------------------------------------
+
+The same mutation initially reported 3 passed. A stray islamic-be process
+left over from the DU3 manual health check still held port 8402, and
+ensureBackendStarted() reused whatever answered on the port -- the shape
+apps/ose-be-e2e uses -- so the suite never executed the code under test:
+
+  ✓  1 .features-gen/health/health.feature.spec.js:6:7 › Islamic BE health endpoint › Health endpoint returns 200 @integration-exempt (60ms)
+  ✓  2 .features-gen/health/health.feature.spec.js:13:7 › Islamic BE health endpoint › Health endpoint reports the JSON content type @integration-exempt (7ms)
+  ✓  3 .features-gen/health/health.feature.spec.js:19:7 › Islamic BE health endpoint › An unknown route is rejected @integration-exempt (10ms)
+  3 passed (466ms)
+
+steps/backend-process.ts now reuses only a process this harness started and
+refuses to run against a foreign listener.

--- a/plans/in-progress/islamic-be-init/learnings.md
+++ b/plans/in-progress/islamic-be-init/learnings.md
@@ -348,3 +348,28 @@ apps/islamic-be`. Same source tree, same linter, same version; the gate passes a
   interpret degrades to "always skip" rather than to an error.
 - **Disposition**: _pending Phase 7_ — reported, not fixed. Correcting the matcher or the glob is a
   repo-rules change outside this plan's authorization and belongs in its own delivery unit.
+
+### DU4: an E2E suite that reuses a listener proves nothing about the build
+
+- **Observed**: `apps/islamic-be-e2e` initially copied `ose-be-e2e`'s `ensureBackendStarted`, which
+  starts the service only `if (!(await endpointResponds()))`. Three health scenarios passed. Then a
+  deliberate mutation — `StatusHealthy` changed from `"healthy"` to `"ok"` — **also** reported three
+  green scenarios. A stray `islamic-be` from the DU3 manual health check had held port 8402 since
+  the previous day, so the harness never spawned the binary it had just built and every assertion
+  ran against day-old code.
+- **Generalizes because**: "reuse whatever answers on the port" is a convenience that silently
+  converts an E2E suite into a test of _some_ process rather than _the_ process. It fails open, and
+  it fails open in exactly the situation where a developer is most likely to have a stray server
+  running — while iterating on the service. Every project that copies this shape inherits it;
+  `ose-be-e2e`, `organiclever-be-e2e`, and the other backend suites all carry the same predicate.
+- **The fix that generalizes**: reuse only a process the harness itself started and still owns, and
+  treat a foreign listener as a hard error with an actionable message. Targeting a real deployed
+  environment is a different intent and already has a different door — `API_BASE_URL`.
+- **The deeper lesson is about method, not ports**: the passing run was captured as evidence before
+  the mutation was tried. Had the mutation step been skipped — and nothing in the checklist demanded
+  it — this suite would have shipped green, permanently unable to fail, with a captured artefact
+  "proving" it worked. A green test is a claim about the test, not about the code, until it has been
+  shown to go red.
+- **Disposition**: _pending Phase 7_ — fixed here. The sibling suites are not this plan's to change;
+  worth proposing that new-process E2E harnesses be required to demonstrate one red run, and that
+  the shared reuse predicate be revisited across the existing backend suites.

--- a/specs/apps/islamic/be/README.md
+++ b/specs/apps/islamic/be/README.md
@@ -18,9 +18,8 @@ route's status code, its response body, and how the process resolves its own con
 ## Related
 
 - [`apps/islamic-be`](../../../../apps/islamic-be/README.md) — the implementing project.
-- `apps/islamic-be-e2e` — the E2E project that drives this corpus against the real process,
-  created in DU4.
+- [`apps/islamic-be-e2e`](../../../../apps/islamic-be-e2e/README.md) — the E2E project that drives
+  this corpus against the real process.
 
-`islamic-be-e2e` is named rather than linked because it does not exist yet: the `md-links` gate
-scans the whole tree rather than only the current change, so a link to a project DU4 has not created
-would fail every push. DU4 adds it, in both directions — exactly as DU3 did for `islamic-be` above.
+The `config/` scenarios carry `@e2e-exempt`; the `health/` scenarios do not, and all three resolve
+in both adapters.

--- a/specs/apps/islamic/be/behaviours/README.md
+++ b/specs/apps/islamic/be/behaviours/README.md
@@ -1,7 +1,9 @@
 # Islamic BE — Gherkin Scenarios
 
-Backend Gherkin scenarios for `islamic-be`. Consumed by Godog at the Unit layer and by
-`playwright-bdd` at the E2E layer.
+Backend Gherkin scenarios for `islamic-be`. Consumed by Godog at the Unit layer, in
+[`apps/islamic-be/internal/bdd`](../../../../../apps/islamic-be/internal/bdd), and by
+`playwright-bdd` at the E2E layer, in
+[`apps/islamic-be-e2e/steps`](../../../../../apps/islamic-be-e2e/README.md).
 
 ## Feature files
 


### PR DESCRIPTION
## Why

DU4 of `plans/in-progress/islamic-be-init`. The behaviour corpus has named an E2E project since DU2
and DU3 deferred the `e2e` adapter to whichever unit could make it resolve. This is that unit:
`apps/islamic-be-e2e` exists, the three `health/` scenarios run against a real `islamic-be` process
over HTTP, and `apps/islamic-be` declares its `e2e` adapter and `test:coverage:e2e` target.

## Cost / benefit of the new code

**Cost.** One new Nx project (~230 lines of TypeScript plus config), one new shell runner, and two
`@playwright/test` / `playwright-bdd` dependencies already pinned at the same versions by nine
sibling suites. `test:coverage` on `islamic-be` gains a third validator.

**Benefit.** The health contract is now proven at the boundary a consumer actually uses, not only
in-process. Without it, `islamic-be`'s `health/` scenarios have Unit proof only, and their
`@integration-exempt` tags name `islamic-be-e2e:test:e2e` as the alternative proof — a promise this
PR makes true.

## The suite starts the process it observes

`ose-be-e2e`'s harness starts the service only if nothing already answers on the port. Copied
verbatim, that made this suite pass against a service it never launched: a stale `islamic-be` from
the DU3 manual health check still held 8402, and a health handler deliberately broken to return
`"ok"` instead of `"healthy"` still reported three green scenarios.

`ensureBackendStarted` now reuses only a process this harness started and still owns, and treats any
foreign listener as a hard error. `evidence/phase-4-e2e.txt` records three runs: the passing one,
the mutation proving it can fail, and the earlier one that passed against day-old code.

## Deliberate divergences from `apps/ose-be-e2e`

| Divergence | Reason |
| --- | --- |
| `retries: 0` rather than `CI ? 2 : 0` | AGENTS.md forbids retrying a flaky test instead of fixing its root cause |
| No `e2e-coverage-baseline.json` | `allowedUnbound` is read by nothing in this repository; the live mechanism is the `@e2e-exempt` tag, which both `playwright.config.ts` and `behaviour-coverage.mjs` already read |
| No `docker-compose` in `run-e2e.sh` | The service owns no database, broker, or disk |
| Reuse only our own process | See above |
| No `@vitejs/plugin-react` dependency | A React plugin has no place in a headless API suite |

## Verification

- `nx run islamic-be-e2e:test:e2e` — 3 passed against a real process; fails as expected under a
  mutated health handler
- `nx run islamic-be-e2e:test:quick` — exits zero (`--skip-nx-cache`)
- `nx run-many -t test:quick --projects=islamic-be,islamic-be-e2e,islamic-contracts` — exits zero,
  Go line coverage still 100.0% against a 99% floor
- `rhino-bin.sh md links validate --exclude plans/done` — all links valid
- Deleting one `@e2e-exempt` tag makes `test:coverage:e2e` fail with `undefined E2E binding`, then
  passes again once restored

## Skip

No `test:unit` or `test:integration` target on the E2E project — both belong to `islamic-be`, and
the anti-echo convention forbids a naming-symmetry stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2pyLiJKoWA6MJtWvzZFdy
