### PR TITLE
feat(islamic-be): register the Go env-contract surface and the app registry

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -11,6 +11,7 @@
 | AyoKoding                                    | [ayokoding-www](./ayokoding-www/README.md)                                                                  | Educational content platform.                                            |
 | OrganicLever's public presence               | [organiclever-www](./organiclever-www/README.md)                                                            | Marketing website for the OrganicLever productivity platform.            |
 | OrganicLever's life journal                  | [organiclever-app-web](./organiclever-app-web/README.md) and [organiclever-be](./organiclever-be/README.md) | Local-first journal and productivity tracker, with its REST API backend. |
+| Islamic tools                                | [islamic-be](./islamic-be/README.md)                                                                        | REST API backend for the Islamic tooling surface.                        |
 
 ## Tools
 
@@ -30,6 +31,7 @@ End-to-end projects keep browser and API behaviour separate from the application
 | AyoKoding                   | [ayokoding-www-fe-e2e](./ayokoding-www-fe-e2e/)                  | [ayokoding-www-be-e2e](./ayokoding-www-be-e2e/)         |
 | OrganicLever public website | [organiclever-www-fe-e2e](./organiclever-www-fe-e2e/README.md)   | Not applicable; the site has no backend public boundary |
 | OrganicLever product        | [organiclever-app-web-e2e](./organiclever-app-web-e2e/README.md) | [organiclever-be-e2e](./organiclever-be-e2e/README.md)  |
+| Islamic tools               | Not applicable; the service has no browser surface               | [islamic-be-e2e](./islamic-be-e2e/README.md)            |
 
 ## Work with an app
 

