### PR TITLE
fix(ose-www): restore container build dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,3 +41,6 @@ test-results
 # Re-include test directories needed by integration Dockerfiles
 !apps/a-demo-be-elixir-phoenix/test
 !apps/a-demo-fs-ts-nextjs/test
+# Re-include the OSE website's matcher type setup for Next.js type-checking
+!apps/ose-www/src/test
+!apps/ose-www/src/test/**

--- a/apps/ose-www/Dockerfile
+++ b/apps/ose-www/Dockerfile
@@ -2,6 +2,7 @@ FROM node:24-alpine AS deps
 WORKDIR /workspace
 COPY ../../package.json ../../package-lock.json ./
 COPY apps/ose-www/package.json apps/ose-www/
+COPY libs/ts-env-loader/package.json libs/ts-env-loader/
 COPY libs/web-ui/package.json libs/web-ui/
 COPY libs/web-ui-token/package.json libs/web-ui-token/
 RUN npm ci --ignore-scripts
@@ -10,8 +11,11 @@ FROM node:24-alpine AS builder
 WORKDIR /workspace
 COPY --from=deps /workspace/node_modules ./node_modules
 COPY apps/ose-www/ apps/ose-www/
+COPY libs/ts-env-loader/ libs/ts-env-loader/
 COPY libs/web-ui/ libs/web-ui/
 COPY libs/web-ui-token/ libs/web-ui-token/
+COPY libs/ts-env-loader/src/ ./node_modules/@open-sharia-enterprise/ts-env-loader/src/
+COPY libs/ts-env-loader/package.json ./node_modules/@open-sharia-enterprise/ts-env-loader/
 COPY libs/web-ui/src/ ./node_modules/@open-sharia-enterprise/web-ui/src/
 COPY libs/web-ui/package.json ./node_modules/@open-sharia-enterprise/web-ui/
 COPY libs/web-ui-token/src/ ./node_modules/@open-sharia-enterprise/web-ui-token/src/

--- a/apps/ose-www/src/test/setup.ts
+++ b/apps/ose-www/src/test/setup.ts
@@ -1,2 +1,2 @@
-import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/vitest";
 import "@testing-library/react/dont-cleanup-after-each";


### PR DESCRIPTION
## Outcome and Why

Restore the OSE website production container build so the already-merged Week 42 update can reach production. The first deployment attempt failed because the isolated builder could not resolve the declared `ts-env-loader` workspace package; after that boundary was restored, the clean build exposed missing Vitest matcher augmentation in the Docker context.

## Scope

- **In scope:** OSE website Docker workspace assembly, Docker-context inclusion of its test type setup, and the correct Vitest-specific jest-dom augmentation.
- **Deliberately not in scope, and why:** Other application Dockerfiles with similar latent workspace omissions; they did not block this OSE website deployment and require separate verification.

## Summary

- Install and assemble `ts-env-loader` in the OSE website build stages using the canonical monorepo library pattern.
- Re-include the OSE website test setup that Next.js needs while type-checking the files present in the container context.
- Load jest-dom through its Vitest entry so `vitest.Assertion` receives the matcher types used by the Unit suite.

## Reading Guide

- **Start here:** `apps/ose-www/Dockerfile`
- **Skip these paths:** None; all three changed files participate directly in the production build boundary.

## Delivery Seam and Deployable State

- **Natural seam:** These changes remove the two consecutive failures revealed by the same clean OSE website container build. Separating them would leave the production image unbuildable at one of the two verified boundaries.
- **Production-deployable state:** Safe to deploy after the PR quality gate proves the clean Docker build, HTTP health check, and OSE website E2E suites at this exact head.
- **Feature flag lifecycle:** Not applicable because this repairs build-time package and type resolution without adding user-facing behavior.

## Cost/Benefit of Added Code

- **What it buys:** A reproducible OSE website image that resolves its declared shared environment loader and type-checks the included Unit sources.
- **What it costs to maintain:** Four Docker copy directives and an app-specific Docker-context exception must remain aligned with the workspace dependency.
- **Simpler alternative rejected, and why:** Excluding tests from TypeScript would conceal the matcher defect, while copying only one part of the workspace package would violate the repository Docker checklist and risk another isolated-build failure.

## Verification

- `rtk ./hippo run --class ephemeral --disk-path . -- npm exec nx -- run ose-www:test:unit --skip-nx-cache` — 16 files and 147 tests passed; 100% line coverage.
- `rtk ./hippo run --class ephemeral --disk-path . -- npm exec nx -- run ose-www:typecheck --skip-nx-cache` — passed.
- `rtk ./hippo run --class ephemeral --disk-path . -- npm exec nx -- run ose-www:lint --skip-nx-cache` — passed.
- `rtk ./hippo run --class ephemeral --disk-path . -- npm exec nx -- run ose-www:test:quick --skip-nx-cache` — passed, including 11 features and 28 expanded scenarios across all coverage adapters.
- Repository pre-push gate — passed for both affected projects and all repository checks.
- Clean local Docker build — the first run advanced past the original missing-module failure and exposed the matcher-type boundary; later retries were not admitted during bounded HIPPO memory-warning windows. The PR Docker-backed E2E gate is therefore required before merge.

## Risk and Rollback

Risk is limited to Docker build-context composition and test-only matcher initialization. Revert this commit to restore the previous image assembly; production remains on its prior SHA until the repaired deployment workflow succeeds.
