### PR TITLE
docs(governance): add a git clean-up workflow

### DIFF
--- a/repo-governance/workflows/README.md
+++ b/repo-governance/workflows/README.md
@@ -34,6 +34,9 @@ Workflows support two execution modes and standard inputs (`mode`, `max-concurre
 - [Gherkin Implementation Review](./gherkin-implementation-review.md) — Semantically inspects every
   applicable scenario adapter for real production invocation and independent evidence; static
   binding counts cannot replace it.
+- [Git Clean-Up](./git-clean-up.md) — Sequences the teardown pass for one repository:
+  pre-removal checks, worktree, branches, build output, then the local `main` reconcile. Use when a
+  plan has finished with a repository worktree and its Git artifacts must come down.
 - [API Workflows](api/README.md) — Orchestrated processes for live REST and GraphQL API quality validation and remediation. Use when routing to a workflow that exercises a running REST or GraphQL API against its contract and specs.
 - [AyoKoding Web Workflows](ayokoding-web/README.md) — Workflows for keeping AyoKoding learning content accurate, useful, and well structured. Use when routing to a workflow that validates a specific AyoKoding tutorial type's quality.
 - [CI Workflows](ci/README.md) — Workflows for checking that repository CI setup follows its documented standards. Use when routing to a workflow that validates or fixes CI/CD standards compliance.

--- a/repo-governance/workflows/git-clean-up.md
+++ b/repo-governance/workflows/git-clean-up.md
@@ -1,0 +1,71 @@
+---
+description: "The ordered teardown pass for one repository — pre-removal checks, worktree, branches, build output, then the local main reconcile"
+when_to_use: "Use when a plan or task has finished with a repository's worktree and its Git artifacts must come down."
+---
+
+# Git Clean-Up
+
+Teardown, in order, for one repository. Every rule this workflow applies is stated elsewhere; this
+is the sequence, and the point at which it stops.
+
+## Goal and Termination
+
+**Goal**: Remove exactly the Git artifacts this work created, and leave the primary checkout's
+`main` level with `origin/main`.
+
+**Termination**: PASS when the worktree, both copies of every branch, and the plan's regenerable
+output are gone and the divergence count reads `0 0`. RETAIN when any required proof is missing —
+retention is a valid terminal state, not a failure to finish.
+
+## Scope
+
+The worktree this plan provisioned, the branches it opened, the regenerable build output it
+produced, and the primary checkout's `main` ref. Nothing else. An artifact another actor created
+stays out of scope even when it looks abandoned — see
+[Hard Safety Rules](../development/workflow/worktree-and-artifact-cleanup/hard-safety-rules.md).
+
+## Steps
+
+1. **Confirm the terminal gate.** Every delivery unit that used the worktree is delivered, or the
+   work is deliberately abandoned. Not between units: one worktree is reused for all of them under
+   the [Worktree Cap](../conventions/structure/plans/worktree-cap.md).
+2. **Run the pre-removal checks** — all six, before any removal:
+   [Mandatory Pre-Removal Checks](../development/workflow/worktree-and-artifact-cleanup/mandatory-pre-removal-checks.md).
+3. **Remove the worktree**, then `git worktree prune`.
+4. **Delete the branches**, local and remote, under the proof gate:
+   [Branch Cleanup](../development/workflow/worktree-and-artifact-cleanup/branch-cleanup.md), or
+   [Patch-Equivalent Branch Cleanup](../development/workflow/worktree-and-artifact-cleanup/patch-equivalent-branch-cleanup.md)
+   where the branch carries no change `main` lacks.
+5. **Purge plan-local build output**, preserving diagnostics and shared caches:
+   [Build-Artifact Cleanup](../development/workflow/worktree-and-artifact-cleanup/build-artifact-cleanup.md).
+6. **Reconcile local `main`.** Choose the command by repository topology —
+   [Terminal Reconcile](../development/workflow/bare-repo-landing-method/terminal-reconcile.md) —
+   then prove `git rev-list --left-right --count HEAD...origin/main` reads `0 0`.
+
+## Why the Reconcile Is Step 6
+
+It is documented as step 8 of the
+[bare-repo landing method](../development/workflow/bare-repo-landing-method.md), keyed to that
+method rather than to teardown. Cleanup is where it is actually reached, and it is the step most
+often missing in practice: it runs in a checkout the merge never touched, so Git reports no error
+and that checkout is simply behind until somebody notices.
+
+Naming it here does not move the rule. The command and its topology reasoning stay canonical where
+they are.
+
+## Verification
+
+`git worktree list` no longer names the path; `git branch -a` no longer lists the branch either
+locally or on `origin`; the divergence count reads `0 0`.
+
+## Retain Rather Than Delete
+
+An artifact belonging to an active, `partial`, or `fail` run is retained and escalated, and the
+reason is stated rather than left implied. A missing proof retains the artifact; it never authorizes
+a forced deletion.
+
+## Related
+
+- [Worktree and Artifact Cleanup](../development/workflow/worktree-and-artifact-cleanup.md) — the convention this workflow sequences.
+- [Worktree Toolchain Initialization](../development/workflow/worktree-setup.md) — the provisioning half of the same lifecycle.
+- [No Destructive Git Operations](../development/workflow/no-destructive-git-operations.md) — the forbidden-operation set this stays within.


### PR DESCRIPTION
## Why this exists

Teardown here has a thorough **convention** and no callable **entry point**.

`development/workflow/worktree-and-artifact-cleanup.md` and its nine child modules already cover the three artifact classes, the hard safety rules, the six mandatory pre-removal checks, branch cleanup, patch-equivalent cleanup, and the four-proof gate that authorizes `git branch -D`. What none of them carries is the **order**, and nothing names the activity, so it could not be invoked by name.

**The reconcile is the concrete gap.** Bringing local `main` level with `origin/main` is documented only as step 8 of the [bare-repo landing method](../development/workflow/bare-repo-landing-method.md), keyed to that method rather than to teardown. A reader running ordinary worktree cleanup never reaches it. It is also the step that document itself calls "the step most often missing in practice" — because it runs in a checkout the merge never touched, so Git reports no error and the checkout is simply behind until somebody notices.

## What was decided

**This workflow sequences; it does not restate.** It links each step to its canonical home and repeats none of it — not a safety rule, not a check, not the `-D` proof gate. Layer 5 composing Layers 2–3 is what `workflows/README.md` already declares the layer is for.

The only content it adds is:

- the **order** the existing modules run in;
- **why the reconcile is step 6**, with the canonical command and its topology reasoning left where they are; and
- a **termination contract** naming `RETAIN` as a valid terminal state rather than a failure to finish.

**Rejected:** restating the pre-removal checks or the branch-deletion proof gate inline. Two statements of one rule is the cross-surface duplication `rules-grooming` exists to catch, and the copy always loses. `branch-cleanup.md`'s `-D` gate in particular is strictly stronger than a summary would be, and summarizing it would weaken it.

**Rejected:** moving the reconcile out of `bare-repo-landing-method/`. It is correct there for that method; naming it in the sequence is enough, and relocating it would break the method's own step 8.

**Rejected:** a sweep mode. Scope is the artifacts *this* plan created — `hard-safety-rules.md` already binds that, and this workflow inherits it by link.

## How it was proved

- `prettier --write` — clean, no reformatting needed.
- `markdownlint-cli2` — `Summary: 0 error(s)`.
- `rhino-cli md frontmatter validate` — passed.
- `rhino-cli governance readme-index validate` — passed (the new entry is annotated).
- `rhino-cli governance word-budget validate` — passed; the file is 490 words against a 750 ceiling.
- `rhino-cli md links validate` — reports **557 broken links**. That is *exactly* the count on clean `origin/main` at `2d3e6a3ae`, which I measured separately in the primary checkout before comparing. Every one predates this change, all are confined to archived plans, and none is in a touched file.
- Pre-commit ran the full staged gate including `harness bindings generate`, which produced no drift (89 agents converted, working tree clean afterwards).

## Deliberately not in this change

- No change to `worktree-and-artifact-cleanup.md` or any of its modules — they remain canonical.
- No change to `bare-repo-landing-method/` — step 8 still owns the reconcile command.
- No enforcement machinery. `plan-execution-checker` already verifies cleanup evidence; adding a second checker for the ordering would be machinery without a demonstrated need.

## Cost and benefit

Prose only, no code. 490 words in one new governance file plus a three-line index entry. The benefit is that the step whose absence leaves a stale primary checkout is now reachable from the activity where it actually happens, and the whole teardown has one name to invoke.