--- a/apps/islamic-be/cmd/islamic-be/main.go
+++ b/apps/islamic-be/cmd/islamic-be/main.go
@@ -18,10 +18,15 @@ import (
 )
 
 func main() {
-	portFlag := flag.String("port", "", "listener port; overrides "+config.PortVariable)
+	// ISLAMIC_BE_PORT is spelled out here rather than held in a constant so the
+	// env-contract scanner can see it. `rhino-cli env validate` matches the key
+	// literal beside the reader it is passed with, mirroring how ose-be's
+	// Program.fs passes "OSE_BE_PORT" beside readEnvironment; a constant would
+	// hide a read that genuinely happens and report the key as unread.
+	portFlag := flag.String("port", "", "listener port; overrides ISLAMIC_BE_PORT")
 	flag.Parse()
 
-	port, err := config.ResolvePort(*portFlag, os.LookupEnv)
+	port, err := config.ResolvePort(*portFlag, os.LookupEnv, "ISLAMIC_BE_PORT")
 	if err != nil {
 		// Refuse to start rather than fall back to the default, so a typo'd port
 		// surfaces immediately instead of as traffic arriving on the wrong one.

--- a/apps/islamic-be/internal/bdd/steps_test.go
+++ b/apps/islamic-be/internal/bdd/steps_test.go
@@ -115,7 +115,7 @@ func (s *state) thePortFlagIsSuppliedWith(value string) error {
 }
 
 func (s *state) theServiceResolvesItsListenerPort() error {
-	s.resolved, s.resolveErr = config.ResolvePort(s.portArg, s.lookup)
+	s.resolved, s.resolveErr = config.ResolvePort(s.portArg, s.lookup, "ISLAMIC_BE_PORT")
 	s.resolveDone = true
 	return nil
 }

--- a/apps/islamic-be/internal/config/port.go
+++ b/apps/islamic-be/internal/config/port.go
@@ -13,28 +13,30 @@ import (
 // variable supplies one.
 const DefaultPort = 8402
 
-// PortVariable is the only environment variable consulted for the port. A bare
-// PORT is deliberately ignored: one exported variable must not be able to
-// retarget every app in the monorepo at once.
-const PortVariable = "ISLAMIC_BE_PORT"
-
 // Lookup reports the value of an environment variable and whether it was set.
 // It has the same shape as os.LookupEnv so main can pass that directly.
 type Lookup func(key string) (string, bool)
 
-// ResolvePort applies the resolution order flag -> ISLAMIC_BE_PORT -> default.
+// ResolvePort applies the resolution order flag -> variable -> default.
+//
+// The caller names the variable rather than this package hardcoding it: the
+// composition root already decides which environment the service reads, and
+// keeping the name there is what lets the repo's env-contract scanner see the
+// key beside the reader it is passed with. A bare PORT is never consulted --
+// callers pass a prefixed name -- so one exported variable cannot retarget
+// every app in the monorepo at once.
 //
 // A malformed value from either source is an error, never a fall back to the
 // default: a typo'd port that silently starts the service on 8402 is harder to
 // diagnose than a refusal to start. On error the returned port is 0, which is
 // not a usable port, so a caller that ignores the error still cannot listen.
-func ResolvePort(flagValue string, lookup Lookup) (int, error) {
+func ResolvePort(flagValue string, lookup Lookup, variable string) (int, error) {
 	if flagValue != "" {
 		return parsePort(flagValue, "--port")
 	}
 
-	if raw, ok := lookup(PortVariable); ok && raw != "" {
-		return parsePort(raw, PortVariable)
+	if raw, ok := lookup(variable); ok && raw != "" {
+		return parsePort(raw, variable)
 	}
 
 	return DefaultPort, nil

--- a/apps/islamic-be/internal/config/port_test.go
+++ b/apps/islamic-be/internal/config/port_test.go
@@ -18,7 +18,7 @@ func envOf(pairs map[string]string) config.Lookup {
 
 // Scenario: The default port applies when nothing is set
 func TestDefaultPortAppliesWhenNothingIsSet(t *testing.T) {
-	got, err := config.ResolvePort("", envOf(map[string]string{}))
+	got, err := config.ResolvePort("", envOf(map[string]string{}), "ISLAMIC_BE_PORT")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -29,7 +29,7 @@ func TestDefaultPortAppliesWhenNothingIsSet(t *testing.T) {
 
 // Scenario: The prefixed variable overrides the default
 func TestPrefixedVariableOverridesTheDefault(t *testing.T) {
-	got, err := config.ResolvePort("", envOf(map[string]string{"ISLAMIC_BE_PORT": "9402"}))
+	got, err := config.ResolvePort("", envOf(map[string]string{"ISLAMIC_BE_PORT": "9402"}), "ISLAMIC_BE_PORT")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -40,7 +40,7 @@ func TestPrefixedVariableOverridesTheDefault(t *testing.T) {
 
 // Scenario: The flag overrides the prefixed variable
 func TestFlagOverridesThePrefixedVariable(t *testing.T) {
-	got, err := config.ResolvePort("9500", envOf(map[string]string{"ISLAMIC_BE_PORT": "9402"}))
+	got, err := config.ResolvePort("9500", envOf(map[string]string{"ISLAMIC_BE_PORT": "9402"}), "ISLAMIC_BE_PORT")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -51,7 +51,7 @@ func TestFlagOverridesThePrefixedVariable(t *testing.T) {
 
 // Scenario: A malformed port fails at startup
 func TestMalformedPortFailsAtStartup(t *testing.T) {
-	got, err := config.ResolvePort("", envOf(map[string]string{"ISLAMIC_BE_PORT": "not-a-port"}))
+	got, err := config.ResolvePort("", envOf(map[string]string{"ISLAMIC_BE_PORT": "not-a-port"}), "ISLAMIC_BE_PORT")
 	if err == nil {
 		t.Fatalf("expected an error, got port %d", got)
 	}
@@ -67,7 +67,7 @@ func TestMalformedPortFailsAtStartup(t *testing.T) {
 
 // Scenario: A bare PORT variable is ignored
 func TestBarePortVariableIsIgnored(t *testing.T) {
-	got, err := config.ResolvePort("", envOf(map[string]string{"PORT": "9999"}))
+	got, err := config.ResolvePort("", envOf(map[string]string{"PORT": "9999"}), "ISLAMIC_BE_PORT")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -80,7 +80,7 @@ func TestBarePortVariableIsIgnored(t *testing.T) {
 // developer-facing surface, not a user journey -- but silently defaulting on a
 // typo'd --port would be the same defect the env case forbids.
 func TestMalformedFlagFailsAtStartup(t *testing.T) {
-	_, err := config.ResolvePort("not-a-port", envOf(map[string]string{}))
+	_, err := config.ResolvePort("not-a-port", envOf(map[string]string{}), "ISLAMIC_BE_PORT")
 	if err == nil {
 		t.Fatal("expected an error for a malformed --port flag")
 	}
@@ -92,7 +92,7 @@ func TestMalformedFlagFailsAtStartup(t *testing.T) {
 // Out-of-range values are not ports. 0 is reserved and >65535 is unrepresentable.
 func TestOutOfRangePortsAreRejected(t *testing.T) {
 	for _, raw := range []string{"0", "65536", "-1"} {
-		if _, err := config.ResolvePort("", envOf(map[string]string{"ISLAMIC_BE_PORT": raw})); err == nil {
+		if _, err := config.ResolvePort("", envOf(map[string]string{"ISLAMIC_BE_PORT": raw}), "ISLAMIC_BE_PORT"); err == nil {
 			t.Errorf("expected %q to be rejected", raw)
 		}
 	}

--- a/docs/reference/monorepo-structure.md
+++ b/docs/reference/monorepo-structure.md
@@ -95,6 +95,8 @@ Flat structure - all apps at the same level, no subdirectories.
 - `organiclever-app-web-e2e` - Playwright FE E2E tests for organiclever-app-web
 - `organiclever-be` - OrganicLever F#/Giraffe/ASP.NET REST API backend (port 8202)
 - `organiclever-be-e2e` - Playwright BE E2E tests for organiclever-be
+- `islamic-be` - Islamic tools Go/Gin REST API backend (port 8402)
+- `islamic-be-e2e` - Playwright BE E2E tests for islamic-be
 
 ### App Structure (Next.js Application — ose-www)
 

--- a/docs/reference/web-sites.md
+++ b/docs/reference/web-sites.md
@@ -21,6 +21,7 @@ created: 2026-08-14
 | ose-be               | api.oseplatform.com (F# / Giraffe / ASP.NET 10)          | 8302 | —                           |
 | ose-lms-be           | (Java 25 / Spring Boot 4)                                | 8303 | —                           |
 | organiclever-be      | (F# / Giraffe / ASP.NET 10, Kubernetes)                  | 8202 | —                           |
+| islamic-be           | (Go 1.26 / Gin)                                          | 8402 | —                           |
 
 ## Overriding a port
 
@@ -38,6 +39,7 @@ than falling back silently.
 | organiclever-be      | `ORGANICLEVER_BE_PORT`      |
 | ose-be               | `OSE_BE_PORT`               |
 | ose-lms-be           | `OSE_LMS_BE_PORT`           |
+| islamic-be           | `ISLAMIC_BE_PORT`           |
 
 ```bash
 ./hippo run --class service --disk-path . -- npm exec nx -- dev ose-www --port=4000       # flag

--- a/plans/in-progress/islamic-be-init/delivery.md
+++ b/plans/in-progress/islamic-be-init/delivery.md
@@ -1298,21 +1298,21 @@ DU1–DU4; gates only DU6.
 
 ### Integration
 
-- [ ] [AI] Commit in each repository on `islamic-be-init/du5-rhino-go-env` with the source edit and the regenerated manifest in **one** commit, message `feat(rhino-cli): scan Go source for environment reads`. Acceptance: `rtk git show --stat` in each lists both `Env.fs` and `parity-manifest.sha256`
-- [ ] [AI] Push both branches and open a draft PR in each repository, each body stating the new-code cost/benefit and naming its counterpart PR. Acceptance: both PRs exist and cross-reference
-- [ ] [AI] Poll CI every 2 minutes in both repositories until `pr-quality-gate.yml` and `pr-leak-review` complete on each current head — acceptance: all report success; never use `gh run watch`
-- [ ] [AI] Merge both pull requests within the same working session, so the nightly parity audit never observes a mismatched pair. Acceptance: both merge; record each PR number and 40-character head SHA in the Delivery Branch Inventory
+- [x] [AI] Commit in each repository on `islamic-be-init/du5-rhino-go-env` with the source edit and the regenerated manifest in **one** commit, message `feat(rhino-cli): scan Go source for environment reads`. Acceptance: `rtk git show --stat` in each lists both `Env.fs` and `parity-manifest.sha256` — public `72c3b6567`, private `a79332f8bf`; each lists `Env.fs` and `parity-manifest.sha256`
+- [x] [AI] Push both branches and open a draft PR in each repository, each body stating the new-code cost/benefit and naming its counterpart PR. Acceptance: both PRs exist and cross-reference — ose-public#500 and ose-private#169, cross-referenced
+- [x] [AI] Poll CI every 2 minutes in both repositories until `pr-quality-gate.yml` and `pr-leak-review` complete on each current head — acceptance: all report success; never use `gh run watch` — all checks pass in both; leak reviews `5146300220` (public) and `5146295091` (private), each pinned to its exact head with `pass` 0/0/0
+- [x] [AI] Merge both pull requests within the same working session, so the nightly parity audit never observes a mismatched pair. Acceptance: both merge; record each PR number and 40-character head SHA in the Delivery Branch Inventory — merged back to back: public squash `4127ff43c5f5d862538fac9202fdc7ae0c90bf7f`, private squash `2ba5397da07403598097eddb1a57d5876a7a0f39`
 - [x] [AI] Record the unconverged counterpart as a sibling obligation in `learnings.md` from the moment the first PR merges until the second does — acceptance: the entry names the outstanding repository and is cleared only when both are in — recorded in `learnings.md` under "a manifest-covered change opens a divergence window until both PRs land"
 
 ### Phase 5 Gate
 
 > All checks below must pass before starting Phase 6.
 
-- [ ] [AI] `rtk ./hippo run --class transactional --disk-path . -- npm exec nx -- run rhino-cli:test:quick` in **both** repositories — exits zero in each
-- [ ] [AI] Recursive diff of `apps/rhino-cli/src`, `project.json`, `LICENSE`, and `parity-manifest.sha256` across repositories — reports zero differences
-- [ ] [AI] `rtk apps/rhino-cli/scripts/rhino-bin.sh parity manifest validate` in both — each reports the manifest is current
-- [ ] [AI] `rtk gh workflow run rhino-cli-parity-audit.yml --repo wahidyankf/ose-private` completes successfully against the merged state — save the run URL to `evidence/du5-parity-audit.txt`
-- [ ] [AI] Confirm both `repo-config.yml` files carry an identical top-level key set — acceptance: the schema-parity comparison reports no difference
+- [x] [AI] `rtk ./hippo run --class transactional --disk-path . -- npm exec nx -- run rhino-cli:test:quick` in **both** repositories — exits zero in each — 757 tests pass in each at merged main
+- [x] [AI] Recursive diff of `apps/rhino-cli/src`, `project.json`, `LICENSE`, and `parity-manifest.sha256` across repositories — reports zero differences — zero differences; behaviours corpus identical too
+- [x] [AI] `rtk apps/rhino-cli/scripts/rhino-bin.sh parity manifest validate` in both — each reports the manifest is current — each reports the manifest is current
+- [x] [AI] `rtk gh workflow run rhino-cli-parity-audit.yml --repo wahidyankf/ose-private` completes successfully against the merged state — save the run URL to `evidence/du5-parity-audit.txt` — run 34272185735 completed/success; saved to `evidence/du5-parity-audit.txt`
+- [x] [AI] Confirm both `repo-config.yml` files carry an identical top-level key set — acceptance: the schema-parity comparison reports no difference — 10 keys each, no difference; DU5 touched the file in neither repository
 
 > **Pause Safety**: both repositories carry the Go env scanner and a matching regenerated parity
 > manifest byte-identically, and every existing env surface still validates. No app is registered

--- a/plans/in-progress/islamic-be-init/evidence/du5-parity-audit.txt
+++ b/plans/in-progress/islamic-be-init/evidence/du5-parity-audit.txt
@@ -1,0 +1,37 @@
+Phase 5 Gate — verified against the MERGED state of both repositories
+=====================================================================
+ose-public  main @ 4127ff43c5f5d862538fac9202fdc7ae0c90bf7f  (PR #500, reviewed head 72c3b65675d07883bdb4ce7a4e98ad0feb74820f)
+ose-private main @ 2ba5397da07403598097eddb1a57d5876a7a0f39  (PR #169, reviewed head a79332f8bf78332ab627317d4df129fc489b561e)
+Both merged in the same session, so the nightly audit never observed a mismatched pair.
+
+1. rhino-cli-parity-audit.yml against the merged state
+------------------------------------------------------
+$ gh workflow run rhino-cli-parity-audit.yml --repo wahidyankf/ose-private
+run 34272185735  completed/success  2026-09-08T19:59:46Z
+https://github.com/wahidyankf/ose-private/actions/runs/34272185735
+
+2. Byte-identity across repositories
+------------------------------------
+$ diff -r apps/rhino-cli/src              (excluding bin/obj/dist)   identical
+$ diff    apps/rhino-cli/project.json                                identical
+$ diff    apps/rhino-cli/LICENSE                                     identical
+$ diff    apps/rhino-cli/parity-manifest.sha256                      identical
+$ diff -r specs/apps/rhino/cli/behaviours                            identical
+
+3. parity manifest validate
+---------------------------
+public : apps/rhino-cli/parity-manifest.sha256 is current
+private: apps/rhino-cli/parity-manifest.sha256 is current
+
+4. rhino-cli test:quick
+-----------------------
+public : Passed! - Failed: 0, Passed: 757, Skipped: 0, Total: 757  -> Successfully ran target test:quick
+private: Passed! - Failed: 0, Passed: 757, Skipped: 0, Total: 757  -> Successfully ran target test:quick
+
+5. repo-config.yml top-level key-set parity
+-------------------------------------------
+public : 10 top-level keys
+private: 10 top-level keys
+only in public : (none)
+only in private: (none)
+=> IDENTICAL KEY SET  (DU5 touched repo-config.yml in neither repository)

--- a/plans/in-progress/islamic-be-init/evidence/du6-env-validation.txt
+++ b/plans/in-progress/islamic-be-init/evidence/du6-env-validation.txt
@@ -1,0 +1,50 @@
+DU6 — `lang: go` env-contract validation, proven on the real repository
+========================================================================
+Registered in repo-config.yml with NO allowlist entries:
+
+    - root: apps/islamic-be
+      kind: app
+      lang: go
+      allowlist: []
+
+1. The gate passes
+------------------
+$ nx run rhino-cli:env:validation
+env validate: no drift detected across all surfaces; env-injection manifest consistent
+NX   Successfully ran target env:validation for project rhino-cli
+
+2. The gate is not vacuous — mutation on the real tree
+------------------------------------------------------
+Moving ISLAMIC_BE_PORT back out of the composition root and into a const, i.e. reverting
+cmd/islamic-be/main.go to
+
+    const portVar = "ISLAMIC_BE_PORT"
+    port, err := config.ResolvePort(*portFlag, os.LookupEnv, portVar)
+
+$ rhino-cli env validate
+DRIFT  apps/islamic-be  declared-but-unread  ISLAMIC_BE_PORT
+Error: env validate: 1 finding(s); fix the divergent keys/manifest entries listed above
+
+Restoring the literal at the call site:
+$ rhino-cli env validate
+env validate: no drift detected across all surfaces; env-injection manifest consistent
+
+=> The scanner really is reading this app's source, and the third regex added in DU5 is what
+   makes ISLAMIC_BE_PORT visible. No allowlist entry was needed or used.
+
+3. Coverage held across the signature change
+--------------------------------------------
+ResolvePort gained a `variable string` parameter; the pure resolver no longer hardcodes the app's
+env var name (mirroring ose-be's PortResolver, which is passed "OSE_BE_PORT" at its composition
+root).
+
+ok  .../internal/bdd     coverage: [no statements]
+ok  .../internal/config  coverage: 100.0% of statements
+ok  .../internal/health  coverage: 100.0% of statements
+ok  .../internal/router  coverage: 100.0% of statements
+
+4. Phase 6 gate
+---------------
+nx run-many -t test:quick -p islamic-be islamic-be-e2e islamic-contracts  -> Successfully ran
+markdownlint-cli2 (9 changed/plan markdown files)                         -> 0 error(s)
+stray .env files                                                          -> none; only .env.example

--- a/plans/in-progress/islamic-be-init/learnings.md
+++ b/plans/in-progress/islamic-be-init/learnings.md
@@ -450,3 +450,28 @@ apps/islamic-be`. Same source tree, same linter, same version; the gate passes a
   "outside the manifest" must be checked per file, not assumed either way.
 - **Disposition**: _pending Phase 7_ — the multi-repo parity workflow already states the paired-PR
   rule; the index-not-worktree detail and the per-file identity check are candidates to add there.
+
+### DU5/DU6: parallel agents sharing one scratchpad corrupted a posted review
+
+- **Observed**: the two DU5 leak reviews were launched concurrently, one per repository. Both wrote
+  their review body to the same generic filename in the shared session scratchpad. One overwrote the
+  other between write and read, and `ose-public#500` was briefly posted with `ose-private#169`'s
+  marker — wrong repository, wrong PR number, wrong head SHA.
+- **How it was caught**: the agent read back what it had posted instead of trusting the API call's
+  exit status, spotted the mismatch, rewrote the body to a uniquely-named file, verified the content
+  in the same step, and `PATCH`ed the review. An independent check afterwards confirmed each PR holds
+  exactly one review with its own correct coordinates and `pass` 0/0/0.
+- **Generalizes because**: the scratchpad is documented as session-isolated, which is true — but
+  "session" includes every concurrently running subagent. Isolation from _other sessions_ is not
+  isolation from _your own fan-out_. Any generic filename (`review-body.md`, `out.json`, `tmp.txt`)
+  is a shared mutable global the moment two agents run at once.
+- **Why it mattered here specifically**: the corrupted artefact was a _merge precondition_. A leak
+  review carrying the wrong `head_sha` is not merely untidy — it is evidence for a commit nobody
+  reviewed, and the merge protocol would have accepted it if the marker had happened to name the
+  right head. Read-back verification is what separated "posted" from "posted correctly".
+- **This was an orchestration error, not an agent defect**: the two agents were told to work
+  concurrently and given no distinct working paths. Either sequence them, or hand each a
+  task-unique directory.
+- **Disposition**: _pending Phase 7_ — worth proposing that agent prompts which write intermediate
+  files require a task-unique filename, and that any agent posting to an external system verify by
+  reading back rather than by exit status.

--- a/repo-config.yml
+++ b/repo-config.yml
@@ -299,7 +299,7 @@ env-contract:
   # Each surface entry carries:
   #   root      — path relative to repo root
   #   kind      — "app" (active); "terraform"/"ansible" are forward-scaffold
-  #   lang      — "rust" or "typescript" (app kind only)
+  #   lang      — "rust", "typescript", "fsharp", or "go" (app kind only)
   #   allowlist — keys exempt from drift detection (framework-injected, test-only, etc.)
   surfaces:
     - root: apps/organiclever-be
@@ -330,6 +330,15 @@ env-contract:
         # Tier-selection control var (which .env.<tier> file to load), not an
         # app config value — same treatment as PORT/HOSTNAME for the TS apps.
         - APP_ENV
+
+    - root: apps/islamic-be
+      kind: app
+      lang: go
+      allowlist: []
+      # No allowlist entries. ISLAMIC_BE_PORT is genuinely read -- cmd/islamic-be
+      # passes it beside os.LookupEnv at the composition root -- so the scanner
+      # sees it and no exemption is needed. APP_ENV is not listed because this
+      # service does not consult a tier-selection variable.
 
     - root: apps/ose-www
       kind: app


### PR DESCRIPTION
Final delivery unit of the `islamic-be-init` plan. Puts the service on the surfaces that already describe every other app: the `env-contract:` registry, the port/domain tables, the monorepo app list, and the apps product map.

## The registration surfaced a real defect, not a paperwork step

`scanGoReads` (added in #500) finds **nothing** in this module as it stood. `main.go` passed `os.LookupEnv` as a function value and kept the key in a package const, so no key literal ever reached a call site.

The surface would therefore have validated only by adding `ISLAMIC_BE_PORT` to `allowlist:` — silencing a drift detector on a variable that genuinely *is* read. That is the failure mode the allowlist exists to avoid, not to enable.

Instead, `ResolvePort` now takes the variable name rather than hardcoding it, and `cmd/islamic-be` names `ISLAMIC_BE_PORT` beside the reader it injects. This is the shape `ose-be`'s `PortResolver` already uses (`readEnvironment "OSE_BE_PORT"` at its composition root), and it is better design independent of the scanner — the pure resolver stops knowing which app it serves.

`allowlist:` is empty and stays empty.

## Proof the registration is not vacuous

Reverting the key back into a const reproduces the drift; restoring it clears the finding:

```
MUTATION  -> DRIFT  apps/islamic-be  declared-but-unread  ISLAMIC_BE_PORT
RESTORED  -> env validate: no drift detected across all surfaces
```

Full transcript in `plans/in-progress/islamic-be-init/evidence/du6-env-validation.txt`.

## Gates

- `nx run rhino-cli:env:validation` — no drift across all surfaces
- `nx run-many -t test:quick -p islamic-be islamic-be-e2e islamic-contracts` — all green
- Coverage unchanged at 100% for `config`, `health`, `router` (the signature change adds no branch)
- `markdownlint-cli2` — 0 errors; no stray `.env` files

## Incidental fix

`repo-config.yml`'s `env-contract:` comment documented only `"rust"` or `"typescript"`. It had already fallen behind `fsharp`; it now names `go` too.

## Cost/benefit

The app-source change is net-neutral in size and removes a hardcoded name from a pure function. The registry edits are documentation that keeps the app discoverable. Tests are exempt from the cost side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2pyLiJKoWA6MJtWvzZFdy